### PR TITLE
fix(orchestrator): prevent terminal session revival on workflow re-entry

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -665,7 +665,7 @@ func (sc *pendingMoveScenario) assertOneTransitionToInProgress(t *testing.T, ste
 	if !freshImpl.IsPrimary {
 		t.Error("fresh impl session must be primary after the deferred move applies")
 	}
-	if freshImpl.State == models.TaskSessionStateCompleted {
+	if isTerminalSessionState(freshImpl.State) {
 		t.Errorf("fresh impl session state = %q, expected non-terminal", freshImpl.State)
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -374,6 +374,9 @@ func buildPendingMoveScenario(t *testing.T) *pendingMoveScenario {
 
 	implSessionID := seedImplSession(t, repo, now)
 	reviewSessionID := seedReviewSession(t, repo, now)
+	if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{ID: "env-1", TaskID: "task-1", ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady}); err != nil {
+		t.Fatalf("create task environment: %v", err)
+	}
 
 	taskRepo := newMockTaskRepo()
 	taskRepo.tasks["task-1"] = &v1.Task{
@@ -471,6 +474,7 @@ func seedImplSession(t *testing.T, repo *sqliterepo.Repository, now time.Time) s
 		AgentProfileID:    profileImpl,
 		ExecutorID:        "exec-local",
 		ExecutorProfileID: "ep1",
+		TaskEnvironmentID: "env-1",
 		AgentExecutionID:  "ae-impl-original",
 		State:             models.TaskSessionStateCompleted,
 		CompletedAt:       &completedAt,
@@ -501,6 +505,7 @@ func seedReviewSession(t *testing.T, repo *sqliterepo.Repository, now time.Time)
 		AgentProfileID:    profileReview,
 		ExecutorID:        "exec-local",
 		ExecutorProfileID: "ep1",
+		TaskEnvironmentID: "env-1",
 		AgentExecutionID:  "ae-review",
 		State:             models.TaskSessionStateRunning,
 		IsPrimary:         true,
@@ -513,12 +518,14 @@ func seedReviewSession(t *testing.T, repo *sqliterepo.Repository, now time.Time)
 	return id
 }
 
-// wireBootReadySimulator stubs LaunchAgent to fire handleAgentBootReady ~50ms
-// after returning. Real agentctl bootstrap publishes events.AgentBootReady from
-// outside the LaunchAgent call; mirroring that timing here lets the resume
-// path complete in unit tests without spawning a real subprocess.
+// wireBootReadySimulator models the two-phase prepared-session lifecycle:
+// LaunchAgent starts the workspace first, then StartAgentProcess starts ACP and
+// emits agent.boot_ready. A workflow replacement transfers its queued hand-off
+// between those phases, so emitting boot-ready from LaunchAgent would drain the
+// wrong session too early and leave the receiving queue without its real drain.
 func wireBootReadySimulator(svc *Service, agentMgr *mockAgentManager, newExecID string) {
 	promptReady := make(chan struct{})
+	var preparedSessionID string
 	agentMgr.isAgentReadyFn = func(_ context.Context, _ string) bool {
 		select {
 		case <-promptReady:
@@ -528,17 +535,8 @@ func wireBootReadySimulator(svc *Service, agentMgr *mockAgentManager, newExecID 
 		}
 	}
 	agentMgr.launchAgentFunc = func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
-		// Record the initial ACP prompt baked into the launch request (this is
-		// how StartCreatedSession/LaunchPreparedSession delivers a merged
-		// hand-off prompt for a fresh session — unlike PromptTask's lazy-resume
-		// path for an already-launched session, there is no separate
-		// PromptAgent call to capture) so assertHandoffDeliveredOrQueued can
-		// find it via the same capturedPromptsForExecution helper.
 		agentMgr.mu.Lock()
-		agentMgr.capturedPromptCalls = append(agentMgr.capturedPromptCalls, promptCall{
-			ExecutionID: newExecID,
-			Prompt:      req.TaskDescription,
-		})
+		preparedSessionID = req.SessionID
 		agentMgr.mu.Unlock()
 		// Simulate the lifecycle manager's persistExecutorRunning: in production
 		// the row is upserted in lockstep with executionStore.Add; here we mirror
@@ -554,21 +552,24 @@ func wireBootReadySimulator(svc *Service, agentMgr *mockAgentManager, newExecID 
 				Status:           "starting",
 			})
 		}
-		go func() {
-			time.Sleep(50 * time.Millisecond)
-			svc.handleAgentBootReady(context.Background(), watcher.AgentEventData{
-				TaskID:           req.TaskID,
-				SessionID:        req.SessionID,
-				AgentExecutionID: newExecID,
-				AgentProfileID:   req.AgentProfileID,
-			})
-			close(promptReady)
-		}()
 		return &executor.LaunchAgentResponse{
 			AgentExecutionID: newExecID,
 			ContainerID:      "container-relaunch",
 			Status:           v1.AgentStatusReady,
 		}, nil
+	}
+	agentMgr.startAgentProcessFunc = func(_ context.Context, executionID string) error {
+		agentMgr.mu.Lock()
+		sessionID := preparedSessionID
+		agentMgr.mu.Unlock()
+		close(promptReady)
+		svc.handleAgentBootReady(context.Background(), watcher.AgentEventData{
+			TaskID:           "task-1",
+			SessionID:        sessionID,
+			AgentExecutionID: executionID,
+			AgentProfileID:   profileImpl,
+		})
+		return nil
 	}
 }
 
@@ -597,8 +598,8 @@ func (sc *pendingMoveScenario) startStepHistorySampler(t *testing.T, duration ti
 
 // assertOneTransitionToInProgress checks every postcondition of the scenario:
 // task moved to In Progress, exactly one transition, sessions in the right
-// state, and the hand-off prompt landed on the impl session (delivered or
-// queued — either is acceptable for this regression).
+// state, and the hand-off prompt landed exactly once on the fresh impl
+// session's initial launch.
 func (sc *pendingMoveScenario) assertOneTransitionToInProgress(t *testing.T, stepHistory []string) {
 	t.Helper()
 
@@ -669,34 +670,43 @@ func (sc *pendingMoveScenario) assertOneTransitionToInProgress(t *testing.T, ste
 		t.Errorf("fresh impl session state = %q, expected non-terminal", freshImpl.State)
 	}
 
-	sc.assertHandoffDeliveredOrQueued(t, freshImpl.ID)
+	sc.assertHandoffDeliveredToFreshLaunch(t, freshImpl.ID)
 }
 
-// assertHandoffDeliveredOrQueued checks the hand-off prompt landed on the
-// given session — either delivered to its agent (PromptAgent capture) or
-// sitting in the queue waiting for delivery. Both are acceptable; the
-// failure mode the regression catches is "lost" (neither delivered nor
-// queued) or "delivered to the wrong session".
-func (sc *pendingMoveScenario) assertHandoffDeliveredOrQueued(t *testing.T, targetSessionID string) {
+// assertHandoffDeliveredToFreshLaunch proves the moved hand-off is consumed by
+// the fresh session's initial launch exactly once. A replacement has already
+// prepared its workspace, so StartCreatedSession configures the initial ACP
+// prompt through SetExecutionDescription before StartAgentProcess; this is the
+// delivery boundary rather than a follow-up PromptAgent call.
+func (sc *pendingMoveScenario) assertHandoffDeliveredToFreshLaunch(t *testing.T, targetSessionID string) {
 	t.Helper()
 	implPrompts := capturedPromptsForExecution(sc.agentMgr, sc.implRelaunchExec)
+	implDescriptions := capturedExecutionDescriptionsForExecution(sc.agentMgr, sc.implRelaunchExec)
 	implQueued := sc.svc.messageQueue.GetStatus(sc.ctx, targetSessionID)
 
-	if len(implPrompts) == 0 && implQueued.Count == 0 {
-		t.Error("hand-off prompt was neither delivered to the impl session nor queued for it")
-		return
-	}
+	const handoffFragment = "fibonacci.py has two bugs"
+	deliveries := 0
 	for _, p := range implPrompts {
-		if strings.Contains(p, "fibonacci.py has two bugs") {
-			return
+		if strings.Contains(p, handoffFragment) {
+			deliveries++
+		}
+	}
+	for _, description := range implDescriptions {
+		if strings.Contains(description, handoffFragment) {
+			deliveries++
 		}
 	}
 	for _, entry := range implQueued.Entries {
-		if strings.Contains(entry.Content, "fibonacci.py has two bugs") {
-			return
+		if strings.Contains(entry.Content, handoffFragment) {
+			deliveries++
 		}
 	}
-	t.Errorf("hand-off prompt was neither delivered nor queued with the expected content")
+	if deliveries != 1 {
+		t.Errorf("hand-off deliveries = %d, want exactly one", deliveries)
+	}
+	if len(implQueued.Entries) != 0 {
+		t.Errorf("fresh session queue = %+v, want empty after accepted initial delivery", implQueued.Entries)
+	}
 }
 
 // --- Helpers ---
@@ -710,6 +720,18 @@ func capturedPromptsForExecution(agentMgr *mockAgentManager, executionID string)
 	defer agentMgr.mu.Unlock()
 	out := make([]string, 0, len(agentMgr.capturedPromptCalls))
 	for _, c := range agentMgr.capturedPromptCalls {
+		if c.ExecutionID == executionID {
+			out = append(out, c.Prompt)
+		}
+	}
+	return out
+}
+
+func capturedExecutionDescriptionsForExecution(agentMgr *mockAgentManager, executionID string) []string {
+	agentMgr.mu.Lock()
+	defer agentMgr.mu.Unlock()
+	out := make([]string, 0, len(agentMgr.setExecutionDescriptionCalls))
+	for _, c := range agentMgr.setExecutionDescriptionCalls {
 		if c.ExecutionID == executionID {
 			out = append(out, c.Prompt)
 		}

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -528,6 +528,18 @@ func wireBootReadySimulator(svc *Service, agentMgr *mockAgentManager, newExecID 
 		}
 	}
 	agentMgr.launchAgentFunc = func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+		// Record the initial ACP prompt baked into the launch request (this is
+		// how StartCreatedSession/LaunchPreparedSession delivers a merged
+		// hand-off prompt for a fresh session — unlike PromptTask's lazy-resume
+		// path for an already-launched session, there is no separate
+		// PromptAgent call to capture) so assertHandoffDeliveredOrQueued can
+		// find it via the same capturedPromptsForExecution helper.
+		agentMgr.mu.Lock()
+		agentMgr.capturedPromptCalls = append(agentMgr.capturedPromptCalls, promptCall{
+			ExecutionID: newExecID,
+			Prompt:      req.TaskDescription,
+		})
+		agentMgr.mu.Unlock()
 		// Simulate the lifecycle manager's persistExecutorRunning: in production
 		// the row is upserted in lockstep with executionStore.Add; here we mirror
 		// that timing so the orchestrator's GetExecutionIDForSession lookup
@@ -619,29 +631,56 @@ func (sc *pendingMoveScenario) assertOneTransitionToInProgress(t *testing.T, ste
 		t.Error("review session must no longer be primary (the impl session takes over)")
 	}
 
-	impl, err := sc.repo.GetTaskSession(sc.ctx, sc.implSessionID)
+	// The original impl session was seeded COMPLETED (it was previously
+	// launched and completed a real turn — mirroring production). Terminal
+	// sessions are never revived for workflow re-entry (see
+	// findReusableSessionForProfile), so it must stay exactly as seeded:
+	// terminal, non-primary, historically intact.
+	oldImpl, err := sc.repo.GetTaskSession(sc.ctx, sc.implSessionID)
 	if err != nil {
-		t.Fatalf("load impl session: %v", err)
+		t.Fatalf("load original impl session: %v", err)
 	}
-	if !impl.IsPrimary {
-		t.Error("impl session must be primary after the deferred move applies")
+	if oldImpl.State != models.TaskSessionStateCompleted {
+		t.Errorf("original impl session state = %q, want it to remain COMPLETED (never revived)", oldImpl.State)
 	}
-	if impl.State == models.TaskSessionStateCompleted {
-		t.Errorf("impl session state = %q, expected non-terminal (revived for a new turn)", impl.State)
+	if oldImpl.IsPrimary {
+		t.Error("original impl session must remain non-primary (never revived)")
 	}
 
-	sc.assertHandoffDeliveredOrQueued(t)
+	// Re-entry into the Impl profile must create a FRESH session rather than
+	// resurrecting session-impl's stale ACP conversation.
+	sessions, err := sc.repo.ListTaskSessions(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	var freshImpl *models.TaskSession
+	for _, s := range sessions {
+		if s.AgentProfileID == profileImpl && s.ID != sc.implSessionID {
+			freshImpl = s
+		}
+	}
+	if freshImpl == nil {
+		t.Fatal("expected a fresh impl-profile session distinct from the original COMPLETED session-impl")
+	}
+	if !freshImpl.IsPrimary {
+		t.Error("fresh impl session must be primary after the deferred move applies")
+	}
+	if freshImpl.State == models.TaskSessionStateCompleted {
+		t.Errorf("fresh impl session state = %q, expected non-terminal", freshImpl.State)
+	}
+
+	sc.assertHandoffDeliveredOrQueued(t, freshImpl.ID)
 }
 
-// assertHandoffDeliveredOrQueued checks the hand-off prompt landed on the impl
-// session — either delivered to its agent (PromptAgent capture) or sitting in
-// the queue waiting for delivery. Both are acceptable; the failure mode the
-// regression catches is "lost" (neither delivered nor queued) or "delivered
-// to the wrong session".
-func (sc *pendingMoveScenario) assertHandoffDeliveredOrQueued(t *testing.T) {
+// assertHandoffDeliveredOrQueued checks the hand-off prompt landed on the
+// given session — either delivered to its agent (PromptAgent capture) or
+// sitting in the queue waiting for delivery. Both are acceptable; the
+// failure mode the regression catches is "lost" (neither delivered nor
+// queued) or "delivered to the wrong session".
+func (sc *pendingMoveScenario) assertHandoffDeliveredOrQueued(t *testing.T, targetSessionID string) {
 	t.Helper()
 	implPrompts := capturedPromptsForExecution(sc.agentMgr, sc.implRelaunchExec)
-	implQueued := sc.svc.messageQueue.GetStatus(sc.ctx, sc.implSessionID)
+	implQueued := sc.svc.messageQueue.GetStatus(sc.ctx, targetSessionID)
 
 	if len(implPrompts) == 0 && implQueued.Count == 0 {
 		t.Error("hand-off prompt was neither delivered to the impl session nor queued for it")

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -288,8 +288,9 @@ type mockAgentManager struct {
 	// Prompt tracking — capturedPrompts records prompts only (legacy, several
 	// tests assert on it directly). capturedPromptCalls records the same with
 	// the execution ID so callers can filter by the agent that received it.
-	capturedPrompts     []string
-	capturedPromptCalls []promptCall
+	capturedPrompts              []string
+	capturedPromptCalls          []promptCall
+	setExecutionDescriptionCalls []promptCall
 	// Steer tracking. capturedSteerCalls records every SteerAgentWithDispatchCallback
 	// invocation; steerErr, when set, is returned instead of dispatching. Having
 	// this method also makes the mock satisfy the executor's optional
@@ -594,7 +595,13 @@ func (m *mockAgentManager) RestartAgentProcess(_ context.Context, agentExecution
 func (m *mockAgentManager) ResetAgentContext(ctx context.Context, agentExecutionID string) error {
 	return m.RestartAgentProcess(ctx, agentExecutionID)
 }
-func (m *mockAgentManager) SetExecutionDescription(_ context.Context, _, _ string) error {
+func (m *mockAgentManager) SetExecutionDescription(_ context.Context, executionID, description string) error {
+	m.mu.Lock()
+	m.setExecutionDescriptionCalls = append(m.setExecutionDescriptionCalls, promptCall{
+		ExecutionID: executionID,
+		Prompt:      description,
+	})
+	m.mu.Unlock()
 	return nil
 }
 func (m *mockAgentManager) SetExecutionEnv(_ context.Context, _ string, _ map[string]string) error {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -31,7 +31,14 @@ import (
 
 type turnCompletionCause string
 
-var errDeferredMoveAlreadyApplied = errors.New("deferred move already applied")
+var (
+	errDeferredMoveAlreadyApplied    = errors.New("deferred move already applied")
+	errReusableSessionNoLongerActive = errors.New("reusable session is no longer active")
+)
+
+type nonterminalPrimarySessionSetter interface {
+	SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
+}
 
 type taskMetadataKeyRemover interface {
 	RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
@@ -1948,7 +1955,17 @@ func (s *Service) switchSessionForStep(ctx context.Context, taskID string, curre
 	}
 
 	if existing != nil {
-		return s.reuseSessionForStep(ctx, taskID, currentSession, existing)
+		reused, err := s.reuseSessionForStep(ctx, taskID, currentSession, existing)
+		if err == nil {
+			return reused, nil
+		}
+		if !errors.Is(err, errReusableSessionNoLongerActive) {
+			return nil, err
+		}
+		s.logger.Info("reusable session became terminal before workflow promotion; creating fresh session",
+			zap.String("task_id", taskID),
+			zap.String("session_id", existing.ID),
+			zap.String("agent_profile_id", newAgentProfileID))
 	}
 
 	return s.createNewSessionForStep(ctx, taskID, currentSession, newAgentProfileID)
@@ -1998,9 +2015,10 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 // session is not relaunched here — when a prompt arrives, the
 // autoStart/PromptTask paths handle the launch (including lazy-resume via
 // ResumeSession for a session that was previously launched and is currently
-// WAITING_FOR_INPUT). findReusableSessionForProfile guarantees `existing` is
-// never terminal (COMPLETED/FAILED/CANCELLED) — see its doc comment for why
-// reviving a terminal session's ACP conversation here would be unsafe.
+// WAITING_FOR_INPUT). Before it promotes the candidate, it atomically checks
+// that the persisted row is still nonterminal. This closes the lookup-to-
+// promotion race where an agent completion could otherwise make a stale ACP
+// conversation primary again.
 func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, currentSession, existing *models.TaskSession) (*models.TaskSession, error) {
 	s.logger.Info("reusing existing session for profile",
 		zap.String("task_id", taskID),
@@ -2009,12 +2027,14 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		zap.String("reused_profile", existing.AgentProfileID),
 		zap.String("reused_state", string(existing.State)))
 
-	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
-
-	if err := s.SetPrimarySession(ctx, existing.ID); err != nil {
+	promoted, err := s.setNonterminalSessionPrimary(ctx, existing.ID)
+	if err != nil {
 		s.logger.Warn("failed to set reused session as primary",
 			zap.String("session_id", existing.ID), zap.Error(err))
+	} else if !promoted {
+		return nil, errReusableSessionNoLongerActive
 	}
+	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
 
 	// Transfer any queued message and pending move from the session being
 	// switched away from to the reused session — without this, a hand-off
@@ -2033,6 +2053,18 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 
 	s.completeAndStopSession(ctx, taskID, currentSession)
 	return existing, nil
+}
+
+// setNonterminalSessionPrimary promotes a workflow-reused session only when
+// its persisted state is still nonterminal. Repositories without the atomic
+// operation fail closed so a stale snapshot can never revive a terminal ACP
+// conversation.
+func (s *Service) setNonterminalSessionPrimary(ctx context.Context, sessionID string) (bool, error) {
+	setter, ok := s.repo.(nonterminalPrimarySessionSetter)
+	if !ok {
+		return false, nil
+	}
+	return setter.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2402,17 +2402,58 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 			// Launch asynchronously because processOnEnter may also be called
 			// synchronously from finalizeStepEnter (manual task move). In that path,
 			// autoStartStepPrompt would block the caller's goroutine.
+			//
+			// Before dispatching, reload the session under the cancel-in-flight guard
+			// to atomically detect concurrent terminalization. If the session is
+			// already terminal, create a replacement directly instead of attempting
+			// an auto-start that will fail and lose the hand-off.
 			go func() {
-				asyncCtx := context.WithoutCancel(ctx)
-				err := s.autoStartStepPrompt(asyncCtx, taskID, session, step, effectivePrompt, planMode, true)
+				lock, release := s.acquireCancelInFlightGuard(sessionID)
+				lock.Lock()
+				fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
+				if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
+					lock.Unlock()
+					release()
+					if reloadErr != nil {
+						s.logger.Error("implicit profile switch: failed to reload session before dispatch",
+							zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(reloadErr))
+						return
+					}
+					s.logger.Info("implicit profile switch: reused session terminalized before dispatch, creating replacement",
+						zap.String("task_id", taskID), zap.String("session_id", sessionID))
+					replacement, replacementErr := s.createNewSessionForStep(
+						ctx, taskID, session, session.AgentProfileID,
+					)
+					if replacementErr != nil {
+						s.logger.Error("failed to create replacement after terminalized profile switch",
+							zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(replacementErr))
+						return
+					}
+					replacementPrompt := s.buildWorkflowPrompt(
+						ctx, taskDescription, step, taskID, replacement.ID, isPassthrough,
+					)
+					if replacementErr = s.autoStartStepPrompt(
+						ctx, taskID, replacement, step, replacementPrompt, planMode, true,
+					); replacementErr != nil {
+						s.logger.Error("failed to auto-start replacement after terminalized profile switch",
+							zap.String("task_id", taskID), zap.String("session_id", replacement.ID), zap.Error(replacementErr))
+						s.setSessionWaitingForInput(ctx, taskID, replacement.ID, replacement)
+						s.publishSessionWaitingEvent(ctx, taskID, replacement.ID, stepID, replacement)
+					}
+					return
+				}
+				lock.Unlock()
+				release()
+
+				err := s.autoStartStepPrompt(ctx, taskID, fresh, step, effectivePrompt, planMode, true)
 				if err != nil {
 					s.logger.Error("failed to launch agent after profile switch",
 						zap.String("task_id", taskID),
 						zap.String("session_id", sessionID),
 						zap.Error(err))
-					s.setSessionWaitingForInput(asyncCtx, taskID, sessionID, session)
-					s.publishSessionWaitingEvent(asyncCtx, taskID, sessionID, stepID, session)
-					s.drainQueuedMessageForPromptableSession(asyncCtx, sessionID)
+					s.setSessionWaitingForInput(ctx, taskID, sessionID, fresh)
+					s.publishSessionWaitingEvent(ctx, taskID, sessionID, stepID, fresh)
+					s.drainQueuedMessageForPromptableSession(ctx, sessionID)
 				}
 			}()
 			return
@@ -3095,7 +3136,24 @@ func (s *Service) autoStartStepPrompt(
 	// preparation from a blocked auto-start). PromptTask will reject CREATED sessions,
 	// so use StartCreatedSession which properly launches the agent on the prepared workspace.
 	// Pass skipMessageRecord=true since recordAutoStartMessage above already recorded it.
+	// Guard against concurrent terminalization before dispatching to a CREATED
+	// session. By the time a nonterminal session was selected, promoted, and the
+	// prompt built, a concurrent completion/cancellation may have terminalized
+	// it. Reload under the cancel-in-flight guard and bail out with the
+	// standard terminalization error so the caller can create a replacement.
 	if session.State == models.TaskSessionStateCreated {
+		lock, release := s.acquireCancelInFlightGuard(sessionID)
+		lock.Lock()
+		fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
+		if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
+			lock.Unlock()
+			release()
+			requeueTaken()
+			return errWorkflowAutoStartSessionTerminalized
+		}
+		lock.Unlock()
+		release()
+
 		s.logger.Info("auto-start: session is CREATED, launching agent via StartCreatedSession",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -37,6 +37,31 @@ var (
 	errWorkflowAutoStartSessionTerminalized = errors.New("workflow auto-start session terminalized")
 )
 
+type workflowAutoStartSessionTerminalizedError struct {
+	state models.TaskSessionState
+}
+
+func (e *workflowAutoStartSessionTerminalizedError) Error() string {
+	return errWorkflowAutoStartSessionTerminalized.Error()
+}
+
+func (e *workflowAutoStartSessionTerminalizedError) Unwrap() error {
+	return errWorkflowAutoStartSessionTerminalized
+}
+
+func newWorkflowAutoStartSessionTerminalizedError(session *models.TaskSession) error {
+	var state models.TaskSessionState
+	if session != nil {
+		state = session.State
+	}
+	return &workflowAutoStartSessionTerminalizedError{state: state}
+}
+
+func workflowAutoStartWasCancelled(err error) bool {
+	var terminalized *workflowAutoStartSessionTerminalizedError
+	return errors.As(err, &terminalized) && terminalized.state == models.TaskSessionStateCancelled
+}
+
 type taskMetadataKeyRemover interface {
 	RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
 }
@@ -2356,6 +2381,11 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 		effectivePrompt := s.buildWorkflowPrompt(ctx, taskDescription, step, taskID, sessionID, isPassthrough)
 		if err := s.autoStartStepPrompt(ctx, taskID, session, step, effectivePrompt, hasPlanMode, true); err != nil {
 			if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+				if workflowAutoStartWasCancelled(err) {
+					s.logger.Info("workflow auto-start cancelled before dispatch; not creating replacement",
+						zap.String("task_id", taskID), zap.String("session_id", sessionID))
+					return
+				}
 				s.logger.Info("creating fresh workflow session after reused session terminalized",
 					zap.String("task_id", taskID), zap.String("session_id", sessionID))
 				replacement, replacementErr := s.createNewSessionForStep(
@@ -2406,8 +2436,8 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 			//
 			// Before dispatching, reload the session under the cancel-in-flight guard
 			// to atomically detect concurrent terminalization. If the session is
-			// already terminal, create a replacement directly instead of attempting
-			// an auto-start that will fail and lose the hand-off.
+			// already terminal, create a replacement directly for automatic recovery states instead of attempting
+			// an auto-start that will fail and lose the hand-off. An explicit cancellation remains terminal.
 			go func() {
 				lock, release := s.acquireCancelInFlightGuard(sessionID)
 				lock.Lock()
@@ -2418,6 +2448,11 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 					if reloadErr != nil {
 						s.logger.Error("implicit profile switch: failed to reload session before dispatch",
 							zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(reloadErr))
+						return
+					}
+					if fresh != nil && fresh.State == models.TaskSessionStateCancelled {
+						s.logger.Info("implicit profile switch cancelled before dispatch; not creating replacement",
+							zap.String("task_id", taskID), zap.String("session_id", sessionID))
 						return
 					}
 					s.logger.Info("implicit profile switch: reused session terminalized before dispatch, creating replacement",
@@ -2449,6 +2484,11 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 				err := s.autoStartStepPrompt(ctx, taskID, fresh, step, effectivePrompt, planMode, true)
 				if err != nil {
 					if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+						if workflowAutoStartWasCancelled(err) {
+							s.logger.Info("implicit profile switch cancelled during dispatch; not creating replacement",
+								zap.String("task_id", taskID), zap.String("session_id", sessionID))
+							return
+						}
 						s.logger.Info("implicit profile switch: reused session terminalized during dispatch, creating replacement",
 							zap.String("task_id", taskID), zap.String("session_id", sessionID))
 						replacement, replacementErr := s.createNewSessionForStep(
@@ -3182,7 +3222,7 @@ func (s *Service) autoStartStepPrompt(
 			lock.Unlock()
 			release()
 			requeueTaken()
-			return errWorkflowAutoStartSessionTerminalized
+			return newWorkflowAutoStartSessionTerminalizedError(fresh)
 		}
 		var releaseOnce sync.Once
 		heldRelease := func() {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2439,9 +2439,10 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 			// already terminal, create a replacement directly for automatic recovery states instead of attempting
 			// an auto-start that will fail and lose the hand-off. An explicit cancellation remains terminal.
 			go func() {
+				asyncCtx := context.WithoutCancel(ctx)
 				lock, release := s.acquireCancelInFlightGuard(sessionID)
 				lock.Lock()
-				fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
+				fresh, reloadErr := s.repo.GetTaskSession(asyncCtx, sessionID)
 				if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
 					lock.Unlock()
 					release()
@@ -2458,7 +2459,7 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 					s.logger.Info("implicit profile switch: reused session terminalized before dispatch, creating replacement",
 						zap.String("task_id", taskID), zap.String("session_id", sessionID))
 					replacement, replacementErr := s.createNewSessionForStep(
-						ctx, taskID, session, session.AgentProfileID,
+						asyncCtx, taskID, session, session.AgentProfileID,
 					)
 					if replacementErr != nil {
 						s.logger.Error("failed to create replacement after terminalized profile switch",
@@ -2466,22 +2467,22 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 						return
 					}
 					replacementPrompt := s.buildWorkflowPrompt(
-						ctx, taskDescription, step, taskID, replacement.ID, isPassthrough,
+						asyncCtx, taskDescription, step, taskID, replacement.ID, isPassthrough,
 					)
 					if replacementErr = s.autoStartStepPrompt(
-						ctx, taskID, replacement, step, replacementPrompt, planMode, true,
+						asyncCtx, taskID, replacement, step, replacementPrompt, planMode, true,
 					); replacementErr != nil {
 						s.logger.Error("failed to auto-start replacement after terminalized profile switch",
 							zap.String("task_id", taskID), zap.String("session_id", replacement.ID), zap.Error(replacementErr))
-						s.setSessionWaitingForInput(ctx, taskID, replacement.ID, replacement)
-						s.publishSessionWaitingEvent(ctx, taskID, replacement.ID, stepID, replacement)
+						s.setSessionWaitingForInput(asyncCtx, taskID, replacement.ID, replacement)
+						s.publishSessionWaitingEvent(asyncCtx, taskID, replacement.ID, stepID, replacement)
 					}
 					return
 				}
 				lock.Unlock()
 				release()
 
-				err := s.autoStartStepPrompt(ctx, taskID, fresh, step, effectivePrompt, planMode, true)
+				err := s.autoStartStepPrompt(asyncCtx, taskID, fresh, step, effectivePrompt, planMode, true)
 				if err != nil {
 					if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
 						if workflowAutoStartWasCancelled(err) {
@@ -2492,7 +2493,7 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 						s.logger.Info("implicit profile switch: reused session terminalized during dispatch, creating replacement",
 							zap.String("task_id", taskID), zap.String("session_id", sessionID))
 						replacement, replacementErr := s.createNewSessionForStep(
-							ctx, taskID, fresh, fresh.AgentProfileID,
+							asyncCtx, taskID, fresh, fresh.AgentProfileID,
 						)
 						if replacementErr != nil {
 							s.logger.Error("failed to create replacement after terminalized dispatch",
@@ -2500,15 +2501,15 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 							return
 						}
 						replacementPrompt := s.buildWorkflowPrompt(
-							ctx, taskDescription, step, taskID, replacement.ID, isPassthrough,
+							asyncCtx, taskDescription, step, taskID, replacement.ID, isPassthrough,
 						)
 						if replacementErr = s.autoStartStepPrompt(
-							ctx, taskID, replacement, step, replacementPrompt, planMode, true,
+							asyncCtx, taskID, replacement, step, replacementPrompt, planMode, true,
 						); replacementErr != nil {
 							s.logger.Error("failed to auto-start replacement after terminalized dispatch",
 								zap.String("task_id", taskID), zap.String("session_id", replacement.ID), zap.Error(replacementErr))
-							s.setSessionWaitingForInput(ctx, taskID, replacement.ID, replacement)
-							s.publishSessionWaitingEvent(ctx, taskID, replacement.ID, stepID, replacement)
+							s.setSessionWaitingForInput(asyncCtx, taskID, replacement.ID, replacement)
+							s.publishSessionWaitingEvent(asyncCtx, taskID, replacement.ID, stepID, replacement)
 						}
 						return
 					}
@@ -2516,9 +2517,9 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 						zap.String("task_id", taskID),
 						zap.String("session_id", sessionID),
 						zap.Error(err))
-					s.setSessionWaitingForInput(ctx, taskID, sessionID, fresh)
-					s.publishSessionWaitingEvent(ctx, taskID, sessionID, stepID, fresh)
-					s.drainQueuedMessageForPromptableSession(ctx, sessionID)
+					s.setSessionWaitingForInput(asyncCtx, taskID, sessionID, fresh)
+					s.publishSessionWaitingEvent(asyncCtx, taskID, sessionID, stepID, fresh)
+					s.drainQueuedMessageForPromptableSession(asyncCtx, sessionID)
 				}
 			}()
 			return

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -36,10 +36,6 @@ var (
 	errReusableSessionNoLongerActive = errors.New("reusable session is no longer active")
 )
 
-type nonterminalPrimarySessionSetter interface {
-	SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
-}
-
 type taskMetadataKeyRemover interface {
 	RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
 }
@@ -2056,15 +2052,9 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 }
 
 // setNonterminalSessionPrimary promotes a workflow-reused session only when
-// its persisted state is still nonterminal. Repositories without the atomic
-// operation fail closed so a stale snapshot can never revive a terminal ACP
-// conversation.
+// its persisted state is still nonterminal.
 func (s *Service) setNonterminalSessionPrimary(ctx context.Context, sessionID string) (bool, error) {
-	setter, ok := s.repo.(nonterminalPrimarySessionSetter)
-	if !ok {
-		return false, nil
-	}
-	return setter.SetSessionPrimaryIfNonterminal(ctx, sessionID)
+	return s.repo.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -34,10 +34,6 @@ var (
 	errReusableSessionNoLongerActive = errors.New("reusable session is no longer active")
 )
 
-type nonterminalPrimarySessionSetter interface {
-	SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
-}
-
 type taskMetadataKeyRemover interface {
 	RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
 }
@@ -1616,15 +1612,9 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 }
 
 // setNonterminalSessionPrimary promotes a workflow-reused session only when
-// its persisted state is still nonterminal. Repositories without the atomic
-// operation fail closed so a stale snapshot can never revive a terminal ACP
-// conversation.
+// its persisted state is still nonterminal.
 func (s *Service) setNonterminalSessionPrimary(ctx context.Context, sessionID string) (bool, error) {
-	setter, ok := s.repo.(nonterminalPrimarySessionSetter)
-	if !ok {
-		return false, nil
-	}
-	return setter.SetSessionPrimaryIfNonterminal(ctx, sessionID)
+	return s.repo.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -32,8 +32,9 @@ import (
 type turnCompletionCause string
 
 var (
-	errDeferredMoveAlreadyApplied    = errors.New("deferred move already applied")
-	errReusableSessionNoLongerActive = errors.New("reusable session is no longer active")
+	errDeferredMoveAlreadyApplied           = errors.New("deferred move already applied")
+	errReusableSessionNoLongerActive        = errors.New("reusable session is no longer active")
+	errWorkflowAutoStartSessionTerminalized = errors.New("workflow auto-start session terminalized")
 )
 
 type taskMetadataKeyRemover interface {
@@ -2029,6 +2030,11 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 			zap.String("session_id", existing.ID), zap.Error(err))
 	} else if !promoted {
 		return nil, errReusableSessionNoLongerActive
+	} else if task, taskErr := s.repo.GetTask(ctx, taskID); taskErr != nil {
+		s.logger.Warn("failed to load task after promoting reused session",
+			zap.String("task_id", taskID), zap.Error(taskErr))
+	} else if task != nil {
+		s.publishTaskUpdated(ctx, task)
 	}
 	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
 
@@ -2348,6 +2354,11 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 		// autoStartStepPrompt sends the prompt directly via PromptTask.
 		effectivePrompt := s.buildWorkflowPrompt(ctx, taskDescription, step, taskID, sessionID, isPassthrough)
 		if err := s.autoStartStepPrompt(ctx, taskID, session, step, effectivePrompt, hasPlanMode, true); err != nil {
+			if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+				s.logger.Info("skipping workflow auto-start after reused session terminalized",
+					zap.String("task_id", taskID), zap.String("session_id", sessionID))
+				return
+			}
 			s.logger.Error("failed to auto-start agent for step",
 				zap.String("task_id", taskID),
 				zap.String("session_id", sessionID),
@@ -3086,9 +3097,14 @@ func (s *Service) autoStartStepPrompt(
 
 	const maxRetryAttempts = 5
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
-		_, err := s.PromptTask(ctx, taskID, sessionID, recordedPrompt, "", planMode, attachments, false)
+		_, err := s.promptTask(ctx, taskID, sessionID, recordedPrompt, "", planMode, attachments, false, promptTaskOptions{
+			requireNonterminalSession: true,
+		})
 		if err == nil {
 			return nil
+		}
+		if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+			return err
 		}
 
 		// ErrExecutionNotFound means ResumeSession landed on an execution that

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1897,10 +1897,14 @@ func (s *Service) tagSessionAsWorkflowSwitched(ctx context.Context, sessionID st
 }
 
 // switchSessionForStep activates a session for the new agent profile.
-// If an existing session on this task already uses the target profile it is
-// reused (re-promoted to primary, brought out of COMPLETED if it had been
-// switched away from previously). Otherwise a new session is prepared.
-// In both cases the previous session is stopped and marked COMPLETED.
+// If a nonterminal session on this task already uses the target profile, it
+// is reused (re-promoted to primary). Otherwise a new session is prepared —
+// including when the only matching session is terminal (COMPLETED, FAILED,
+// or CANCELLED): workflow re-entry never resumes a terminal session's ACP
+// conversation, because prior-completion state in that conversation can
+// mislead the agent into replaying stale routing intent (see
+// findReusableSessionForProfile). In both cases the previous session is
+// stopped and marked COMPLETED.
 func (s *Service) switchSessionForStep(ctx context.Context, taskID string, currentSession *models.TaskSession, newAgentProfileID string) (*models.TaskSession, error) {
 	s.logger.Info("switching session for workflow step agent profile change",
 		zap.String("task_id", taskID),
@@ -1950,10 +1954,19 @@ func (s *Service) switchSessionForStep(ctx context.Context, taskID string, curre
 	return s.createNewSessionForStep(ctx, taskID, currentSession, newAgentProfileID)
 }
 
-// findReusableSessionForProfile returns the most-recently-updated session on
-// this task that uses the target profile (and is not the session being
-// switched away from), or nil if none exists. Failed/cancelled sessions are
-// excluded — those are dead and shouldn't be revived implicitly.
+// findReusableSessionForProfile returns the most-recently-updated
+// *nonterminal* session on this task that uses the target profile (and is
+// not the session being switched away from), or nil if none exists.
+//
+// Terminal sessions (COMPLETED, FAILED, CANCELLED) are always excluded —
+// they are historical endpoints, not workflow-reusable. A prior incident
+// showed why: reviving a COMPLETED session lazily resumed its persisted ACP
+// conversation, which still contained the agent's earlier completion state.
+// Seeing the task routed back to that step, the agent reasonably inferred
+// its prior completion had been cancelled and moved the task backward,
+// re-arming the same cycle on the next re-entry. Terminal-profile re-entry
+// always goes through createNewSessionForStep instead, which gets a fresh
+// ACP conversation and the canonical current task/workflow context.
 func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, profileID, excludeSessionID string) (*models.TaskSession, error) {
 	if profileID == "" {
 		return nil, nil
@@ -1970,11 +1983,7 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 		if sess.AgentProfileID != profileID {
 			continue
 		}
-		// Skip user-cancelled sessions — those are explicit stops and
-		// shouldn't be auto-revived. FAILED sessions are reused (the failure
-		// may have been transient; either way the user expects "one session
-		// per profile per task" so we revive rather than orphan a duplicate).
-		if sess.State == models.TaskSessionStateCancelled {
+		if isTerminalSessionState(sess.State) {
 			continue
 		}
 		if best == nil || sess.UpdatedAt.After(best.UpdatedAt) {
@@ -1984,19 +1993,14 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 	return best, nil
 }
 
-// reuseSessionForStep promotes an existing session to primary, brings it out
-// of COMPLETED/FAILED if needed, and stops + completes the previous session.
-// The agent for the reused session is not relaunched here — when a prompt
-// arrives, the autoStart/PromptTask paths handle the launch.
-//
-// Previously-launched sessions (executors_running record exists, has resume
-// token) are flipped to WAITING_FOR_INPUT so PromptTask's ensureSessionRunning
-// lazy-resumes them via ResumeSession.
-//
-// Never-launched sessions (e.g. PrepareSession created the row but the
-// workflow switched away before the agent started) have no executors_running
-// record. They go to CREATED so autoStartStepPrompt routes through
-// StartCreatedSession → LaunchPreparedSession (a full fresh launch).
+// reuseSessionForStep promotes an existing nonterminal session to primary
+// and stops + completes the previous session. The agent for the reused
+// session is not relaunched here — when a prompt arrives, the
+// autoStart/PromptTask paths handle the launch (including lazy-resume via
+// ResumeSession for a session that was previously launched and is currently
+// WAITING_FOR_INPUT). findReusableSessionForProfile guarantees `existing` is
+// never terminal (COMPLETED/FAILED/CANCELLED) — see its doc comment for why
+// reviving a terminal session's ACP conversation here would be unsafe.
 func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, currentSession, existing *models.TaskSession) (*models.TaskSession, error) {
 	s.logger.Info("reusing existing session for profile",
 		zap.String("task_id", taskID),
@@ -2004,10 +2008,6 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		zap.String("reused_session", existing.ID),
 		zap.String("reused_profile", existing.AgentProfileID),
 		zap.String("reused_state", string(existing.State)))
-
-	if existing.State == models.TaskSessionStateCompleted || existing.State == models.TaskSessionStateFailed {
-		s.reviveReusedSession(ctx, existing)
-	}
 
 	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
 
@@ -2033,35 +2033,6 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 
 	s.completeAndStopSession(ctx, taskID, currentSession)
 	return existing, nil
-}
-
-// reviveReusedSession flips a terminal (COMPLETED/FAILED) session back to a
-// state where the downstream autoStart/PromptTask paths can launch its agent.
-// The target state depends on whether the session was ever launched:
-//   - Has executors_running record → WAITING_FOR_INPUT, lazy-resume from token
-//   - No record → CREATED, fresh launch via StartCreatedSession
-//
-// The previous error message (from a prior FAILED state) is cleared so the
-// frontend stops surfacing stale red banners on a now-active session.
-func (s *Service) reviveReusedSession(ctx context.Context, session *models.TaskSession) {
-	wasLaunched := false
-	if running, err := s.repo.GetExecutorRunningBySessionID(ctx, session.ID); err == nil && running != nil {
-		wasLaunched = true
-	}
-	if wasLaunched {
-		session.State = models.TaskSessionStateWaitingForInput
-	} else {
-		session.State = models.TaskSessionStateCreated
-	}
-	session.CompletedAt = nil
-	session.ErrorMessage = ""
-	session.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTaskSession(ctx, session); err != nil {
-		s.logger.Warn("failed to revive reused session out of COMPLETED",
-			zap.String("session_id", session.ID),
-			zap.String("target_state", string(session.State)),
-			zap.Error(err))
-	}
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -29,7 +29,14 @@ import (
 
 type turnCompletionCause string
 
-var errDeferredMoveAlreadyApplied = errors.New("deferred move already applied")
+var (
+	errDeferredMoveAlreadyApplied    = errors.New("deferred move already applied")
+	errReusableSessionNoLongerActive = errors.New("reusable session is no longer active")
+)
+
+type nonterminalPrimarySessionSetter interface {
+	SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
+}
 
 type taskMetadataKeyRemover interface {
 	RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
@@ -1508,7 +1515,17 @@ func (s *Service) switchSessionForStep(ctx context.Context, taskID string, curre
 			zap.Error(lookupErr))
 	}
 	if existing != nil {
-		return s.reuseSessionForStep(ctx, taskID, currentSession, existing)
+		reused, err := s.reuseSessionForStep(ctx, taskID, currentSession, existing)
+		if err == nil {
+			return reused, nil
+		}
+		if !errors.Is(err, errReusableSessionNoLongerActive) {
+			return nil, err
+		}
+		s.logger.Info("reusable session became terminal before workflow promotion; creating fresh session",
+			zap.String("task_id", taskID),
+			zap.String("session_id", existing.ID),
+			zap.String("agent_profile_id", newAgentProfileID))
 	}
 
 	return s.createNewSessionForStep(ctx, taskID, currentSession, newAgentProfileID)
@@ -1558,9 +1575,10 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 // session is not relaunched here — when a prompt arrives, the
 // autoStart/PromptTask paths handle the launch (including lazy-resume via
 // ResumeSession for a session that was previously launched and is currently
-// WAITING_FOR_INPUT). findReusableSessionForProfile guarantees `existing` is
-// never terminal (COMPLETED/FAILED/CANCELLED) — see its doc comment for why
-// reviving a terminal session's ACP conversation here would be unsafe.
+// WAITING_FOR_INPUT). Before it promotes the candidate, it atomically checks
+// that the persisted row is still nonterminal. This closes the lookup-to-
+// promotion race where an agent completion could otherwise make a stale ACP
+// conversation primary again.
 func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, currentSession, existing *models.TaskSession) (*models.TaskSession, error) {
 	s.logger.Info("reusing existing session for profile",
 		zap.String("task_id", taskID),
@@ -1569,12 +1587,14 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		zap.String("reused_profile", existing.AgentProfileID),
 		zap.String("reused_state", string(existing.State)))
 
-	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
-
-	if err := s.SetPrimarySession(ctx, existing.ID); err != nil {
+	promoted, err := s.setNonterminalSessionPrimary(ctx, existing.ID)
+	if err != nil {
 		s.logger.Warn("failed to set reused session as primary",
 			zap.String("session_id", existing.ID), zap.Error(err))
+	} else if !promoted {
+		return nil, errReusableSessionNoLongerActive
 	}
+	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
 
 	// Transfer any queued message and pending move from the session being
 	// switched away from to the reused session — without this, a hand-off
@@ -1593,6 +1613,18 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 
 	s.completeAndStopSession(ctx, taskID, currentSession)
 	return existing, nil
+}
+
+// setNonterminalSessionPrimary promotes a workflow-reused session only when
+// its persisted state is still nonterminal. Repositories without the atomic
+// operation fail closed so a stale snapshot can never revive a terminal ACP
+// conversation.
+func (s *Service) setNonterminalSessionPrimary(ctx context.Context, sessionID string) (bool, error) {
+	setter, ok := s.repo.(nonterminalPrimarySessionSetter)
+	if !ok {
+		return false, nil
+	}
+	return setter.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -3104,6 +3104,7 @@ func (s *Service) autoStartStepPrompt(
 			return nil
 		}
 		if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+			requeueTaken()
 			return err
 		}
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2355,8 +2355,27 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 		effectivePrompt := s.buildWorkflowPrompt(ctx, taskDescription, step, taskID, sessionID, isPassthrough)
 		if err := s.autoStartStepPrompt(ctx, taskID, session, step, effectivePrompt, hasPlanMode, true); err != nil {
 			if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
-				s.logger.Info("skipping workflow auto-start after reused session terminalized",
+				s.logger.Info("creating fresh workflow session after reused session terminalized",
 					zap.String("task_id", taskID), zap.String("session_id", sessionID))
+				replacement, replacementErr := s.createNewSessionForStep(
+					ctx, taskID, session, session.AgentProfileID,
+				)
+				if replacementErr != nil {
+					s.logger.Error("failed to create replacement after reused session terminalized",
+						zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(replacementErr))
+					return
+				}
+				replacementPrompt := s.buildWorkflowPrompt(
+					ctx, taskDescription, step, taskID, replacement.ID, isPassthrough,
+				)
+				if replacementErr = s.autoStartStepPrompt(
+					ctx, taskID, replacement, step, replacementPrompt, hasPlanMode, true,
+				); replacementErr != nil {
+					s.logger.Error("failed to auto-start replacement after reused session terminalized",
+						zap.String("task_id", taskID), zap.String("session_id", replacement.ID), zap.Error(replacementErr))
+					s.setSessionWaitingForInput(ctx, taskID, replacement.ID, replacement)
+					s.publishSessionWaitingEvent(ctx, taskID, replacement.ID, step.ID, replacement)
+				}
 				return
 			}
 			s.logger.Error("failed to auto-start agent for step",

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2026,11 +2026,12 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 
 	promoted, err := s.setNonterminalSessionPrimary(ctx, existing.ID)
 	if err != nil {
-		s.logger.Warn("failed to set reused session as primary",
-			zap.String("session_id", existing.ID), zap.Error(err))
-	} else if !promoted {
+		return nil, fmt.Errorf("conditional primary promotion: %w", err)
+	}
+	if !promoted {
 		return nil, errReusableSessionNoLongerActive
-	} else if task, taskErr := s.repo.GetTask(ctx, taskID); taskErr != nil {
+	}
+	if task, taskErr := s.repo.GetTask(ctx, taskID); taskErr != nil {
 		s.logger.Warn("failed to load task after promoting reused session",
 			zap.String("task_id", taskID), zap.Error(taskErr))
 	} else if task != nil {
@@ -2447,6 +2448,30 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 
 				err := s.autoStartStepPrompt(ctx, taskID, fresh, step, effectivePrompt, planMode, true)
 				if err != nil {
+					if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+						s.logger.Info("implicit profile switch: reused session terminalized during dispatch, creating replacement",
+							zap.String("task_id", taskID), zap.String("session_id", sessionID))
+						replacement, replacementErr := s.createNewSessionForStep(
+							ctx, taskID, fresh, fresh.AgentProfileID,
+						)
+						if replacementErr != nil {
+							s.logger.Error("failed to create replacement after terminalized dispatch",
+								zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(replacementErr))
+							return
+						}
+						replacementPrompt := s.buildWorkflowPrompt(
+							ctx, taskDescription, step, taskID, replacement.ID, isPassthrough,
+						)
+						if replacementErr = s.autoStartStepPrompt(
+							ctx, taskID, replacement, step, replacementPrompt, planMode, true,
+						); replacementErr != nil {
+							s.logger.Error("failed to auto-start replacement after terminalized dispatch",
+								zap.String("task_id", taskID), zap.String("session_id", replacement.ID), zap.Error(replacementErr))
+							s.setSessionWaitingForInput(ctx, taskID, replacement.ID, replacement)
+							s.publishSessionWaitingEvent(ctx, taskID, replacement.ID, stepID, replacement)
+						}
+						return
+					}
 					s.logger.Error("failed to launch agent after profile switch",
 						zap.String("task_id", taskID),
 						zap.String("session_id", sessionID),
@@ -3141,18 +3166,31 @@ func (s *Service) autoStartStepPrompt(
 	// prompt built, a concurrent completion/cancellation may have terminalized
 	// it. Reload under the cancel-in-flight guard and bail out with the
 	// standard terminalization error so the caller can create a replacement.
+	// The guard is held through the entire StartCreatedSession call to prevent
+	// terminalization between the reload and the admission of the launch.
 	if session.State == models.TaskSessionStateCreated {
 		lock, release := s.acquireCancelInFlightGuard(sessionID)
 		lock.Lock()
 		fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
-		if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
+		if reloadErr != nil {
+			lock.Unlock()
+			release()
+			requeueTaken()
+			return reloadErr
+		}
+		if fresh == nil || isTerminalSessionState(fresh.State) {
 			lock.Unlock()
 			release()
 			requeueTaken()
 			return errWorkflowAutoStartSessionTerminalized
 		}
-		lock.Unlock()
-		release()
+		var releaseOnce sync.Once
+		heldRelease := func() {
+			releaseOnce.Do(func() {
+				lock.Unlock()
+				release()
+			})
+		}
 
 		s.logger.Info("auto-start: session is CREATED, launching agent via StartCreatedSession",
 			zap.String("task_id", taskID),
@@ -3162,6 +3200,10 @@ func (s *Service) autoStartStepPrompt(
 			ctx, taskID, sessionID, session.AgentProfileID,
 			recordedPrompt, true, planMode, true, attachments, references,
 		)
+		// Release the guard as soon as StartCreatedSession has admitted the
+		// launch (succeeded or failed definitively). The deferred release
+		// via heldRelease ensures the guard is always released even on panic.
+		defer heldRelease()
 		if err != nil {
 			s.handleCreatedAutoStartLaunchFailure(
 				ctx, taskID, sessionID, stepName, prompt, err,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1479,10 +1479,14 @@ func (s *Service) tagSessionAsWorkflowSwitched(ctx context.Context, sessionID st
 }
 
 // switchSessionForStep activates a session for the new agent profile.
-// If an existing session on this task already uses the target profile it is
-// reused (re-promoted to primary, brought out of COMPLETED if it had been
-// switched away from previously). Otherwise a new session is prepared.
-// In both cases the previous session is stopped and marked COMPLETED.
+// If a nonterminal session on this task already uses the target profile, it
+// is reused (re-promoted to primary). Otherwise a new session is prepared —
+// including when the only matching session is terminal (COMPLETED, FAILED,
+// or CANCELLED): workflow re-entry never resumes a terminal session's ACP
+// conversation, because prior-completion state in that conversation can
+// mislead the agent into replaying stale routing intent (see
+// findReusableSessionForProfile). In both cases the previous session is
+// stopped and marked COMPLETED.
 func (s *Service) switchSessionForStep(ctx context.Context, taskID string, currentSession *models.TaskSession, newAgentProfileID string) (*models.TaskSession, error) {
 	s.logger.Info("switching session for workflow step agent profile change",
 		zap.String("task_id", taskID),
@@ -1510,10 +1514,19 @@ func (s *Service) switchSessionForStep(ctx context.Context, taskID string, curre
 	return s.createNewSessionForStep(ctx, taskID, currentSession, newAgentProfileID)
 }
 
-// findReusableSessionForProfile returns the most-recently-updated session on
-// this task that uses the target profile (and is not the session being
-// switched away from), or nil if none exists. Failed/cancelled sessions are
-// excluded — those are dead and shouldn't be revived implicitly.
+// findReusableSessionForProfile returns the most-recently-updated
+// *nonterminal* session on this task that uses the target profile (and is
+// not the session being switched away from), or nil if none exists.
+//
+// Terminal sessions (COMPLETED, FAILED, CANCELLED) are always excluded —
+// they are historical endpoints, not workflow-reusable. A prior incident
+// showed why: reviving a COMPLETED session lazily resumed its persisted ACP
+// conversation, which still contained the agent's earlier completion state.
+// Seeing the task routed back to that step, the agent reasonably inferred
+// its prior completion had been cancelled and moved the task backward,
+// re-arming the same cycle on the next re-entry. Terminal-profile re-entry
+// always goes through createNewSessionForStep instead, which gets a fresh
+// ACP conversation and the canonical current task/workflow context.
 func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, profileID, excludeSessionID string) (*models.TaskSession, error) {
 	if profileID == "" {
 		return nil, nil
@@ -1530,11 +1543,7 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 		if sess.AgentProfileID != profileID {
 			continue
 		}
-		// Skip user-cancelled sessions — those are explicit stops and
-		// shouldn't be auto-revived. FAILED sessions are reused (the failure
-		// may have been transient; either way the user expects "one session
-		// per profile per task" so we revive rather than orphan a duplicate).
-		if sess.State == models.TaskSessionStateCancelled {
+		if isTerminalSessionState(sess.State) {
 			continue
 		}
 		if best == nil || sess.UpdatedAt.After(best.UpdatedAt) {
@@ -1544,19 +1553,14 @@ func (s *Service) findReusableSessionForProfile(ctx context.Context, taskID, pro
 	return best, nil
 }
 
-// reuseSessionForStep promotes an existing session to primary, brings it out
-// of COMPLETED/FAILED if needed, and stops + completes the previous session.
-// The agent for the reused session is not relaunched here — when a prompt
-// arrives, the autoStart/PromptTask paths handle the launch.
-//
-// Previously-launched sessions (executors_running record exists, has resume
-// token) are flipped to WAITING_FOR_INPUT so PromptTask's ensureSessionRunning
-// lazy-resumes them via ResumeSession.
-//
-// Never-launched sessions (e.g. PrepareSession created the row but the
-// workflow switched away before the agent started) have no executors_running
-// record. They go to CREATED so autoStartStepPrompt routes through
-// StartCreatedSession → LaunchPreparedSession (a full fresh launch).
+// reuseSessionForStep promotes an existing nonterminal session to primary
+// and stops + completes the previous session. The agent for the reused
+// session is not relaunched here — when a prompt arrives, the
+// autoStart/PromptTask paths handle the launch (including lazy-resume via
+// ResumeSession for a session that was previously launched and is currently
+// WAITING_FOR_INPUT). findReusableSessionForProfile guarantees `existing` is
+// never terminal (COMPLETED/FAILED/CANCELLED) — see its doc comment for why
+// reviving a terminal session's ACP conversation here would be unsafe.
 func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, currentSession, existing *models.TaskSession) (*models.TaskSession, error) {
 	s.logger.Info("reusing existing session for profile",
 		zap.String("task_id", taskID),
@@ -1564,10 +1568,6 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		zap.String("reused_session", existing.ID),
 		zap.String("reused_profile", existing.AgentProfileID),
 		zap.String("reused_state", string(existing.State)))
-
-	if existing.State == models.TaskSessionStateCompleted || existing.State == models.TaskSessionStateFailed {
-		s.reviveReusedSession(ctx, existing)
-	}
 
 	s.tagSessionAsWorkflowSwitched(ctx, existing.ID)
 
@@ -1593,35 +1593,6 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 
 	s.completeAndStopSession(ctx, taskID, currentSession)
 	return existing, nil
-}
-
-// reviveReusedSession flips a terminal (COMPLETED/FAILED) session back to a
-// state where the downstream autoStart/PromptTask paths can launch its agent.
-// The target state depends on whether the session was ever launched:
-//   - Has executors_running record → WAITING_FOR_INPUT, lazy-resume from token
-//   - No record → CREATED, fresh launch via StartCreatedSession
-//
-// The previous error message (from a prior FAILED state) is cleared so the
-// frontend stops surfacing stale red banners on a now-active session.
-func (s *Service) reviveReusedSession(ctx context.Context, session *models.TaskSession) {
-	wasLaunched := false
-	if running, err := s.repo.GetExecutorRunningBySessionID(ctx, session.ID); err == nil && running != nil {
-		wasLaunched = true
-	}
-	if wasLaunched {
-		session.State = models.TaskSessionStateWaitingForInput
-	} else {
-		session.State = models.TaskSessionStateCreated
-	}
-	session.CompletedAt = nil
-	session.ErrorMessage = ""
-	session.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTaskSession(ctx, session); err != nil {
-		s.logger.Warn("failed to revive reused session out of COMPLETED",
-			zap.String("session_id", session.ID),
-			zap.String("target_state", string(session.State)),
-			zap.Error(err))
-	}
 }
 
 // createNewSessionForStep is the original switch-and-create-fresh-session path,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_preflight_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_preflight_test.go
@@ -250,7 +250,7 @@ func TestSwitchSessionForStepUsesReusableSessionExecutorProfileForCredentialAdmi
 	}
 	target := &models.TaskSession{
 		ID: "s-target", TaskID: "t1", AgentProfileID: "profile-b", ExecutorID: "exec-ssh",
-		ExecutorProfileID: "ep-token", State: models.TaskSessionStateCompleted,
+		ExecutorProfileID: "ep-token", State: models.TaskSessionStateWaitingForInput,
 		StartedAt: now.Add(-time.Minute), UpdatedAt: now,
 	}
 	if err := repo.CreateTaskSession(ctx, current); err != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -142,9 +142,7 @@ func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimaryIfNonterminal
 	sessionID string,
 ) (bool, error) {
 	r.waitForPromotion()
-	return r.sessionExecutorStore.(interface {
-		SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
-	}).SetSessionPrimaryIfNonterminal(ctx, sessionID)
+	return r.sessionExecutorStore.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 func seedAutopilotTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessionID string, sessionState models.TaskSessionState) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -884,10 +884,12 @@ func TestSwitchSessionForStep_CreatesFreshSessionWhenCandidateTerminalizesBefore
 	current := &models.TaskSession{
 		ID: "session-b", TaskID: "t1", AgentProfileID: "profile-b", ExecutorID: "exec-local",
 		ExecutorProfileID: "ep1", State: models.TaskSessionStateRunning, IsPrimary: true,
-		StartedAt: now, UpdatedAt: now,
+		TaskEnvironmentID: "env-1",
+		StartedAt:         now, UpdatedAt: now,
 	}
 	requireNoError(t, repo.CreateTaskSession(ctx, candidate))
 	requireNoError(t, repo.CreateTaskSession(ctx, current))
+	requireNoError(t, repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{ID: "env-1", TaskID: "t1", ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady}))
 
 	taskRepo := newMockTaskRepo()
 	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "Test", Description: "Test", State: v1.TaskStateInProgress}
@@ -1004,10 +1006,12 @@ func TestSwitchSessionForStep_CompletedSessionNotReused(t *testing.T) {
 		AgentExecutionID:  "ae-b",
 		State:             models.TaskSessionStateRunning,
 		IsPrimary:         true,
+		TaskEnvironmentID: "env-1",
 		StartedAt:         now,
 		UpdatedAt:         now,
 	}
 	_ = repo.CreateTaskSession(ctx, current)
+	_ = repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{ID: "env-1", TaskID: "t1", ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady})
 
 	taskRepo := newMockTaskRepo()
 	taskRepo.tasks["t1"] = &v1.Task{
@@ -1165,10 +1169,12 @@ func TestSwitchSessionForStep_FailedSessionNotReused(t *testing.T) {
 		AgentExecutionID:  "ae-b",
 		State:             models.TaskSessionStateRunning,
 		IsPrimary:         true,
+		TaskEnvironmentID: "env-1",
 		StartedAt:         now,
 		UpdatedAt:         now,
 	}
 	_ = repo.CreateTaskSession(ctx, current)
+	_ = repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{ID: "env-1", TaskID: "t1", ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady})
 
 	taskRepo := newMockTaskRepo()
 	taskRepo.tasks["t1"] = &v1.Task{

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +20,36 @@ import (
 	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
+
+// terminalizeCandidateBeforePromotionRepo pauses a profile-switch promotion
+// after lookup so the test can terminalize the selected row before the
+// promotion write begins.
+type terminalizeCandidateBeforePromotionRepo struct {
+	sessionExecutorStore
+	promotionReached chan struct{}
+	allowPromotion   chan struct{}
+	once             sync.Once
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) waitForPromotion() {
+	r.once.Do(func() { close(r.promotionReached) })
+	<-r.allowPromotion
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimary(ctx context.Context, sessionID string) error {
+	r.waitForPromotion()
+	return r.sessionExecutorStore.SetSessionPrimary(ctx, sessionID)
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimaryIfNonterminal(
+	ctx context.Context,
+	sessionID string,
+) (bool, error) {
+	r.waitForPromotion()
+	return r.sessionExecutorStore.(interface {
+		SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
+	}).SetSessionPrimaryIfNonterminal(ctx, sessionID)
+}
 
 func seedAutopilotTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessionID string, sessionState models.TaskSessionState) {
 	t.Helper()
@@ -713,6 +744,83 @@ func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	}
 	if parked.IsPrimary {
 		t.Error("previous current session must no longer be primary")
+	}
+}
+
+func TestSwitchSessionForStep_CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	repo := setupTestRepo(t)
+
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "t1", WorkflowID: "wf1", WorkflowStepID: "step1", Title: "Test", Description: "Test",
+		State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	candidate := &models.TaskSession{
+		ID: "session-a", TaskID: "t1", AgentProfileID: "profile-a", ExecutorID: "exec-local",
+		ExecutorProfileID: "ep1", State: models.TaskSessionStateWaitingForInput,
+		StartedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute),
+	}
+	current := &models.TaskSession{
+		ID: "session-b", TaskID: "t1", AgentProfileID: "profile-b", ExecutorID: "exec-local",
+		ExecutorProfileID: "ep1", State: models.TaskSessionStateRunning, IsPrimary: true,
+		StartedAt: now, UpdatedAt: now,
+	}
+	requireNoError(t, repo.CreateTaskSession(ctx, candidate))
+	requireNoError(t, repo.CreateTaskSession(ctx, current))
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "Test", Description: "Test", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	log := testLogger()
+	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+	svc := &Service{
+		logger: log, workflowStepGetter: newMockStepGetter(), taskRepo: taskRepo, agentManager: agentMgr,
+		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
+		scheduler: scheduler.NewScheduler(queue.NewTaskQueue(100), exec, taskRepo, log, scheduler.SchedulerConfig{}),
+	}
+	barrierRepo := &terminalizeCandidateBeforePromotionRepo{
+		sessionExecutorStore: repo,
+		promotionReached:     make(chan struct{}),
+		allowPromotion:       make(chan struct{}),
+	}
+	svc.repo = barrierRepo
+
+	resultCh := make(chan *models.TaskSession, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+		resultCh <- result
+		errCh <- err
+	}()
+
+	<-barrierRepo.promotionReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, candidate.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowPromotion)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("switch session: %v", err)
+	}
+	result := <-resultCh
+	if result == nil || result.ID == candidate.ID {
+		t.Fatalf("expected a fresh session after candidate terminalized, got %+v", result)
+	}
+
+	storedCandidate, err := repo.GetTaskSession(ctx, candidate.ID)
+	requireNoError(t, err)
+	if storedCandidate.State != models.TaskSessionStateCompleted {
+		t.Errorf("candidate state = %s, want COMPLETED", storedCandidate.State)
+	}
+	if storedCandidate.IsPrimary {
+		t.Error("terminalized candidate must not become primary")
+	}
+	fresh, err := repo.GetTaskSession(ctx, result.ID)
+	requireNoError(t, err)
+	if fresh.State != models.TaskSessionStateCreated || !fresh.IsPrimary {
+		t.Errorf("fresh session = state %s, primary %t; want CREATED primary", fresh.State, fresh.IsPrimary)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -807,6 +807,7 @@ func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	log := testLogger()
 	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
 	sched := scheduler.NewScheduler(queue.NewTaskQueue(100), exec, taskRepo, log, scheduler.SchedulerConfig{})
+	publisher := &recordingTaskUpdatedPublisher{}
 	svc := &Service{
 		logger:             log,
 		repo:               repo,
@@ -816,6 +817,7 @@ func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 		messageQueue:       messagequeue.NewServiceMemory(log),
 		executor:           exec,
 		scheduler:          sched,
+		taskEvents:         publisher,
 	}
 
 	revived, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
@@ -861,6 +863,9 @@ func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	}
 	if parked.IsPrimary {
 		t.Error("previous current session must no longer be primary")
+	}
+	if got := publisher.updatedTaskIDs; len(got) != 1 || got[0] != "t1" {
+		t.Errorf("task.updated publishes = %v, want [t1] after reused-session promotion", got)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -706,11 +706,14 @@ func TestSwitchSessionForStep(t *testing.T) {
 	})
 }
 
-// TestSwitchSessionForStep_ReusesExistingProfileSession verifies the core
-// requirement: when switching to a profile that already has a session on this
-// task, switchSessionForStep reuses it instead of creating a third session.
-// Covers the A→B→A round trip (and beyond) at the unit-test level.
-func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
+// TestSwitchSessionForStep_ReusesNonterminalSession verifies the core
+// requirement: when switching to a profile that already has a *nonterminal*
+// session on this task, switchSessionForStep reuses it instead of creating a
+// third session. Covers the A→B→A round trip (and beyond) at the unit-test
+// level for the case where profile-A's prior session is still legitimately
+// active (WAITING_FOR_INPUT), e.g. it was previously launched and has a
+// resume token it should keep using.
+func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -727,23 +730,28 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 	}
 	_ = repo.CreateTask(ctx, task)
 
-	// Prior session for profile-A — was active before, then completed when
-	// the workflow switched away from this profile last time.
-	completedAt := now.Add(-2 * time.Minute)
+	// Prior session for profile-A — still nonterminal (waiting for the next
+	// prompt) from the last time this profile was active on this task.
 	prior := &models.TaskSession{
 		ID:                "session-a",
 		TaskID:            "t1",
 		AgentProfileID:    "profile-a",
 		ExecutorID:        "exec-local",
 		ExecutorProfileID: "ep1",
-		State:             models.TaskSessionStateCompleted,
+		AgentExecutionID:  "ae-a",
+		State:             models.TaskSessionStateWaitingForInput,
 		IsPrimary:         false,
 		Metadata:          map[string]interface{}{"existing": "preserved"},
-		CompletedAt:       &completedAt,
 		StartedAt:         now.Add(-3 * time.Minute),
-		UpdatedAt:         completedAt,
+		UpdatedAt:         now.Add(-2 * time.Minute),
 	}
 	_ = repo.CreateTaskSession(ctx, prior)
+	_ = repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: "er-a", SessionID: "session-a", TaskID: "t1",
+		ResumeToken: "acp-session-a",
+		Resumable:   true,
+		CreatedAt:   now.Add(-2 * time.Minute), UpdatedAt: now.Add(-2 * time.Minute),
+	})
 
 	// Currently-active session for profile-B — about to be switched away from.
 	current := &models.TaskSession{
@@ -800,18 +808,12 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 		t.Errorf("expected 2 sessions after reuse, got %d", len(sessions))
 	}
 
-	// The reused session must be back to a non-terminal state (so it can
-	// receive the next prompt) and be primary. Specifically, since the prior
-	// session has no executors_running record (never launched), it should
-	// flip to CREATED so autoStartStepPrompt routes through StartCreatedSession
-	// for a fresh launch (instead of hitting "no executor record" in
-	// ensureSessionRunning).
+	// The reused session must keep its nonterminal state (still WAITING, so
+	// PromptTask's ensureSessionRunning lazy-resumes it via ResumeSession) and
+	// become primary.
 	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateCreated {
-		t.Errorf("never-launched reused session must be CREATED (so StartCreatedSession launches it fresh), got %s", reused.State)
-	}
-	if reused.CompletedAt != nil {
-		t.Error("reused session must have CompletedAt cleared")
+	if reused.State != models.TaskSessionStateWaitingForInput {
+		t.Errorf("nonterminal reused session must stay WAITING_FOR_INPUT, got %s", reused.State)
 	}
 	if !reused.IsPrimary {
 		t.Error("reused session must be primary")
@@ -833,12 +835,17 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 	}
 }
 
-// TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession covers the other
-// branch of the revive: when the reused session has an executors_running
-// record (it was previously launched and has a resume token), it flips to
-// WAITING_FOR_INPUT so PromptTask's ensureSessionRunning lazy-resumes the
-// agent via ResumeSession (preserving its prior conversation context).
-func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
+// TestSwitchSessionForStep_CompletedSessionNotReused locks in the corrective
+// fix: a COMPLETED session for the target profile must NOT be revived and
+// resumed. Reviving it would lazily resume its persisted ACP conversation,
+// which still contains the agent's earlier completion state — the live
+// incident this test guards against had the agent see the task routed back
+// to a step it had already completed and, reading its own prior "done"
+// context, infer the completion had been undone and move the task backward,
+// re-arming the same cycle on every re-entry. A fresh session must be
+// created instead, and the old COMPLETED session must be left immutable and
+// non-primary.
+func TestSwitchSessionForStep_CompletedSessionNotReused(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -855,10 +862,9 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 	}
 	_ = repo.CreateTask(ctx, task)
 
-	// Prior session for profile-A — was previously active and has the
-	// signals of a real launch: an executors_running record with a resume
-	// token. This should route through the WAITING_FOR_INPUT branch of
-	// reviveReusedSession.
+	// Prior QA session for profile-A: COMPLETED, and — like the live
+	// incident — it was previously launched and still carries a persisted
+	// ACP resume token via its executors_running record.
 	completedAt := now.Add(-2 * time.Minute)
 	prior := &models.TaskSession{
 		ID:                "session-a",
@@ -868,6 +874,8 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		ExecutorProfileID: "ep1",
 		AgentExecutionID:  "ae-a-1",
 		State:             models.TaskSessionStateCompleted,
+		IsPrimary:         false,
+		Metadata:          map[string]interface{}{"existing": "preserved"},
 		CompletedAt:       &completedAt,
 		StartedAt:         now.Add(-3 * time.Minute),
 		UpdatedAt:         completedAt,
@@ -880,6 +888,7 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		CreatedAt:   completedAt, UpdatedAt: completedAt,
 	})
 
+	// Currently-active session for profile-B — about to be switched away from.
 	current := &models.TaskSession{
 		ID:                "session-b",
 		TaskID:            "t1",
@@ -915,28 +924,94 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		scheduler:          sched,
 	}
 
-	revived, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+	fresh, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if revived == nil || revived.ID != "session-a" {
-		t.Fatalf("expected reused session-a, got %+v", revived)
+
+	// Critical: a brand-new session must be created — the COMPLETED session
+	// is never selected for reuse.
+	if fresh == nil || fresh.ID == "session-a" {
+		t.Fatalf("expected a fresh session distinct from the COMPLETED session-a, got %+v", fresh)
+	}
+	if fresh.AgentProfileID != "profile-a" {
+		t.Errorf("fresh session profile = %q, want profile-a", fresh.AgentProfileID)
+	}
+	// AC2: the fresh session starts through the CREATED/StartCreatedSession
+	// path, so it gets a new ACP conversation on first prompt.
+	if fresh.State != models.TaskSessionStateCreated {
+		t.Errorf("fresh session state = %s, want CREATED", fresh.State)
+	}
+	freshFromDB, err := repo.GetTaskSession(ctx, fresh.ID)
+	if err != nil {
+		t.Fatalf("failed to get fresh session: %v", err)
+	}
+	if !freshFromDB.IsPrimary {
+		t.Error("fresh session must be primary")
 	}
 
-	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateWaitingForInput {
-		t.Errorf("previously-launched reused session must be WAITING_FOR_INPUT (so PromptTask lazy-resumes via ResumeSession), got %s", reused.State)
+	// AC3: the fresh session must not inherit the old session's resume token.
+	freshRunning, err := repo.GetExecutorRunningBySessionID(ctx, fresh.ID)
+	if err == nil || freshRunning != nil {
+		t.Errorf("fresh session must have no executors_running record (no inherited resume token), got running=%+v err=%v", freshRunning, err)
 	}
-	if got := reused.Metadata[models.SessionMetaKeyCreatedBy]; got != models.SessionCreatedByWorkflowSwitch {
-		t.Errorf("reused session created_by metadata = %v, want %q", got, models.SessionCreatedByWorkflowSwitch)
+
+	// Total session count is now 3: the old COMPLETED session-a, the parked
+	// session-b, and the fresh session.
+	sessions, err := repo.ListTaskSessions(ctx, "t1")
+	if err != nil {
+		t.Fatalf("failed to list sessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Errorf("expected 3 sessions (old completed + parked + fresh), got %d", len(sessions))
+	}
+
+	// AC3: the old COMPLETED session must remain terminal, non-primary, and
+	// historically intact — untouched by the switch.
+	oldSession, err := repo.GetTaskSession(ctx, "session-a")
+	if err != nil {
+		t.Fatalf("failed to get old session: %v", err)
+	}
+	if oldSession.State != models.TaskSessionStateCompleted {
+		t.Errorf("old session state = %s, want it to remain COMPLETED", oldSession.State)
+	}
+	if oldSession.IsPrimary {
+		t.Error("old COMPLETED session must remain non-primary")
+	}
+	if oldSession.CompletedAt == nil || !oldSession.CompletedAt.Equal(completedAt) {
+		t.Errorf("old session CompletedAt = %v, want unchanged %v", oldSession.CompletedAt, completedAt)
+	}
+	if got := oldSession.Metadata["existing"]; got != "preserved" {
+		t.Errorf("old session metadata must be untouched, got %v", got)
+	}
+
+	// The old session's resume token itself must remain on file (history is
+	// preserved) even though it is never handed to the fresh execution.
+	oldRunning, err := repo.GetExecutorRunningBySessionID(ctx, "session-a")
+	if err != nil {
+		t.Fatalf("failed to look up executor running for old session: %v", err)
+	}
+	if oldRunning == nil || oldRunning.ResumeToken != "acp-session-a" {
+		t.Errorf("old session's own resume token must remain intact, got %+v", oldRunning)
+	}
+
+	// The previous current session-b must now be COMPLETED, not primary.
+	parked, _ := repo.GetTaskSession(ctx, "session-b")
+	if parked.State != models.TaskSessionStateCompleted {
+		t.Errorf("previous current session must be COMPLETED, got %s", parked.State)
+	}
+	if parked.IsPrimary {
+		t.Error("previous current session must no longer be primary")
 	}
 }
 
-// TestSwitchSessionForStep_ReusesFailedSession exercises the requirement that
-// FAILED sessions are reused too. Without this, a previously-failed session
-// would be skipped and a fresh one created, leaving the FAILED one as a
-// duplicate tab in the UI showing its stale error banner.
-func TestSwitchSessionForStep_ReusesFailedSession(t *testing.T) {
+// TestSwitchSessionForStep_FailedSessionNotReused mirrors
+// TestSwitchSessionForStep_CompletedSessionNotReused for FAILED sessions.
+// FAILED is terminal too, and a failed ACP conversation can carry equally
+// stale or partial routing intent, so it must not be implicitly resumed
+// either — a fresh session is created and the FAILED session is left as
+// historical record (including its error message).
+func TestSwitchSessionForStep_FailedSessionNotReused(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -1010,29 +1085,37 @@ func TestSwitchSessionForStep_ReusesFailedSession(t *testing.T) {
 		scheduler:          sched,
 	}
 
-	revived, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+	fresh, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if revived == nil || revived.ID != "session-a" {
-		t.Fatalf("expected reused FAILED session-a, got %+v", revived)
+	if fresh == nil || fresh.ID == "session-a" {
+		t.Fatalf("expected a fresh session distinct from the FAILED session-a, got %+v", fresh)
+	}
+	if fresh.State != models.TaskSessionStateCreated {
+		t.Errorf("fresh session state = %s, want CREATED", fresh.State)
 	}
 
-	// No duplicate session must be created.
+	// No session should be reused; a third session now exists.
 	sessions, _ := repo.ListTaskSessions(ctx, "t1")
-	if len(sessions) != 2 {
-		t.Errorf("expected 2 sessions, got %d (FAILED session was not reused)", len(sessions))
+	if len(sessions) != 3 {
+		t.Errorf("expected 3 sessions (old failed + parked + fresh), got %d", len(sessions))
 	}
 
-	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateWaitingForInput {
-		t.Errorf("FAILED reused session must flip to WAITING_FOR_INPUT (lazy-resume via token), got %s", reused.State)
+	// The FAILED session must be left exactly as it was — including the
+	// error message, which a revive-in-place would have cleared.
+	oldSession, _ := repo.GetTaskSession(ctx, "session-a")
+	if oldSession.State != models.TaskSessionStateFailed {
+		t.Errorf("old session state = %s, want it to remain FAILED", oldSession.State)
 	}
-	if reused.ErrorMessage != "" {
-		t.Errorf("FAILED reused session must have ErrorMessage cleared, got %q", reused.ErrorMessage)
+	if oldSession.ErrorMessage != "execution already running" {
+		t.Errorf("old FAILED session ErrorMessage must be preserved, got %q", oldSession.ErrorMessage)
 	}
-	if reused.CompletedAt != nil {
-		t.Error("FAILED reused session must have CompletedAt cleared")
+	if oldSession.CompletedAt == nil || !oldSession.CompletedAt.Equal(failedAt) {
+		t.Errorf("old session CompletedAt = %v, want unchanged %v", oldSession.CompletedAt, failedAt)
+	}
+	if oldSession.IsPrimary {
+		t.Error("old FAILED session must remain non-primary")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -46,9 +46,7 @@ func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimaryIfNonterminal
 	sessionID string,
 ) (bool, error) {
 	r.waitForPromotion()
-	return r.sessionExecutorStore.(interface {
-		SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
-	}).SetSessionPrimaryIfNonterminal(ctx, sessionID)
+	return r.sessionExecutorStore.SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 func seedAutopilotTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessionID string, sessionState models.TaskSessionState) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,6 +115,36 @@ func TestCreateNewSessionForStepKeepsCurrentSessionWhenWorkspaceAttachFails(t *t
 	if persisted.State != models.TaskSessionStateRunning || !persisted.IsPrimary {
 		t.Fatalf("current session after failed attach = state %q primary %t, want running primary", persisted.State, persisted.IsPrimary)
 	}
+}
+
+// terminalizeCandidateBeforePromotionRepo pauses a profile-switch promotion
+// after lookup so the test can terminalize the selected row before the
+// promotion write begins.
+type terminalizeCandidateBeforePromotionRepo struct {
+	sessionExecutorStore
+	promotionReached chan struct{}
+	allowPromotion   chan struct{}
+	once             sync.Once
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) waitForPromotion() {
+	r.once.Do(func() { close(r.promotionReached) })
+	<-r.allowPromotion
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimary(ctx context.Context, sessionID string) error {
+	r.waitForPromotion()
+	return r.sessionExecutorStore.SetSessionPrimary(ctx, sessionID)
+}
+
+func (r *terminalizeCandidateBeforePromotionRepo) SetSessionPrimaryIfNonterminal(
+	ctx context.Context,
+	sessionID string,
+) (bool, error) {
+	r.waitForPromotion()
+	return r.sessionExecutorStore.(interface {
+		SetSessionPrimaryIfNonterminal(context.Context, string) (bool, error)
+	}).SetSessionPrimaryIfNonterminal(ctx, sessionID)
 }
 
 func seedAutopilotTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessionID string, sessionState models.TaskSessionState) {
@@ -832,6 +863,83 @@ func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	}
 	if parked.IsPrimary {
 		t.Error("previous current session must no longer be primary")
+	}
+}
+
+func TestSwitchSessionForStep_CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	repo := setupTestRepo(t)
+
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "t1", WorkflowID: "wf1", WorkflowStepID: "step1", Title: "Test", Description: "Test",
+		State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	candidate := &models.TaskSession{
+		ID: "session-a", TaskID: "t1", AgentProfileID: "profile-a", ExecutorID: "exec-local",
+		ExecutorProfileID: "ep1", State: models.TaskSessionStateWaitingForInput,
+		StartedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute),
+	}
+	current := &models.TaskSession{
+		ID: "session-b", TaskID: "t1", AgentProfileID: "profile-b", ExecutorID: "exec-local",
+		ExecutorProfileID: "ep1", State: models.TaskSessionStateRunning, IsPrimary: true,
+		StartedAt: now, UpdatedAt: now,
+	}
+	requireNoError(t, repo.CreateTaskSession(ctx, candidate))
+	requireNoError(t, repo.CreateTaskSession(ctx, current))
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "Test", Description: "Test", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	log := testLogger()
+	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+	svc := &Service{
+		logger: log, workflowStepGetter: newMockStepGetter(), taskRepo: taskRepo, agentManager: agentMgr,
+		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
+		scheduler: scheduler.NewScheduler(queue.NewTaskQueue(100), exec, taskRepo, log, scheduler.SchedulerConfig{}),
+	}
+	barrierRepo := &terminalizeCandidateBeforePromotionRepo{
+		sessionExecutorStore: repo,
+		promotionReached:     make(chan struct{}),
+		allowPromotion:       make(chan struct{}),
+	}
+	svc.repo = barrierRepo
+
+	resultCh := make(chan *models.TaskSession, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+		resultCh <- result
+		errCh <- err
+	}()
+
+	<-barrierRepo.promotionReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, candidate.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowPromotion)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("switch session: %v", err)
+	}
+	result := <-resultCh
+	if result == nil || result.ID == candidate.ID {
+		t.Fatalf("expected a fresh session after candidate terminalized, got %+v", result)
+	}
+
+	storedCandidate, err := repo.GetTaskSession(ctx, candidate.ID)
+	requireNoError(t, err)
+	if storedCandidate.State != models.TaskSessionStateCompleted {
+		t.Errorf("candidate state = %s, want COMPLETED", storedCandidate.State)
+	}
+	if storedCandidate.IsPrimary {
+		t.Error("terminalized candidate must not become primary")
+	}
+	fresh, err := repo.GetTaskSession(ctx, result.ID)
+	requireNoError(t, err)
+	if fresh.State != models.TaskSessionStateCreated || !fresh.IsPrimary {
+		t.Errorf("fresh session = state %s, primary %t; want CREATED primary", fresh.State, fresh.IsPrimary)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -587,11 +587,14 @@ func TestSwitchSessionForStep(t *testing.T) {
 	})
 }
 
-// TestSwitchSessionForStep_ReusesExistingProfileSession verifies the core
-// requirement: when switching to a profile that already has a session on this
-// task, switchSessionForStep reuses it instead of creating a third session.
-// Covers the A→B→A round trip (and beyond) at the unit-test level.
-func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
+// TestSwitchSessionForStep_ReusesNonterminalSession verifies the core
+// requirement: when switching to a profile that already has a *nonterminal*
+// session on this task, switchSessionForStep reuses it instead of creating a
+// third session. Covers the A→B→A round trip (and beyond) at the unit-test
+// level for the case where profile-A's prior session is still legitimately
+// active (WAITING_FOR_INPUT), e.g. it was previously launched and has a
+// resume token it should keep using.
+func TestSwitchSessionForStep_ReusesNonterminalSession(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -608,23 +611,28 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 	}
 	_ = repo.CreateTask(ctx, task)
 
-	// Prior session for profile-A — was active before, then completed when
-	// the workflow switched away from this profile last time.
-	completedAt := now.Add(-2 * time.Minute)
+	// Prior session for profile-A — still nonterminal (waiting for the next
+	// prompt) from the last time this profile was active on this task.
 	prior := &models.TaskSession{
 		ID:                "session-a",
 		TaskID:            "t1",
 		AgentProfileID:    "profile-a",
 		ExecutorID:        "exec-local",
 		ExecutorProfileID: "ep1",
-		State:             models.TaskSessionStateCompleted,
+		AgentExecutionID:  "ae-a",
+		State:             models.TaskSessionStateWaitingForInput,
 		IsPrimary:         false,
 		Metadata:          map[string]interface{}{"existing": "preserved"},
-		CompletedAt:       &completedAt,
 		StartedAt:         now.Add(-3 * time.Minute),
-		UpdatedAt:         completedAt,
+		UpdatedAt:         now.Add(-2 * time.Minute),
 	}
 	_ = repo.CreateTaskSession(ctx, prior)
+	_ = repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: "er-a", SessionID: "session-a", TaskID: "t1",
+		ResumeToken: "acp-session-a",
+		Resumable:   true,
+		CreatedAt:   now.Add(-2 * time.Minute), UpdatedAt: now.Add(-2 * time.Minute),
+	})
 
 	// Currently-active session for profile-B — about to be switched away from.
 	current := &models.TaskSession{
@@ -681,18 +689,12 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 		t.Errorf("expected 2 sessions after reuse, got %d", len(sessions))
 	}
 
-	// The reused session must be back to a non-terminal state (so it can
-	// receive the next prompt) and be primary. Specifically, since the prior
-	// session has no executors_running record (never launched), it should
-	// flip to CREATED so autoStartStepPrompt routes through StartCreatedSession
-	// for a fresh launch (instead of hitting "no executor record" in
-	// ensureSessionRunning).
+	// The reused session must keep its nonterminal state (still WAITING, so
+	// PromptTask's ensureSessionRunning lazy-resumes it via ResumeSession) and
+	// become primary.
 	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateCreated {
-		t.Errorf("never-launched reused session must be CREATED (so StartCreatedSession launches it fresh), got %s", reused.State)
-	}
-	if reused.CompletedAt != nil {
-		t.Error("reused session must have CompletedAt cleared")
+	if reused.State != models.TaskSessionStateWaitingForInput {
+		t.Errorf("nonterminal reused session must stay WAITING_FOR_INPUT, got %s", reused.State)
 	}
 	if !reused.IsPrimary {
 		t.Error("reused session must be primary")
@@ -714,12 +716,17 @@ func TestSwitchSessionForStep_ReusesExistingProfileSession(t *testing.T) {
 	}
 }
 
-// TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession covers the other
-// branch of the revive: when the reused session has an executors_running
-// record (it was previously launched and has a resume token), it flips to
-// WAITING_FOR_INPUT so PromptTask's ensureSessionRunning lazy-resumes the
-// agent via ResumeSession (preserving its prior conversation context).
-func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
+// TestSwitchSessionForStep_CompletedSessionNotReused locks in the corrective
+// fix: a COMPLETED session for the target profile must NOT be revived and
+// resumed. Reviving it would lazily resume its persisted ACP conversation,
+// which still contains the agent's earlier completion state — the live
+// incident this test guards against had the agent see the task routed back
+// to a step it had already completed and, reading its own prior "done"
+// context, infer the completion had been undone and move the task backward,
+// re-arming the same cycle on every re-entry. A fresh session must be
+// created instead, and the old COMPLETED session must be left immutable and
+// non-primary.
+func TestSwitchSessionForStep_CompletedSessionNotReused(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -736,10 +743,9 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 	}
 	_ = repo.CreateTask(ctx, task)
 
-	// Prior session for profile-A — was previously active and has the
-	// signals of a real launch: an executors_running record with a resume
-	// token. This should route through the WAITING_FOR_INPUT branch of
-	// reviveReusedSession.
+	// Prior QA session for profile-A: COMPLETED, and — like the live
+	// incident — it was previously launched and still carries a persisted
+	// ACP resume token via its executors_running record.
 	completedAt := now.Add(-2 * time.Minute)
 	prior := &models.TaskSession{
 		ID:                "session-a",
@@ -749,6 +755,8 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		ExecutorProfileID: "ep1",
 		AgentExecutionID:  "ae-a-1",
 		State:             models.TaskSessionStateCompleted,
+		IsPrimary:         false,
+		Metadata:          map[string]interface{}{"existing": "preserved"},
 		CompletedAt:       &completedAt,
 		StartedAt:         now.Add(-3 * time.Minute),
 		UpdatedAt:         completedAt,
@@ -761,6 +769,7 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		CreatedAt:   completedAt, UpdatedAt: completedAt,
 	})
 
+	// Currently-active session for profile-B — about to be switched away from.
 	current := &models.TaskSession{
 		ID:                "session-b",
 		TaskID:            "t1",
@@ -796,28 +805,94 @@ func TestSwitchSessionForStep_ReusesPreviouslyLaunchedSession(t *testing.T) {
 		scheduler:          sched,
 	}
 
-	revived, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+	fresh, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if revived == nil || revived.ID != "session-a" {
-		t.Fatalf("expected reused session-a, got %+v", revived)
+
+	// Critical: a brand-new session must be created — the COMPLETED session
+	// is never selected for reuse.
+	if fresh == nil || fresh.ID == "session-a" {
+		t.Fatalf("expected a fresh session distinct from the COMPLETED session-a, got %+v", fresh)
+	}
+	if fresh.AgentProfileID != "profile-a" {
+		t.Errorf("fresh session profile = %q, want profile-a", fresh.AgentProfileID)
+	}
+	// AC2: the fresh session starts through the CREATED/StartCreatedSession
+	// path, so it gets a new ACP conversation on first prompt.
+	if fresh.State != models.TaskSessionStateCreated {
+		t.Errorf("fresh session state = %s, want CREATED", fresh.State)
+	}
+	freshFromDB, err := repo.GetTaskSession(ctx, fresh.ID)
+	if err != nil {
+		t.Fatalf("failed to get fresh session: %v", err)
+	}
+	if !freshFromDB.IsPrimary {
+		t.Error("fresh session must be primary")
 	}
 
-	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateWaitingForInput {
-		t.Errorf("previously-launched reused session must be WAITING_FOR_INPUT (so PromptTask lazy-resumes via ResumeSession), got %s", reused.State)
+	// AC3: the fresh session must not inherit the old session's resume token.
+	freshRunning, err := repo.GetExecutorRunningBySessionID(ctx, fresh.ID)
+	if err == nil || freshRunning != nil {
+		t.Errorf("fresh session must have no executors_running record (no inherited resume token), got running=%+v err=%v", freshRunning, err)
 	}
-	if got := reused.Metadata[models.SessionMetaKeyCreatedBy]; got != models.SessionCreatedByWorkflowSwitch {
-		t.Errorf("reused session created_by metadata = %v, want %q", got, models.SessionCreatedByWorkflowSwitch)
+
+	// Total session count is now 3: the old COMPLETED session-a, the parked
+	// session-b, and the fresh session.
+	sessions, err := repo.ListTaskSessions(ctx, "t1")
+	if err != nil {
+		t.Fatalf("failed to list sessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Errorf("expected 3 sessions (old completed + parked + fresh), got %d", len(sessions))
+	}
+
+	// AC3: the old COMPLETED session must remain terminal, non-primary, and
+	// historically intact — untouched by the switch.
+	oldSession, err := repo.GetTaskSession(ctx, "session-a")
+	if err != nil {
+		t.Fatalf("failed to get old session: %v", err)
+	}
+	if oldSession.State != models.TaskSessionStateCompleted {
+		t.Errorf("old session state = %s, want it to remain COMPLETED", oldSession.State)
+	}
+	if oldSession.IsPrimary {
+		t.Error("old COMPLETED session must remain non-primary")
+	}
+	if oldSession.CompletedAt == nil || !oldSession.CompletedAt.Equal(completedAt) {
+		t.Errorf("old session CompletedAt = %v, want unchanged %v", oldSession.CompletedAt, completedAt)
+	}
+	if got := oldSession.Metadata["existing"]; got != "preserved" {
+		t.Errorf("old session metadata must be untouched, got %v", got)
+	}
+
+	// The old session's resume token itself must remain on file (history is
+	// preserved) even though it is never handed to the fresh execution.
+	oldRunning, err := repo.GetExecutorRunningBySessionID(ctx, "session-a")
+	if err != nil {
+		t.Fatalf("failed to look up executor running for old session: %v", err)
+	}
+	if oldRunning == nil || oldRunning.ResumeToken != "acp-session-a" {
+		t.Errorf("old session's own resume token must remain intact, got %+v", oldRunning)
+	}
+
+	// The previous current session-b must now be COMPLETED, not primary.
+	parked, _ := repo.GetTaskSession(ctx, "session-b")
+	if parked.State != models.TaskSessionStateCompleted {
+		t.Errorf("previous current session must be COMPLETED, got %s", parked.State)
+	}
+	if parked.IsPrimary {
+		t.Error("previous current session must no longer be primary")
 	}
 }
 
-// TestSwitchSessionForStep_ReusesFailedSession exercises the requirement that
-// FAILED sessions are reused too. Without this, a previously-failed session
-// would be skipped and a fresh one created, leaving the FAILED one as a
-// duplicate tab in the UI showing its stale error banner.
-func TestSwitchSessionForStep_ReusesFailedSession(t *testing.T) {
+// TestSwitchSessionForStep_FailedSessionNotReused mirrors
+// TestSwitchSessionForStep_CompletedSessionNotReused for FAILED sessions.
+// FAILED is terminal too, and a failed ACP conversation can carry equally
+// stale or partial routing intent, so it must not be implicitly resumed
+// either — a fresh session is created and the FAILED session is left as
+// historical record (including its error message).
+func TestSwitchSessionForStep_FailedSessionNotReused(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -891,29 +966,37 @@ func TestSwitchSessionForStep_ReusesFailedSession(t *testing.T) {
 		scheduler:          sched,
 	}
 
-	revived, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
+	fresh, err := svc.switchSessionForStep(ctx, "t1", current, "profile-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if revived == nil || revived.ID != "session-a" {
-		t.Fatalf("expected reused FAILED session-a, got %+v", revived)
+	if fresh == nil || fresh.ID == "session-a" {
+		t.Fatalf("expected a fresh session distinct from the FAILED session-a, got %+v", fresh)
+	}
+	if fresh.State != models.TaskSessionStateCreated {
+		t.Errorf("fresh session state = %s, want CREATED", fresh.State)
 	}
 
-	// No duplicate session must be created.
+	// No session should be reused; a third session now exists.
 	sessions, _ := repo.ListTaskSessions(ctx, "t1")
-	if len(sessions) != 2 {
-		t.Errorf("expected 2 sessions, got %d (FAILED session was not reused)", len(sessions))
+	if len(sessions) != 3 {
+		t.Errorf("expected 3 sessions (old failed + parked + fresh), got %d", len(sessions))
 	}
 
-	reused, _ := repo.GetTaskSession(ctx, "session-a")
-	if reused.State != models.TaskSessionStateWaitingForInput {
-		t.Errorf("FAILED reused session must flip to WAITING_FOR_INPUT (lazy-resume via token), got %s", reused.State)
+	// The FAILED session must be left exactly as it was — including the
+	// error message, which a revive-in-place would have cleared.
+	oldSession, _ := repo.GetTaskSession(ctx, "session-a")
+	if oldSession.State != models.TaskSessionStateFailed {
+		t.Errorf("old session state = %s, want it to remain FAILED", oldSession.State)
 	}
-	if reused.ErrorMessage != "" {
-		t.Errorf("FAILED reused session must have ErrorMessage cleared, got %q", reused.ErrorMessage)
+	if oldSession.ErrorMessage != "execution already running" {
+		t.Errorf("old FAILED session ErrorMessage must be preserved, got %q", oldSession.ErrorMessage)
 	}
-	if reused.CompletedAt != nil {
-		t.Error("FAILED reused session must have CompletedAt cleared")
+	if oldSession.CompletedAt == nil || !oldSession.CompletedAt.Equal(failedAt) {
+		t.Errorf("old session CompletedAt = %v, want unchanged %v", oldSession.CompletedAt, failedAt)
+	}
+	if oldSession.IsPrimary {
+		t.Error("old FAILED session must remain non-primary")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -1,0 +1,73 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// terminalizeAfterPromotionRepo pauses the prompt claim after the session has
+// been promoted, so the test can reproduce a terminal transition in that gap.
+type terminalizeAfterPromotionRepo struct {
+	sessionExecutorStore
+	targetSessionID string
+	claimReached    chan struct{}
+	allowClaim      chan struct{}
+	once            sync.Once
+}
+
+func (r *terminalizeAfterPromotionRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	if sessionID == r.targetSessionID {
+		r.once.Do(func() { close(r.claimReached) })
+		<-r.allowClaim
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+func TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-terminalized-reuse", "session-terminalized-reuse", "step-one")
+	session, err := repo.GetTaskSession(ctx, "session-terminalized-reuse")
+	requireNoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+
+	svc := &Service{repo: repo, logger: testLogger()}
+	promoted, err := svc.setNonterminalSessionPrimary(ctx, session.ID)
+	requireNoError(t, err)
+	if !promoted {
+		t.Fatal("expected nonterminal session to be promoted")
+	}
+
+	barrierRepo := &terminalizeAfterPromotionRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      session.ID,
+		claimReached:         make(chan struct{}),
+		allowClaim:           make(chan struct{}),
+	}
+	svc.repo = barrierRepo
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, _, _, _, claimErr := svc.claimSessionRunningForPrompt(
+			ctx, session.TaskID, session.ID, "", false, nil, nil, "", true,
+		)
+		errCh <- claimErr
+	}()
+
+	<-barrierRepo.claimReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, session.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowClaim)
+
+	if err := <-errCh; !errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+		t.Fatalf("claim error = %v, want terminalized workflow auto-start error", err)
+	}
+	stored, err := repo.GetTaskSession(ctx, session.ID)
+	requireNoError(t, err)
+	if stored.State != models.TaskSessionStateCompleted {
+		t.Fatalf("terminalized session state = %s, want COMPLETED", stored.State)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
@@ -107,11 +108,16 @@ func TestWorkflowAutoStartRejectsSessionTerminalizedBeforeResume(t *testing.T) {
 		allowClaim:           make(chan struct{}),
 	}
 	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	queue := messagequeue.NewServiceMemory(testLogger())
+	if _, err := queue.QueueMessage(ctx, session.ID, session.TaskID, "handoff", "", messagequeue.QueuedByUser, true, nil); err != nil {
+		t.Fatalf("queue handoff: %v", err)
+	}
 	svc := &Service{
 		repo:         barrierRepo,
 		logger:       testLogger(),
 		agentManager: agentMgr,
 		executor:     executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{}),
+		messageQueue: queue,
 	}
 	errCh := make(chan error, 1)
 	go func() {
@@ -129,5 +135,8 @@ func TestWorkflowAutoStartRejectsSessionTerminalizedBeforeResume(t *testing.T) {
 	requireNoError(t, err)
 	if stored.State != models.TaskSessionStateCompleted {
 		t.Fatalf("terminalized session state = %s, want COMPLETED", stored.State)
+	}
+	if status := queue.GetStatus(ctx, session.ID); status.Count != 1 {
+		t.Fatalf("queued handoff count = %d, want 1 after terminal auto-start rejection", status.Count)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -67,6 +68,52 @@ func (s *postClaimReloadErrorTurnService) StartTurn(ctx context.Context, session
 	turn, err := s.repoBackedTurnService.StartTurn(ctx, sessionID)
 	if err == nil {
 		s.repo.armReloadFailure()
+	}
+	return turn, err
+}
+
+// terminalizeAfterPromptClaimRepo pauses the guarded reload after the prompt
+// claim has persisted its RUNNING state and turn, so a competing completion
+// can win before agentctl admission.
+type terminalizeAfterPromptClaimRepo struct {
+	sessionExecutorStore
+	targetSessionID string
+	claimReached    chan struct{}
+	allowReload     chan struct{}
+	mu              sync.Mutex
+	armed           bool
+	once            sync.Once
+}
+
+func (r *terminalizeAfterPromptClaimRepo) armTerminalization() {
+	r.mu.Lock()
+	r.armed = true
+	r.mu.Unlock()
+}
+
+func (r *terminalizeAfterPromptClaimRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	r.mu.Lock()
+	shouldBlock := sessionID == r.targetSessionID && r.armed
+	if shouldBlock {
+		r.armed = false
+	}
+	r.mu.Unlock()
+	if shouldBlock {
+		r.once.Do(func() { close(r.claimReached) })
+		<-r.allowReload
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+type terminalizeAfterPromptClaimTurnService struct {
+	*repoBackedTurnService
+	repo *terminalizeAfterPromptClaimRepo
+}
+
+func (s *terminalizeAfterPromptClaimTurnService) StartTurn(ctx context.Context, sessionID string) (*models.Turn, error) {
+	turn, err := s.repoBackedTurnService.StartTurn(ctx, sessionID)
+	if err == nil {
+		s.repo.armTerminalization()
 	}
 	return turn, err
 }
@@ -265,6 +312,173 @@ func TestWorkflowAutoStartRollsBackPromptClaimWhenPostClaimReloadFails(t *testin
 	queued, ok := queue.TakeQueued(ctx, session.ID)
 	if !ok || queued.Content != "handoff" {
 		t.Fatalf("requeued handoff = %#v, ok=%t; want original handoff", queued, ok)
+	}
+}
+
+func TestWorkflowAutoStartRollsBackPromptClaimWhenTerminalizedAfterClaim(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-auto-start-terminal-after-claim", "session-auto-start-terminal-after-claim", "step-one")
+	session, err := repo.GetTaskSession(ctx, "session-auto-start-terminal-after-claim")
+	requireNoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "execution-auto-start-terminal-after-claim")
+
+	barrierRepo := &terminalizeAfterPromptClaimRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      session.ID,
+		claimReached:         make(chan struct{}),
+		allowReload:          make(chan struct{}),
+	}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo, isAgentRunning: true}
+	queue := messagequeue.NewServiceMemory(testLogger())
+	if _, err := queue.QueueMessage(ctx, session.ID, session.TaskID, "handoff", "", messagequeue.QueuedByUser, true, nil); err != nil {
+		t.Fatalf("queue handoff: %v", err)
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.repo = barrierRepo
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	svc.messageQueue = queue
+	svc.turnService = &terminalizeAfterPromptClaimTurnService{
+		repoBackedTurnService: &repoBackedTurnService{repo: repo},
+		repo:                  barrierRepo,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.autoStartStepPrompt(ctx, session.TaskID, session, &wfmodels.WorkflowStep{}, "review the task", false, false)
+	}()
+
+	<-barrierRepo.claimReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, session.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowReload)
+
+	if err := <-errCh; !errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+		t.Fatalf("auto-start error = %v, want terminalized workflow auto-start error", err)
+	}
+	stored, err := repo.GetTaskSession(ctx, session.ID)
+	requireNoError(t, err)
+	if stored.State != models.TaskSessionStateCompleted {
+		t.Fatalf("terminalized session state = %s, want COMPLETED", stored.State)
+	}
+	if active, err := repo.GetActiveTurnBySessionID(ctx, session.ID); err == nil || active != nil {
+		t.Fatalf("active turn after terminalization = %#v, %v; want no active turn", active, err)
+	}
+	queued, ok := queue.TakeQueued(ctx, session.ID)
+	if !ok || queued.Content != "handoff" {
+		t.Fatalf("requeued handoff = %#v, ok=%t; want original handoff", queued, ok)
+	}
+}
+
+func TestProcessOnEnterReplacesReusedSessionTerminalizedAfterPromptClaim(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-terminalized-replacement", "session-source", "step-source")
+
+	source, err := repo.GetTaskSession(ctx, "session-source")
+	requireNoError(t, err)
+	source.AgentProfileID = "profile-source"
+	source.ExecutorID = "exec-local"
+	source.ExecutorProfileID = "ep1"
+	source.TaskEnvironmentID = "environment-terminalized-replacement"
+	source.IsPrimary = true
+	requireNoError(t, repo.UpdateTaskSession(ctx, source))
+	requireNoError(t, repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: source.TaskEnvironmentID, TaskID: source.TaskID,
+		ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady,
+	}))
+
+	target := &models.TaskSession{
+		ID:                "session-target",
+		TaskID:            source.TaskID,
+		AgentProfileID:    "profile-target",
+		ExecutorID:        source.ExecutorID,
+		ExecutorProfileID: source.ExecutorProfileID,
+		TaskEnvironmentID: source.TaskEnvironmentID,
+		State:             models.TaskSessionStateWaitingForInput,
+		StartedAt:         source.StartedAt,
+		UpdatedAt:         source.UpdatedAt,
+	}
+	requireNoError(t, repo.CreateTaskSession(ctx, target))
+	seedExecutorRunning(t, repo, target.ID, target.TaskID, "execution-target")
+
+	barrierRepo := &terminalizeAfterPromptClaimRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      target.ID,
+		claimReached:         make(chan struct{}),
+		allowReload:          make(chan struct{}),
+	}
+	var launchPrompts []string
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		isAgentRunning:         true,
+		launchAgentFunc: func(_ context.Context, request *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchPrompts = append(launchPrompts, request.TaskDescription)
+			return &executor.LaunchAgentResponse{AgentExecutionID: "execution-replacement"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[source.TaskID] = &v1.Task{
+		ID: source.TaskID, WorkspaceID: "ws1", WorkflowID: "wf1", Title: "Test Task", Description: "Test",
+		State: v1.TaskStateInProgress,
+	}
+	stepGetter := newMockStepGetter()
+	step := &wfmodels.WorkflowStep{
+		ID:             "step-target",
+		WorkflowID:     "wf1",
+		Name:           "Target",
+		AgentProfileID: target.AgentProfileID,
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{
+			{Type: wfmodels.OnEnterAutoStartAgent},
+		}},
+	}
+	stepGetter.steps[step.ID] = step
+	dbTask, err := repo.GetTask(ctx, source.TaskID)
+	requireNoError(t, err)
+	dbTask.WorkflowStepID = step.ID
+	requireNoError(t, repo.UpdateTask(ctx, dbTask))
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+	svc.repo = barrierRepo
+	svc.turnService = &terminalizeAfterPromptClaimTurnService{
+		repoBackedTurnService: &repoBackedTurnService{repo: repo},
+		repo:                  barrierRepo,
+	}
+	if _, err := svc.messageQueue.QueueMessage(ctx, source.ID, source.TaskID, "handoff", "", messagequeue.QueuedByUser, true, nil); err != nil {
+		t.Fatalf("queue handoff: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		svc.processOnEnter(ctx, source.TaskID, source, step, "Test")
+		close(done)
+	}()
+
+	<-barrierRepo.claimReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowReload)
+	<-done
+
+	sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+	requireNoError(t, err)
+	if len(sessions) != 3 {
+		t.Fatalf("session count = %d, want replacement after terminalized reuse", len(sessions))
+	}
+	var replacement *models.TaskSession
+	for _, session := range sessions {
+		if session.ID != source.ID && session.ID != target.ID {
+			replacement = session
+			break
+		}
+	}
+	if replacement == nil || replacement.AgentProfileID != target.AgentProfileID || !replacement.IsPrimary {
+		t.Fatalf("replacement = %#v, want primary fresh target-profile session", replacement)
+	}
+	if isTerminalSessionState(replacement.State) {
+		t.Fatalf("replacement state = %s, want a nonterminal launched session", replacement.State)
+	}
+	if len(launchPrompts) == 0 || !strings.Contains(launchPrompts[len(launchPrompts)-1], "handoff") {
+		t.Fatalf("replacement launch prompts = %#v, want handoff delivery", launchPrompts)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -523,3 +523,241 @@ func TestWorkflowAutoStartReleasesTerminalGuardAfterPromptAdmission(t *testing.T
 		t.Fatalf("auto-start prompt: %v", err)
 	}
 }
+
+// terminalizeCreatedSessionRepo pauses the CREATED-path auto-start just before
+// the guard reload, so the test can terminalize the session in that gap and
+// assert the guard detects it and returns errWorkflowAutoStartSessionTerminalized.
+type terminalizeCreatedSessionRepo struct {
+	sessionExecutorStore
+	targetSessionID string
+	lockAcquired    chan struct{} // closed when the guard lock is acquired
+	allowReload     chan struct{} // close to let the reload continue
+}
+
+func (r *terminalizeCreatedSessionRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	if sessionID == r.targetSessionID {
+		select {
+		case r.lockAcquired <- struct{}{}:
+		default:
+		}
+		<-r.allowReload
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+// TestWorkflowAutoStartCreatedTerminalizedGuard verifies that the CREATED
+// session branch in autoStartStepPrompt checks terminal state under the
+// cancel-in-flight guard before calling StartCreatedSession, and returns
+// errWorkflowAutoStartSessionTerminalized when the session was terminalized
+// concurrently.
+func TestWorkflowAutoStartCreatedTerminalizedGuard(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-created-guard", "session-created-guard", "step-created-guard")
+	session, err := repo.GetTaskSession(ctx, "session-created-guard")
+	requireNoError(t, err)
+	session.AgentProfileID = "profile-target"
+	session.ExecutorID = "exec-local"
+	session.ExecutorProfileID = "ep1"
+	session.State = models.TaskSessionStateCreated
+	session.IsPrimary = true
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+
+	barrierRepo := &terminalizeCreatedSessionRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      session.ID,
+		lockAcquired:         make(chan struct{}, 1),
+		allowReload:          make(chan struct{}),
+	}
+
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		isAgentRunning:         true,
+		launchAgentFunc: func(_ context.Context, request *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			return &executor.LaunchAgentResponse{AgentExecutionID: "execution-created-guard"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[session.TaskID] = &v1.Task{
+		ID: session.TaskID, WorkspaceID: "ws1", WorkflowID: "wf1",
+		Title: "Test Task", Description: "Test", State: v1.TaskStateInProgress,
+	}
+	step := &wfmodels.WorkflowStep{
+		ID:   "step-created-guard",
+		Name: "Target",
+	}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.repo = barrierRepo
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.autoStartStepPrompt(ctx, session.TaskID, session, step, "review the task", false, false)
+	}()
+
+	<-barrierRepo.lockAcquired
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, session.ID, models.TaskSessionStateCompleted, "concurrent completion"))
+	close(barrierRepo.allowReload)
+
+	autoStartErr := <-errCh
+	if !errors.Is(autoStartErr, errWorkflowAutoStartSessionTerminalized) {
+		t.Fatalf("autoStartStepPrompt error = %v, want errWorkflowAutoStartSessionTerminalized", autoStartErr)
+	}
+
+	// The CREATED session must remain terminal (the guard must not have
+	// launched it).
+	finalSession, err := repo.GetTaskSession(ctx, session.ID)
+	requireNoError(t, err)
+	if finalSession.State != models.TaskSessionStateCompleted {
+		t.Errorf("final session state = %s, must remain COMPLETED (was not launched)", finalSession.State)
+	}
+}
+
+// terminalizeImplicitSwitchRepo pauses the implicit profile-switch goroutine
+// just before autoStartStepPrompt, so the test can terminalize the session
+// and assert the goroutine detects it and creates a replacement.
+type terminalizeImplicitSwitchRepo struct {
+	sessionExecutorStore
+	targetSessionID string
+	promptCalled    chan struct{} // closed when autoStartStepPrompt is about to run
+	allowPrompt     chan struct{} // close to let autoStartStepPrompt proceed
+}
+
+func (r *terminalizeImplicitSwitchRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	if sessionID == r.targetSessionID {
+		select {
+		case r.promptCalled <- struct{}{}:
+		default:
+		}
+		<-r.allowPrompt
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+func (r *terminalizeImplicitSwitchRepo) GetTask(ctx context.Context, taskID string) (*models.Task, error) {
+	return r.sessionExecutorStore.(interface {
+		GetTask(context.Context, string) (*models.Task, error)
+	}).GetTask(ctx, taskID)
+}
+
+// TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard verifies that the
+// implicit profile-switch goroutine in processOnEnter's default branch detects
+// that a reused session has terminalized before dispatch and creates a
+// replacement session via createNewSessionForStep.
+func TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-implicit-switch", "session-implicit-switch-source", "step-source")
+
+	source, err := repo.GetTaskSession(ctx, "session-implicit-switch-source")
+	requireNoError(t, err)
+	source.AgentProfileID = "profile-source"
+	source.ExecutorID = "exec-local"
+	source.ExecutorProfileID = "ep1"
+	source.TaskEnvironmentID = "env-implicit-switch"
+	source.IsPrimary = true
+	requireNoError(t, repo.UpdateTaskSession(ctx, source))
+	requireNoError(t, repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: source.TaskEnvironmentID, TaskID: source.TaskID,
+		ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady,
+	}))
+
+	target := &models.TaskSession{
+		ID:                "session-implicit-switch-target",
+		TaskID:            source.TaskID,
+		AgentProfileID:    "profile-target",
+		ExecutorID:        source.ExecutorID,
+		ExecutorProfileID: source.ExecutorProfileID,
+		TaskEnvironmentID: source.TaskEnvironmentID,
+		State:             models.TaskSessionStateWaitingForInput,
+		StartedAt:         source.StartedAt,
+		UpdatedAt:         source.UpdatedAt,
+	}
+	requireNoError(t, repo.CreateTaskSession(ctx, target))
+	seedExecutorRunning(t, repo, target.ID, target.TaskID, "execution-implicit-switch")
+
+	barrierRepo := &terminalizeImplicitSwitchRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      target.ID,
+		promptCalled:         make(chan struct{}, 1),
+		allowPrompt:          make(chan struct{}),
+	}
+
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		isAgentRunning:         true,
+		launchAgentFunc: func(_ context.Context, request *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			return &executor.LaunchAgentResponse{AgentExecutionID: "execution-implicit-replacement"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[source.TaskID] = &v1.Task{
+		ID: source.TaskID, WorkspaceID: "ws1", WorkflowID: "wf1",
+		Title: "Test Task", Description: "Test", State: v1.TaskStateInProgress,
+	}
+	stepGetter := newMockStepGetter()
+	// Register the existing step-source so the replacement session's task
+	// (which inherits dbTask.WorkflowStepID) is resolvable.
+	stepGetter.steps["step-source"] = &wfmodels.WorkflowStep{
+		ID: "step-source", WorkflowID: "wf1", Name: "Source", AgentProfileID: source.AgentProfileID,
+	}
+	step := &wfmodels.WorkflowStep{
+		ID:             "step-implicit-switch",
+		WorkflowID:     "wf1",
+		Name:           "Target",
+		AgentProfileID: target.AgentProfileID,
+		Prompt:         "review the task",
+		// No auto_start_agent — implicit profile switch path.
+	}
+	stepGetter.steps[step.ID] = step
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+	svc.repo = barrierRepo
+
+	done := make(chan struct{})
+	go func() {
+		svc.processOnEnter(ctx, source.TaskID, source, step, "Test")
+		close(done)
+	}()
+
+	// Terminalize the reused target session before the goroutine's guarded
+	// reload can detect it.
+	<-barrierRepo.promptCalled
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, models.TaskSessionStateCompleted, "concurrent completion"))
+	close(barrierRepo.allowPrompt)
+
+	<-done
+	// The inner goroutine (implicit profile switch) needs time to run its
+	// guarded reload, detect terminalization, and create a replacement.
+	time.Sleep(200 * time.Millisecond)
+
+	// A replacement session must be created with the target profile and be primary.
+	sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+	requireNoError(t, err)
+	if len(sessions) != 3 {
+		t.Fatalf("session count = %d, want 3 (source + terminalized target + replacement)", len(sessions))
+	}
+	var replacement *models.TaskSession
+	for _, s := range sessions {
+		if s.ID != source.ID && s.ID != target.ID {
+			replacement = s
+			break
+		}
+	}
+	if replacement == nil || !replacement.IsPrimary {
+		t.Fatalf("replacement = %#v, want primary fresh session", replacement)
+	}
+	if isTerminalSessionState(replacement.State) {
+		t.Fatalf("replacement state = %s, want nonterminal", replacement.State)
+	}
+	// The terminalized target must remain in its COMPLETED state.
+	finalTarget, err := repo.GetTaskSession(ctx, target.ID)
+	requireNoError(t, err)
+	if finalTarget.State != models.TaskSessionStateCompleted {
+		t.Errorf("terminalized target state = %s, must remain COMPLETED", finalTarget.State)
+	}
+	// The source session (the previous current session) must not be primary.
+	finalSource, err := repo.GetTaskSession(ctx, source.ID)
+	requireNoError(t, err)
+	if finalSource.IsPrimary {
+		t.Error("source session must not be primary after the implicit switch")
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -373,6 +373,14 @@ func TestWorkflowAutoStartRollsBackPromptClaimWhenTerminalizedAfterClaim(t *test
 }
 
 func TestProcessOnEnterReplacesReusedSessionTerminalizedAfterPromptClaim(t *testing.T) {
+	testProcessOnEnterTerminalizedAfterPromptClaim(t, models.TaskSessionStateCompleted, true)
+}
+
+func TestProcessOnEnterPreservesCancelledReusedSessionTerminalizedAfterPromptClaim(t *testing.T) {
+	testProcessOnEnterTerminalizedAfterPromptClaim(t, models.TaskSessionStateCancelled, false)
+}
+
+func testProcessOnEnterTerminalizedAfterPromptClaim(t *testing.T, terminalState models.TaskSessionState, wantReplacement bool) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "task-terminalized-replacement", "session-source", "step-source")
@@ -456,12 +464,26 @@ func TestProcessOnEnterReplacesReusedSessionTerminalizedAfterPromptClaim(t *test
 	}()
 
 	<-barrierRepo.claimReached
-	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, terminalState, "terminalized concurrently"))
 	close(barrierRepo.allowReload)
 	<-done
 
 	sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
 	requireNoError(t, err)
+	if !wantReplacement {
+		if len(sessions) != 2 {
+			t.Fatalf("session count = %d, want no replacement after cancellation", len(sessions))
+		}
+		stored, err := repo.GetTaskSession(ctx, target.ID)
+		requireNoError(t, err)
+		if stored.State != models.TaskSessionStateCancelled {
+			t.Fatalf("cancelled target state = %s, want CANCELLED", stored.State)
+		}
+		if len(launchPrompts) != 0 {
+			t.Fatalf("launch prompts = %#v, want no replacement launch after cancellation", launchPrompts)
+		}
+		return
+	}
 	if len(sessions) != 3 {
 		t.Fatalf("session count = %d, want replacement after terminalized reuse", len(sessions))
 	}
@@ -645,6 +667,14 @@ func (r *terminalizeImplicitSwitchRepo) GetTask(ctx context.Context, taskID stri
 // that a reused session has terminalized before dispatch and creates a
 // replacement session via createNewSessionForStep.
 func TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T) {
+	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCompleted, true)
+}
+
+func TestProcessOnEnterImplicitProfileSwitchPreservesCancellation(t *testing.T) {
+	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCancelled, false)
+}
+
+func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T, terminalState models.TaskSessionState, wantReplacement bool) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "task-implicit-switch", "session-implicit-switch-source", "step-source")
@@ -722,10 +752,22 @@ func TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T) {
 	// Terminalize the reused target session before the goroutine's guarded
 	// reload can detect it.
 	<-barrierRepo.promptCalled
-	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, models.TaskSessionStateCompleted, "concurrent completion"))
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, terminalState, "terminalized concurrently"))
 	close(barrierRepo.allowPrompt)
 
 	<-done
+
+	if !wantReplacement {
+		require.Eventually(t, func() bool {
+			sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+			if err != nil || len(sessions) != 2 {
+				return false
+			}
+			stored, err := repo.GetTaskSession(ctx, target.ID)
+			return err == nil && stored.State == models.TaskSessionStateCancelled
+		}, 5*time.Second, 50*time.Millisecond, "expected cancellation to prevent a replacement session")
+		return
+	}
 
 	// The inner goroutine (implicit profile switch) must finish before we can
 	// assert on its results. Wait on a progress observation: the replacement

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
 // terminalizeAfterPromotionRepo pauses the prompt claim after the session has
@@ -14,13 +16,27 @@ import (
 type terminalizeAfterPromotionRepo struct {
 	sessionExecutorStore
 	targetSessionID string
+	blockOnGetCall  int
+	returnStale     bool
 	claimReached    chan struct{}
 	allowClaim      chan struct{}
+	mu              sync.Mutex
+	getCalls        int
 	once            sync.Once
 }
 
 func (r *terminalizeAfterPromotionRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
-	if sessionID == r.targetSessionID {
+	r.mu.Lock()
+	r.getCalls++
+	shouldBlock := sessionID == r.targetSessionID && r.getCalls == r.blockOnGetCall
+	r.mu.Unlock()
+	if shouldBlock {
+		if r.returnStale {
+			session, err := r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+			r.once.Do(func() { close(r.claimReached) })
+			<-r.allowClaim
+			return session, err
+		}
 		r.once.Do(func() { close(r.claimReached) })
 		<-r.allowClaim
 	}
@@ -46,6 +62,7 @@ func TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion(t 
 	barrierRepo := &terminalizeAfterPromotionRepo{
 		sessionExecutorStore: repo,
 		targetSessionID:      session.ID,
+		blockOnGetCall:       1,
 		claimReached:         make(chan struct{}),
 		allowClaim:           make(chan struct{}),
 	}
@@ -64,6 +81,49 @@ func TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion(t 
 
 	if err := <-errCh; !errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
 		t.Fatalf("claim error = %v, want terminalized workflow auto-start error", err)
+	}
+	stored, err := repo.GetTaskSession(ctx, session.ID)
+	requireNoError(t, err)
+	if stored.State != models.TaskSessionStateCompleted {
+		t.Fatalf("terminalized session state = %s, want COMPLETED", stored.State)
+	}
+}
+
+func TestWorkflowAutoStartRejectsSessionTerminalizedBeforeResume(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-auto-start-terminalized", "session-auto-start-terminalized", "step-one")
+	session, err := repo.GetTaskSession(ctx, "session-auto-start-terminalized")
+	requireNoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+
+	barrierRepo := &terminalizeAfterPromotionRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      session.ID,
+		blockOnGetCall:       1,
+		returnStale:          true,
+		claimReached:         make(chan struct{}),
+		allowClaim:           make(chan struct{}),
+	}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := &Service{
+		repo:         barrierRepo,
+		logger:       testLogger(),
+		agentManager: agentMgr,
+		executor:     executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{}),
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.autoStartStepPrompt(ctx, session.TaskID, session, &wfmodels.WorkflowStep{}, "review the task", false, false)
+	}()
+
+	<-barrierRepo.claimReached
+	requireNoError(t, repo.UpdateTaskSessionState(ctx, session.ID, models.TaskSessionStateCompleted, "finished concurrently"))
+	close(barrierRepo.allowClaim)
+
+	if err := <-errCh; !errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+		t.Fatalf("auto-start error = %v, want terminalized workflow auto-start error", err)
 	}
 	stored, err := repo.GetTaskSession(ctx, session.ID)
 	requireNoError(t, err)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -667,15 +667,26 @@ func (r *terminalizeImplicitSwitchRepo) GetTask(ctx context.Context, taskID stri
 // that a reused session has terminalized before dispatch and creates a
 // replacement session via createNewSessionForStep.
 func TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T) {
-	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCompleted, true)
+	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCompleted, true, false)
 }
 
 func TestProcessOnEnterImplicitProfileSwitchPreservesCancellation(t *testing.T) {
-	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCancelled, false)
+	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCancelled, false, false)
 }
 
-func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T, terminalState models.TaskSessionState, wantReplacement bool) {
-	ctx := context.Background()
+func TestProcessOnEnterImplicitProfileSwitchSurvivesCallerCancellation(t *testing.T) {
+	testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t, models.TaskSessionStateCompleted, true, true)
+}
+
+func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(
+	t *testing.T,
+	terminalState models.TaskSessionState,
+	wantReplacement bool,
+	cancelCaller bool,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	assertCtx := context.Background()
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "task-implicit-switch", "session-implicit-switch-source", "step-source")
 
@@ -752,18 +763,21 @@ func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T, term
 	// Terminalize the reused target session before the goroutine's guarded
 	// reload can detect it.
 	<-barrierRepo.promptCalled
-	requireNoError(t, repo.UpdateTaskSessionState(ctx, target.ID, terminalState, "terminalized concurrently"))
+	if cancelCaller {
+		cancel()
+	}
+	requireNoError(t, repo.UpdateTaskSessionState(context.Background(), target.ID, terminalState, "terminalized concurrently"))
 	close(barrierRepo.allowPrompt)
 
 	<-done
 
 	if !wantReplacement {
 		require.Eventually(t, func() bool {
-			sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+			sessions, err := repo.ListTaskSessions(assertCtx, source.TaskID)
 			if err != nil || len(sessions) != 2 {
 				return false
 			}
-			stored, err := repo.GetTaskSession(ctx, target.ID)
+			stored, err := repo.GetTaskSession(assertCtx, target.ID)
 			return err == nil && stored.State == models.TaskSessionStateCancelled
 		}, 5*time.Second, 50*time.Millisecond, "expected cancellation to prevent a replacement session")
 		return
@@ -774,7 +788,7 @@ func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T, term
 	// session appearing as primary in the database.
 	var replacement *models.TaskSession
 	require.Eventually(t, func() bool {
-		sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+		sessions, err := repo.ListTaskSessions(assertCtx, source.TaskID)
 		if err != nil || len(sessions) != 3 {
 			return false
 		}
@@ -791,13 +805,13 @@ func testProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T, term
 		t.Fatalf("replacement state = %s, want nonterminal", replacement.State)
 	}
 	// The terminalized target must remain in its COMPLETED state.
-	finalTarget, err := repo.GetTaskSession(ctx, target.ID)
+	finalTarget, err := repo.GetTaskSession(assertCtx, target.ID)
 	requireNoError(t, err)
 	if finalTarget.State != models.TaskSessionStateCompleted {
 		t.Errorf("terminalized target state = %s, must remain COMPLETED", finalTarget.State)
 	}
 	// The source session (the previous current session) must not be primary.
-	finalSource, err := repo.GetTaskSession(ctx, source.ID)
+	finalSource, err := repo.GetTaskSession(assertCtx, source.ID)
 	requireNoError(t, err)
 	if finalSource.IsPrimary {
 		t.Error("source session must not be primary after the implicit switch")

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -28,6 +28,49 @@ type terminalizeAfterPromotionRepo struct {
 	once            sync.Once
 }
 
+// postClaimReloadErrorRepo fails the guarded reload that follows a successful
+// prompt claim. The turn service arms it only after that claim has persisted
+// the RUNNING state and created the turn.
+type postClaimReloadErrorRepo struct {
+	sessionExecutorStore
+	targetSessionID string
+	err             error
+	mu              sync.Mutex
+	failNextReload  bool
+}
+
+func (r *postClaimReloadErrorRepo) armReloadFailure() {
+	r.mu.Lock()
+	r.failNextReload = true
+	r.mu.Unlock()
+}
+
+func (r *postClaimReloadErrorRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	r.mu.Lock()
+	fail := sessionID == r.targetSessionID && r.failNextReload
+	if fail {
+		r.failNextReload = false
+	}
+	r.mu.Unlock()
+	if fail {
+		return nil, r.err
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+type postClaimReloadErrorTurnService struct {
+	*repoBackedTurnService
+	repo *postClaimReloadErrorRepo
+}
+
+func (s *postClaimReloadErrorTurnService) StartTurn(ctx context.Context, sessionID string) (*models.Turn, error) {
+	turn, err := s.repoBackedTurnService.StartTurn(ctx, sessionID)
+	if err == nil {
+		s.repo.armReloadFailure()
+	}
+	return turn, err
+}
+
 // dispatchBoundaryAgentManager blocks after agentctl has accepted the prompt,
 // giving the test a deterministic way to inspect the guard after admission but
 // before the prompt call returns.
@@ -166,6 +209,62 @@ func TestWorkflowAutoStartRejectsSessionTerminalizedBeforeResume(t *testing.T) {
 	}
 	if status := queue.GetStatus(ctx, session.ID); status.Count != 1 {
 		t.Fatalf("queued handoff count = %d, want 1 after terminal auto-start rejection", status.Count)
+	}
+}
+
+func TestWorkflowAutoStartRollsBackPromptClaimWhenPostClaimReloadFails(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-auto-start-reload-error", "session-auto-start-reload-error", "step-one")
+	session, err := repo.GetTaskSession(ctx, "session-auto-start-reload-error")
+	requireNoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "execution-auto-start-reload-error")
+
+	reloadErr := errors.New("post-claim session reload failed")
+	failingRepo := &postClaimReloadErrorRepo{
+		sessionExecutorStore: repo,
+		targetSessionID:      session.ID,
+		err:                  reloadErr,
+	}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo, isAgentRunning: true}
+	queue := messagequeue.NewServiceMemory(testLogger())
+	if _, err := queue.QueueMessage(ctx, session.ID, session.TaskID, "handoff", "", messagequeue.QueuedByUser, true, nil); err != nil {
+		t.Fatalf("queue handoff: %v", err)
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.repo = failingRepo
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	svc.messageQueue = queue
+	svc.turnService = &postClaimReloadErrorTurnService{
+		repoBackedTurnService: &repoBackedTurnService{repo: repo},
+		repo:                  failingRepo,
+	}
+
+	err = svc.autoStartStepPrompt(ctx, session.TaskID, session, &wfmodels.WorkflowStep{}, "review the task", false, false)
+	if !errors.Is(err, reloadErr) {
+		t.Fatalf("auto-start error = %v, want post-claim reload error", err)
+	}
+	stored, err := repo.GetTaskSession(ctx, session.ID)
+	requireNoError(t, err)
+	if stored.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("session state after reload failure = %s, want WAITING_FOR_INPUT", stored.State)
+	}
+	if active, err := repo.GetActiveTurnBySessionID(ctx, session.ID); err == nil || active != nil {
+		t.Fatalf("active turn after reload failure = %#v, %v; want no active turn", active, err)
+	}
+	turns, err := repo.ListTurnsBySession(ctx, session.ID)
+	requireNoError(t, err)
+	if len(turns) != 1 || turns[0].CompletedAt == nil {
+		t.Fatalf("turns after reload failure = %#v, want one completed rollback turn", turns)
+	}
+	if len(agentMgr.capturedPrompts) != 0 {
+		t.Fatalf("prompt dispatches = %d, want none after reload failure", len(agentMgr.capturedPrompts))
+	}
+	queued, ok := queue.TakeQueued(ctx, session.ID)
+	if !ok || queued.Content != "handoff" {
+		t.Fatalf("requeued handoff = %#v, ok=%t; want original handoff", queued, ok)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // terminalizeAfterPromotionRepo pauses the prompt claim after the session has
@@ -24,6 +26,32 @@ type terminalizeAfterPromotionRepo struct {
 	mu              sync.Mutex
 	getCalls        int
 	once            sync.Once
+}
+
+// dispatchBoundaryAgentManager blocks after agentctl has accepted the prompt,
+// giving the test a deterministic way to inspect the guard after admission but
+// before the prompt call returns.
+type dispatchBoundaryAgentManager struct {
+	*mockAgentManager
+	dispatched chan struct{}
+	release    chan struct{}
+}
+
+func (m *dispatchBoundaryAgentManager) PromptAgentWithDispatchCallback(
+	ctx context.Context,
+	executionID, prompt string,
+	attachments []v1.MessageAttachment,
+	dispatchOnly bool,
+	onDispatched func(),
+) (*executor.PromptResult, error) {
+	result, err := m.PromptAgent(ctx, executionID, prompt, attachments, dispatchOnly)
+	if err != nil {
+		return result, err
+	}
+	onDispatched()
+	close(m.dispatched)
+	<-m.release
+	return result, nil
 }
 
 func (r *terminalizeAfterPromotionRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
@@ -138,5 +166,47 @@ func TestWorkflowAutoStartRejectsSessionTerminalizedBeforeResume(t *testing.T) {
 	}
 	if status := queue.GetStatus(ctx, session.ID); status.Count != 1 {
 		t.Fatalf("queued handoff count = %d, want 1 after terminal auto-start rejection", status.Count)
+	}
+}
+
+func TestWorkflowAutoStartReleasesTerminalGuardAfterPromptAdmission(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-auto-start-dispatch", "session-auto-start-dispatch", "step-one")
+	session, err := repo.GetTaskSession(ctx, "session-auto-start-dispatch")
+	requireNoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	requireNoError(t, repo.UpdateTaskSession(ctx, session))
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "execution-auto-start-dispatch")
+
+	agentMgr := &dispatchBoundaryAgentManager{
+		mockAgentManager: &mockAgentManager{repoForExecutionLookup: repo, isAgentRunning: true},
+		dispatched:       make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.autoStartStepPrompt(ctx, session.TaskID, session, &wfmodels.WorkflowStep{}, "review the task", false, false)
+	}()
+
+	<-agentMgr.dispatched
+	guard, release := svc.acquireCancelInFlightGuard(session.ID)
+	acquired := make(chan struct{})
+	go func() {
+		guard.Lock()
+		close(acquired)
+		guard.Unlock()
+		release()
+	}()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("workflow auto-start held the terminal guard after agentctl accepted the prompt")
+	}
+	close(agentMgr.release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("auto-start prompt: %v", err)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_prompt_claim_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
+	"github.com/stretchr/testify/require"
 )
 
 // terminalizeAfterPromotionRepo pauses the prompt claim after the session has
@@ -725,26 +726,25 @@ func TestProcessOnEnterImplicitProfileSwitchTerminalizedGuard(t *testing.T) {
 	close(barrierRepo.allowPrompt)
 
 	<-done
-	// The inner goroutine (implicit profile switch) needs time to run its
-	// guarded reload, detect terminalization, and create a replacement.
-	time.Sleep(200 * time.Millisecond)
 
-	// A replacement session must be created with the target profile and be primary.
-	sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
-	requireNoError(t, err)
-	if len(sessions) != 3 {
-		t.Fatalf("session count = %d, want 3 (source + terminalized target + replacement)", len(sessions))
-	}
+	// The inner goroutine (implicit profile switch) must finish before we can
+	// assert on its results. Wait on a progress observation: the replacement
+	// session appearing as primary in the database.
 	var replacement *models.TaskSession
-	for _, s := range sessions {
-		if s.ID != source.ID && s.ID != target.ID {
-			replacement = s
-			break
+	require.Eventually(t, func() bool {
+		sessions, err := repo.ListTaskSessions(ctx, source.TaskID)
+		if err != nil || len(sessions) != 3 {
+			return false
 		}
-	}
-	if replacement == nil || !replacement.IsPrimary {
-		t.Fatalf("replacement = %#v, want primary fresh session", replacement)
-	}
+		for _, s := range sessions {
+			if s.ID != source.ID && s.ID != target.ID && s.IsPrimary {
+				replacement = s
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "expected a primary replacement session to appear")
+
 	if isTerminalSessionState(replacement.State) {
 		t.Fatalf("replacement state = %s, want nonterminal", replacement.State)
 	}

--- a/apps/backend/internal/orchestrator/prompt_claim_rollback_context_test.go
+++ b/apps/backend/internal/orchestrator/prompt_claim_rollback_context_test.go
@@ -153,6 +153,7 @@ func TestOrdinaryPromptRollsBackClaimAfterTurnCallCancelsContext(t *testing.T) {
 		nil,
 		nil,
 		"",
+		false,
 	)
 	if !errors.Is(err, persistenceErr) {
 		t.Fatalf("claim error = %v, want %v", err, persistenceErr)

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -266,6 +266,7 @@ type sessionExecutorStore interface {
 	GetActiveTaskSessionByTaskID(ctx context.Context, taskID string) (*models.TaskSession, error)
 	ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	SetSessionPrimary(ctx context.Context, sessionID string) error
+	SetSessionPrimaryIfNonterminal(ctx context.Context, sessionID string) (bool, error)
 	RenameTaskSession(ctx context.Context, id, name string) error
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	UpdateTaskSessionIfCurrentState(ctx context.Context, session *models.TaskSession, expected models.TaskSessionState) (bool, error)

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -258,6 +258,7 @@ type sessionExecutorStore interface {
 	GetActiveTaskSessionByTaskID(ctx context.Context, taskID string) (*models.TaskSession, error)
 	ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	SetSessionPrimary(ctx context.Context, sessionID string) error
+	SetSessionPrimaryIfNonterminal(ctx context.Context, sessionID string) (bool, error)
 	RenameTaskSession(ctx context.Context, id, name string) error
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	UpdateTaskSessionIfCurrentState(ctx context.Context, session *models.TaskSession, expected models.TaskSessionState) (bool, error)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -4050,7 +4050,10 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 		if fresh == nil || isTerminalSessionState(fresh.State) {
 			guard.Unlock()
 			releaseDispatchGuard()
-			s.rollbackForegroundDispatchOnFailure(ctx, taskID, sessionID, foregroundDispatch)
+			failureCtx, cancel := options.failureContext(ctx)
+			defer cancel()
+			s.rollbackForegroundDispatchOnFailure(failureCtx, taskID, sessionID, foregroundDispatch)
+			s.rollbackPromptClaim(failureCtx, taskID, sessionID, rollback)
 			return nil, errWorkflowAutoStartSessionTerminalized
 		}
 		var releaseOnce sync.Once

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -3852,9 +3852,10 @@ type promptTaskOptions struct {
 	preservePromptContext bool
 	// reserveTurnUntilDispatch persists detached-resume ownership before agentctl
 	// dispatch, while delaying the visible turn.started event until acceptance.
-	reserveTurnUntilDispatch bool
-	promptDispatchRecovery   *models.PromptDispatchRecovery
-	expectedCurrentTurnID    string
+	reserveTurnUntilDispatch  bool
+	promptDispatchRecovery    *models.PromptDispatchRecovery
+	expectedCurrentTurnID     string
+	requireNonterminalSession bool
 }
 
 type promptDispatchOutcome struct {
@@ -4012,6 +4013,7 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 		ctx, taskID, sessionID, options.claimEntryID, options.lifecyclePrompt,
 		options.reserveTurnUntilDispatch, options.promptDispatchRecovery,
 		options.afterClaim, foregroundClaim, options.expectedCurrentTurnID,
+		options.requireNonterminalSession,
 	)
 	if err != nil {
 		s.rollbackForegroundDispatchOnFailure(ctx, taskID, sessionID, foregroundDispatch)
@@ -4254,6 +4256,7 @@ func (s *Service) claimPromptDispatch(
 	afterClaim func() error,
 	foregroundClaim *foregroundClaim,
 	expectedCurrentTurnID string,
+	requireNonterminalSession bool,
 ) (*models.TaskSession, promptClaimRollback, error) {
 	if lifecyclePrompt {
 		return s.claimLifecyclePromptDispatch(
@@ -4262,7 +4265,7 @@ func (s *Service) claimPromptDispatch(
 	}
 	claimed, previousState, turnID, createdTurn, reservedTurn, err := s.claimSessionRunningForPrompt(
 		ctx, taskID, sessionID, claimEntryID, reserveTurnUntilDispatch,
-		promptDispatchRecovery, foregroundClaim, expectedCurrentTurnID,
+		promptDispatchRecovery, foregroundClaim, expectedCurrentTurnID, requireNonterminalSession,
 	)
 	if err != nil {
 		return nil, promptClaimRollback{}, err
@@ -4578,6 +4581,7 @@ func (s *Service) claimSessionRunningForPrompt(
 	promptDispatchRecovery *models.PromptDispatchRecovery,
 	foregroundClaim *foregroundClaim,
 	expectedCurrentTurnID string,
+	requireNonterminalSession bool,
 ) (*models.TaskSession, models.TaskSessionState, string, bool, *models.Turn, error) {
 	lock, release := s.acquireCancelInFlightGuard(sessionID)
 	defer release()
@@ -4612,6 +4616,9 @@ func (s *Service) claimSessionRunningForPrompt(
 	if freshSession == nil {
 		return nil, "", "", false, nil, errQueuedDispatchSuperseded
 	}
+	if requireNonterminalSession && isTerminalSessionState(freshSession.State) {
+		return nil, "", "", false, nil, errWorkflowAutoStartSessionTerminalized
+	}
 	if promptErr := s.recheckPromptableWithForegroundClaim(
 		taskID, sessionID, freshSession.State, foregroundClaim,
 	); promptErr != nil {
@@ -4622,6 +4629,9 @@ func (s *Service) claimSessionRunningForPrompt(
 	// setSessionRunning refreshes freshSession in place when its guarded write
 	// loses, so a cancellation landing after the promptability check is visible
 	// here as a terminal state.
+	if requireNonterminalSession && isTerminalSessionState(freshSession.State) {
+		return nil, "", "", false, nil, errWorkflowAutoStartSessionTerminalized
+	}
 	if isTerminalSessionState(freshSession.State) && freshSession.State != models.TaskSessionStateCompleted {
 		return nil, "", "", false, nil, &executor.SessionStateSupersededError{
 			SessionID: freshSession.ID,

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -3964,6 +3964,12 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 	if err != nil {
 		return nil, err
 	}
+	if options.requireNonterminalSession {
+		session, err = s.loadNonterminalWorkflowAutoStartSession(ctx, sessionID)
+		if err != nil {
+			return nil, err
+		}
+	}
 	foregroundClaim, err := s.claimForegroundForPrompt(taskID, sessionID, session)
 	if err != nil {
 		return nil, err
@@ -4143,6 +4149,29 @@ func (s *Service) loadPromptableSession(ctx context.Context, taskID, sessionID s
 			return nil, promptErr
 		}
 		return s.waitForStartingSessionPromptable(ctx, taskID, sessionID)
+	}
+	return session, nil
+}
+
+// loadNonterminalWorkflowAutoStartSession reloads a session under the shared
+// cancellation guard before auto-start can trigger a lazy ACP resume. Manual
+// prompts intentionally do not use this path and can still resume terminal
+// history when explicitly requested.
+func (s *Service) loadNonterminalWorkflowAutoStartSession(
+	ctx context.Context,
+	sessionID string,
+) (*models.TaskSession, error) {
+	lock, release := s.acquireCancelInFlightGuard(sessionID)
+	defer release()
+	lock.Lock()
+	defer lock.Unlock()
+
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("reload workflow auto-start session: %w", err)
+	}
+	if session == nil || isTerminalSessionState(session.State) {
+		return nil, errWorkflowAutoStartSessionTerminalized
 	}
 	return session, nil
 }

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -4038,7 +4038,16 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 		guard, releaseDispatchGuard = s.acquireCancelInFlightGuard(sessionID)
 		guard.Lock()
 		fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
-		if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
+		if reloadErr != nil {
+			guard.Unlock()
+			releaseDispatchGuard()
+			failureCtx, cancel := options.failureContext(ctx)
+			defer cancel()
+			s.rollbackForegroundDispatchOnFailure(failureCtx, taskID, sessionID, foregroundDispatch)
+			s.rollbackPromptClaim(failureCtx, taskID, sessionID, rollback)
+			return nil, reloadErr
+		}
+		if fresh == nil || isTerminalSessionState(fresh.State) {
 			guard.Unlock()
 			releaseDispatchGuard()
 			s.rollbackForegroundDispatchOnFailure(ctx, taskID, sessionID, foregroundDispatch)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -4032,6 +4032,23 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 	if foregroundDispatch.yieldedBeforeBegin || foregroundClaim != nil {
 		s.publishForegroundActivityChanged(ctx, taskID, sessionID)
 	}
+	var releaseDispatchGuard func()
+	if options.requireNonterminalSession {
+		var guard *sync.Mutex
+		guard, releaseDispatchGuard = s.acquireCancelInFlightGuard(sessionID)
+		guard.Lock()
+		fresh, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
+		if reloadErr != nil || fresh == nil || isTerminalSessionState(fresh.State) {
+			guard.Unlock()
+			releaseDispatchGuard()
+			s.rollbackForegroundDispatchOnFailure(ctx, taskID, sessionID, foregroundDispatch)
+			return nil, errWorkflowAutoStartSessionTerminalized
+		}
+		defer func() {
+			guard.Unlock()
+			releaseDispatchGuard()
+		}()
+	}
 
 	// Only bounded-ack callers preserve request context; ordinary prompts can take minutes.
 	promptCtx := options.executorContext(ctx)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -4044,10 +4044,18 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 			s.rollbackForegroundDispatchOnFailure(ctx, taskID, sessionID, foregroundDispatch)
 			return nil, errWorkflowAutoStartSessionTerminalized
 		}
-		defer func() {
-			guard.Unlock()
-			releaseDispatchGuard()
-		}()
+		var releaseOnce sync.Once
+		originalRelease := releaseDispatchGuard
+		releaseDispatchGuard = func() {
+			releaseOnce.Do(func() {
+				guard.Unlock()
+				originalRelease()
+			})
+		}
+		// The agentctl dispatch callback is the acceptance boundary. Releasing
+		// here keeps terminalization mutually exclusive with admission without
+		// holding the session guard for the rest of the (potentially long) turn.
+		defer releaseDispatchGuard()
 	}
 
 	// Only bounded-ack callers preserve request context; ordinary prompts can take minutes.
@@ -4057,6 +4065,13 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 	onDispatched := s.promptDispatchCallback(
 		promptCtx, taskID, sessionID, rollback.reservedTurn, foregroundDispatch, dispatchOutcome,
 	)
+	if releaseDispatchGuard != nil {
+		originalOnDispatched := onDispatched
+		onDispatched = func() {
+			releaseDispatchGuard()
+			originalOnDispatched()
+		}
+	}
 	result, err := s.executor.PromptWithDispatchCallback(
 		promptCtx, taskID, sessionID, effectivePrompt, attachments, dispatchOnly,
 		onDispatched, session,

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -4054,7 +4054,7 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 			defer cancel()
 			s.rollbackForegroundDispatchOnFailure(failureCtx, taskID, sessionID, foregroundDispatch)
 			s.rollbackPromptClaim(failureCtx, taskID, sessionID, rollback)
-			return nil, errWorkflowAutoStartSessionTerminalized
+			return nil, newWorkflowAutoStartSessionTerminalizedError(fresh)
 		}
 		var releaseOnce sync.Once
 		originalRelease := releaseDispatchGuard
@@ -4215,7 +4215,7 @@ func (s *Service) loadNonterminalWorkflowAutoStartSession(
 		return nil, fmt.Errorf("reload workflow auto-start session: %w", err)
 	}
 	if session == nil || isTerminalSessionState(session.State) {
-		return nil, errWorkflowAutoStartSessionTerminalized
+		return nil, newWorkflowAutoStartSessionTerminalizedError(session)
 	}
 	return session, nil
 }
@@ -4690,7 +4690,7 @@ func (s *Service) claimSessionRunningForPrompt(
 		return nil, "", "", false, nil, errQueuedDispatchSuperseded
 	}
 	if requireNonterminalSession && isTerminalSessionState(freshSession.State) {
-		return nil, "", "", false, nil, errWorkflowAutoStartSessionTerminalized
+		return nil, "", "", false, nil, newWorkflowAutoStartSessionTerminalizedError(freshSession)
 	}
 	if promptErr := s.recheckPromptableWithForegroundClaim(
 		taskID, sessionID, freshSession.State, foregroundClaim,
@@ -4703,7 +4703,7 @@ func (s *Service) claimSessionRunningForPrompt(
 	// loses, so a cancellation landing after the promptability check is visible
 	// here as a terminal state.
 	if requireNonterminalSession && isTerminalSessionState(freshSession.State) {
-		return nil, "", "", false, nil, errWorkflowAutoStartSessionTerminalized
+		return nil, "", "", false, nil, newWorkflowAutoStartSessionTerminalizedError(freshSession)
 	}
 	if isTerminalSessionState(freshSession.State) && freshSession.State != models.TaskSessionStateCompleted {
 		return nil, "", "", false, nil, &executor.SessionStateSupersededError{

--- a/apps/backend/internal/orchestrator/turn_lifecycle_test.go
+++ b/apps/backend/internal/orchestrator/turn_lifecycle_test.go
@@ -536,6 +536,7 @@ func TestReservedTurnAttemptMarkingHoldsCancellationGuard(t *testing.T) {
 			nil,
 			nil,
 			"",
+			false,
 		)
 		claimDone <- err
 	}()

--- a/apps/backend/internal/task/repository/sqlite/postgres_schema_test.go
+++ b/apps/backend/internal/task/repository/sqlite/postgres_schema_test.go
@@ -741,6 +741,55 @@ func TestPostgresSetSessionPrimary_ConcurrentPromotionsLeaveExactlyOnePrimary(t 
 	}
 }
 
+func TestPostgresSetSessionPrimaryIfNonterminalRejectsTerminalAndSerializesPromotions(t *testing.T) {
+	const concurrency = 4
+	db := openIsolatedPostgresMultiConn(t, testutil.PostgresDSNFromEnv(t), concurrency)
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if _, err := db.Exec(db.Rebind(`INSERT INTO tasks (id, workspace_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`), "task-primary-nonterminal-pg", "ws-primary-nonterminal-pg", "Task", now, now); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	terminal := &models.TaskSession{ID: "terminal-primary-pg", TaskID: "task-primary-nonterminal-pg", State: models.TaskSessionStateCompleted}
+	if err := repo.CreateTaskSession(ctx, terminal); err != nil {
+		t.Fatalf("seed terminal session: %v", err)
+	}
+	promoted, err := repo.SetSessionPrimaryIfNonterminal(ctx, terminal.ID)
+	if err != nil || promoted {
+		t.Fatalf("terminal promotion = (%t, %v), want (false, nil)", promoted, err)
+	}
+
+	ids := make([]string, concurrency)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("active-primary-pg-%d", i)
+		if err := repo.CreateTaskSession(ctx, &models.TaskSession{ID: ids[i], TaskID: terminal.TaskID, State: models.TaskSessionStateWaitingForInput}); err != nil {
+			t.Fatalf("seed active session: %v", err)
+		}
+	}
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			ok, promoteErr := repo.SetSessionPrimaryIfNonterminal(ctx, id)
+			if promoteErr != nil || !ok {
+				t.Errorf("promote %s = (%t, %v), want (true, nil)", id, ok, promoteErr)
+			}
+		}(id)
+	}
+	wg.Wait()
+	var count int
+	if err := db.Get(&count, db.Rebind(`SELECT COUNT(*) FROM task_sessions WHERE task_id = ? AND is_primary = 1`), terminal.TaskID); err != nil {
+		t.Fatalf("count primaries: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("primary count = %d, want 1", count)
+	}
+}
+
 // TestPostgresClearRecoveredAgentErrors is the Postgres counterpart to
 // TestClearRecoveredAgentErrorsBackfill. clearRecoveredAgentErrors is built from
 // three dialect-sensitive helpers (jsonColumn, jsonText/timestamp*,

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -3137,22 +3137,43 @@ func (r *Repository) GetPrimarySessionInfoByTaskIDs(ctx context.Context, taskIDs
 // (`SELECT ... FOR UPDATE`) before touching its sessions, so a second
 // concurrent promotion for the same task blocks until the first commits.
 func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) error {
+	_, err := r.setSessionPrimary(ctx, sessionID, false)
+	return err
+}
+
+// SetSessionPrimaryIfNonterminal marks a session primary only while it remains
+// nonterminal. It is used by workflow profile switching so a completed agent
+// cannot be promoted from a stale lookup and have its ACP conversation resumed.
+func (r *Repository) SetSessionPrimaryIfNonterminal(ctx context.Context, sessionID string) (bool, error) {
+	return r.setSessionPrimary(ctx, sessionID, true)
+}
+
+func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, requireNonterminal bool) (bool, error) {
 	now := time.Now().UTC()
 
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// First, get the task_id for this session
+	// First, get the task_id for this session. Postgres also locks the target
+	// row, which serializes this nonterminal check against a concurrent state
+	// transition until the primary-session transaction commits.
 	var taskID string
-	err = tx.QueryRowContext(ctx, r.db.Rebind(`SELECT task_id FROM task_sessions WHERE id = ?`), sessionID).Scan(&taskID)
+	query := `SELECT task_id FROM task_sessions WHERE id = ?`
+	if requireNonterminal {
+		query += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
+	}
+	if dialect.IsPostgres(r.db.DriverName()) {
+		query += ` FOR UPDATE`
+	}
+	err = tx.QueryRowContext(ctx, r.db.Rebind(query), sessionID).Scan(&taskID)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("session not found: %s", sessionID)
+		return primarySessionNotPromoted(sessionID, requireNonterminal)
 	}
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Serialize concurrent promotions for the same task across Postgres
@@ -3162,7 +3183,7 @@ func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) er
 		var lockedTaskID string
 		err := tx.QueryRowContext(ctx, r.db.Rebind(`SELECT id FROM tasks WHERE id = ? FOR UPDATE`), taskID).Scan(&lockedTaskID)
 		if err != nil && err != sql.ErrNoRows {
-			return err
+			return false, err
 		}
 	}
 
@@ -3171,20 +3192,25 @@ func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) er
 		UPDATE task_sessions SET is_primary = 0, updated_at = ? WHERE task_id = ?
 	`), now, taskID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Set primary flag on the specified session
-	result, err := tx.ExecContext(ctx, r.db.Rebind(`
-		UPDATE task_sessions SET is_primary = 1, updated_at = ? WHERE id = ?
-	`), now, sessionID)
+	promoteQuery := `UPDATE task_sessions SET is_primary = 1, updated_at = ? WHERE id = ?`
+	if requireNonterminal {
+		promoteQuery += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
+	}
+	result, err := tx.ExecContext(ctx, r.db.Rebind(promoteQuery), now, sessionID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("session not found: %s", sessionID)
+		return primarySessionNotPromoted(sessionID, requireNonterminal)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -2737,22 +2737,43 @@ func (r *Repository) GetPrimarySessionInfoByTaskIDs(ctx context.Context, taskIDs
 // (`SELECT ... FOR UPDATE`) before touching its sessions, so a second
 // concurrent promotion for the same task blocks until the first commits.
 func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) error {
+	_, err := r.setSessionPrimary(ctx, sessionID, false)
+	return err
+}
+
+// SetSessionPrimaryIfNonterminal marks a session primary only while it remains
+// nonterminal. It is used by workflow profile switching so a completed agent
+// cannot be promoted from a stale lookup and have its ACP conversation resumed.
+func (r *Repository) SetSessionPrimaryIfNonterminal(ctx context.Context, sessionID string) (bool, error) {
+	return r.setSessionPrimary(ctx, sessionID, true)
+}
+
+func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, requireNonterminal bool) (bool, error) {
 	now := time.Now().UTC()
 
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// First, get the task_id for this session
+	// First, get the task_id for this session. Postgres also locks the target
+	// row, which serializes this nonterminal check against a concurrent state
+	// transition until the primary-session transaction commits.
 	var taskID string
-	err = tx.QueryRowContext(ctx, r.db.Rebind(`SELECT task_id FROM task_sessions WHERE id = ?`), sessionID).Scan(&taskID)
+	query := `SELECT task_id FROM task_sessions WHERE id = ?`
+	if requireNonterminal {
+		query += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
+	}
+	if dialect.IsPostgres(r.db.DriverName()) {
+		query += ` FOR UPDATE`
+	}
+	err = tx.QueryRowContext(ctx, r.db.Rebind(query), sessionID).Scan(&taskID)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("session not found: %s", sessionID)
+		return primarySessionNotPromoted(sessionID, requireNonterminal)
 	}
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Serialize concurrent promotions for the same task across Postgres
@@ -2762,7 +2783,7 @@ func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) er
 		var lockedTaskID string
 		err := tx.QueryRowContext(ctx, r.db.Rebind(`SELECT id FROM tasks WHERE id = ? FOR UPDATE`), taskID).Scan(&lockedTaskID)
 		if err != nil && err != sql.ErrNoRows {
-			return err
+			return false, err
 		}
 	}
 
@@ -2771,20 +2792,25 @@ func (r *Repository) SetSessionPrimary(ctx context.Context, sessionID string) er
 		UPDATE task_sessions SET is_primary = 0, updated_at = ? WHERE task_id = ?
 	`), now, taskID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Set primary flag on the specified session
-	result, err := tx.ExecContext(ctx, r.db.Rebind(`
-		UPDATE task_sessions SET is_primary = 1, updated_at = ? WHERE id = ?
-	`), now, sessionID)
+	promoteQuery := `UPDATE task_sessions SET is_primary = 1, updated_at = ? WHERE id = ?`
+	if requireNonterminal {
+		promoteQuery += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
+	}
+	result, err := tx.ExecContext(ctx, r.db.Rebind(promoteQuery), now, sessionID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("session not found: %s", sessionID)
+		return primarySessionNotPromoted(sessionID, requireNonterminal)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -3157,17 +3157,11 @@ func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, re
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// First, get the task_id for this session. Postgres also locks the target
-	// row, which serializes this nonterminal check against a concurrent state
-	// transition until the primary-session transaction commits.
+	// First, get the task_id for this session. Do not lock the target row here:
+	// every primary promotion must take the owning task lock first so concurrent
+	// promotions keep one lock order.
 	var taskID string
 	query := `SELECT task_id FROM task_sessions WHERE id = ?`
-	if requireNonterminal {
-		query += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
-	}
-	if dialect.IsPostgres(r.db.DriverName()) {
-		query += ` FOR UPDATE`
-	}
 	err = tx.QueryRowContext(ctx, r.db.Rebind(query), sessionID).Scan(&taskID)
 	if err == sql.ErrNoRows {
 		return primarySessionNotPromoted(sessionID, requireNonterminal)
@@ -3184,6 +3178,19 @@ func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, re
 		err := tx.QueryRowContext(ctx, r.db.Rebind(`SELECT id FROM tasks WHERE id = ? FOR UPDATE`), taskID).Scan(&lockedTaskID)
 		if err != nil && err != sql.ErrNoRows {
 			return false, err
+		}
+	}
+
+	// Once the task lock is held, lock and validate the target row before
+	// promoting it. This serializes the nonterminal check with a concurrent
+	// state transition without reversing the task -> session lock order above.
+	if requireNonterminal {
+		valid, err := r.lockNonterminalPrimarySession(ctx, tx, sessionID)
+		if err != nil {
+			return false, err
+		}
+		if !valid {
+			return false, nil
 		}
 	}
 

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -2757,17 +2757,11 @@ func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, re
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// First, get the task_id for this session. Postgres also locks the target
-	// row, which serializes this nonterminal check against a concurrent state
-	// transition until the primary-session transaction commits.
+	// First, get the task_id for this session. Do not lock the target row here:
+	// every primary promotion must take the owning task lock first so concurrent
+	// promotions keep one lock order.
 	var taskID string
 	query := `SELECT task_id FROM task_sessions WHERE id = ?`
-	if requireNonterminal {
-		query += ` AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
-	}
-	if dialect.IsPostgres(r.db.DriverName()) {
-		query += ` FOR UPDATE`
-	}
 	err = tx.QueryRowContext(ctx, r.db.Rebind(query), sessionID).Scan(&taskID)
 	if err == sql.ErrNoRows {
 		return primarySessionNotPromoted(sessionID, requireNonterminal)
@@ -2784,6 +2778,19 @@ func (r *Repository) setSessionPrimary(ctx context.Context, sessionID string, re
 		err := tx.QueryRowContext(ctx, r.db.Rebind(`SELECT id FROM tasks WHERE id = ? FOR UPDATE`), taskID).Scan(&lockedTaskID)
 		if err != nil && err != sql.ErrNoRows {
 			return false, err
+		}
+	}
+
+	// Once the task lock is held, lock and validate the target row before
+	// promoting it. This serializes the nonterminal check with a concurrent
+	// state transition without reversing the task -> session lock order above.
+	if requireNonterminal {
+		valid, err := r.lockNonterminalPrimarySession(ctx, tx, sessionID)
+		if err != nil {
+			return false, err
+		}
+		if !valid {
+			return false, nil
 		}
 	}
 

--- a/apps/backend/internal/task/repository/sqlite/session_primary.go
+++ b/apps/backend/internal/task/repository/sqlite/session_primary.go
@@ -1,0 +1,10 @@
+package sqlite
+
+import "fmt"
+
+func primarySessionNotPromoted(sessionID string, requireNonterminal bool) (bool, error) {
+	if requireNonterminal {
+		return false, nil
+	}
+	return false, fmt.Errorf("session not found: %s", sessionID)
+}

--- a/apps/backend/internal/task/repository/sqlite/session_primary.go
+++ b/apps/backend/internal/task/repository/sqlite/session_primary.go
@@ -1,10 +1,31 @@
 package sqlite
 
-import "fmt"
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/db/dialect"
+)
 
 func primarySessionNotPromoted(sessionID string, requireNonterminal bool) (bool, error) {
 	if requireNonterminal {
 		return false, nil
 	}
 	return false, fmt.Errorf("session not found: %s", sessionID)
+}
+
+func (r *Repository) lockNonterminalPrimarySession(ctx context.Context, tx *sqlx.Tx, sessionID string) (bool, error) {
+	query := `SELECT id FROM task_sessions WHERE id = ? AND state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')`
+	if dialect.IsPostgres(r.db.DriverName()) {
+		query += ` FOR UPDATE`
+	}
+	var lockedSessionID string
+	err := tx.QueryRowContext(ctx, r.db.Rebind(query), sessionID).Scan(&lockedSessionID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return true, err
 }


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2766/a29fd5e5f515.html)
<!-- kandev-pr-walkthrough-end -->

Workflow re-entry now creates a new session when its target profile has only terminal history, preventing a stale ACP conversation from replaying old routing intent. Nonterminal sessions remain reusable.

## Important Changes

- Excludes completed, failed, and cancelled sessions from automatic workflow reuse, preserving them as history.
- Rejects a workflow auto-start if a reused session becomes terminal after promotion, while retaining manual terminal-session resume behavior.
- Publishes `task.updated` after a successful reused-session promotion so clients receive the new primary session.

## Validation

- Focused normal and race-detector coverage for cancellation during auto-start and implicit profile switching.

- `go test ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `go test ./internal/orchestrator ./internal/orchestrator/messagequeue ./internal/workflow/... -count=1`
- `go test -race ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `make -C apps/backend lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

 -count=1`
- `go test -race ./internal/orchestrator -run 'TestProcessOnEnter(PreservesCancelledReusedSessionTerminalizedAfterPromptClaim|ImplicitProfileSwitchPreservesCancellation)
- `go test ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `go test ./internal/orchestrator ./internal/orchestrator/messagequeue ./internal/workflow/... -count=1`
- `go test -race ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `make -C apps/backend lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2766-bwo7.sprites.app |
| **Commit** | `825952f` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->

 -count=1`

- `go test ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `go test ./internal/orchestrator ./internal/orchestrator/messagequeue ./internal/workflow/... -count=1`
- `go test -race ./internal/orchestrator -run 'TestSwitchSessionForStep_(ReusesNonterminalSession|CreatesFreshSessionWhenCandidateTerminalizesBeforePromotion)$|TestWorkflowAutoStartPromptClaimRejectsSessionTerminalizedAfterPromotion' -count=1`
- `make -C apps/backend lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2766-bwo7.sprites.app |
| **Commit** | `825952f` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->


