### PR TITLE
feat(registry): add kandev-plugin-youtrack

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -50,6 +50,9 @@ plugins:
   - id: kandev-plugin-voice
     repo: kdlbs/kandev-plugin-voice
     categories: [tools]
+  - id: kandev-plugin-youtrack
+    repo: ahmedbally/kandev-plugin-youtrack
+    categories: [integrations]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
## Summary

Adds the YouTrack plugin to the official Kandev plugin registry.

## Plugin

- **Repo:** https://github.com/ahmedbally/kandev-plugin-youtrack
- **Release:** https://github.com/ahmedbally/kandev-plugin-youtrack/releases/tag/v0.1.0
- **Manifest ID:** `kandev-plugin-youtrack`
- **Categories:** `integrations`

## Features

- Per-workspace YouTrack connection config (base URL + permanent token via encrypted vault)
- Issue list dashboard with Jira-identical UI (filters, sort, saved views, cursor pagination, assignee avatars, state badges)
- Issue watchers with background polling, inflight cap, dedup, prompt templates, workflow/step/repo/agent binding
- Task presets with icon picker and `{key}/{url}/{title}/{description}` placeholder templates
- Start task from YouTrack issue (with preset dropdown menu)
- Link YouTrack issue to existing Kandev task (task Link menu)
- Agent tool: `search_issues` (kanban-task surface)
- Inbound webhook handler
- Per-workspace sidebar enabled badge (via `host.setIntegrationEnabled` + registry)
- Enable toggle in section header (via `registerIntegrationSettings({ action })`)
- Native floating Save/Reset bar (via `host.useSettingsSaveContributor`)
- IntegrationAuthStatusBanner for connection health

## Compatibility

Requires Kandev >= 0.89.0 (the plugin integration settings API from PR #2736).

## Motivation

This plugin was built to validate and exercise the plugin integration settings API contributed in #2736. It serves as the reference implementation for third-party integration plugins.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

