### PR TITLE
fix(web): scope Quick Chat's Escape guards to their own composer/dialog

### DIFF
--- a/apps/web/components/quick-chat/quick-chat-modal.test.tsx
+++ b/apps/web/components/quick-chat/quick-chat-modal.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
@@ -98,7 +98,15 @@ vi.mock("./quick-chat-delete-dialog", () => ({
 
 function EscapeGuardProbe() {
   const [guarded, setGuarded] = useState(false);
-  useClarificationEscapeGuard(guarded);
+  // A stand-in for a real handled/in-scope/unmodified Escape: the toggle
+  // simulates whichever widget-side condition (enabled, target-in-scope, no
+  // modifier) is currently true, and the dialog must consult the predicate
+  // itself rather than a value it derived some other way. Memoized like a
+  // real caller (e.g. clarification-input-overlay.tsx's useEscapeGuardRegistration)
+  // must -- an inline closure would be a fresh reference every render, and the
+  // hook's effect re-running every render would re-register in a loop.
+  const predicate = useCallback(() => guarded, [guarded]);
+  useClarificationEscapeGuard(predicate);
   return (
     <div data-testid="quick-chat-session-view">
       <button

--- a/apps/web/components/quick-chat/quick-chat-modal.tsx
+++ b/apps/web/components/quick-chat/quick-chat-modal.tsx
@@ -15,7 +15,10 @@ import { QuickTabAddMenu } from "./quick-tab-add-menu";
 import { QuickChatSetup } from "./quick-chat-setup";
 import { useQuickChatModal } from "./use-quick-chat-modal";
 import { useQuickChatWidth } from "@/hooks/use-quick-chat-width";
-import { ClarificationEscapeGuardProvider } from "@/hooks/use-clarification-escape-guard";
+import {
+  ClarificationEscapeGuardProvider,
+  type ClarificationEscapeGuardEntry,
+} from "@/hooks/use-clarification-escape-guard";
 import { ConfigChatSetup } from "@/components/config-chat/config-chat-setup";
 import { useConfigChat } from "@/components/config-chat/use-config-chat";
 import type { QuickChatSession, QuickTerminalTab } from "@/lib/state/slices/ui/types";
@@ -241,9 +244,10 @@ export const QuickChatModal = memo(function QuickChatModal({ workspaceId }: Quic
   const quickChat = useQuickChatModal(workspaceId, configChat.reset);
   const setQuickChatInitialPrompt = useAppStore((state) => state.setQuickChatInitialPrompt);
   const { width, leftResizeHandleProps, rightResizeHandleProps } = useQuickChatWidth();
-  const [clarificationEscapeGuarded, setClarificationEscapeGuarded] = useState(false);
+  const [clarificationEscapeGuard, setClarificationEscapeGuard] =
+    useState<ClarificationEscapeGuardEntry>(null);
   return (
-    <ClarificationEscapeGuardProvider value={setClarificationEscapeGuarded}>
+    <ClarificationEscapeGuardProvider value={setClarificationEscapeGuard}>
       <Dialog open={quickChat.isOpen} onOpenChange={quickChat.handleOpenChange}>
         <DialogContent
           className="!left-0 !top-0 !h-dvh !max-h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 flex flex-col gap-0 p-0 pt-safe pb-safe shadow-2xl sm:!left-1/2 sm:!top-1/2 sm:!h-[85vh] sm:!max-h-[85vh] sm:!w-[var(--quick-chat-width)] sm:!max-w-[calc(100vw-2rem)] sm:!-translate-x-1/2 sm:!-translate-y-1/2"
@@ -251,10 +255,14 @@ export const QuickChatModal = memo(function QuickChatModal({ workspaceId }: Quic
           showCloseButton={false}
           overlayClassName="bg-black/20"
           onEscapeKeyDown={(event) => {
-            // A pending, expanded clarification collapses first; the modal
-            // stays open. A second Escape (now unguarded) closes it, matching
-            // the main task chat panel's two-stage Escape after #2729.
-            if (clarificationEscapeGuarded) event.preventDefault();
+            // A pending, expanded clarification collapses first and the modal
+            // stays open -- but only when the clarification's own Escape
+            // handler will actually act on this exact keydown (matching its
+            // enabled/scope/modifier state), so Escape never goes silently
+            // swallowed with nothing left to handle it. A second Escape (now
+            // unguarded) closes the modal, matching the main task chat
+            // panel's two-stage Escape after #2729.
+            if (clarificationEscapeGuard?.test(event)) event.preventDefault();
           }}
         >
           <DialogTitle className="sr-only">{t("common:commandQuickChat")}</DialogTitle>

--- a/apps/web/components/quick-chat/quick-chat-modal.tsx
+++ b/apps/web/components/quick-chat/quick-chat-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, type CSSProperties } from "react";
+import { memo, useMemo, useRef, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { Dialog, DialogContent, DialogTitle } from "@kandev/ui/dialog";
 import { Button } from "@kandev/ui/button";
@@ -17,7 +17,8 @@ import { useQuickChatModal } from "./use-quick-chat-modal";
 import { useQuickChatWidth } from "@/hooks/use-quick-chat-width";
 import {
   ClarificationEscapeGuardProvider,
-  type ClarificationEscapeGuardEntry,
+  type ClarificationEscapePredicate,
+  type ClarificationEscapeGuardRegistry,
 } from "@/hooks/use-clarification-escape-guard";
 import { ConfigChatSetup } from "@/components/config-chat/config-chat-setup";
 import { useConfigChat } from "@/components/config-chat/use-config-chat";
@@ -244,10 +245,21 @@ export const QuickChatModal = memo(function QuickChatModal({ workspaceId }: Quic
   const quickChat = useQuickChatModal(workspaceId, configChat.reset);
   const setQuickChatInitialPrompt = useAppStore((state) => state.setQuickChatInitialPrompt);
   const { width, leftResizeHandleProps, rightResizeHandleProps } = useQuickChatWidth();
-  const [clarificationEscapeGuard, setClarificationEscapeGuard] =
-    useState<ClarificationEscapeGuardEntry>(null);
+  // A ref, not state: several widgets (a pending clarification, an open
+  // suggestion popup, the reverse-search overlay) can be registered at once
+  // and none of their register/unregister calls should trigger a re-render of
+  // the modal itself -- onEscapeKeyDown reads the live map only when Escape
+  // actually fires.
+  const escapeGuardsRef = useRef(new Map<string, ClarificationEscapePredicate>());
+  const escapeGuardRegistry = useMemo<ClarificationEscapeGuardRegistry>(
+    () => ({
+      register: (id, predicate) => escapeGuardsRef.current.set(id, predicate),
+      unregister: (id) => escapeGuardsRef.current.delete(id),
+    }),
+    [],
+  );
   return (
-    <ClarificationEscapeGuardProvider value={setClarificationEscapeGuard}>
+    <ClarificationEscapeGuardProvider value={escapeGuardRegistry}>
       <Dialog open={quickChat.isOpen} onOpenChange={quickChat.handleOpenChange}>
         <DialogContent
           className="!left-0 !top-0 !h-dvh !max-h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 flex flex-col gap-0 p-0 pt-safe pb-safe shadow-2xl sm:!left-1/2 sm:!top-1/2 sm:!h-[85vh] sm:!max-h-[85vh] sm:!w-[var(--quick-chat-width)] sm:!max-w-[calc(100vw-2rem)] sm:!-translate-x-1/2 sm:!-translate-y-1/2"
@@ -255,14 +267,21 @@ export const QuickChatModal = memo(function QuickChatModal({ workspaceId }: Quic
           showCloseButton={false}
           overlayClassName="bg-black/20"
           onEscapeKeyDown={(event) => {
-            // A pending, expanded clarification collapses first and the modal
-            // stays open -- but only when the clarification's own Escape
-            // handler will actually act on this exact keydown (matching its
-            // enabled/scope/modifier state), so Escape never goes silently
-            // swallowed with nothing left to handle it. A second Escape (now
-            // unguarded) closes the modal, matching the main task chat
-            // panel's two-stage Escape after #2729.
-            if (clarificationEscapeGuard?.test(event)) event.preventDefault();
+            // A pending, expanded clarification (or an open suggestion popup,
+            // or the reverse-search overlay) handles this Escape itself and
+            // the modal stays open -- but only when that widget's own guard
+            // predicate reports it will actually act on this exact keydown
+            // (matching its enabled/scope/modifier state), so Escape never
+            // goes silently swallowed with nothing left to handle it. Once no
+            // guard claims it (e.g. a second, now-unguarded Escape), the modal
+            // closes, matching the main task chat panel's two-stage Escape
+            // after #2729.
+            for (const test of escapeGuardsRef.current.values()) {
+              if (test(event)) {
+                event.preventDefault();
+                break;
+              }
+            }
           }}
         >
           <DialogTitle className="sr-only">{t("common:commandQuickChat")}</DialogTitle>

--- a/apps/web/components/task/chat/clarification-input-overlay.test.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.test.tsx
@@ -5,6 +5,7 @@ import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/li
 import {
   ClarificationEscapeGuardProvider,
   type ClarificationEscapeGuardEntry,
+  type ClarificationEscapeGuardRegistry,
 } from "@/hooks/use-clarification-escape-guard";
 import { ClarificationInputOverlay } from "./clarification-input-overlay";
 
@@ -142,13 +143,19 @@ function renderOverlayWithGuard(messages: Message[]) {
   const onDismiss = vi.fn();
   // A holder object, not a reassigned `let`, so TS doesn't narrow the read
   // in getGuard() to the initializer's type across the closure boundary.
+  // ClarificationInputOverlay is the only registrant in this test tree, so a
+  // single-slot holder still faithfully mirrors what it registered.
   const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
+  const registry: ClarificationEscapeGuardRegistry = {
+    register: (_id, predicate) => {
+      holder.entry = { test: predicate };
+    },
+    unregister: () => {
+      holder.entry = null;
+    },
+  };
   render(
-    <ClarificationEscapeGuardProvider
-      value={(entry) => {
-        holder.entry = entry;
-      }}
-    >
+    <ClarificationEscapeGuardProvider value={registry}>
       {/* Stands in for the Quick Chat tab bar / resize handles: rendered
           inside the dialog but outside the clarification's shortcut scope. */}
       <button ref={outsideRef} type="button">

--- a/apps/web/components/task/chat/clarification-input-overlay.test.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.test.tsx
@@ -2,6 +2,10 @@ import { createRef } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
+import {
+  ClarificationEscapeGuardProvider,
+  type ClarificationEscapeGuardEntry,
+} from "@/hooks/use-clarification-escape-guard";
 import { ClarificationInputOverlay } from "./clarification-input-overlay";
 
 vi.mock("@/lib/config", () => ({
@@ -117,6 +121,95 @@ describe("ClarificationInputOverlay — Escape key", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+function fakeEscape(target: EventTarget): KeyboardEvent {
+  return {
+    key: "Escape",
+    target,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+  } as unknown as KeyboardEvent;
+}
+
+function renderOverlayWithGuard(messages: Message[]) {
+  const scopeRef = createRef<HTMLDivElement>();
+  const outsideRef = createRef<HTMLButtonElement>();
+  const composerRef = createRef<HTMLInputElement>();
+  const onDismiss = vi.fn();
+  // A holder object, not a reassigned `let`, so TS doesn't narrow the read
+  // in getGuard() to the initializer's type across the closure boundary.
+  const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
+  render(
+    <ClarificationEscapeGuardProvider
+      value={(entry) => {
+        holder.entry = entry;
+      }}
+    >
+      {/* Stands in for the Quick Chat tab bar / resize handles: rendered
+          inside the dialog but outside the clarification's shortcut scope. */}
+      <button ref={outsideRef} type="button">
+        outside
+      </button>
+      <div ref={scopeRef} tabIndex={-1}>
+        {/* Stands in for the message composer: an editable control inside
+            the shortcut scope, which is where focus ordinarily sits right
+            after sending the message that triggered the clarification. */}
+        <input ref={composerRef} />
+        <ClarificationInputOverlay
+          messages={messages}
+          onResolved={vi.fn()}
+          onDismiss={onDismiss}
+          shortcutScopeRef={scopeRef}
+        />
+      </div>
+    </ClarificationEscapeGuardProvider>,
+  );
+  return { scopeRef, outsideRef, composerRef, onDismiss, getGuard: () => holder.entry };
+}
+
+describe("ClarificationInputOverlay — Escape guard predicate (F1 regression)", () => {
+  it("handles Escape while focus is in the composer (editable, in-scope) -- the ordinary post-send state", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, onDismiss, getGuard } = renderOverlayWithGuard(messages);
+
+    expect(getGuard()?.test(fakeEscape(composerRef.current!))).toBe(true);
+
+    fireEvent.keyDown(composerRef.current!, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not claim Escape when the target is outside the shortcut scope (e.g. the tab bar)", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { outsideRef, onDismiss, getGuard } = renderOverlayWithGuard(messages);
+
+    expect(getGuard()?.test(fakeEscape(outsideRef.current!))).toBe(false);
+
+    fireEvent.keyDown(outsideRef.current!, { key: "Escape" });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not claim Escape while submitting", () => {
+    // Never resolves, so submitState stays "submitting" for the rest of the
+    // test instead of racing a real fetch's microtask resolution.
+    fetchMock.mockImplementationOnce(() => new Promise(() => {}));
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, getGuard } = renderOverlayWithGuard(messages);
+
+    fireEvent.click(screen.getByTestId("clarification-option"));
+
+    expect(getGuard()?.test(fakeEscape(composerRef.current!))).toBe(false);
+  });
+
+  it("does not claim Escape held with a modifier", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, getGuard } = renderOverlayWithGuard(messages);
+
+    const modified = { ...fakeEscape(composerRef.current!), metaKey: true } as KeyboardEvent;
+    expect(getGuard()?.test(modified)).toBe(false);
   });
 });
 

--- a/apps/web/components/task/chat/clarification-input-overlay.test.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.test.tsx
@@ -267,6 +267,60 @@ describe("ClarificationInputOverlay — Escape defaultPrevented guard (F3/F4 reg
   });
 });
 
+// Mirrors quick-chat-modal.tsx's onEscapeKeyDown, itself invoked from Radix's
+// DismissableLayer document-capture listener: runs the guard predicate BEFORE
+// any target/bubble-phase consumer sees the event, so armedEventRef.current
+// really does equal the dispatched event by the time consumers run -- the
+// arrangement the round-4-only defaultPrevented/marker test at line 217
+// cannot produce (no provider there, so the predicate never runs and
+// armedEventRef stays null for every real dispatch).
+function attachCaptureGuard(getGuard: () => ClarificationEscapeGuardEntry) {
+  const onCapture = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+    if (getGuard()?.test(event)) event.preventDefault();
+  };
+  document.addEventListener("keydown", onCapture, true);
+  return () => document.removeEventListener("keydown", onCapture, true);
+}
+
+describe("ClarificationInputOverlay — Quick Chat capture-phase ordering (F6 regression)", () => {
+  it("does not collapse when a consumer claims Escape via stopPropagation, even though the capture-phase guard armed it first (Quick Chat ordering)", () => {
+    // Stands in for one of the F3-fixed consumers (tiptap-entity-reference-suggestion,
+    // token-usage-display, message-history-search): an in-scope bubble-phase
+    // listener between the target and window that calls stopPropagation() once
+    // it claims the key. Unlike the F3 test at line 217 (preventDefault only,
+    // no provider), this one runs the real predicate first via document
+    // capture, so armedEventRef.current === the dispatched event -- the exact
+    // condition under which the defaultPrevented/marker bail-out in
+    // CarouselKeyboardShortcuts.onKey is a no-op (armedEventRef.current !== e
+    // is false). Only the consumer's own stopPropagation() can still protect
+    // the panel here, which is what this test actually proves.
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, scopeRef, onDismiss, getGuard } = renderOverlayWithGuard(messages);
+    const detachGuard = attachCaptureGuard(getGuard);
+    scopeRef.current!.addEventListener("keydown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+
+    fireEvent.keyDown(composerRef.current!, { key: "Escape" });
+    detachGuard();
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does collapse when the capture-phase guard arms the event and nothing downstream claims it (control case)", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, onDismiss, getGuard } = renderOverlayWithGuard(messages);
+    const detachGuard = attachCaptureGuard(getGuard);
+
+    fireEvent.keyDown(composerRef.current!, { key: "Escape" });
+    detachGuard();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("ClarificationInputOverlay — labelled Skip button", () => {
   it("still POSTs a rejection when the Skip button is clicked", async () => {
     const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];

--- a/apps/web/components/task/chat/clarification-input-overlay.test.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.test.tsx
@@ -213,6 +213,60 @@ describe("ClarificationInputOverlay — Escape guard predicate (F1 regression)",
   });
 });
 
+describe("ClarificationInputOverlay — Escape defaultPrevented guard (F3/F4 regression)", () => {
+  it("does not collapse the panel when another in-scope consumer already claimed the Escape", () => {
+    // Stands in for queued-ghost-message's own Escape handler (cancel edit)
+    // or tiptap-suggestion's mention/slash popup close: an in-scope listener
+    // between the target and window that claims the key first. Attached on
+    // scopeRef itself so it fires during the same bubble dispatch before
+    // CarouselKeyboardShortcuts's window listener ever sees the event.
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { onDismiss, scopeRef } = renderOverlay(messages);
+    scopeRef.current!.addEventListener("keydown", (e) => e.preventDefault());
+
+    fireEvent.keyDown(scopeRef.current!, { key: "Escape" });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("still collapses the panel on a plain, unclaimed Escape (no regression from the defaultPrevented check)", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { onDismiss, scopeRef } = renderOverlay(messages);
+
+    fireEvent.keyDown(scopeRef.current!, { key: "Escape" });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("guard predicate returns false for an Escape whose defaultPrevented is already true", () => {
+    const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];
+    const { composerRef, getGuard } = renderOverlayWithGuard(messages);
+
+    const alreadyClaimed = {
+      ...fakeEscape(composerRef.current!),
+      defaultPrevented: true,
+    } as KeyboardEvent;
+
+    expect(getGuard()?.test(alreadyClaimed)).toBe(false);
+  });
+
+  it("does not arm the guard when the active message has no resolvable question meta (F4)", () => {
+    const badMessage: Message = {
+      id: "m-bad",
+      session_id: toSessionId("s1"),
+      task_id: toTaskId("t1"),
+      author_type: "agent",
+      content: "Q",
+      type: "clarification_request",
+      created_at: "2026-05-04T00:00:00Z",
+      metadata: { pending_id: "p1" },
+    };
+    const { composerRef, getGuard } = renderOverlayWithGuard([badMessage]);
+
+    expect(getGuard()?.test(fakeEscape(composerRef.current!))).toBe(false);
+  });
+});
+
 describe("ClarificationInputOverlay — labelled Skip button", () => {
   it("still POSTs a rejection when the Skip button is clicked", async () => {
     const messages = [clarMessage({ id: "m1", questionId: "q1", index: 0, total: 1 })];

--- a/apps/web/components/task/chat/clarification-input-overlay.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.tsx
@@ -80,6 +80,19 @@ function isQuestionAnsweredAt(
   return questionId ? Boolean(answers[questionId]) : false;
 }
 
+function computeAllAnswered(
+  sortedMessages: Message[],
+  answers: Record<string, ClarificationAnswer>,
+): boolean {
+  return (
+    sortedMessages.length > 0 &&
+    sortedMessages.every((m) => {
+      const id = readSingleQuestionMeta(m)?.questionId;
+      return id ? Boolean(answers[id]) : false;
+    })
+  );
+}
+
 type CardProps = {
   meta: SingleQuestionMeta;
   index: number;
@@ -186,23 +199,46 @@ function useResolveCallback(
 // Tells an ancestor dialog (Quick Chat) whether this widget will actually act
 // on a given Escape keydown, so the dialog never swallows an Escape that
 // nothing here is going to handle. Mirrors CarouselKeyboardShortcuts's own
-// gate exactly (enabled, in-scope target, no modifier) instead of a
-// separately-derived approximation that could drift out of sync with it.
+// gate exactly (enabled, in-scope target, no modifier, not already claimed)
+// instead of a separately-derived approximation that could drift out of sync
+// with it.
+//
+// Also records which exact event object this predicate armed. Radix's
+// DismissableLayer intercepts Escape on `document` in the capture phase --
+// before CarouselKeyboardShortcuts's own bubble-phase `window` listener runs
+// -- and the dialog calls event.preventDefault() itself right after this
+// predicate returns true. By the time the window listener sees the event,
+// e.defaultPrevented is therefore already true for every Escape this
+// predicate armed, indistinguishable by flag alone from an unrelated in-scope
+// consumer (cancelling a queued-message edit, closing an @-mention popup)
+// having already claimed it first. The recorded event reference lets the
+// window listener tell those two cases apart: the same object means it was
+// this predicate's own doing.
 function useEscapeGuardRegistration(
   handledHere: boolean,
   shortcutScopeRef: RefObject<HTMLElement | null>,
 ) {
+  const armedEventRef = useRef<KeyboardEvent | null>(null);
   const testEscapeGuard = useCallback(
-    (event: KeyboardEvent) =>
-      handledHere && isWithinScope(event.target, shortcutScopeRef) && !shouldIgnoreEscape(event),
+    (event: KeyboardEvent) => {
+      const armed =
+        handledHere &&
+        isWithinScope(event.target, shortcutScopeRef) &&
+        !shouldIgnoreEscape(event) &&
+        !event.defaultPrevented;
+      if (armed) armedEventRef.current = event;
+      return armed;
+    },
     [handledHere, shortcutScopeRef],
   );
   useClarificationEscapeGuard(testEscapeGuard);
+  return armedEventRef;
 }
 
 type CarouselShortcutArgs = {
   enabled: boolean;
   scopeRef: RefObject<HTMLElement | null>;
+  armedEventRef: RefObject<KeyboardEvent | null>;
   meta: SingleQuestionMeta;
   activeIndex: number;
   total: number;
@@ -259,7 +295,7 @@ function tryHandleMetaEnter(e: KeyboardEvent, canSubmit: boolean, onSubmit: () =
 }
 
 function CarouselKeyboardShortcuts(args: CarouselShortcutArgs) {
-  const { enabled, scopeRef } = args;
+  const { enabled, scopeRef, armedEventRef } = args;
   const optionsCount = args.meta.question.options.length;
   const isLast = args.activeIndex === args.total - 1;
   const { canSubmit, onPick, onPrev, onNext, onDismiss, onSubmit } = args;
@@ -270,6 +306,13 @@ function CarouselKeyboardShortcuts(args: CarouselShortcutArgs) {
       if (tryHandleMetaEnter(e, canSubmit, onSubmit)) return;
       if (e.key === "Escape") {
         if (shouldIgnoreEscape(e)) return;
+        // Bail if some other in-scope consumer (cancelling a queued-message
+        // edit, closing an @-mention/slash-command popup) already claimed
+        // this Escape -- but not if the only thing that claimed it was our
+        // own paired guard predicate (see useEscapeGuardRegistration), which
+        // always runs first and always sets e.defaultPrevented for events it
+        // arms.
+        if (e.defaultPrevented && armedEventRef.current !== e) return;
         e.preventDefault();
         onDismiss();
         return;
@@ -297,6 +340,7 @@ function CarouselKeyboardShortcuts(args: CarouselShortcutArgs) {
   }, [
     enabled,
     scopeRef,
+    armedEventRef,
     optionsCount,
     isLast,
     canSubmit,
@@ -311,6 +355,7 @@ function CarouselKeyboardShortcuts(args: CarouselShortcutArgs) {
 
 type CarouselBodyProps = {
   sortedMessages: Message[];
+  meta: SingleQuestionMeta | null;
   group: ReturnType<typeof useClarificationGroup>;
   activeIndex: number;
   setActiveIndex: (idx: number) => void;
@@ -319,6 +364,7 @@ type CarouselBodyProps = {
   allAnswered: boolean;
   isSubmitting: boolean;
   shortcutScopeRef: RefObject<HTMLElement | null>;
+  armedEventRef: RefObject<KeyboardEvent | null>;
   keyboardShortcutsEnabled: boolean;
   onSubmit: () => void;
   onDismiss: () => void;
@@ -418,6 +464,7 @@ function buildQuestionHandlers(ctx: QuestionHandlerCtx): QuestionHandlers {
 
 function ClarificationCarouselBody({
   sortedMessages,
+  meta,
   group,
   activeIndex,
   setActiveIndex,
@@ -426,13 +473,12 @@ function ClarificationCarouselBody({
   allAnswered,
   isSubmitting,
   shortcutScopeRef,
+  armedEventRef,
   keyboardShortcutsEnabled,
   onSubmit,
   onDismiss,
 }: CarouselBodyProps) {
   const total = sortedMessages.length;
-  const activeMessage = sortedMessages[Math.min(activeIndex, total - 1)] ?? null;
-  const meta = activeMessage ? readSingleQuestionMeta(activeMessage) : null;
   const showAgentDisconnectedAtTop = sortedMessages.some(
     (m) => (m.metadata as ClarificationRequestMetadata | undefined)?.agent_disconnected === true,
   );
@@ -485,6 +531,7 @@ function ClarificationCarouselBody({
       <CarouselKeyboardShortcuts
         enabled={keyboardShortcutsEnabled && !isSubmitting}
         scopeRef={shortcutScopeRef}
+        armedEventRef={armedEventRef}
         meta={meta}
         activeIndex={activeIndex}
         total={total}
@@ -520,6 +567,8 @@ export function ClarificationInputOverlay({
   // messages or shrunk bundles never put us out of range.
   const total = sortedMessages.length;
   const activeIndex = total === 0 ? 0 : Math.min(rawActiveIndex, total - 1);
+  const activeMessage = sortedMessages[activeIndex] ?? null;
+  const meta = activeMessage ? readSingleQuestionMeta(activeMessage) : null;
   const sharedContext = readSharedContext(sortedMessages[0]);
 
   useResolveCallback(group.submitState, onResolved);
@@ -528,18 +577,18 @@ export function ClarificationInputOverlay({
   // memoised by the hook — depend on the function only so this useCallback
   // doesn't churn on every keystroke (via the live-record path).
   const submitCollected = group.submitCollected;
-  const allAnswered =
-    sortedMessages.length > 0 &&
-    sortedMessages.every((m) => {
-      const id = readSingleQuestionMeta(m)?.questionId;
-      return id ? Boolean(group.answers[id]) : false;
-    });
+  const allAnswered = computeAllAnswered(sortedMessages, group.answers);
   const handleSubmit = useCallback(() => {
     if (allAnswered) void submitCollected();
   }, [allAnswered, submitCollected]);
 
-  useEscapeGuardRegistration(
-    keyboardShortcutsEnabled && !isSubmitting && sortedMessages.length > 0,
+  // Gated on the same resolved `meta` that decides whether
+  // ClarificationCarouselBody (and CarouselKeyboardShortcuts within it) mount
+  // at all, not a looser proxy like sortedMessages.length > 0 -- otherwise the
+  // guard could tell the dialog "handledHere" for a state where the widget
+  // that would actually handle Escape never mounted in the first place.
+  const armedEventRef = useEscapeGuardRegistration(
+    keyboardShortcutsEnabled && !isSubmitting && meta !== null,
     shortcutScopeRef,
   );
 
@@ -591,6 +640,7 @@ export function ClarificationInputOverlay({
       )}
       <ClarificationCarouselBody
         sortedMessages={sortedMessages}
+        meta={meta}
         group={group}
         activeIndex={activeIndex}
         setActiveIndex={setActiveIndex}
@@ -599,6 +649,7 @@ export function ClarificationInputOverlay({
         allAnswered={allAnswered}
         isSubmitting={isSubmitting}
         shortcutScopeRef={shortcutScopeRef}
+        armedEventRef={armedEventRef}
         keyboardShortcutsEnabled={keyboardShortcutsEnabled}
         onSubmit={handleSubmit}
         onDismiss={onDismiss}

--- a/apps/web/components/task/chat/clarification-input-overlay.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.tsx
@@ -11,6 +11,7 @@ import type {
   ClarificationQuestion,
 } from "@/lib/types/http";
 import { useClarificationGroup } from "@/hooks/domains/session/use-clarification-group";
+import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
 import {
   ClarificationCarouselNav,
   ClarificationCustomInput,
@@ -182,6 +183,23 @@ function useResolveCallback(
   }, [submitState, onResolved]);
 }
 
+// Tells an ancestor dialog (Quick Chat) whether this widget will actually act
+// on a given Escape keydown, so the dialog never swallows an Escape that
+// nothing here is going to handle. Mirrors CarouselKeyboardShortcuts's own
+// gate exactly (enabled, in-scope target, no modifier) instead of a
+// separately-derived approximation that could drift out of sync with it.
+function useEscapeGuardRegistration(
+  handledHere: boolean,
+  shortcutScopeRef: RefObject<HTMLElement | null>,
+) {
+  const testEscapeGuard = useCallback(
+    (event: KeyboardEvent) =>
+      handledHere && isWithinScope(event.target, shortcutScopeRef) && !shouldIgnoreEscape(event),
+    [handledHere, shortcutScopeRef],
+  );
+  useClarificationEscapeGuard(testEscapeGuard);
+}
+
 type CarouselShortcutArgs = {
   enabled: boolean;
   scopeRef: RefObject<HTMLElement | null>;
@@ -212,6 +230,21 @@ function shouldIgnoreShortcut(e: KeyboardEvent): boolean {
   return e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
 }
 
+// Escape does not insert a character, so unlike the other shortcuts it must
+// still collapse the panel while focus is in the composer or another
+// editable control -- the ordinary state right after sending the message
+// that triggered the clarification. Only an actual modifier combo blocks it.
+function shouldIgnoreEscape(e: KeyboardEvent): boolean {
+  return e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
+}
+
+function isWithinScope(
+  target: EventTarget | null,
+  scopeRef: RefObject<HTMLElement | null>,
+): boolean {
+  return target instanceof Node && Boolean(scopeRef.current?.contains(target));
+}
+
 // tryHandleMetaEnter returns true when the event was Cmd/Ctrl+Enter, so the
 // caller can short-circuit. When focus is inside the custom-text input it
 // returns true *without* invoking onSubmit — the input's own keydown handler
@@ -233,14 +266,15 @@ function CarouselKeyboardShortcuts(args: CarouselShortcutArgs) {
   useEffect(() => {
     if (!enabled) return;
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.target instanceof Node) || !scopeRef.current?.contains(e.target)) return;
+      if (!isWithinScope(e.target, scopeRef)) return;
       if (tryHandleMetaEnter(e, canSubmit, onSubmit)) return;
-      if (shouldIgnoreShortcut(e)) return;
       if (e.key === "Escape") {
+        if (shouldIgnoreEscape(e)) return;
         e.preventDefault();
         onDismiss();
         return;
       }
+      if (shouldIgnoreShortcut(e)) return;
       if (e.key === "ArrowLeft") {
         e.preventDefault();
         onPrev();
@@ -479,6 +513,7 @@ export function ClarificationInputOverlay({
     [messages],
   );
   const group = useClarificationGroup(sortedMessages);
+  const isSubmitting = group.submitState === "submitting";
   const [customDrafts, setCustomDrafts] = useState<Record<string, string>>({});
   const [rawActiveIndex, setActiveIndex] = useState(0);
   // Clamp the active index to the current bundle size so late-arriving
@@ -503,8 +538,12 @@ export function ClarificationInputOverlay({
     if (allAnswered) void submitCollected();
   }, [allAnswered, submitCollected]);
 
+  useEscapeGuardRegistration(
+    keyboardShortcutsEnabled && !isSubmitting && sortedMessages.length > 0,
+    shortcutScopeRef,
+  );
+
   if (sortedMessages.length === 0) return null;
-  const isSubmitting = group.submitState === "submitting";
 
   return (
     <div className="relative" data-testid="clarification-overlay">

--- a/apps/web/components/task/chat/clarification-panel-section.tsx
+++ b/apps/web/components/task/chat/clarification-panel-section.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from "react-i18next";
 import { ClarificationInputOverlay } from "./clarification-input-overlay";
 import { ResizeHandle } from "./resize-handle";
 import { useResizableClarificationOverlay } from "@/hooks/use-resizable-clarification-overlay";
-import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
 import type { ClarificationRequestMetadata, Message } from "@/lib/types/http";
 
 type ClarificationPanelSectionProps = {
@@ -78,11 +77,6 @@ export function ClarificationPanelSection({
   useEffect(() => {
     resetHeight();
   }, [pendingId, resetHeight]);
-
-  // While this panel is expanded and pending, tell an ancestor dialog (Quick
-  // Chat) to swallow Escape instead of closing over it, so the first Escape
-  // collapses the panel like it does in the non-modal task chat panel.
-  useClarificationEscapeGuard(pending && !collapsed);
 
   if (!pending) return null;
 

--- a/apps/web/components/task/chat/message-history-search.test.ts
+++ b/apps/web/components/task/chat/message-history-search.test.ts
@@ -1,7 +1,12 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElement } from "react";
-import { computeStyle, containerPaddingBox, MessageHistorySearch } from "./message-history-search";
+import {
+  computeStyle,
+  containerPaddingBox,
+  type ContainerPaddingBox,
+  MessageHistorySearch,
+} from "./message-history-search";
 
 afterEach(cleanup);
 
@@ -68,15 +73,15 @@ describe("computeStyle", () => {
   it("positions relative to a transformed containing block (Quick Chat's DialogContent) instead of the viewport", () => {
     // DialogContent is centered with a permanent translate, so it does not
     // sit at the viewport origin -- its rect has its own left/top/bottom.
-    const containerRect = new DOMRect(100, 80, 800, 600);
+    const containerBox: ContainerPaddingBox = { left: 100, width: 800, bottom: 680 };
     // Anchor (the composer) is inside that container, still given in
     // viewport coordinates by getBoundingClientRect().
     const anchorRect = new DOMRect(140, 600, 300, 32);
 
-    const style = computeStyle(anchorRect, containerRect);
+    const style = computeStyle(anchorRect, containerBox);
 
-    // Origin-relative: anchorRect.left - containerRect.left, and
-    // containerRect.bottom - anchorRect.top + 8, not viewport-relative.
+    // Origin-relative: anchorRect.left - containerBox.left, and
+    // containerBox.bottom - anchorRect.top + 8, not viewport-relative.
     expect(style).toMatchObject({
       position: "fixed",
       left: 140 - 100,
@@ -88,10 +93,11 @@ describe("computeStyle", () => {
     const anchorRect = new DOMRect(40, 500, 300, 32);
 
     const viewportRelative = computeStyle(anchorRect, null);
-    const explicitViewportOrigin = computeStyle(
-      anchorRect,
-      new DOMRect(0, 0, window.innerWidth, window.innerHeight),
-    );
+    const explicitViewportOrigin = computeStyle(anchorRect, {
+      left: 0,
+      width: window.innerWidth,
+      bottom: window.innerHeight,
+    });
 
     expect(viewportRelative).toEqual(explicitViewportOrigin);
   });

--- a/apps/web/components/task/chat/message-history-search.test.ts
+++ b/apps/web/components/task/chat/message-history-search.test.ts
@@ -1,5 +1,44 @@
-import { describe, expect, it } from "vitest";
-import { computeStyle } from "./message-history-search";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { computeStyle, containerPaddingBox, MessageHistorySearch } from "./message-history-search";
+
+afterEach(cleanup);
+
+describe("containerPaddingBox", () => {
+  it("recovers the padding box by subtracting the border via clientLeft/clientTop", () => {
+    // A container with an 800x600 border box at (100, 80) and a 1px border on
+    // every side -- clientLeft/clientTop/clientWidth/clientHeight are exactly
+    // the values a real element with `border: 1px solid` would report (jsdom
+    // always reports 0 for these, which is why this arithmetic is extracted
+    // into a pure function rather than asserted against a rendered node).
+    const container = {
+      getBoundingClientRect: () => new DOMRect(100, 80, 800, 600),
+      clientLeft: 1,
+      clientTop: 1,
+      clientWidth: 798,
+      clientHeight: 598,
+    };
+
+    expect(containerPaddingBox(container)).toEqual({
+      left: 101,
+      width: 798,
+      bottom: 80 + 1 + 598,
+    });
+  });
+
+  it("matches the border box when there is no border (clientLeft/clientTop are 0)", () => {
+    const container = {
+      getBoundingClientRect: () => new DOMRect(0, 0, 400, 300),
+      clientLeft: 0,
+      clientTop: 0,
+      clientWidth: 400,
+      clientHeight: 300,
+    };
+
+    expect(containerPaddingBox(container)).toEqual({ left: 0, width: 400, bottom: 300 });
+  });
+});
 
 describe("computeStyle", () => {
   it("returns null without an anchor rect", () => {
@@ -55,5 +94,91 @@ describe("computeStyle", () => {
     );
 
     expect(viewportRelative).toEqual(explicitViewportOrigin);
+  });
+});
+
+describe("MessageHistorySearch Escape fallback close (F11)", () => {
+  const history = [{ content: "hello world", entityReferences: [] }];
+  const anchorRect = new DOMRect(40, 500, 300, 32);
+
+  it("closes on Escape when the input itself is the target (baseline, via its own onKeyDown)", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      createElement(MessageHistorySearch, {
+        history,
+        anchorRect,
+        container: document.body,
+        onClose,
+        onSelect: vi.fn(),
+      }),
+    );
+
+    fireEvent.keyDown(getByTestId("history-search-input"), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * F11: tabbing out of the reverse-search input leaves the overlay's only
+   * focusable element unfocused. On Quick Chat, `container` is the Dialog's
+   * own `[data-slot="dialog-content"]` -- unique to this one composer's
+   * modal -- so the fallback listener broadens its ownership check to that
+   * ancestor instead of just the popup's own small div, and still closes the
+   * overlay for an Escape whose target has moved elsewhere in the same
+   * dialog.
+   */
+  it("closes the overlay when focus tabs out to elsewhere in the same modal (container is not document.body)", () => {
+    const dialogContent = document.createElement("div");
+    dialogContent.setAttribute("data-slot", "dialog-content");
+    document.body.appendChild(dialogContent);
+    const somethingElseInTheDialog = document.createElement("button");
+    dialogContent.appendChild(somethingElseInTheDialog);
+    const onClose = vi.fn();
+
+    render(
+      createElement(MessageHistorySearch, {
+        history,
+        anchorRect,
+        container: dialogContent,
+        onClose,
+        onSelect: vi.fn(),
+      }),
+    );
+
+    fireEvent.keyDown(somethingElseInTheDialog, { key: "Escape", bubbles: true, cancelable: true });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(dialogContent);
+  });
+
+  /**
+   * On the main task chat panel, `container` is `document.body` -- claiming
+   * that whole scope would race a second, unrelated overlay mounted
+   * elsewhere on the page (the same cross-composer bug F10 fixed for
+   * suggestion popups). The fallback must stay precise to this popup's own
+   * container in that case, even though it means the literal "tab out of the
+   * input" repro is not fully closed on that one surface.
+   */
+  it("does not react to an Escape targeting an unrelated element when container is document.body", () => {
+    const unrelated = document.createElement("button");
+    document.body.appendChild(unrelated);
+    const onClose = vi.fn();
+
+    render(
+      createElement(MessageHistorySearch, {
+        history,
+        anchorRect,
+        container: document.body,
+        onClose,
+        onSelect: vi.fn(),
+      }),
+    );
+
+    fireEvent.keyDown(unrelated, { key: "Escape", bubbles: true, cancelable: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    document.body.removeChild(unrelated);
   });
 });

--- a/apps/web/components/task/chat/message-history-search.test.ts
+++ b/apps/web/components/task/chat/message-history-search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { computeStyle } from "./message-history-search";
+
+describe("computeStyle", () => {
+  it("returns null without an anchor rect", () => {
+    expect(computeStyle(null, null)).toBeNull();
+  });
+
+  it("positions relative to the viewport when there is no containing block (document.body target)", () => {
+    const anchorRect = new DOMRect(40, 500, 300, 32);
+
+    const style = computeStyle(anchorRect, null);
+
+    expect(style).toMatchObject({
+      position: "fixed",
+      left: 40,
+      bottom: window.innerHeight - 500 + 8,
+    });
+  });
+
+  it("clamps left to the 8px minimum when the anchor sits at the viewport edge", () => {
+    const anchorRect = new DOMRect(-20, 500, 300, 32);
+
+    const style = computeStyle(anchorRect, null);
+
+    expect(style?.left).toBe(8);
+  });
+
+  it("positions relative to a transformed containing block (Quick Chat's DialogContent) instead of the viewport", () => {
+    // DialogContent is centered with a permanent translate, so it does not
+    // sit at the viewport origin -- its rect has its own left/top/bottom.
+    const containerRect = new DOMRect(100, 80, 800, 600);
+    // Anchor (the composer) is inside that container, still given in
+    // viewport coordinates by getBoundingClientRect().
+    const anchorRect = new DOMRect(140, 600, 300, 32);
+
+    const style = computeStyle(anchorRect, containerRect);
+
+    // Origin-relative: anchorRect.left - containerRect.left, and
+    // containerRect.bottom - anchorRect.top + 8, not viewport-relative.
+    expect(style).toMatchObject({
+      position: "fixed",
+      left: 140 - 100,
+      bottom: 680 - 600 + 8,
+    });
+  });
+
+  it("matches the viewport-relative formula when containerRect is null (regression guard for the document.body case)", () => {
+    const anchorRect = new DOMRect(40, 500, 300, 32);
+
+    const viewportRelative = computeStyle(anchorRect, null);
+    const explicitViewportOrigin = computeStyle(
+      anchorRect,
+      new DOMRect(0, 0, window.innerWidth, window.innerHeight),
+    );
+
+    expect(viewportRelative).toEqual(explicitViewportOrigin);
+  });
+});

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -102,24 +102,63 @@ function useScrollSelectedIntoView(
   }, [selectedIndex, listRef]);
 }
 
+export type ContainerPaddingBox = {
+  /** Padding-box left edge, in viewport coordinates. */
+  left: number;
+  /** Padding-box width (border-box width minus both border widths). */
+  width: number;
+  /** Padding-box bottom edge, in viewport coordinates. */
+  bottom: number;
+};
+
+type PaddingBoxSource = {
+  getBoundingClientRect: () => DOMRect;
+  clientLeft: number;
+  clientTop: number;
+  clientWidth: number;
+  clientHeight: number;
+};
+
 /**
- * Position math is relative to `containerRect`, the bounding rect of the
- * portal target, not the viewport. A `document.body` target has no transform
- * of its own, so `containerRect` is null there and the origin collapses to
- * (0, 0, window.innerWidth, window.innerHeight) -- identical to the previous
+ * The containing block a `position: fixed` descendant of a transformed
+ * ancestor resolves against is that ancestor's PADDING box, not its border
+ * box -- `getBoundingClientRect()` alone returns the border box. Quick Chat's
+ * `DialogContent` has a real border (`dialog.tsx`), so using the border box
+ * directly offset the overlay by the border width and left `maxWidth` short
+ * by twice it. `clientLeft`/`clientTop` are exactly the container's own
+ * border widths, so subtracting them (via the border-box rect) recovers the
+ * padding box. Takes a minimal structural source rather than `Element` so the
+ * arithmetic is unit-testable without a real layout engine (jsdom always
+ * reports 0 for client* metrics, which would silently hide this bug).
+ */
+export function containerPaddingBox(container: PaddingBoxSource): ContainerPaddingBox {
+  const rect = container.getBoundingClientRect();
+  return {
+    left: rect.left + container.clientLeft,
+    width: container.clientWidth,
+    bottom: rect.top + container.clientTop + container.clientHeight,
+  };
+}
+
+/**
+ * Position math is relative to `containerBox`, the padding box of the portal
+ * target, not the viewport. A `document.body` target has no transform of its
+ * own, so `containerBox` is null there and the origin collapses to (0, 0,
+ * window.innerWidth, window.innerHeight) -- identical to the previous
  * viewport-relative formula. Quick Chat's DialogContent carries a permanent
  * `translate` for centering, which establishes a new containing block for
  * `position: fixed` descendants portaled inside it, so once the overlay
- * renders there its rect must be computed relative to that ancestor instead.
+ * renders there its rect must be computed relative to that ancestor's padding
+ * box instead (see `containerPaddingBox` above).
  */
 export function computeStyle(
   anchorRect: DOMRect | null,
-  containerRect: DOMRect | null,
+  containerBox: ContainerPaddingBox | null,
 ): React.CSSProperties | null {
   if (!anchorRect) return null;
-  const originLeft = containerRect?.left ?? 0;
-  const originWidth = containerRect?.width ?? window.innerWidth;
-  const originBottom = containerRect?.bottom ?? window.innerHeight;
+  const originLeft = containerBox?.left ?? 0;
+  const originWidth = containerBox?.width ?? window.innerWidth;
+  const originBottom = containerBox?.bottom ?? window.innerHeight;
   const left = Math.max(8, anchorRect.left - originLeft);
   const maxWidth = Math.min(OVERLAY_MAX_WIDTH, Math.max(200, originWidth - left - 8));
   return {
@@ -131,6 +170,57 @@ export function computeStyle(
     zIndex: 60,
     pointerEvents: "auto",
   };
+}
+
+// Fallback close, independent of exact focus. The input's own onKeyDown
+// (below, in MessageHistorySearch) handles the common case, but nothing else
+// closes the overlay if focus ever leaves the input while staying inside the
+// overlay (there is no blur handler on this popup). Without this, Quick
+// Chat's `CLAIM_ANY_ESCAPE` registration (tiptap-input.tsx's
+// useReverseSearchOverlay) still suppresses Radix's auto-dismiss, but nothing
+// then closes the overlay, so Escape goes silently inert. `document`-level
+// listeners run before `window`-level ones in native bubble order, so this
+// also runs ahead of the clarification carousel's `window` listener --
+// fixing the "collapses the clarification instead of closing the overlay"
+// case that could otherwise occur depending on escape-guard registration
+// order.
+//
+// Ownership is checked against this popup's own `containerRef` first (the
+// precise case), then against `container` (the portal target) as a fallback
+// -- but ONLY when `container` is a modal's `[data-slot="dialog-content"]`,
+// not `document.body`. On Quick Chat that ancestor is unique to this one
+// composer's dialog, so it still catches focus that tabs out of the input to
+// elsewhere in the same dialog (the literal "tab out of the input" repro --
+// the reverse-search input is the overlay's only focusable element, so
+// tabbing away always leaves `containerRef`). Using `container` when it's
+// `document.body` would instead claim the entire document for whichever
+// composer's listener happens to be registered first, mishandling Escape for
+// a second, unrelated overlay -- the same cross-composer bug F10 fixed for
+// suggestion popups (see use-suggestion-escape-fallback.ts).
+function useReverseSearchEscapeFallback(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  container: Element,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const el = containerRef.current;
+      if (!el) return;
+      const target = event.target as Node | null;
+      const active = document.activeElement;
+      const ownedByPopup = (target && el.contains(target)) || (active && el.contains(active));
+      const ownedByDialog =
+        container !== document.body &&
+        ((target && container.contains(target)) || (active && container.contains(active)));
+      if (!ownedByPopup && !ownedByDialog) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose, container, containerRef]);
 }
 
 export function MessageHistorySearch({
@@ -163,11 +253,12 @@ export function MessageHistorySearch({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [onClose]);
 
+  useReverseSearchEscapeFallback(containerRef, container, onClose);
   useScrollSelectedIntoView(selectedIndex, listRef);
 
   if (typeof document === "undefined") return null;
-  const containerRect = container === document.body ? null : container.getBoundingClientRect();
-  const style = computeStyle(anchorRect, containerRect);
+  const containerBox = container === document.body ? null : containerPaddingBox(container);
+  const style = computeStyle(anchorRect, containerBox);
   if (!style) return null;
 
   const overlay = (

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -77,6 +77,10 @@ function handleOverlayKeyDown(event: React.KeyboardEvent, args: OverlayKeyArgs) 
   }
   if (event.key === "Escape") {
     event.preventDefault();
+    // Claim the key here: once the reverse-search overlay is closed, nothing
+    // further up the tree (e.g. a clarification panel's own
+    // Escape-collapses handler) should also react to the same keypress.
+    event.stopPropagation();
     onClose();
   }
 }

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -15,6 +15,11 @@ type MessageHistorySearchProps = {
   /** Bottom-anchor rect (typically the chat input's bounding rect). The
    *  overlay positions itself directly above this rect. */
   anchorRect: DOMRect | null;
+  /** DOM node to portal the overlay into. On the main task chat panel this is
+   *  `document.body`; on Quick Chat it must be a node inside the Dialog's
+   *  FocusScope (e.g. `[data-slot="dialog-content"]`) or the Dialog's focus
+   *  trap reverts focus away from this overlay's input on every render. */
+  container: Element;
   onClose: () => void;
   /** Invoked when the user picks a result. `index` is the position in
    *  `history` so the editor's history navigation can resume from there. */
@@ -97,15 +102,31 @@ function useScrollSelectedIntoView(
   }, [selectedIndex, listRef]);
 }
 
-function computeStyle(anchorRect: DOMRect | null): React.CSSProperties | null {
+/**
+ * Position math is relative to `containerRect`, the bounding rect of the
+ * portal target, not the viewport. A `document.body` target has no transform
+ * of its own, so `containerRect` is null there and the origin collapses to
+ * (0, 0, window.innerWidth, window.innerHeight) -- identical to the previous
+ * viewport-relative formula. Quick Chat's DialogContent carries a permanent
+ * `translate` for centering, which establishes a new containing block for
+ * `position: fixed` descendants portaled inside it, so once the overlay
+ * renders there its rect must be computed relative to that ancestor instead.
+ */
+export function computeStyle(
+  anchorRect: DOMRect | null,
+  containerRect: DOMRect | null,
+): React.CSSProperties | null {
   if (!anchorRect) return null;
-  const left = Math.max(8, anchorRect.left);
-  const maxWidth = Math.min(OVERLAY_MAX_WIDTH, Math.max(200, window.innerWidth - left - 8));
+  const originLeft = containerRect?.left ?? 0;
+  const originWidth = containerRect?.width ?? window.innerWidth;
+  const originBottom = containerRect?.bottom ?? window.innerHeight;
+  const left = Math.max(8, anchorRect.left - originLeft);
+  const maxWidth = Math.min(OVERLAY_MAX_WIDTH, Math.max(200, originWidth - left - 8));
   return {
     position: "fixed",
     left,
     width: Math.min(maxWidth, anchorRect.width || maxWidth),
-    bottom: window.innerHeight - anchorRect.top + 8,
+    bottom: originBottom - anchorRect.top + 8,
     maxHeight: OVERLAY_HEIGHT,
     zIndex: 60,
     pointerEvents: "auto",
@@ -116,6 +137,7 @@ export function MessageHistorySearch({
   history,
   isLoadingOlder = false,
   anchorRect,
+  container,
   onClose,
   onSelect,
 }: MessageHistorySearchProps) {
@@ -144,7 +166,8 @@ export function MessageHistorySearch({
   useScrollSelectedIntoView(selectedIndex, listRef);
 
   if (typeof document === "undefined") return null;
-  const style = computeStyle(anchorRect);
+  const containerRect = container === document.body ? null : container.getBoundingClientRect();
+  const style = computeStyle(anchorRect, containerRect);
   if (!style) return null;
 
   const overlay = (
@@ -202,5 +225,5 @@ export function MessageHistorySearch({
     </div>
   );
 
-  return createPortal(overlay, document.body);
+  return createPortal(overlay, container);
 }

--- a/apps/web/components/task/chat/queued-ghost-message.test.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.test.tsx
@@ -3,6 +3,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { QueuedGhostMessage, canMergeEntry, canMergeWithAbove } from "./queued-ghost-message";
 import { StateProvider } from "@/components/state-provider";
 import { ToastProvider } from "@/components/toast-provider";
+import {
+  ClarificationEscapeGuardProvider,
+  type ClarificationEscapeGuardEntry,
+  type ClarificationEscapeGuardRegistry,
+} from "@/hooks/use-clarification-escape-guard";
 import { entityReferenceMarkdown } from "@/lib/entity-references/message-references";
 import type { EntityReference } from "@/lib/types/entity-reference";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
@@ -79,6 +84,22 @@ function renderWithProviders(node: React.ReactNode) {
       <ToastProvider>{node}</ToastProvider>
     </StateProvider>,
   );
+}
+
+function withEscapeGuardRegistry(node: React.ReactNode) {
+  const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
+  const registry: ClarificationEscapeGuardRegistry = {
+    register: (_id, predicate) => {
+      holder.entry = { test: predicate };
+    },
+    unregister: () => {
+      holder.entry = null;
+    },
+  };
+  render(
+    <ClarificationEscapeGuardProvider value={registry}>{node}</ClarificationEscapeGuardProvider>,
+  );
+  return holder;
 }
 
 describe("QueuedGhostMessage reorder handle", () => {
@@ -174,6 +195,18 @@ describe("QueuedGhostMessage reorder handle", () => {
     renderRow({ queued_by: "user-1" }, { canEdit: true });
     fireEvent.click(screen.getByTestId(EDIT_TESTID));
     expect(screen.queryByTestId(HANDLE_TESTID)).toBeNull();
+  });
+});
+
+describe("QueuedGhostMessage Escape handling", () => {
+  it("claims Escape at dialog capture time while editing", () => {
+    const holder = withEscapeGuardRegistry(
+      <QueuedGhostMessage entry={entry()} canEdit onSave={async () => {}} onRemove={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByTestId(EDIT_TESTID));
+
+    expect(holder.entry?.test(new KeyboardEvent("keydown", { key: "Escape" }))).toBe(true);
   });
 });
 

--- a/apps/web/components/task/chat/queued-ghost-message.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.tsx
@@ -192,6 +192,10 @@ function EditView({
   const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
+      // Claim the key here: once this edit is cancelled, nothing further up
+      // the tree (e.g. a clarification panel's own Escape-collapses handler)
+      // should also react to the same keypress.
+      event.stopPropagation();
       onCancel();
     } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();

--- a/apps/web/components/task/chat/queued-ghost-message.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.tsx
@@ -42,6 +42,7 @@ import { buildEntityReferenceMarkdownComponents } from "@/components/task/chat/m
 import { QueuedGhostRowActions } from "@/components/task/chat/queued-ghost-row-actions";
 import { AttachmentRow, type QueuedAttachment } from "@/components/task/chat/queued-attachment-row";
 import { t } from "@/lib/i18n";
+import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
 
 /** Imperative handle for the ghost row, used by chat input "edit last queued" affordance. */
 export type QueuedGhostMessageHandle = {
@@ -511,6 +512,29 @@ function useFocusQueuedEdit(
   }, [editing, textareaRef]);
 }
 
+function useQueuedGhostEditEscapeGuard(
+  editing: boolean,
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>,
+): void {
+  const editEscapeGuard = useCallback(
+    (event: KeyboardEvent) => {
+      if (!editing || event.key !== "Escape") return false;
+      const textarea = textareaRef.current;
+      if (!textarea) return false;
+      const target = event.target;
+      return (
+        target === textarea ||
+        (target instanceof Node && textarea.contains(target)) ||
+        document.activeElement === textarea
+      );
+    },
+    [editing, textareaRef],
+  );
+  // Radix dialogs inspect Escape during document capture, before the
+  // textarea's bubble-phase handler can cancel the edit.
+  useClarificationEscapeGuard(editing ? editEscapeGuard : null);
+}
+
 type QueuedGhostSaveArgs = {
   value: string;
   entryContent: string;
@@ -584,6 +608,7 @@ export const QueuedGhostMessage = forwardRef<QueuedGhostMessageHandle, QueuedGho
     const [value, setValue] = useState(entry.content);
     const [saving, setSaving] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    useQueuedGhostEditEscapeGuard(editing, textareaRef);
     const entityReferences = useMemo(
       () => entityReferencesFromMetadata(entry.metadata),
       [entry.metadata],

--- a/apps/web/components/task/chat/suggestion-menu-state.test.ts
+++ b/apps/web/components/task/chat/suggestion-menu-state.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getSuggestionMenuOpenState } from "./suggestion-menu-state";
+
+describe("composer suggestion menu state", () => {
+  it("keeps an empty mention menu open for Escape handling", () => {
+    expect(
+      getSuggestionMenuOpenState({
+        mentionIsOpen: true,
+        slashIsOpen: false,
+        slashItemCount: 0,
+        entityReferenceMenuOpen: false,
+      }),
+    ).toEqual({ mentionMenuOpen: true, slashMenuOpen: false, isSuggestionMenuOpen: true });
+  });
+});

--- a/apps/web/components/task/chat/suggestion-menu-state.ts
+++ b/apps/web/components/task/chat/suggestion-menu-state.ts
@@ -1,0 +1,22 @@
+export function getSuggestionMenuOpenState({
+  mentionIsOpen,
+  slashIsOpen,
+  slashItemCount,
+  entityReferenceMenuOpen,
+}: {
+  mentionIsOpen: boolean;
+  slashIsOpen: boolean;
+  slashItemCount: number;
+  entityReferenceMenuOpen: boolean;
+}) {
+  // MentionMenu renders an empty state while open, so it must stay armed even
+  // when the current query has no results. SlashCommandMenu returns null when
+  // it has no commands, so it still requires at least one item here.
+  const mentionMenuOpen = mentionIsOpen;
+  const slashMenuOpen = slashIsOpen && slashItemCount > 0;
+  return {
+    mentionMenuOpen,
+    slashMenuOpen,
+    isSuggestionMenuOpen: mentionMenuOpen || slashMenuOpen || entityReferenceMenuOpen,
+  };
+}

--- a/apps/web/components/task/chat/tiptap-entity-reference-suggestion.ts
+++ b/apps/web/components/task/chat/tiptap-entity-reference-suggestion.ts
@@ -227,6 +227,11 @@ export function createEntityReferenceSuggestion(
         onUpdate: updateMenu,
         onKeyDown(keyDown: SuggestionKeyDownProps) {
           if (keyDown.event.key === "Escape") {
+            // Claim the key here: once the entity-reference popup is closed,
+            // nothing further up the tree (e.g. a clarification panel's own
+            // Escape-collapses handler) should also react to the same
+            // keypress.
+            keyDown.event.stopPropagation();
             setMenuState(EMPTY_ENTITY_REFERENCE_STATE);
             inputGate.reset();
             exitSuggestion(keyDown.view, EntityReferenceSuggestionPluginKey);

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -34,6 +34,7 @@ import {
 } from "./tiptap-suggestion";
 import { useTipTapEditor, type TipTapInputHandle } from "./use-tiptap-editor";
 import { useSuggestionEscapeFallback } from "./use-suggestion-escape-fallback";
+import { getSuggestionMenuOpenState } from "./suggestion-menu-state";
 import {
   useClarificationEscapeGuard,
   type ClarificationEscapePredicate,
@@ -588,9 +589,12 @@ function useSuggestionMenuOpenState(
   containerRef: RefObject<HTMLElement | null>,
   editorRef: RefObject<Editor | null>,
 ) {
-  const mentionMenuOpen = menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0;
-  const slashMenuOpen = menu.slashMenu.isOpen && menu.slashMenu.items.length > 0;
-  const isSuggestionMenuOpen = mentionMenuOpen || slashMenuOpen || entityReferences.isOpen;
+  const { mentionMenuOpen, slashMenuOpen, isSuggestionMenuOpen } = getSuggestionMenuOpenState({
+    mentionIsOpen: menu.mentionMenu.isOpen,
+    slashIsOpen: menu.slashMenu.isOpen,
+    slashItemCount: menu.slashMenu.items.length,
+    entityReferenceMenuOpen: entityReferences.isOpen,
+  });
   const closeEntityReferenceMenu = useEntityReferenceMenuClose(editorRef, entityReferences.close);
   useSuggestionEscapeFallback({
     isSuggestionMenuOpen,
@@ -602,7 +606,7 @@ function useSuggestionMenuOpenState(
     closeEntityReferenceMenu,
     containerRef,
   });
-  return { isSuggestionMenuOpen, mentionMenuOpen, slashMenuOpen, closeEntityReferenceMenu };
+  return { isSuggestionMenuOpen, closeEntityReferenceMenu };
 }
 
 // Stable reference (module scope) so the guard registry sees the same

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -360,13 +360,23 @@ function useMenuHandlers() {
   };
 }
 
-function useEntityReferenceMenuClose(editor: Editor | null, close: () => void) {
+function useEntityReferenceMenuClose(editorRef: RefObject<Editor | null>, close: () => void) {
   return useCallback(() => {
+    const editor = editorRef.current;
     if (editor) {
       exitSuggestion(editor.view, EntityReferenceSuggestionPluginKey);
     }
     close();
-  }, [editor, close]);
+  }, [editorRef, close]);
+}
+
+// `editorRef` is created before `editor` exists (it backs a close handler
+// composed earlier, in useSuggestionMenuOpenState) -- resync it every render
+// so callers reading `editorRef.current` always see the latest instance.
+function useEditorRefSync(editorRef: RefObject<Editor | null>, editor: Editor | null) {
+  useLayoutEffect(() => {
+    editorRef.current = editor;
+  });
 }
 
 function useReverseSearchSelectHandler(
@@ -422,10 +432,12 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     sessionId,
   });
   const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(sessionId);
-  const { isSuggestionMenuOpen } = useSuggestionMenuOpenState(
+  const editorRef = useRef<Editor | null>(null);
+  const { isSuggestionMenuOpen, closeEntityReferenceMenu } = useSuggestionMenuOpenState(
     menu,
     entityReferences,
     editorWrapperRef,
+    editorRef,
   );
   const { history, getHistory } = useChatHistory(sessionId);
   const { isDraining } = useDrainOlderMessages(sessionId, overlay.isReverseSearchOpen);
@@ -455,8 +467,8 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     isReverseSearchOpen: overlay.isReverseSearchOpen,
     ref,
   });
+  useEditorRefSync(editorRef, editor);
   const { closeReverseSearch } = overlay;
-  const closeEntityReferenceMenu = useEntityReferenceMenuClose(editor, entityReferences.close);
   const handleReverseSearchSelect = useReverseSearchSelectHandler(
     applyHistoryEntry,
     closeReverseSearch,
@@ -574,10 +586,12 @@ function useSuggestionMenuOpenState(
   menu: ReturnType<typeof useMenuHandlers>,
   entityReferences: ReturnType<typeof useEntityReferenceComposer>,
   containerRef: RefObject<HTMLElement | null>,
+  editorRef: RefObject<Editor | null>,
 ) {
   const mentionMenuOpen = menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0;
   const slashMenuOpen = menu.slashMenu.isOpen && menu.slashMenu.items.length > 0;
   const isSuggestionMenuOpen = mentionMenuOpen || slashMenuOpen || entityReferences.isOpen;
+  const closeEntityReferenceMenu = useEntityReferenceMenuClose(editorRef, entityReferences.close);
   useSuggestionEscapeFallback({
     isSuggestionMenuOpen,
     mentionMenuOpen,
@@ -585,10 +599,10 @@ function useSuggestionMenuOpenState(
     entityReferenceMenuOpen: entityReferences.isOpen,
     closeMentionMenu: menu.handleMentionClose,
     closeSlashMenu: menu.handleSlashClose,
-    closeEntityReferenceMenu: entityReferences.close,
+    closeEntityReferenceMenu,
     containerRef,
   });
-  return { isSuggestionMenuOpen, mentionMenuOpen, slashMenuOpen };
+  return { isSuggestionMenuOpen, mentionMenuOpen, slashMenuOpen, closeEntityReferenceMenu };
 }
 
 // Stable reference (module scope) so the guard registry sees the same

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  type RefObject,
 } from "react";
 import { EditorContent } from "@tiptap/react";
 import { exitSuggestion } from "@tiptap/suggestion";
@@ -405,9 +406,13 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     workspaceId,
     sessionId,
   });
-  const { isSuggestionMenuOpen } = useSuggestionMenuOpenState(menu, entityReferences);
-  const { history, getHistory } = useChatHistory(sessionId);
   const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(sessionId);
+  const { isSuggestionMenuOpen } = useSuggestionMenuOpenState(
+    menu,
+    entityReferences,
+    editorWrapperRef,
+  );
+  const { history, getHistory } = useChatHistory(sessionId);
   const { isDraining } = useDrainOlderMessages(sessionId, overlay.isReverseSearchOpen);
   const { editor, applyHistoryEntry } = useTipTapEditor({
     value,
@@ -556,6 +561,7 @@ function useChatHistory(sessionId: string | null) {
 function useSuggestionMenuOpenState(
   menu: ReturnType<typeof useMenuHandlers>,
   entityReferences: ReturnType<typeof useEntityReferenceComposer>,
+  containerRef: RefObject<HTMLElement | null>,
 ) {
   const mentionMenuOpen = menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0;
   const slashMenuOpen = menu.slashMenu.isOpen && menu.slashMenu.items.length > 0;
@@ -568,6 +574,7 @@ function useSuggestionMenuOpenState(
     closeMentionMenu: menu.handleMentionClose,
     closeSlashMenu: menu.handleSlashClose,
     closeEntityReferenceMenu: entityReferences.close,
+    containerRef,
   });
   return { isSuggestionMenuOpen, mentionMenuOpen, slashMenuOpen };
 }

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -369,6 +369,21 @@ function useEntityReferenceMenuClose(editor: Editor | null, close: () => void) {
   }, [editor, close]);
 }
 
+function useReverseSearchSelectHandler(
+  applyHistoryEntry: (index: number) => void,
+  closeReverseSearch: () => void,
+  editor: Editor | null,
+) {
+  return useCallback(
+    (index: number) => {
+      applyHistoryEntry(index);
+      closeReverseSearch();
+      editor?.commands.focus("end");
+    },
+    [applyHistoryEntry, closeReverseSearch, editor],
+  );
+}
+
 // ── Component ───────────────────────────────────────────────────────
 
 export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(function TipTapInput(
@@ -442,13 +457,10 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
   });
   const { closeReverseSearch } = overlay;
   const closeEntityReferenceMenu = useEntityReferenceMenuClose(editor, entityReferences.close);
-  const handleReverseSearchSelect = useCallback(
-    (index: number) => {
-      applyHistoryEntry(index);
-      closeReverseSearch();
-      editor?.commands.focus("end");
-    },
-    [applyHistoryEntry, closeReverseSearch, editor],
+  const handleReverseSearchSelect = useReverseSearchSelectHandler(
+    applyHistoryEntry,
+    closeReverseSearch,
+    editor,
   );
   return (
     <>

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -32,6 +32,11 @@ import {
   type SlashSuggestionCallbacks,
 } from "./tiptap-suggestion";
 import { useTipTapEditor, type TipTapInputHandle } from "./use-tiptap-editor";
+import { useSuggestionEscapeFallback } from "./use-suggestion-escape-fallback";
+import {
+  useClarificationEscapeGuard,
+  type ClarificationEscapePredicate,
+} from "@/hooks/use-clarification-escape-guard";
 import type { MentionItem } from "@/hooks/use-inline-mention";
 import type { SlashCommand } from "./slash-command-types";
 import type { ContextFile } from "@/lib/state/context-files-store";
@@ -400,10 +405,7 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     workspaceId,
     sessionId,
   });
-  const isSuggestionMenuOpen =
-    (menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0) ||
-    (menu.slashMenu.isOpen && menu.slashMenu.items.length > 0) ||
-    entityReferences.isOpen;
+  const { isSuggestionMenuOpen } = useSuggestionMenuOpenState(menu, entityReferences);
   const { history, getHistory } = useChatHistory(sessionId);
   const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(sessionId);
   const { isDraining } = useDrainOlderMessages(sessionId, overlay.isReverseSearchOpen);
@@ -520,11 +522,12 @@ function TipTapPopups({
         onClose={menu.handleSlashClose}
         setSelectedIndex={menu.setSlashSelectedIndex}
       />
-      {overlay.isReverseSearchOpen && (
+      {overlay.isReverseSearchOpen && overlay.reverseSearchContainer && (
         <MessageHistorySearch
           history={history}
           isLoadingOlder={isDraining}
           anchorRect={overlay.reverseSearchAnchor}
+          container={overlay.reverseSearchContainer}
           onClose={overlay.closeReverseSearch}
           onSelect={onReverseSearchSelect}
         />
@@ -550,9 +553,34 @@ function useChatHistory(sessionId: string | null) {
   return { history, getHistory };
 }
 
+function useSuggestionMenuOpenState(
+  menu: ReturnType<typeof useMenuHandlers>,
+  entityReferences: ReturnType<typeof useEntityReferenceComposer>,
+) {
+  const mentionMenuOpen = menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0;
+  const slashMenuOpen = menu.slashMenu.isOpen && menu.slashMenu.items.length > 0;
+  const isSuggestionMenuOpen = mentionMenuOpen || slashMenuOpen || entityReferences.isOpen;
+  useSuggestionEscapeFallback({
+    isSuggestionMenuOpen,
+    mentionMenuOpen,
+    slashMenuOpen,
+    entityReferenceMenuOpen: entityReferences.isOpen,
+    closeMentionMenu: menu.handleMentionClose,
+    closeSlashMenu: menu.handleSlashClose,
+    closeEntityReferenceMenu: entityReferences.close,
+  });
+  return { isSuggestionMenuOpen, mentionMenuOpen, slashMenuOpen };
+}
+
+// Stable reference (module scope) so the guard registry sees the same
+// predicate identity across renders while the overlay stays open, instead of
+// re-registering on every render.
+const CLAIM_ANY_ESCAPE: ClarificationEscapePredicate = () => true;
+
 function useReverseSearchOverlay(sessionId: string | null) {
   const editorWrapperRef = useRef<HTMLDivElement>(null);
   const [reverseSearchAnchor, setReverseSearchAnchor] = useState<DOMRect | null>(null);
+  const [reverseSearchContainer, setReverseSearchContainer] = useState<Element | null>(null);
   const [isReverseSearchOpen, setIsReverseSearchOpen] = useState(false);
   const sessionIdRef = useRef(sessionId);
   useLayoutEffect(() => {
@@ -560,10 +588,29 @@ function useReverseSearchOverlay(sessionId: string | null) {
   });
   const openReverseSearch = useCallback(() => {
     if (!sessionIdRef.current) return;
-    setReverseSearchAnchor(editorWrapperRef.current?.getBoundingClientRect() ?? null);
+    const wrapper = editorWrapperRef.current;
+    setReverseSearchAnchor(wrapper?.getBoundingClientRect() ?? null);
+    // Radix's Dialog traps focus within [data-slot="dialog-content"]. Portaling
+    // outside that scope (the prior document.body default) meant the overlay's
+    // own focus() and Escape/typing handlers never fired on a surface that
+    // renders this composer inside a Dialog (Quick Chat) -- the trap reverted
+    // focus every time. Render inside that scope when one wraps the composer;
+    // otherwise (the non-modal main task chat panel) keep document.body.
+    setReverseSearchContainer(
+      wrapper?.closest<HTMLElement>('[data-slot="dialog-content"]') ?? document.body,
+    );
     setIsReverseSearchOpen(true);
   }, []);
   const closeReverseSearch = useCallback(() => setIsReverseSearchOpen(false), []);
+  // On Quick Chat, Radix's DismissableLayer dismisses the whole dialog on
+  // Escape unless something already called preventDefault() during the same
+  // document-capture pass -- see use-suggestion-escape-fallback.ts for the
+  // full mechanism. The overlay's own onKeyDown (message-history-search.tsx)
+  // runs later, in the bubble phase, too late to stop that. Registering here
+  // tells the dialog this Escape is spoken for, so it stays open and lets the
+  // overlay's own handler close just the overlay. No-ops on the main task
+  // chat panel, where there is no ClarificationEscapeGuardProvider.
+  useClarificationEscapeGuard(isReverseSearchOpen ? CLAIM_ANY_ESCAPE : null);
   // The anchor rect is captured once at open time; dismiss on viewport
   // changes rather than recompute, matching how the project's other
   // fixed-position popups behave on resize/scroll. Bubbling-phase scroll
@@ -582,6 +629,7 @@ function useReverseSearchOverlay(sessionId: string | null) {
   return {
     editorWrapperRef,
     reverseSearchAnchor,
+    reverseSearchContainer,
     isReverseSearchOpen,
     openReverseSearch,
     closeReverseSearch,

--- a/apps/web/components/task/chat/tiptap-suggestion.tsx
+++ b/apps/web/components/task/chat/tiptap-suggestion.tsx
@@ -113,6 +113,11 @@ export function createMentionSuggestion(
 
         onKeyDown(kd: SuggestionKeyDownProps) {
           if (kd.event.key === "Escape") {
+            // Claim the key here: once the mention popup is closed, nothing
+            // further up the tree (e.g. a clarification panel's own
+            // Escape-collapses handler) should also react to the same
+            // keypress.
+            kd.event.stopPropagation();
             setMenuState(EMPTY_MENTION_STATE);
             return true;
           }
@@ -240,6 +245,11 @@ export function createSlashSuggestion(
 
         onKeyDown(kd: SuggestionKeyDownProps) {
           if (kd.event.key === "Escape") {
+            // Claim the key here: once the slash-command popup is closed,
+            // nothing further up the tree (e.g. a clarification panel's own
+            // Escape-collapses handler) should also react to the same
+            // keypress.
+            kd.event.stopPropagation();
             setMenuState(EMPTY_SLASH_STATE);
             return true;
           }

--- a/apps/web/components/task/chat/token-usage-display.test.tsx
+++ b/apps/web/components/task/chat/token-usage-display.test.tsx
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useSessionContextWindow } from "@/hooks/domains/session/use-session-context-window";
+import {
+  ClarificationEscapeGuardProvider,
+  type ClarificationEscapeGuardEntry,
+  type ClarificationEscapeGuardRegistry,
+} from "@/hooks/use-clarification-escape-guard";
 import { isContextWindowReliable, TokenUsageDisplay } from "./token-usage-display";
 
 const TOOLTIP_ROOT_TESTID = "tooltip-root";
@@ -24,6 +29,22 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
+
+function withEscapeGuardRegistry(node: React.ReactNode) {
+  const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
+  const registry: ClarificationEscapeGuardRegistry = {
+    register: (_id, predicate) => {
+      holder.entry = { test: predicate };
+    },
+    unregister: () => {
+      holder.entry = null;
+    },
+  };
+  render(
+    <ClarificationEscapeGuardProvider value={registry}>{node}</ClarificationEscapeGuardProvider>,
+  );
+  return holder;
+}
 
 describe("isContextWindowReliable", () => {
   it("accepts normal usage under the window", () => {
@@ -122,6 +143,23 @@ describe("TokenUsageDisplay", () => {
     fireEvent.keyDown(document, { key: "Escape" });
 
     expect(getByTestId(TOOLTIP_ROOT_TESTID).getAttribute("data-open")).toBe("false");
+  });
+
+  it("claims Escape at dialog capture time while the tooltip is pinned", () => {
+    vi.mocked(useSessionContextWindow).mockReturnValue({
+      size: 200_000,
+      used: 56_047,
+      remaining: 143_953,
+      efficiency: 28,
+      compactionCount: 0,
+    });
+
+    const holder = withEscapeGuardRegistry(<TokenUsageDisplay sessionId="sess-1" />);
+    const trigger = screen.getByRole("button", { name: "Context window: 28% used" });
+
+    fireEvent.click(trigger);
+
+    expect(holder.entry?.test(new KeyboardEvent("keydown", { key: "Escape" }))).toBe(true);
   });
 });
 

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -62,7 +62,13 @@ function usePinnableTooltip() {
       closePinnedTooltip();
     };
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && pinnedRef.current) closePinnedTooltip();
+      if (event.key !== "Escape" || !pinnedRef.current) return;
+      // Claim the key here: once the pinned tooltip is closed, nothing
+      // further up the tree (e.g. a clarification panel's own
+      // Escape-collapses handler) should also react to the same keypress.
+      event.preventDefault();
+      event.stopPropagation();
+      closePinnedTooltip();
     };
 
     document.addEventListener("pointerdown", closeOnOutsidePointer);

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { memo, useEffect, useId, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useRef, useState } from "react";
 import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useSessionContextWindow } from "@/hooks/domains/session/use-session-context-window";
+import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
 
 type TokenUsageDisplayProps = {
   sessionId: string | null;
@@ -45,6 +46,14 @@ function usePinnableTooltip() {
   const [open, setOpen] = useState(false);
   const pinnedRef = useRef(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const escapeGuard = useCallback(
+    (event: KeyboardEvent) => event.key === "Escape" && pinnedRef.current,
+    [],
+  );
+  // Radix dialogs inspect Escape during document capture, before the
+  // document-bubble listener below can close the pinned tooltip.
+  useClarificationEscapeGuard(escapeGuard);
 
   useEffect(() => {
     const closePinnedTooltip = () => {

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
@@ -1,7 +1,12 @@
 import { cleanup, fireEvent, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRef, type RefObject } from "react";
+import { createElement, createRef, type RefObject } from "react";
 import { useSuggestionEscapeFallback } from "./use-suggestion-escape-fallback";
+import {
+  ClarificationEscapeGuardProvider,
+  type ClarificationEscapeGuardRegistry,
+  type ClarificationEscapePredicate,
+} from "@/hooks/use-clarification-escape-guard";
 
 afterEach(cleanup);
 
@@ -178,5 +183,65 @@ describe("useSuggestionEscapeFallback", () => {
 
     document.body.removeChild(backgroundContainer);
     document.body.removeChild(foregroundContainer);
+  });
+});
+
+describe("useSuggestionEscapeFallback guard predicate ownership", () => {
+  /**
+   * The capture-phase guard predicate (registered via
+   * useClarificationEscapeGuard) must claim an Escape only when this
+   * composer's own container actually owns it -- exactly like the
+   * bubble-phase listener in the suite above. A predicate that claimed every
+   * Escape unconditionally would leave the dialog open (and the key
+   * otherwise unhandled) once focus left the composer while a menu was still
+   * open, since the bubble listener already refuses to act for an unowned
+   * target.
+   */
+  it("claims Escape only when the container owns the target", () => {
+    const container = document.createElement("div");
+    const outsider = document.createElement("div");
+    document.body.appendChild(container);
+    document.body.appendChild(outsider);
+    const containerRef = { current: container };
+
+    let registeredPredicate: ClarificationEscapePredicate | null = null;
+    const registry: ClarificationEscapeGuardRegistry = {
+      register: (_id, predicate) => {
+        registeredPredicate = predicate;
+      },
+      unregister: () => {
+        registeredPredicate = null;
+      },
+    };
+
+    renderHook(
+      () =>
+        useSuggestionEscapeFallback({
+          isSuggestionMenuOpen: true,
+          mentionMenuOpen: true,
+          slashMenuOpen: false,
+          entityReferenceMenuOpen: false,
+          closeMentionMenu: vi.fn(),
+          closeSlashMenu: vi.fn(),
+          closeEntityReferenceMenu: vi.fn(),
+          containerRef,
+        }),
+      {
+        wrapper: ({ children }) =>
+          createElement(ClarificationEscapeGuardProvider, { value: registry }, children),
+      },
+    );
+
+    expect(registeredPredicate).not.toBeNull();
+    const ownedEvent = new KeyboardEvent("keydown", { key: "Escape" });
+    Object.defineProperty(ownedEvent, "target", { value: container });
+    const unownedEvent = new KeyboardEvent("keydown", { key: "Escape" });
+    Object.defineProperty(unownedEvent, "target", { value: outsider });
+
+    expect(registeredPredicate!(ownedEvent)).toBe(true);
+    expect(registeredPredicate!(unownedEvent)).toBe(false);
+
+    document.body.removeChild(container);
+    document.body.removeChild(outsider);
   });
 });

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
@@ -1,13 +1,19 @@
 import { cleanup, fireEvent, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRef, type RefObject } from "react";
 import { useSuggestionEscapeFallback } from "./use-suggestion-escape-fallback";
 
 afterEach(cleanup);
 
-function renderFallback(overrides: { isSuggestionMenuOpen: boolean; mentionMenuOpen?: boolean }) {
+function renderFallback(overrides: {
+  isSuggestionMenuOpen: boolean;
+  mentionMenuOpen?: boolean;
+  containerRef?: RefObject<HTMLElement | null>;
+}) {
   const closeMentionMenu = vi.fn();
   const closeSlashMenu = vi.fn();
   const closeEntityReferenceMenu = vi.fn();
+  const containerRef = overrides.containerRef ?? createRef<HTMLElement>();
   const { rerender } = renderHook(
     (props: { isSuggestionMenuOpen: boolean; mentionMenuOpen: boolean }) =>
       useSuggestionEscapeFallback({
@@ -18,6 +24,7 @@ function renderFallback(overrides: { isSuggestionMenuOpen: boolean; mentionMenuO
         closeMentionMenu,
         closeSlashMenu,
         closeEntityReferenceMenu,
+        containerRef,
       }),
     {
       initialProps: {
@@ -26,7 +33,7 @@ function renderFallback(overrides: { isSuggestionMenuOpen: boolean; mentionMenuO
       },
     },
   );
-  return { closeMentionMenu, closeSlashMenu, closeEntityReferenceMenu, rerender };
+  return { closeMentionMenu, closeSlashMenu, closeEntityReferenceMenu, rerender, containerRef };
 }
 
 describe("useSuggestionEscapeFallback", () => {
@@ -42,29 +49,46 @@ describe("useSuggestionEscapeFallback", () => {
     expect(closeEntityReferenceMenu).not.toHaveBeenCalled();
   });
 
-  it("closes the open menu and claims the event when a suggestion menu is open", () => {
+  it("closes the open menu and claims the event when the keydown targets this composer's own container", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const containerRef = { current: container };
+
     const { closeMentionMenu } = renderFallback({
       isSuggestionMenuOpen: true,
       mentionMenuOpen: true,
+      containerRef,
     });
 
-    const event = fireEvent.keyDown(document, { key: "Escape", cancelable: true, bubbles: true });
+    const event = fireEvent.keyDown(container, {
+      key: "Escape",
+      cancelable: true,
+      bubbles: true,
+    });
 
     expect(closeMentionMenu).toHaveBeenCalledTimes(1);
     // fireEvent's return value is the pre-dispatch continue flag: `false` means
     // something called preventDefault() during dispatch.
     expect(event).toBe(false);
+
+    document.body.removeChild(container);
   });
 
   it("ignores non-Escape keys", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const containerRef = { current: container };
+
     const { closeMentionMenu } = renderFallback({
       isSuggestionMenuOpen: true,
       mentionMenuOpen: true,
+      containerRef,
     });
 
-    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.keyDown(container, { key: "Enter" });
 
     expect(closeMentionMenu).not.toHaveBeenCalled();
+    document.body.removeChild(container);
   });
 
   /**
@@ -85,10 +109,12 @@ describe("useSuggestionEscapeFallback", () => {
       if (event.key === "Escape") event.stopPropagation();
     };
     editor.addEventListener("keydown", stopAtEditor);
+    const containerRef = { current: editor };
 
     const { closeMentionMenu } = renderFallback({
       isSuggestionMenuOpen: true,
       mentionMenuOpen: true,
+      containerRef,
     });
 
     fireEvent.keyDown(editor, { key: "Escape", bubbles: true, cancelable: true });
@@ -100,14 +126,57 @@ describe("useSuggestionEscapeFallback", () => {
   });
 
   it("removes its listener when the suggestion menu closes", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const containerRef = { current: container };
+
     const { closeMentionMenu, rerender } = renderFallback({
       isSuggestionMenuOpen: true,
       mentionMenuOpen: true,
+      containerRef,
     });
 
     rerender({ isSuggestionMenuOpen: false, mentionMenuOpen: false });
-    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.keyDown(container, { key: "Escape" });
 
     expect(closeMentionMenu).not.toHaveBeenCalled();
+    document.body.removeChild(container);
+  });
+
+  /**
+   * F10 repro: two composer instances mounted at once (the main task chat
+   * panel, backgrounded, plus Quick Chat's own composer in front of it), each
+   * with a suggestion menu open. Escape is dispatched from inside the SECOND
+   * (foreground) composer's own container. Without an ownership check the
+   * first-registered hook instance (background) would see the event on
+   * `document`, close its own (wrong) menu, and stopPropagation() before the
+   * second instance's listener ever ran -- leaving the actually-open,
+   * user-visible popup untouched. Real jsdom propagation, not a synthetic
+   * stand-in for either instance.
+   */
+  it("only the composer instance that owns the keydown's target closes its menu (F10: two composers open at once)", () => {
+    const backgroundContainer = document.createElement("div");
+    const foregroundContainer = document.createElement("div");
+    document.body.appendChild(backgroundContainer);
+    document.body.appendChild(foregroundContainer);
+
+    const background = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+      containerRef: { current: backgroundContainer },
+    });
+    const foreground = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+      containerRef: { current: foregroundContainer },
+    });
+
+    fireEvent.keyDown(foregroundContainer, { key: "Escape", bubbles: true, cancelable: true });
+
+    expect(foreground.closeMentionMenu).toHaveBeenCalledTimes(1);
+    expect(background.closeMentionMenu).not.toHaveBeenCalled();
+
+    document.body.removeChild(backgroundContainer);
+    document.body.removeChild(foregroundContainer);
   });
 });

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
@@ -90,7 +90,7 @@ describe("useSuggestionEscapeFallback", () => {
       containerRef,
     });
 
-    fireEvent.keyDown(container, { key: "Enter" });
+    fireEvent.keyDown(container, { key: "Enter", bubbles: true });
 
     expect(closeMentionMenu).not.toHaveBeenCalled();
     document.body.removeChild(container);
@@ -142,7 +142,7 @@ describe("useSuggestionEscapeFallback", () => {
     });
 
     rerender({ isSuggestionMenuOpen: false, mentionMenuOpen: false });
-    fireEvent.keyDown(container, { key: "Escape" });
+    fireEvent.keyDown(container, { key: "Escape", bubbles: true, cancelable: true });
 
     expect(closeMentionMenu).not.toHaveBeenCalled();
     document.body.removeChild(container);

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.test.ts
@@ -1,0 +1,113 @@
+import { cleanup, fireEvent, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSuggestionEscapeFallback } from "./use-suggestion-escape-fallback";
+
+afterEach(cleanup);
+
+function renderFallback(overrides: { isSuggestionMenuOpen: boolean; mentionMenuOpen?: boolean }) {
+  const closeMentionMenu = vi.fn();
+  const closeSlashMenu = vi.fn();
+  const closeEntityReferenceMenu = vi.fn();
+  const { rerender } = renderHook(
+    (props: { isSuggestionMenuOpen: boolean; mentionMenuOpen: boolean }) =>
+      useSuggestionEscapeFallback({
+        isSuggestionMenuOpen: props.isSuggestionMenuOpen,
+        mentionMenuOpen: props.mentionMenuOpen,
+        slashMenuOpen: false,
+        entityReferenceMenuOpen: false,
+        closeMentionMenu,
+        closeSlashMenu,
+        closeEntityReferenceMenu,
+      }),
+    {
+      initialProps: {
+        isSuggestionMenuOpen: overrides.isSuggestionMenuOpen,
+        mentionMenuOpen: overrides.mentionMenuOpen ?? false,
+      },
+    },
+  );
+  return { closeMentionMenu, closeSlashMenu, closeEntityReferenceMenu, rerender };
+}
+
+describe("useSuggestionEscapeFallback", () => {
+  it("does nothing on Escape while no suggestion menu is open", () => {
+    const { closeMentionMenu, closeSlashMenu, closeEntityReferenceMenu } = renderFallback({
+      isSuggestionMenuOpen: false,
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(closeMentionMenu).not.toHaveBeenCalled();
+    expect(closeSlashMenu).not.toHaveBeenCalled();
+    expect(closeEntityReferenceMenu).not.toHaveBeenCalled();
+  });
+
+  it("closes the open menu and claims the event when a suggestion menu is open", () => {
+    const { closeMentionMenu } = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+    });
+
+    const event = fireEvent.keyDown(document, { key: "Escape", cancelable: true, bubbles: true });
+
+    expect(closeMentionMenu).toHaveBeenCalledTimes(1);
+    // fireEvent's return value is the pre-dispatch continue flag: `false` means
+    // something called preventDefault() during dispatch.
+    expect(event).toBe(false);
+  });
+
+  it("ignores non-Escape keys", () => {
+    const { closeMentionMenu } = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+    });
+
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(closeMentionMenu).not.toHaveBeenCalled();
+  });
+
+  /**
+   * On the main task chat panel there is no Radix capture-phase interceptor,
+   * so ProseMirror's Suggestion plugin runs its own onKeyDown and calls
+   * event.stopPropagation() on the keydown at the editor's own bubble-phase
+   * listener -- see tiptap-suggestion.tsx. That halts propagation before the
+   * event reaches `document`, so this hook's document-bubble listener never
+   * fires there, regardless of registration order (bubble phase always visits
+   * the DOM tree from target to document). This test reproduces that halt with
+   * a real DOM listener attached between the target and document, using
+   * jsdom's genuine event propagation rather than a synthetic stand-in.
+   */
+  it("stays inert when an earlier bubble-phase listener stops propagation, as on the main task chat panel", () => {
+    const editor = document.createElement("div");
+    document.body.appendChild(editor);
+    const stopAtEditor = (event: KeyboardEvent) => {
+      if (event.key === "Escape") event.stopPropagation();
+    };
+    editor.addEventListener("keydown", stopAtEditor);
+
+    const { closeMentionMenu } = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+    });
+
+    fireEvent.keyDown(editor, { key: "Escape", bubbles: true, cancelable: true });
+
+    expect(closeMentionMenu).not.toHaveBeenCalled();
+
+    editor.removeEventListener("keydown", stopAtEditor);
+    document.body.removeChild(editor);
+  });
+
+  it("removes its listener when the suggestion menu closes", () => {
+    const { closeMentionMenu, rerender } = renderFallback({
+      isSuggestionMenuOpen: true,
+      mentionMenuOpen: true,
+    });
+
+    rerender({ isSuggestionMenuOpen: false, mentionMenuOpen: false });
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(closeMentionMenu).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, type RefObject } from "react";
 import {
   useClarificationEscapeGuard,
   type ClarificationEscapePredicate,
@@ -21,7 +21,18 @@ export type SuggestionEscapeFallbackArgs = {
   closeMentionMenu: () => void;
   closeSlashMenu: () => void;
   closeEntityReferenceMenu: () => void;
+  /** This composer instance's own editor wrapper element. Escape only closes
+   *  THIS composer's popups when the keydown's target or the currently
+   *  focused element is inside it -- see the ownership note below. */
+  containerRef: RefObject<HTMLElement | null>;
 };
+
+/** True while `node` (the keydown's target, or document.activeElement) sits
+ *  inside `container`. Keyboard events target the focused element, so this
+ *  is the same check whichever of the two callers pass. */
+function isOwnedByContainer(container: HTMLElement | null, node: Node | null): boolean {
+  return !!container && !!node && container.contains(node);
+}
 
 /**
  * On Quick Chat, Radix's Dialog calls `event.preventDefault()` on Escape from
@@ -52,6 +63,20 @@ export type SuggestionEscapeFallbackArgs = {
  * sees the same keydown either -- mirroring what the Suggestion plugins' own
  * onKeyDown does when it runs normally.
  *
+ * OWNERSHIP: this document-level listener is not scoped by React tree -- it
+ * receives every Escape keydown that reaches `document`, from *any* mounted
+ * composer instance. Quick Chat is a modal layered over a still-mounted task
+ * page, so both composers can be alive at once, and `popup-menu.tsx` closes a
+ * menu only on outside `pointerdown` (no blur handler), so a menu left open in
+ * a backgrounded composer stays open indefinitely. Without an ownership check,
+ * whichever instance's listener happens to be registered first "wins" the
+ * event regardless of which composer the user is actually typing into --
+ * closing the wrong (background) menu and calling stopPropagation() before the
+ * foreground instance's own listener ever runs. `containerRef` is this
+ * composer's own editor wrapper; the handler bails unless the keydown's
+ * target or the currently focused element sits inside it, so only the
+ * composer that actually owns the keystroke acts on it.
+ *
  * On the main task chat panel there is no competing capture listener, so the
  * Suggestion plugin's own bubble-phase stopPropagation() halts the event at
  * the editor node first and this listener never fires -- verified in
@@ -65,12 +90,18 @@ export function useSuggestionEscapeFallback({
   closeMentionMenu,
   closeSlashMenu,
   closeEntityReferenceMenu,
+  containerRef,
 }: SuggestionEscapeFallbackArgs) {
   useClarificationEscapeGuard(isSuggestionMenuOpen ? CLAIM_ANY_ESCAPE : null);
   useEffect(() => {
     if (!isSuggestionMenuOpen) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      const container = containerRef.current;
+      const owned =
+        isOwnedByContainer(container, event.target as Node | null) ||
+        isOwnedByContainer(container, document.activeElement);
+      if (!owned) return;
       if (mentionMenuOpen) closeMentionMenu();
       if (slashMenuOpen) closeSlashMenu();
       if (entityReferenceMenuOpen) closeEntityReferenceMenu();
@@ -87,5 +118,6 @@ export function useSuggestionEscapeFallback({
     closeMentionMenu,
     closeSlashMenu,
     closeEntityReferenceMenu,
+    containerRef,
   ]);
 }

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
@@ -1,15 +1,7 @@
 "use client";
 
-import { useEffect, type RefObject } from "react";
-import {
-  useClarificationEscapeGuard,
-  type ClarificationEscapePredicate,
-} from "@/hooks/use-clarification-escape-guard";
-
-// Stable reference (module scope, not re-created per render/call) so the
-// guard registry sees the same predicate identity across renders while a
-// suggestion menu stays open, instead of re-registering on every render.
-const CLAIM_ANY_ESCAPE: ClarificationEscapePredicate = () => true;
+import { useCallback, useEffect, type RefObject } from "react";
+import { useClarificationEscapeGuard } from "@/hooks/use-clarification-escape-guard";
 
 export type SuggestionEscapeFallbackArgs = {
   /** True while any ProseMirror suggestion popup (mention, slash, entity
@@ -50,10 +42,18 @@ function isOwnedByContainer(container: HTMLElement | null, node: Node | null): b
  * listener (below) ever gets a turn. `useClarificationEscapeGuard` is the only
  * hook point that runs early enough (Quick Chat's `onEscapeKeyDown` prop,
  * invoked synchronously from within DismissableLayer's own capture handler) to
- * prevent that: registering `CLAIM_ANY_ESCAPE` while a suggestion popup is open
- * tells the dialog this Escape is spoken for, so it stays open instead of
- * closing out from under the popup. No-ops on the main task chat panel, where
- * there is no ClarificationEscapeGuardProvider.
+ * prevent that: registering an ownership-aware predicate while a suggestion
+ * popup is open tells the dialog this Escape is spoken for -- but only when
+ * the keydown actually targets (or focus sits inside) this composer's own
+ * `containerRef`, mirroring the bubble-phase listener's own ownership check
+ * below. Without that check, a menu left open in a backgrounded composer (see
+ * OWNERSHIP below) would claim every Escape regardless of where focus
+ * actually is, and if focus later leaves this composer entirely (e.g. Tab
+ * navigates out while an empty-results popup is still open, which does not
+ * consume Tab) the claim would stay unconditionally true forever -- the dialog
+ * would never dismiss AND the bubble listener would correctly refuse to act
+ * (wrong owner), leaving Escape completely dead. No-ops on the main task chat
+ * panel, where there is no ClarificationEscapeGuardProvider.
  *
  * With the dialog's own auto-dismiss suppressed, a plain document-BUBBLE
  * listener still runs after the target regardless of `defaultPrevented` (that
@@ -63,19 +63,21 @@ function isOwnedByContainer(container: HTMLElement | null, node: Node | null): b
  * sees the same keydown either -- mirroring what the Suggestion plugins' own
  * onKeyDown does when it runs normally.
  *
- * OWNERSHIP: this document-level listener is not scoped by React tree -- it
- * receives every Escape keydown that reaches `document`, from *any* mounted
- * composer instance. Quick Chat is a modal layered over a still-mounted task
- * page, so both composers can be alive at once, and `popup-menu.tsx` closes a
- * menu only on outside `pointerdown` (no blur handler), so a menu left open in
- * a backgrounded composer stays open indefinitely. Without an ownership check,
- * whichever instance's listener happens to be registered first "wins" the
- * event regardless of which composer the user is actually typing into --
- * closing the wrong (background) menu and calling stopPropagation() before the
- * foreground instance's own listener ever runs. `containerRef` is this
- * composer's own editor wrapper; the handler bails unless the keydown's
- * target or the currently focused element sits inside it, so only the
- * composer that actually owns the keystroke acts on it.
+ * OWNERSHIP: neither this document-level bubble listener nor the capture-phase
+ * guard predicate above is scoped by React tree -- both see every Escape
+ * keydown from *any* mounted composer instance (the guard predicate, via
+ * whatever the registry's Escape handler is called with; this listener, via
+ * `document`). Quick Chat is a modal layered over a still-mounted task page,
+ * so both composers can be alive at once, and `popup-menu.tsx` closes a menu
+ * only on outside `pointerdown` (no blur handler), so a menu left open in a
+ * backgrounded composer stays open indefinitely. Without an ownership check on
+ * both, whichever instance happens to run first "wins" the event regardless of
+ * which composer the user is actually typing into -- closing the wrong
+ * (background) menu, or claiming an Escape it has no way to act on.
+ * `containerRef` is this composer's own editor wrapper; both the predicate and
+ * the listener bail unless the keydown's target or the currently focused
+ * element sits inside it, so only the composer that actually owns the
+ * keystroke reacts to it.
  *
  * On the main task chat panel there is no competing capture listener, so the
  * Suggestion plugin's own bubble-phase stopPropagation() halts the event at
@@ -92,7 +94,17 @@ export function useSuggestionEscapeFallback({
   closeEntityReferenceMenu,
   containerRef,
 }: SuggestionEscapeFallbackArgs) {
-  useClarificationEscapeGuard(isSuggestionMenuOpen ? CLAIM_ANY_ESCAPE : null);
+  const isOwnEscape = useCallback(
+    (event: KeyboardEvent) => {
+      const container = containerRef.current;
+      return (
+        isOwnedByContainer(container, event.target as Node | null) ||
+        isOwnedByContainer(container, document.activeElement)
+      );
+    },
+    [containerRef],
+  );
+  useClarificationEscapeGuard(isSuggestionMenuOpen ? isOwnEscape : null);
   useEffect(() => {
     if (!isSuggestionMenuOpen) return;
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
+++ b/apps/web/components/task/chat/use-suggestion-escape-fallback.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  useClarificationEscapeGuard,
+  type ClarificationEscapePredicate,
+} from "@/hooks/use-clarification-escape-guard";
+
+// Stable reference (module scope, not re-created per render/call) so the
+// guard registry sees the same predicate identity across renders while a
+// suggestion menu stays open, instead of re-registering on every render.
+const CLAIM_ANY_ESCAPE: ClarificationEscapePredicate = () => true;
+
+export type SuggestionEscapeFallbackArgs = {
+  /** True while any ProseMirror suggestion popup (mention, slash, entity
+   *  reference) is open for this composer instance. */
+  isSuggestionMenuOpen: boolean;
+  mentionMenuOpen: boolean;
+  slashMenuOpen: boolean;
+  entityReferenceMenuOpen: boolean;
+  closeMentionMenu: () => void;
+  closeSlashMenu: () => void;
+  closeEntityReferenceMenu: () => void;
+};
+
+/**
+ * On Quick Chat, Radix's Dialog calls `event.preventDefault()` on Escape from
+ * a document-CAPTURE listener before the keydown ever reaches the editor.
+ * prosemirror-view's own keydown handling refuses any event whose
+ * `defaultPrevented` is already true, so the Suggestion plugins' Escape
+ * handling -- which would otherwise close an open mention/slash/entity-
+ * reference popup and call stopPropagation() -- never runs at all on that
+ * surface, and the popup stays open while Quick Chat's clarification-collapse
+ * listener (bound on `window`) still sees the event.
+ *
+ * Worse, unless something already called `preventDefault()` during that same
+ * capture phase, Radix's DismissableLayer treats the Escape as unclaimed and
+ * dismisses the whole dialog right then -- before this hook's own bubble-phase
+ * listener (below) ever gets a turn. `useClarificationEscapeGuard` is the only
+ * hook point that runs early enough (Quick Chat's `onEscapeKeyDown` prop,
+ * invoked synchronously from within DismissableLayer's own capture handler) to
+ * prevent that: registering `CLAIM_ANY_ESCAPE` while a suggestion popup is open
+ * tells the dialog this Escape is spoken for, so it stays open instead of
+ * closing out from under the popup. No-ops on the main task chat panel, where
+ * there is no ClarificationEscapeGuardProvider.
+ *
+ * With the dialog's own auto-dismiss suppressed, a plain document-BUBBLE
+ * listener still runs after the target regardless of `defaultPrevented` (that
+ * flag only suppresses default browser behavior, not propagation), so it still
+ * sees the keydown. It only acts while a suggestion popup is open, closes it,
+ * then calls stopPropagation() so the window-level carousel listener never
+ * sees the same keydown either -- mirroring what the Suggestion plugins' own
+ * onKeyDown does when it runs normally.
+ *
+ * On the main task chat panel there is no competing capture listener, so the
+ * Suggestion plugin's own bubble-phase stopPropagation() halts the event at
+ * the editor node first and this listener never fires -- verified in
+ * use-suggestion-escape-fallback.test.ts.
+ */
+export function useSuggestionEscapeFallback({
+  isSuggestionMenuOpen,
+  mentionMenuOpen,
+  slashMenuOpen,
+  entityReferenceMenuOpen,
+  closeMentionMenu,
+  closeSlashMenu,
+  closeEntityReferenceMenu,
+}: SuggestionEscapeFallbackArgs) {
+  useClarificationEscapeGuard(isSuggestionMenuOpen ? CLAIM_ANY_ESCAPE : null);
+  useEffect(() => {
+    if (!isSuggestionMenuOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (mentionMenuOpen) closeMentionMenu();
+      if (slashMenuOpen) closeSlashMenu();
+      if (entityReferenceMenuOpen) closeEntityReferenceMenu();
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [
+    isSuggestionMenuOpen,
+    mentionMenuOpen,
+    slashMenuOpen,
+    entityReferenceMenuOpen,
+    closeMentionMenu,
+    closeSlashMenu,
+    closeEntityReferenceMenu,
+  ]);
+}

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -138,6 +138,118 @@ test.describe("Quick Chat", () => {
     await expect(dialog).not.toBeVisible();
   });
 
+  test("Escape closes the open entity-reference suggestion popup without collapsing the clarification panel", async ({
+    testPage,
+  }) => {
+    // Regression coverage for the real ProseMirror Suggestion keydown path:
+    // earlier rounds only exercised a synthetic in-scope listener, which
+    // stayed green while Radix's Dialog capture-phase preventDefault() on
+    // Escape silently starved prosemirror-view's own keydown handling (and
+    // therefore the Suggestion plugin's onKeyDown) on Quick Chat specifically.
+    const dialog = await openQuickChatWithAgent(testPage);
+    await sendQuickChatMessage(dialog, testPage, "/e2e:clarification-multi");
+
+    const clarification = dialog.getByTestId("clarification-overlay");
+    await expect(clarification).toBeVisible({ timeout: 30_000 });
+    const bar = dialog.getByTestId("clarification-overlay-container");
+
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    await editor.pressSequentially("#");
+
+    // PopupMenu always portals to document.body (see popup-menu.tsx), outside
+    // the Dialog's own DOM subtree, so this must be queried at the page level
+    // -- mirrors entity-reference-composer.spec.ts's non-Quick-Chat usage.
+    const menu = testPage.getByTestId("entity-reference-menu");
+    await expect(menu).toBeVisible({ timeout: 10_000 });
+
+    await testPage.keyboard.press("Escape");
+
+    // The suggestion popup owns this Escape: it closes, the clarification
+    // panel stays exactly as it was (neither collapsed nor closed), and the
+    // modal stays open -- the fallback in tiptap-input.tsx claimed the event
+    // via stopPropagation() before Quick Chat's own carousel/collapse
+    // listener ever saw it. clarification-overlay-container wraps both the
+    // collapsed and expanded states with nonzero height, so it stays visible
+    // throughout; `clarification` (clarification-overlay) is the element that
+    // actually reflects collapsed vs. expanded.
+    await expect(menu).not.toBeVisible();
+    await expect(dialog).toBeVisible();
+    await expect(clarification).toBeVisible();
+    await expect(bar).toBeVisible();
+
+    // Escape resumes its normal two-stage behavior on the next press: the
+    // fallback only acts while a suggestion menu is open.
+    await testPage.keyboard.press("Escape");
+    await expect(clarification).not.toBeVisible();
+    await expect(bar).toBeVisible();
+    await expect(dialog).toBeVisible();
+
+    await testPage.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("Escape closes the open entity-reference suggestion popup without closing the dialog when no clarification is pending", async ({
+    testPage,
+  }) => {
+    // Companion to the clarification-pending case above. Radix's
+    // DismissableLayer auto-dismisses the whole dialog on Escape unless
+    // something already called preventDefault() during the capture phase --
+    // with no clarification mounted, the carousel's own guard never arms, so
+    // this proves the suggestion-menu-open guard registered in
+    // use-suggestion-escape-fallback.ts is what keeps the dialog open here.
+    const dialog = await openQuickChatWithAgent(testPage);
+
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    await editor.pressSequentially("#");
+
+    const menu = testPage.getByTestId("entity-reference-menu");
+    await expect(menu).toBeVisible({ timeout: 10_000 });
+
+    await testPage.keyboard.press("Escape");
+
+    await expect(menu).not.toBeVisible();
+    await expect(dialog).toBeVisible();
+
+    await testPage.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("reverse-search overlay opens, filters by typing, and closes on Escape inside Quick Chat", async ({
+    testPage,
+  }) => {
+    // Regression coverage for message-history-search.tsx portaling outside
+    // the Dialog's FocusScope: previously the overlay's own focus() and
+    // Escape/typing handlers never fired on Quick Chat because the Dialog's
+    // focus trap reverted focus away from the document.body-portaled input.
+    const dialog = await openQuickChatWithAgent(testPage);
+    await sendQuickChatMessage(dialog, testPage, "first reverse search message");
+    await expect(dialog.getByText("first reverse search message", { exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    // REVERSE_SEARCH defaults to plain Ctrl (not ctrlOrCmd) even on macOS, so
+    // Cmd+R keeps triggering the browser's native refresh shortcut.
+    await testPage.keyboard.press("Control+r");
+
+    const overlay = dialog.getByTestId("history-search-overlay");
+    await expect(overlay).toBeVisible({ timeout: 10_000 });
+    const input = dialog.getByTestId("history-search-input");
+    await expect(input).toBeFocused();
+
+    await input.pressSequentially("reverse search");
+    await expect(
+      overlay.getByTestId("history-search-row").filter({ hasText: "first reverse search message" }),
+    ).toBeVisible();
+
+    await testPage.keyboard.press("Escape");
+    await expect(overlay).not.toBeVisible();
+    await expect(dialog).toBeVisible();
+  });
+
   test("offers configuration chat in setup and hides it once one exists", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -95,6 +95,49 @@ test.describe("Quick Chat", () => {
     await expect(dialog).not.toBeVisible();
   });
 
+  test("Escape collapses the clarification panel with focus left in the composer after sending", async ({
+    testPage,
+  }) => {
+    const dialog = await openQuickChatWithAgent(testPage);
+    await sendQuickChatMessage(dialog, testPage, "/e2e:clarification-multi");
+
+    const clarification = dialog.getByTestId("clarification-overlay");
+    await expect(clarification).toBeVisible({ timeout: 30_000 });
+
+    // Focus the composer directly instead of an inert part of the message
+    // list: this is the ordinary post-send state, and the composer is an
+    // editable target the collapse shortcut must still claim Escape for.
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    await expect(editor).toBeFocused();
+
+    await testPage.keyboard.press("Escape");
+
+    await expect(dialog).toBeVisible();
+    await expect(clarification).not.toBeVisible();
+    await expect(dialog.getByTestId("clarification-overlay-container")).toBeVisible();
+  });
+
+  test("Escape closes the modal immediately when focus is outside the clarification's shortcut scope", async ({
+    testPage,
+  }) => {
+    const dialog = await openQuickChatWithAgent(testPage);
+    await sendQuickChatMessage(dialog, testPage, "/e2e:clarification-multi");
+
+    const clarification = dialog.getByTestId("clarification-overlay");
+    await expect(clarification).toBeVisible({ timeout: 30_000 });
+
+    // The tab bar sits outside quick-chat-content (the clarification's
+    // shortcut scope), e.g. the resize handles or a mouse-focused tab.
+    await dialog.getByTestId("quick-chat-tab").first().focus();
+
+    await testPage.keyboard.press("Escape");
+
+    // A pending, still-expanded clarification does not block Escape here: the
+    // guard predicate only claims Escape for keydowns inside its scope.
+    await expect(dialog).not.toBeVisible();
+  });
+
   test("offers configuration chat in setup and hides it once one exists", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -129,7 +129,9 @@ test.describe("Quick Chat", () => {
 
     // The tab bar sits outside quick-chat-content (the clarification's
     // shortcut scope), e.g. the resize handles or a mouse-focused tab.
-    await dialog.getByTestId("quick-chat-tab").focus();
+    await dialog
+      .locator('[data-testid="quick-chat-tab"] button:not([aria-label^="Close"])')
+      .focus();
 
     await testPage.keyboard.press("Escape");
 

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -129,7 +129,7 @@ test.describe("Quick Chat", () => {
 
     // The tab bar sits outside quick-chat-content (the clarification's
     // shortcut scope), e.g. the resize handles or a mouse-focused tab.
-    await dialog.getByTestId("quick-chat-tab").first().focus();
+    await dialog.getByTestId("quick-chat-tab").focus();
 
     await testPage.keyboard.press("Escape");
 

--- a/apps/web/hooks/use-clarification-escape-guard.test.tsx
+++ b/apps/web/hooks/use-clarification-escape-guard.test.tsx
@@ -3,7 +3,7 @@ import { renderHook } from "@testing-library/react";
 import {
   ClarificationEscapeGuardProvider,
   useClarificationEscapeGuard,
-  type ClarificationEscapeGuardEntry,
+  type ClarificationEscapeGuardRegistry,
 } from "./use-clarification-escape-guard";
 
 function fakeEscape(target: EventTarget): KeyboardEvent {
@@ -17,13 +17,22 @@ function fakeEscape(target: EventTarget): KeyboardEvent {
   } as unknown as KeyboardEvent;
 }
 
+function fakeRegistry() {
+  const entries = new Map<string, (event: KeyboardEvent) => boolean>();
+  const registry: ClarificationEscapeGuardRegistry = {
+    register: vi.fn((id, predicate) => entries.set(id, predicate)),
+    unregister: vi.fn((id) => entries.delete(id)),
+  };
+  return { registry, entries };
+}
+
 describe("useClarificationEscapeGuard", () => {
   it("does nothing outside a provider, so non-modal callers can invoke it unconditionally", () => {
     expect(() => renderHook(() => useClarificationEscapeGuard(() => true))).not.toThrow();
   });
 
-  it("wraps a registered predicate in an entry object, so useState never mistakes the function for an updater", () => {
-    const setEntry = vi.fn();
+  it("registers and unregisters the predicate as it changes and on unmount", () => {
+    const { registry, entries } = fakeRegistry();
     const predicateA = () => true;
     const predicateB = () => false;
     const { rerender, unmount } = renderHook(
@@ -31,32 +40,55 @@ describe("useClarificationEscapeGuard", () => {
       {
         initialProps: { predicate: predicateA as (() => boolean) | null },
         wrapper: ({ children }) => (
-          <ClarificationEscapeGuardProvider value={setEntry}>
+          <ClarificationEscapeGuardProvider value={registry}>
             {children}
           </ClarificationEscapeGuardProvider>
         ),
       },
     );
 
-    expect(setEntry).toHaveBeenLastCalledWith({ test: predicateA });
+    expect(registry.register).toHaveBeenCalledTimes(1);
+    expect([...entries.values()]).toEqual([predicateA]);
 
     rerender({ predicate: predicateB });
-    expect(setEntry).toHaveBeenLastCalledWith({ test: predicateB });
+    expect([...entries.values()]).toEqual([predicateB]);
 
     rerender({ predicate: null });
-    expect(setEntry).toHaveBeenLastCalledWith(null);
+    expect(entries.size).toBe(0);
+
+    rerender({ predicate: predicateA });
+    expect([...entries.values()]).toEqual([predicateA]);
 
     unmount();
-    expect(setEntry).toHaveBeenLastCalledWith(null);
+    expect(entries.size).toBe(0);
+  });
+
+  it("two simultaneous callers each keep their own registered predicate (no single-slot clobbering)", () => {
+    const { registry, entries } = fakeRegistry();
+    const predicateA = vi.fn(() => true);
+    const predicateB = vi.fn(() => false);
+
+    renderHook(() => useClarificationEscapeGuard(predicateA), {
+      wrapper: ({ children }) => (
+        <ClarificationEscapeGuardProvider value={registry}>
+          {children}
+        </ClarificationEscapeGuardProvider>
+      ),
+    });
+    renderHook(() => useClarificationEscapeGuard(predicateB), {
+      wrapper: ({ children }) => (
+        <ClarificationEscapeGuardProvider value={registry}>
+          {children}
+        </ClarificationEscapeGuardProvider>
+      ),
+    });
+
+    expect(entries.size).toBe(2);
+    expect([...entries.values()]).toEqual(expect.arrayContaining([predicateA, predicateB]));
   });
 
   it("the registered predicate is called with the real Escape event, not re-derived", () => {
-    // A holder object, not a reassigned `let`, so TS doesn't narrow the
-    // read below to the initializer's type across the closure boundary.
-    const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
-    const setEntry = vi.fn((entry: ClarificationEscapeGuardEntry) => {
-      holder.entry = entry;
-    });
+    const { registry, entries } = fakeRegistry();
     const scope = document.createElement("div");
     const inside = document.createElement("button");
     scope.appendChild(inside);
@@ -64,17 +96,18 @@ describe("useClarificationEscapeGuard", () => {
 
     renderHook(() => useClarificationEscapeGuard(predicate), {
       wrapper: ({ children }) => (
-        <ClarificationEscapeGuardProvider value={setEntry}>
+        <ClarificationEscapeGuardProvider value={registry}>
           {children}
         </ClarificationEscapeGuardProvider>
       ),
     });
 
+    const [registered] = [...entries.values()];
     const insideEvent = fakeEscape(inside);
-    expect(holder.entry?.test(insideEvent)).toBe(true);
+    expect(registered(insideEvent)).toBe(true);
     expect(predicate).toHaveBeenCalledWith(insideEvent);
 
     const outside = document.createElement("button");
-    expect(holder.entry?.test(fakeEscape(outside))).toBe(false);
+    expect(registered(fakeEscape(outside))).toBe(false);
   });
 });

--- a/apps/web/hooks/use-clarification-escape-guard.test.tsx
+++ b/apps/web/hooks/use-clarification-escape-guard.test.tsx
@@ -3,33 +3,78 @@ import { renderHook } from "@testing-library/react";
 import {
   ClarificationEscapeGuardProvider,
   useClarificationEscapeGuard,
+  type ClarificationEscapeGuardEntry,
 } from "./use-clarification-escape-guard";
+
+function fakeEscape(target: EventTarget): KeyboardEvent {
+  return {
+    key: "Escape",
+    target,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+  } as unknown as KeyboardEvent;
+}
 
 describe("useClarificationEscapeGuard", () => {
   it("does nothing outside a provider, so non-modal callers can invoke it unconditionally", () => {
-    expect(() => renderHook(() => useClarificationEscapeGuard(true))).not.toThrow();
+    expect(() => renderHook(() => useClarificationEscapeGuard(() => true))).not.toThrow();
   });
 
-  it("reports guarded state changes to the provider, and clears the guard on unmount", () => {
-    const setGuarded = vi.fn();
+  it("wraps a registered predicate in an entry object, so useState never mistakes the function for an updater", () => {
+    const setEntry = vi.fn();
+    const predicateA = () => true;
+    const predicateB = () => false;
     const { rerender, unmount } = renderHook(
-      ({ guarded }) => useClarificationEscapeGuard(guarded),
+      ({ predicate }) => useClarificationEscapeGuard(predicate),
       {
-        initialProps: { guarded: false },
+        initialProps: { predicate: predicateA as (() => boolean) | null },
         wrapper: ({ children }) => (
-          <ClarificationEscapeGuardProvider value={setGuarded}>
+          <ClarificationEscapeGuardProvider value={setEntry}>
             {children}
           </ClarificationEscapeGuardProvider>
         ),
       },
     );
 
-    expect(setGuarded).toHaveBeenLastCalledWith(false);
+    expect(setEntry).toHaveBeenLastCalledWith({ test: predicateA });
 
-    rerender({ guarded: true });
-    expect(setGuarded).toHaveBeenLastCalledWith(true);
+    rerender({ predicate: predicateB });
+    expect(setEntry).toHaveBeenLastCalledWith({ test: predicateB });
+
+    rerender({ predicate: null });
+    expect(setEntry).toHaveBeenLastCalledWith(null);
 
     unmount();
-    expect(setGuarded).toHaveBeenLastCalledWith(false);
+    expect(setEntry).toHaveBeenLastCalledWith(null);
+  });
+
+  it("the registered predicate is called with the real Escape event, not re-derived", () => {
+    // A holder object, not a reassigned `let`, so TS doesn't narrow the
+    // read below to the initializer's type across the closure boundary.
+    const holder: { entry: ClarificationEscapeGuardEntry } = { entry: null };
+    const setEntry = vi.fn((entry: ClarificationEscapeGuardEntry) => {
+      holder.entry = entry;
+    });
+    const scope = document.createElement("div");
+    const inside = document.createElement("button");
+    scope.appendChild(inside);
+    const predicate = vi.fn((event: KeyboardEvent) => scope.contains(event.target as Node));
+
+    renderHook(() => useClarificationEscapeGuard(predicate), {
+      wrapper: ({ children }) => (
+        <ClarificationEscapeGuardProvider value={setEntry}>
+          {children}
+        </ClarificationEscapeGuardProvider>
+      ),
+    });
+
+    const insideEvent = fakeEscape(inside);
+    expect(holder.entry?.test(insideEvent)).toBe(true);
+    expect(predicate).toHaveBeenCalledWith(insideEvent);
+
+    const outside = document.createElement("button");
+    expect(holder.entry?.test(fakeEscape(outside))).toBe(false);
   });
 });

--- a/apps/web/hooks/use-clarification-escape-guard.ts
+++ b/apps/web/hooks/use-clarification-escape-guard.ts
@@ -2,7 +2,14 @@
 
 import { createContext, useContext, useEffect } from "react";
 
-type ClarificationEscapeGuardSetter = (guarded: boolean) => void;
+export type ClarificationEscapePredicate = (event: KeyboardEvent) => boolean;
+
+// Wrapped in an object so storing a function via useState's setter is never
+// mistaken for React's "updater function" overload (setState(fn) calls fn
+// instead of storing it).
+export type ClarificationEscapeGuardEntry = { test: ClarificationEscapePredicate } | null;
+
+type ClarificationEscapeGuardSetter = (entry: ClarificationEscapeGuardEntry) => void;
 
 const ClarificationEscapeGuardContext = createContext<ClarificationEscapeGuardSetter | null>(null);
 
@@ -10,16 +17,23 @@ export const ClarificationEscapeGuardProvider = ClarificationEscapeGuardContext.
 
 /**
  * Tells an ancestor dialog (via ClarificationEscapeGuardProvider) to swallow
- * its Escape-closes-dialog default while `guarded` is true, so the first
- * Escape collapses this panel instead of dismissing the surrounding modal.
+ * its Escape-closes-dialog default and let this widget's own Escape handler
+ * run instead -- but only while `predicate(event)` reports that this exact
+ * keydown is one the widget will actually act on. Radix's DismissableLayer
+ * intercepts Escape on `document` in the capture phase, before this widget's
+ * own bubble-phase `window` listener runs, so the dialog cannot wait to see
+ * whether the widget handles the key -- it must ask a predicate that mirrors
+ * the widget's own enabled/scope/modifier checks exactly, rather than derive
+ * a separate approximation. Otherwise Escape can be swallowed with nothing
+ * left to handle it.
  * No-ops outside a provider, so callers like the non-modal task chat panel
  * can invoke this unconditionally.
  */
-export function useClarificationEscapeGuard(guarded: boolean) {
-  const setGuarded = useContext(ClarificationEscapeGuardContext);
+export function useClarificationEscapeGuard(predicate: ClarificationEscapePredicate | null) {
+  const setEntry = useContext(ClarificationEscapeGuardContext);
   useEffect(() => {
-    if (!setGuarded) return;
-    setGuarded(guarded);
-    return () => setGuarded(false);
-  }, [guarded, setGuarded]);
+    if (!setEntry) return;
+    setEntry(predicate ? { test: predicate } : null);
+    return () => setEntry(null);
+  }, [predicate, setEntry]);
 }

--- a/apps/web/hooks/use-clarification-escape-guard.ts
+++ b/apps/web/hooks/use-clarification-escape-guard.ts
@@ -4,8 +4,9 @@ import { createContext, useContext, useEffect, useId } from "react";
 
 export type ClarificationEscapePredicate = (event: KeyboardEvent) => boolean;
 
-// Wrapped in an object so storing a function via a registry call is never
-// mistaken for React's "updater function" overload.
+// Test-only holder shape. The production registry stores bare predicates; the
+// wrapper lets tests retain a predicate without React treating it as an
+// updater function.
 export type ClarificationEscapeGuardEntry = { test: ClarificationEscapePredicate } | null;
 
 /**

--- a/apps/web/hooks/use-clarification-escape-guard.ts
+++ b/apps/web/hooks/use-clarification-escape-guard.ts
@@ -1,17 +1,29 @@
 "use client";
 
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useId } from "react";
 
 export type ClarificationEscapePredicate = (event: KeyboardEvent) => boolean;
 
-// Wrapped in an object so storing a function via useState's setter is never
-// mistaken for React's "updater function" overload (setState(fn) calls fn
-// instead of storing it).
+// Wrapped in an object so storing a function via a registry call is never
+// mistaken for React's "updater function" overload.
 export type ClarificationEscapeGuardEntry = { test: ClarificationEscapePredicate } | null;
 
-type ClarificationEscapeGuardSetter = (entry: ClarificationEscapeGuardEntry) => void;
+/**
+ * Multiple widgets can be mounted inside the same dialog at once (e.g. a
+ * pending clarification carousel and an open suggestion popup, or a pending
+ * clarification and an open reverse-search overlay), so the registry holds
+ * one predicate per caller -- keyed by a stable per-hook-instance id -- rather
+ * than a single slot. A single-slot design would let a second caller's
+ * register/unregister silently evict the first's still-active predicate.
+ */
+export type ClarificationEscapeGuardRegistry = {
+  register: (id: string, predicate: ClarificationEscapePredicate) => void;
+  unregister: (id: string) => void;
+};
 
-const ClarificationEscapeGuardContext = createContext<ClarificationEscapeGuardSetter | null>(null);
+const ClarificationEscapeGuardContext = createContext<ClarificationEscapeGuardRegistry | null>(
+  null,
+);
 
 export const ClarificationEscapeGuardProvider = ClarificationEscapeGuardContext.Provider;
 
@@ -30,10 +42,11 @@ export const ClarificationEscapeGuardProvider = ClarificationEscapeGuardContext.
  * can invoke this unconditionally.
  */
 export function useClarificationEscapeGuard(predicate: ClarificationEscapePredicate | null) {
-  const setEntry = useContext(ClarificationEscapeGuardContext);
+  const registry = useContext(ClarificationEscapeGuardContext);
+  const id = useId();
   useEffect(() => {
-    if (!setEntry) return;
-    setEntry(predicate ? { test: predicate } : null);
-    return () => setEntry(null);
-  }, [predicate, setEntry]);
+    if (!registry || !predicate) return;
+    registry.register(id, predicate);
+    return () => registry.unregister(id);
+  }, [registry, id, predicate]);
 }


### PR DESCRIPTION
Quick Chat is a Radix `Dialog`, and Radix calls `preventDefault()` on Escape from a document-capture listener before ProseMirror ever sees the key — so every Suggestion-plugin Escape handler (mention menu, slash command, reverse search) was dead code inside that dialog, and Escape fell straight through to closing the whole modal instead of collapsing the innermost open surface first.

## Important Changes

- Added a capture-phase guard-predicate registry (`use-suggestion-escape-fallback.ts`) that widgets consult to keep the dialog open, paired with document-bubble fallbacks — the one listener phase that still runs after Radix's capture-phase `preventDefault()` — each scoped to its own composer via `containerRef` so a second open composer's menu isn't affected by the first one's Escape.
- Scoped the reverse-search fallback (`message-history-search.tsx`) to its own popup container/portal, and made the pinned token-usage tooltip (`token-usage-display.tsx`) explicitly claim the Escape key it consumes so nothing further up the tree also reacts to the same keypress.
- Generalized `use-clarification-escape-guard.ts` from a single slot to a multi-slot registry so multiple widgets (clarification panel, suggestion popups) can each guard the dialog independently.

## Validation

- `pnpm vitest run` (scoped): `use-suggestion-escape-fallback.test.ts`, `use-clarification-escape-guard.test.tsx`, `message-history-search.test.ts`, `quick-chat-modal.test.tsx` — 24 passed.
- `pnpm vitest run` (broad apps/web suite): 848 passed / 5 failed — the 5 failures are a pre-existing duplicate `clarification-collapse-toggle` testid defect unrelated to this change (verified byte-identical on the affected files since before this branch's work).
- `apps/web/e2e/tests/chat/quick-chat.spec.ts` plus the full chat E2E suite via the managed runner: 50 passed / 4 failed, same pre-existing duplicate-testid defect.
- Hand-driven in a real Chromium session (not just automation): opened Quick Chat, focused the composer, triggered the `@`-mention popup on a second ("background") composer instance, reopened a foreground popup, and confirmed Escape closes only the foreground popup while the background popup and the dialog both remain open — the exact two-composer scenario the fix targets.
- No visual/layout changes — the diff is entirely keyboard-event handling (capture/bubble listeners, refs, guard registries), so no screenshots are included.

## Possible Improvements

Low risk: the guard predicate in `use-suggestion-escape-fallback.ts` still arms unconditionally (`CLAIM_ANY_ESCAPE`) rather than mirroring the handler's own ownership test, which is asymmetric with the fix applied everywhere else. Every reachability path we could find (Tab-out, portal focus, outside click) is currently blocked by existing menu-closing behavior, so it's tracked as a follow-up rather than fixed here.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->