### PR TITLE
fix(office): mark codex usage estimated and backfill cost attribution

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/event_types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/event_types.go
@@ -686,6 +686,9 @@ func (p SessionTodosEventPayload) GetSessionID() string {
 // AgentID is the lifecycle execution.ID (UUID); AgentType is the CLI engine
 // slug (claude-acp, codex-acp, ...). The office cost subscriber derives the
 // provider name from AgentType — AgentID is kept for legacy consumers.
+// AgentProfileID is the stable profile recorded on the task session. It is
+// copied at publish time so asynchronous cost consumers do not use a mutable
+// workflow runner projection for attribution.
 //
 // TurnID is captured on the lifecycle completion frame before AgentReady can
 // admit a successor prompt and is forwarded by the orchestrator. The
@@ -694,15 +697,16 @@ func (p SessionTodosEventPayload) GetSessionID() string {
 // Both are empty when unavailable (e.g. no active turn), never a synthesized
 // placeholder.
 type SessionPromptUsageEventPayload struct {
-	TaskID       string               `json:"task_id"`
-	SessionID    string               `json:"session_id"`
-	AgentID      string               `json:"agent_id"`
-	AgentType    string               `json:"agent_type,omitempty"`
-	Model        string               `json:"model,omitempty"`
-	Usage        *streams.PromptUsage `json:"usage"`
-	Timestamp    string               `json:"timestamp"`
-	TurnID       string               `json:"turn_id,omitempty"`
-	UsageEventID string               `json:"usage_event_id,omitempty"`
+	TaskID         string               `json:"task_id"`
+	SessionID      string               `json:"session_id"`
+	AgentID        string               `json:"agent_id"`
+	AgentProfileID string               `json:"agent_profile_id,omitempty"`
+	AgentType      string               `json:"agent_type,omitempty"`
+	Model          string               `json:"model,omitempty"`
+	Usage          *streams.PromptUsage `json:"usage"`
+	Timestamp      string               `json:"timestamp"`
+	TurnID         string               `json:"turn_id,omitempty"`
+	UsageEventID   string               `json:"usage_event_id,omitempty"`
 }
 
 // GetSessionID returns the session ID for this event (used by event routing).

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -227,11 +227,17 @@ type Adapter struct {
 	availableModels []modelInfo
 
 	// usageBySession tracks the latest and previously consumed cumulative
-	// `usage_update` samples. codex-acp emits no per-turn usage frame, so the
-	// prompt-complete handler uses nonnegative context-occupancy growth as an
-	// estimated input count and derives true deltas from cumulative USD cost.
-	// claude-acp / opencode-acp report a real `result.usage` so this
-	// cache contributes only their provider-reported cost delta.
+	// `usage_update` samples. codex-acp DOES emit a typed per-turn usage
+	// frame on the prompt response, but it is scoped to the LAST model
+	// request of the turn, not the whole turn (see
+	// normalizeCodexPromptUsage in dialect_codex.go) — so this cache
+	// mainly contributes the provider-reported cost delta for adapters
+	// like claude-acp / opencode-acp that report a real `result.usage`.
+	// For an adapter with no typed usage frame at all, the prompt-complete
+	// handler falls back to nonnegative context-occupancy growth as an
+	// estimated input count (fallbackUsageForNilTypedUsage in
+	// adapter_prompt.go), gated on a provider-reported cost sample being
+	// present to attach.
 	usageBySession map[string]*usageTracker
 
 	// Available auth methods captured from the ACP initialize response.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -236,8 +236,9 @@ type Adapter struct {
 	// For an adapter with no typed usage frame at all, the prompt-complete
 	// handler falls back to nonnegative context-occupancy growth as an
 	// estimated input count (fallbackUsageForNilTypedUsage in
-	// adapter_prompt.go), gated on a provider-reported cost sample being
-	// present to attach.
+	// adapter_prompt.go). It attaches when context occupancy grew
+	// (delta > 0) OR a provider-reported cost sample is present —
+	// either condition alone is enough.
 	usageBySession map[string]*usageTracker
 
 	// Available auth methods captured from the ACP initialize response.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -267,21 +267,16 @@ func (a *Adapter) sendPrompt(
 		zap.String("stop_reason", stopReason))
 	a.cancelAsyncTurnComplete(sessionID)
 	usage := a.dialect.promptUsage(extractUsage(&resp), resp.Meta)
-	// codex-acp emits no per-turn usage frame, only cumulative context
-	// occupancy. Fall back to nonnegative occupancy growth so the office cost
-	// subscriber sees an approximate input count. It has no input/output split,
-	// so Estimated remains true. usage_update cost is cumulative session cost;
-	// consumeUsageDelta converts it to the current turn's nonnegative delta.
+	// Typed per-turn usage frames aren't universal — an adapter with no
+	// result.usage and no recognized _meta shape leaves usage nil here.
+	// usageBySession tracks cumulative context-window occupancy
+	// (usage_update frames) as a fallback signal for that case; see
+	// fallbackUsageForNilTypedUsage's doc comment. usage_update cost is
+	// cumulative session cost; consumeUsageDelta converts it to the
+	// current turn's nonnegative delta.
 	delta, costSubcents, costPresent := a.consumeUsageDeltaWithPresence(sessionID)
 	if usage == nil {
-		if delta > 0 || costPresent {
-			usage = &streams.PromptUsage{
-				InputTokens:                  delta,
-				Estimated:                    true,
-				ProviderReportedCostSubcents: costSubcents,
-				ProviderReportedCostPresent:  costPresent,
-			}
-		}
+		usage = fallbackUsageForNilTypedUsage(delta, costSubcents, costPresent)
 	} else if costPresent {
 		// claude-acp: usage_update.cost.amount carries authoritative cumulative
 		// USD cost — attach the derived turn delta so Layer A wins
@@ -301,6 +296,30 @@ func (a *Adapter) sendPrompt(
 	})
 
 	return nil
+}
+
+// fallbackUsageForNilTypedUsage synthesizes a usage frame from
+// context-window-occupancy growth for an adapter that reported no typed
+// per-turn usage at all (extractUsage found nothing recognizable). It
+// fires on nonnegative context growth or a provider-reported cost sample —
+// whichever is present — matching the pre-existing contract other callers
+// (e.g. the steering handoff path, which reports usage via cumulative
+// context growth alone with no cost) already depend on. It only ever
+// carries InputTokens: this adapter shape has no way to observe output
+// tokens, so OutputTokens is left at its zero value and Estimated=true is
+// the signal downstream must use to treat the whole row, including that
+// zero, as approximate rather than measured (see streams.PromptUsage's
+// doc comment).
+func fallbackUsageForNilTypedUsage(delta, costSubcents int64, costPresent bool) *streams.PromptUsage {
+	if delta <= 0 && !costPresent {
+		return nil
+	}
+	return &streams.PromptUsage{
+		InputTokens:                  delta,
+		Estimated:                    true,
+		ProviderReportedCostSubcents: costSubcents,
+		ProviderReportedCostPresent:  costPresent,
+	}
 }
 
 // supportsPromptHandoff reports whether this adapter's connected agent may have

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_codex.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_codex.go
@@ -3,6 +3,8 @@ package acp
 import (
 	"path"
 	"strings"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
 )
 
 const (
@@ -26,7 +28,33 @@ const (
 // operations through the same envelope, so only spawnAgent and the matching
 // "started" activity are creation signals.
 func newCodexACPDialect() acpDialect {
-	return acpDialect{subagentFrame: parseCodexSubagentFrame}
+	return acpDialect{
+		subagentFrame:        parseCodexSubagentFrame,
+		normalizePromptUsage: normalizeCodexPromptUsage,
+	}
+}
+
+// normalizeCodexPromptUsage marks codex-acp's typed usage frame as
+// estimated. codex-acp 1.4.0 does emit a typed usage block on the prompt
+// response, but its three response-construction sites (normal end_turn,
+// cancelled, terminal failure) all hardcode it to
+// sessionState.lastTokenUsage — the LAST model request of the turn, not a
+// per-turn total (sessionState.totalTokenUsage is tracked internally but
+// never crosses the ACP boundary). A turn making N requests reports only
+// request N's counts: verified against codex's own rollout log on both a
+// 22-request turn (recorded 410 output tokens vs a true 8813) and a
+// 4-request turn (recorded 9 vs a true 219). Estimated is the existing
+// signal for "not an authoritative per-turn frame" (streams.PromptUsage's
+// doc comment), so this keeps the row honest until codex-acp emits a
+// genuine per-turn total upstream.
+func normalizeCodexPromptUsage(
+	usage *streams.PromptUsage,
+	_ map[string]any,
+) *streams.PromptUsage {
+	if usage != nil {
+		usage.Estimated = true
+	}
+	return usage
 }
 
 // codexSystemErrorMeta reports the explicit thread-status marker emitted by

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_codex_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_codex_test.go
@@ -1,6 +1,48 @@
 package acp
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/coder/acp-go-sdk"
+)
+
+// TestCodexDialect_MarksTypedUsageEstimated is a regression test for the
+// codex-acp usage undercount: codex-acp 1.4.0 hardcodes the prompt
+// response's typed usage to the LAST model request of the turn
+// (buildPromptUsage reads sessionState.lastTokenUsage, never
+// totalTokenUsage), not a per-turn total. A 22-request Tetris-build turn
+// stored only request #22's counts (410 output tokens instead of 8813,
+// confirmed against the codex rollout log's total_token_usage). Before this
+// fix the codex dialect had no normalizePromptUsage hook, so this typed
+// frame passed through unmarked (Estimated stayed false) and was recorded
+// as an authoritative per-turn measurement.
+func TestCodexDialect_MarksTypedUsageEstimated(t *testing.T) {
+	response := &acp.PromptResponse{
+		Usage: &acp.Usage{
+			InputTokens:  37616,
+			OutputTokens: 410,
+			TotalTokens:  38026,
+		},
+	}
+	dialect := newCodexACPDialect()
+	usage := dialect.promptUsage(extractUsage(response), response.Meta)
+	if usage == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if !usage.Estimated {
+		t.Fatal("codex-acp typed usage is per-request, not per-turn; Estimated should be true")
+	}
+	if usage.InputTokens != 37616 || usage.OutputTokens != 410 {
+		t.Fatalf("token counts should pass through unchanged: got %+v", usage)
+	}
+}
+
+func TestCodexDialect_LeavesNilUsageAlone(t *testing.T) {
+	dialect := newCodexACPDialect()
+	if usage := dialect.promptUsage(nil, nil); usage != nil {
+		t.Fatalf("expected nil usage to stay nil, got %#v", usage)
+	}
+}
 
 func TestParseCodexSubagentFrameCollaboration(t *testing.T) {
 	meta := codexCollaborationMeta(codexCollaborationSpawnAgent, []any{"thread-child"})

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/usage_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/usage_test.go
@@ -287,6 +287,53 @@ func TestConsumeUsageDelta_UnknownSession(t *testing.T) {
 	}
 }
 
+// TestFallbackUsageForNilTypedUsage pins the extracted fallback's existing
+// contract (adapter_prompt.go's usage==nil branch, unchanged by this card):
+// it fires on nonnegative context growth OR a provider-reported cost
+// sample, and always carries InputTokens only — this adapter shape has no
+// way to observe output tokens, which is exactly what Estimated=true
+// signals downstream (see fallbackUsageForNilTypedUsage's doc comment).
+func TestFallbackUsageForNilTypedUsage(t *testing.T) {
+	t.Run("no growth and no cost sample yields nil", func(t *testing.T) {
+		if got := fallbackUsageForNilTypedUsage(0, 0, false); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("context growth alone attaches an estimated input-only frame", func(t *testing.T) {
+		got := fallbackUsageForNilTypedUsage(350, 0, false)
+		if got == nil {
+			t.Fatal("expected non-nil usage")
+		}
+		if !got.Estimated {
+			t.Error("Estimated should be true")
+		}
+		if got.InputTokens != 350 {
+			t.Errorf("InputTokens = %d, want 350", got.InputTokens)
+		}
+		if got.ProviderReportedCostPresent {
+			t.Error("no cost sample was supplied; ProviderReportedCostPresent should be false")
+		}
+	})
+
+	t.Run("cost sample present attaches the delta as an estimated frame", func(t *testing.T) {
+		got := fallbackUsageForNilTypedUsage(350, 615, true)
+		if got == nil {
+			t.Fatal("expected non-nil usage")
+		}
+		if got.ProviderReportedCostSubcents != 615 || !got.ProviderReportedCostPresent {
+			t.Errorf("provider cost not forwarded: %#v", got)
+		}
+	})
+
+	t.Run("cost sample present with zero growth still attaches", func(t *testing.T) {
+		got := fallbackUsageForNilTypedUsage(0, 0, true)
+		if got == nil {
+			t.Fatal("expected non-nil usage for an explicit zero cost sample")
+		}
+	})
+}
+
 func TestNewSession_ClearsUsageTrackers(t *testing.T) {
 	a, _ := setupConcurrencyFakeAgent(t)
 	if err := a.Initialize(context.Background()); err != nil {

--- a/apps/backend/internal/agentctl/types/streams/agent.go
+++ b/apps/backend/internal/agentctl/types/streams/agent.go
@@ -528,11 +528,17 @@ type ConfigOptionValue struct {
 // of a cent (amount_usd * 10000). When > 0 the office subscriber records
 // it verbatim and skips the models.dev pricing lookup.
 //
-// Estimated is true when the adapter synthesised token counts (e.g.
-// codex-acp's cumulative-delta inference) rather than receiving an
-// authoritative per-turn usage frame. Rows flagged estimated still count
-// toward budget totals at face value per
-// docs/specs/office-costs/spec.md.
+// Estimated is true when the token counts do not represent an
+// authoritative per-turn measurement: either the adapter synthesised them
+// (e.g. codex-acp's cumulative-delta inference when no typed usage frame
+// is present at all — fallbackUsageForNilTypedUsage in
+// server/adapter/transport/acp/adapter_prompt.go), or the typed frame
+// itself is scoped to less than the whole turn (codex-acp's usage field is
+// hardcoded to the LAST model request of a multi-request turn, not a
+// per-turn total — see normalizeCodexPromptUsage in
+// server/adapter/transport/acp/dialect_codex.go). Rows flagged estimated
+// still count toward budget totals at face value per
+// docs/specs/office/costs.md.
 type PromptUsage struct {
 	InputTokens                  int64 `json:"input_tokens"`
 	OutputTokens                 int64 `json:"output_tokens"`

--- a/apps/backend/internal/office/models/enums.go
+++ b/apps/backend/internal/office/models/enums.go
@@ -131,7 +131,7 @@ func (s BudgetScopeType) Valid() bool {
 }
 
 // CostSource records which layer priced a CostEvent's dollars, distinct
-// from Estimated (a token-synthesis flag). NULL on legacy rows written
+// from Estimated (a usage-authority flag). NULL on legacy rows written
 // before this field existed — never inferred.
 type CostSource string
 

--- a/apps/backend/internal/office/models/models.go
+++ b/apps/backend/internal/office/models/models.go
@@ -290,18 +290,17 @@ var ValidProjectStatuses = map[ProjectStatus]bool{
 //
 // CostSubcents is stored as hundredths of a cent (int64) to keep token-rate
 // math integer-only. UI divides by 10000 when rendering dollars. Estimated
-// is true when token counts were synthesised by the adapter (e.g.
-// cumulative-delta inference for codex-acp) rather than reported directly
-// by the agent; the row still counts toward budget totals at face value.
+// is true when token counts are not authoritative for a complete turn, such
+// as adapter synthesis or a provider frame that covers only part of a turn;
+// the row still counts toward budget totals at face value.
 //
 // TokensCachedRead / TokensCachedWrite / TurnID / UsageEventID / CostSource /
 // the Rate*PerMillion columns / PricingCatalogVersion / CostContractVersion
 // are all nullable (pointer fields): NULL means "not recorded" — a legacy
 // row written before the column existed, or (for the cache split
-// specifically) an adapter with no per-turn usage frame, such as codex-acp's
-// occupancy-growth synthesis (Estimated=true). NULL is never backfilled to
-// 0; TokensCachedIn keeps its original read+write sum semantics on every
-// row so existing consumers of that column are unaffected. See
+// specifically) an adapter that did not report cache data. NULL is never
+// backfilled to 0; TokensCachedIn keeps its original read+write sum semantics
+// on every row so existing consumers of that column are unaffected. See
 // docs/specs/office/costs.md.
 type CostEvent struct {
 	ID                        string      `json:"id" db:"id"`

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -266,9 +266,9 @@ func (r *Repository) createAgentRuntimeTable() error {
 
 func (r *Repository) createCostTables() error {
 	// cost_subcents stores hundredths of a cent (int64). UI divides by
-	// 10000 when rendering dollars. The estimated flag is set when
-	// token counts were synthesised (e.g. cumulative-delta inference for
-	// codex-acp) rather than reported directly by the agent.
+	// 10000 when rendering dollars. The estimated flag is set when token
+	// counts are not authoritative for a complete turn, such as adapter
+	// synthesis or a provider frame that covers only part of a turn.
 	//
 	// tokens_cached_read / tokens_cached_write / turn_id / usage_event_id /
 	// cost_source / rate_*_per_million / pricing_catalog_version /
@@ -276,8 +276,8 @@ func (r *Repository) createCostTables() error {
 	// is what makes a fresh row's un-set columns NULL rather than 0, matching
 	// the ALTER-based migration in migrateCostEventContract (which the same
 	// columns must stay byte-identical to — see base_migrations.go). NULL
-	// means "not recorded" (legacy row, or an adapter with no per-turn usage
-	// frame); 0 would silently claim zero cache activity. See
+	// means "not recorded" (legacy row, or an adapter that did not report
+	// cache data); 0 would silently claim zero cache activity. See
 	// docs/specs/office/costs.md.
 	_, err := r.db.Exec(`
 	CREATE TABLE IF NOT EXISTS office_cost_events (

--- a/apps/backend/internal/office/repository/sqlite/sessions.go
+++ b/apps/backend/internal/office/repository/sqlite/sessions.go
@@ -39,3 +39,21 @@ func (r *Repository) HasPriorSessionForAgent(ctx context.Context, taskID, agentI
 	}
 	return state != "CREATED", nil
 }
+
+// GetSessionAgentProfileID returns the agent_profile_id recorded on a
+// task_sessions row — the agent that actually ran the session, as opposed
+// to RunnerProjection's workflow-configured runner. Returns "" if the
+// session or its agent_profile_id is not found.
+func (r *Repository) GetSessionAgentProfileID(ctx context.Context, sessionID string) (string, error) {
+	var agentProfileID string
+	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(
+		`SELECT COALESCE(agent_profile_id, '') FROM task_sessions WHERE id = ?`,
+	), sessionID).Scan(&agentProfileID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return agentProfileID, nil
+}

--- a/apps/backend/internal/office/repository/sqlite/sessions.go
+++ b/apps/backend/internal/office/repository/sqlite/sessions.go
@@ -40,15 +40,18 @@ func (r *Repository) HasPriorSessionForAgent(ctx context.Context, taskID, agentI
 	return state != "CREATED", nil
 }
 
-// GetSessionAgentProfileID returns the agent_profile_id recorded on a
-// task_sessions row — the agent that actually ran the session, as opposed
-// to RunnerProjection's workflow-configured runner. Returns "" if the
-// session or its agent_profile_id is not found.
-func (r *Repository) GetSessionAgentProfileID(ctx context.Context, sessionID string) (string, error) {
+// GetSessionAgentProfileID returns the agent_profile_id recorded on the
+// task_sessions row for the given task. This is the agent that actually ran
+// the session, as opposed to RunnerProjection's workflow-configured runner.
+// Returns "" if the session, task pair, or agent_profile_id is not found.
+func (r *Repository) GetSessionAgentProfileID(
+	ctx context.Context, taskID, sessionID string,
+) (string, error) {
 	var agentProfileID string
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(
-		`SELECT COALESCE(agent_profile_id, '') FROM task_sessions WHERE id = ?`,
-	), sessionID).Scan(&agentProfileID)
+		`SELECT COALESCE(agent_profile_id, '') FROM task_sessions
+		 WHERE task_id = ? AND id = ?`,
+	), taskID, sessionID).Scan(&agentProfileID)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}

--- a/apps/backend/internal/office/service/base_test.go
+++ b/apps/backend/internal/office/service/base_test.go
@@ -96,6 +96,17 @@ func newTestService(t *testing.T, overrides ...service.ServiceOptions) *service.
 	)`); err != nil {
 		t.Fatalf("create workflow_step_participants: %v", err)
 	}
+	// Stub of task_sessions, mirroring the columns GetSessionAgentProfileID
+	// (RunnerProjection's fallback source, see prompt_usage_cost.go) reads.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS task_sessions (
+		id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL,
+		agent_profile_id TEXT,
+		started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create task_sessions: %v", err)
+	}
 
 	initSharedAgentProfilesSchema(t, db)
 
@@ -249,6 +260,18 @@ func setTestTaskAssignee(t *testing.T, svc *service.Service, taskID, agentID str
 			COALESCE((SELECT workflow_step_id FROM tasks WHERE id = ?), ''),
 			?, 'runner', ?, 0, 0
 		)`, taskID, taskID, taskID, taskID, agentID)
+}
+
+// insertTestTaskSession inserts a minimal task_sessions row so tests can
+// exercise the session-level agent_profile_id fallback in buildCostEvent
+// (prompt_usage_cost.go) — distinct from setTestTaskAssignee's
+// workflow_step_participants runner row.
+func insertTestTaskSession(t *testing.T, svc *service.Service, sessionID, taskID, agentProfileID string) {
+	t.Helper()
+	svc.ExecSQL(t,
+		`INSERT INTO task_sessions (id, task_id, agent_profile_id, started_at, updated_at)
+		 VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+		sessionID, taskID, agentProfileID)
 }
 
 // newTestServiceWithConfig returns a service backed by in-memory SQLite with a

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -569,9 +569,18 @@ func (s *Service) handlePromptUsage(ctx context.Context, event *bus.Event) error
 		return nil
 	}
 
+	sessionAgentProfileID := ""
+	if fields.AssigneeAgentProfileID == "" {
+		if id, err := s.repo.GetSessionAgentProfileID(ctx, data.SessionID); err == nil {
+			sessionAgentProfileID = id
+		}
+	}
+
 	resolution := s.resolveCostForUsage(ctx, *data)
 	provider := resolveProvider(*data)
-	costEvent := buildCostEvent(*data, fields, s.projectIDForTask(ctx, data.TaskID), provider, resolution)
+	costEvent := buildCostEvent(
+		*data, fields, s.projectIDForTask(ctx, data.TaskID), provider, resolution, sessionAgentProfileID,
+	)
 
 	if err := s.recordCostEventAndRollup(
 		ctx, costEvent, data.SessionID,

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -607,7 +607,7 @@ func (s *Service) handlePromptUsage(ctx context.Context, event *bus.Event) error
 
 	if fields.WorkspaceID != "" {
 		if err := s.CheckBudget(
-			ctx, fields.WorkspaceID, fields.AssigneeAgentProfileID, costEvent.ProjectID,
+			ctx, fields.WorkspaceID, costEvent.AgentProfileID, costEvent.ProjectID,
 		); err != nil {
 			s.logger.Warn("post-event budget check failed",
 				zap.String("task_id", data.TaskID), zap.Error(err))

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -571,7 +571,17 @@ func (s *Service) handlePromptUsage(ctx context.Context, event *bus.Event) error
 
 	sessionAgentProfileID := ""
 	if fields.AssigneeAgentProfileID == "" {
-		if id, err := s.repo.GetSessionAgentProfileID(ctx, data.SessionID); err == nil {
+		id, lookupErr := s.repo.GetSessionAgentProfileID(ctx, data.SessionID)
+		if lookupErr != nil {
+			// Best-effort attribution fallback: log and continue with an
+			// unattributed row rather than dropping the cost event over a
+			// failed lookup, which would reproduce the exact symptom this
+			// fallback exists to fix.
+			s.logger.Warn("session agent profile lookup failed",
+				zap.String("task_id", data.TaskID),
+				zap.String("session_id", data.SessionID),
+				zap.Error(lookupErr))
+		} else {
 			sessionAgentProfileID = id
 		}
 	}

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -116,15 +116,16 @@ type AgentLifecycleData struct {
 }
 
 type PromptUsageData struct {
-	TaskID       string      `json:"task_id"`
-	SessionID    string      `json:"session_id"`
-	AgentID      string      `json:"agent_id"`
-	AgentType    string      `json:"agent_type"`
-	Model        string      `json:"model"`
-	Provider     string      `json:"provider"`
-	Usage        UsageTokens `json:"usage"`
-	TurnID       string      `json:"turn_id,omitempty"`
-	UsageEventID string      `json:"usage_event_id,omitempty"`
+	TaskID         string      `json:"task_id"`
+	SessionID      string      `json:"session_id"`
+	AgentID        string      `json:"agent_id"`
+	AgentProfileID string      `json:"agent_profile_id,omitempty"`
+	AgentType      string      `json:"agent_type"`
+	Model          string      `json:"model"`
+	Provider       string      `json:"provider"`
+	Usage          UsageTokens `json:"usage"`
+	TurnID         string      `json:"turn_id,omitempty"`
+	UsageEventID   string      `json:"usage_event_id,omitempty"`
 }
 
 // UsageTokens mirrors streams.PromptUsage on the wire. All counts are int64
@@ -134,8 +135,9 @@ type PromptUsageData struct {
 // ProviderReportedCostPresent is true (including an explicit zero), the
 // subscriber uses it directly and skips the models.dev lookup. The legacy
 // positive-value check remains in the resolver for older events. Estimated is
-// true when the adapter synthesised tokens (codex-acp cumulative-delta
-// inference).
+// true when the token counts are not authoritative for a complete turn: the
+// adapter synthesised them (codex-acp cumulative-delta inference), or the
+// provider returned a frame that covers only part of the turn.
 type UsageTokens struct {
 	InputTokens                  int64 `json:"input_tokens"`
 	OutputTokens                 int64 `json:"output_tokens"`
@@ -529,7 +531,7 @@ func (s *Service) tryPostStartFallback(
 // update. Cost resolution follows the two-layer order from
 // docs/specs/office/costs.md, and CostSource on the row records which
 // layer actually produced the dollar amount (see resolveCostForUsage in
-// prompt_usage_cost.go — distinct from Estimated, a token-synthesis flag):
+// prompt_usage_cost.go — distinct from Estimated, a usage-authority flag):
 //
 //  1. Provider-reported cost (Layer A) — claude-acp emits exact USD per
 //     turn on usage_update.cost.amount; the adapter forwards this as
@@ -544,7 +546,7 @@ func (s *Service) tryPostStartFallback(
 //     data.Usage.Estimated verbatim on this path, not hardcoded true.
 //
 // buildCostEvent (prompt_usage_cost.go) also records the cache read/write
-// split (NULL when Usage.Estimated — see its doc comment) and turn_id /
+// split when the usage frame reports cache data, and turn_id /
 // usage_event_id threaded from the publish site. The ledger insert and the
 // task_sessions rollup increment (tokens_in / tokens_cached_in / tokens_out /
 // cost_subcents) are written atomically by recordCostEventAndRollup — see its
@@ -569,9 +571,9 @@ func (s *Service) handlePromptUsage(ctx context.Context, event *bus.Event) error
 		return nil
 	}
 
-	sessionAgentProfileID := ""
-	if fields.AssigneeAgentProfileID == "" {
-		id, lookupErr := s.repo.GetSessionAgentProfileID(ctx, data.SessionID)
+	sessionAgentProfileID := data.AgentProfileID
+	if sessionAgentProfileID == "" {
+		id, lookupErr := s.repo.GetSessionAgentProfileID(ctx, data.TaskID, data.SessionID)
 		if lookupErr != nil {
 			// Best-effort attribution fallback: log and continue with an
 			// unattributed row rather than dropping the cost event over a

--- a/apps/backend/internal/office/service/event_subscribers_cost_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_cost_test.go
@@ -317,8 +317,8 @@ func TestPromptUsage_CostSourceModelsDevList(t *testing.T) {
 	if row.PricingCatalogVersion == nil || *row.PricingCatalogVersion != "2026-08-12T00:00:00Z" {
 		t.Errorf("PricingCatalogVersion = %v, want the fake's version", row.PricingCatalogVersion)
 	}
-	if row.CostContractVersion == nil || *row.CostContractVersion != 2 {
-		t.Errorf("CostContractVersion = %v, want 2 (in-band activation point)", row.CostContractVersion)
+	if row.CostContractVersion == nil || *row.CostContractVersion != 3 {
+		t.Errorf("CostContractVersion = %v, want 3 (in-band activation point)", row.CostContractVersion)
 	}
 }
 
@@ -385,9 +385,9 @@ func TestPromptUsage_ThoughtTokensDoNotAffectCost(t *testing.T) {
 // covers the R2-F4 regression: usage carrying authoritative (non-synthesised)
 // token counts must keep Estimated=false even though the row is unpriced —
 // cost_source=unpriced alone carries "we could not resolve a price";
-// Estimated is strictly "the token counts were synthesised" (see
-// costContractVersion's v1→v2 doc comment in prompt_usage_cost.go). Before
-// that fix this case incorrectly forced Estimated=true.
+// Estimated remains independent from pricing resolution (see the
+// costContractVersion history in prompt_usage_cost.go). Before v2 this case
+// incorrectly forced Estimated=true.
 func TestPromptUsage_CostSourceUnpriced(t *testing.T) {
 	svc, eb := newTestServiceWithBus(t)
 	ctx := context.Background()
@@ -419,7 +419,7 @@ func TestPromptUsage_CostSourceUnpriced(t *testing.T) {
 		t.Fatalf("CostSource = %v, want %q", row.CostSource, models.CostSourceUnpriced)
 	}
 	if row.Estimated {
-		t.Error("Estimated = true, want false: unpriced must not overwrite the adapter's own token-synthesis flag")
+		t.Error("Estimated = true, want false: unpriced must not overwrite the adapter's usage-authority flag")
 	}
 }
 
@@ -463,11 +463,10 @@ func TestPromptUsage_FallsBackToSessionAgentProfileWhenUnassigned(t *testing.T) 
 	}
 }
 
-// TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile confirms the
-// session fallback strictly fills blanks: when RunnerProjection already
-// resolves an assignee, the session's own agent_profile_id (which could
-// differ, e.g. after a mid-task agent swap) must never override it.
-func TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile(t *testing.T) {
+// TestPromptUsage_SessionAgentProfileWinsOverWorkflowRunner protects the
+// immutable attribution boundary: the session's profile owns the usage event,
+// even when RunnerProjection now points at a different workflow runner.
+func TestPromptUsage_SessionAgentProfileWinsOverWorkflowRunner(t *testing.T) {
 	svc, eb := newTestServiceWithBus(t)
 	ctx := context.Background()
 
@@ -494,8 +493,8 @@ func TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile(t *testing.T) {
 	if err != nil || len(costs) != 1 {
 		t.Fatalf("list costs: %v (len=%d)", err, len(costs))
 	}
-	if got := costs[0].AgentProfileID; got != "workflow-runner" {
-		t.Errorf("AgentProfileID = %q, want %q (workflow projection must win)", got, "workflow-runner")
+	if got := costs[0].AgentProfileID; got != "session-runner" {
+		t.Errorf("AgentProfileID = %q, want %q (session identity must win)", got, "session-runner")
 	}
 }
 

--- a/apps/backend/internal/office/service/event_subscribers_cost_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_cost_test.go
@@ -627,3 +627,61 @@ func TestPromptUsage_DuplicateUsageEventIDIsIdempotent(t *testing.T) {
 		t.Fatalf("cost count = %d, want 1 (redelivery must not double-record)", len(costs))
 	}
 }
+
+// TestPromptUsage_BudgetCheckUsesSessionFallbackProfile is a regression test
+// for the companion budget-check gap: buildCostEvent already resolves the
+// session fallback into costEvent.AgentProfileID (see
+// TestPromptUsage_FallsBackToSessionAgentProfileWhenUnassigned), but the
+// post-event CheckBudget call still passed the empty
+// fields.AssigneeAgentProfileID. filterApplicablePolicies matches an
+// agent-scoped policy against that argument, so on this fallback path an
+// over-budget agent's pause_agent policy never matched and the agent was
+// never paused, no matter how much it spent.
+func TestPromptUsage_BudgetCheckUsesSessionFallbackProfile(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "codex-runner-budget")
+	policy := &models.BudgetPolicy{
+		WorkspaceID:       "ws-1",
+		ScopeType:         "agent",
+		ScopeID:           "codex-runner-budget",
+		LimitSubcents:     10,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "pause_agent",
+	}
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	insertTestTask(t, svc, "task-budget-fallback", "ws-1")
+	// Deliberately no setTestTaskAssignee call: no workflow runner, so the
+	// session fallback path is exercised exactly as in
+	// TestPromptUsage_FallsBackToSessionAgentProfileWhenUnassigned.
+	insertTestTaskSession(t, svc, "session-budget-fallback", "task-budget-fallback", "codex-runner-budget")
+
+	event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+		"task_id":    "task-budget-fallback",
+		"session_id": "session-budget-fallback",
+		"model":      "sonnet",
+		"usage": map[string]interface{}{
+			"input_tokens":                    100,
+			"output_tokens":                   200,
+			"provider_reported_cost_subcents": 1000,
+			"provider_reported_cost_present":  true,
+		},
+	})
+	if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject("session-budget-fallback"), event); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	agent, err := svc.GetAgentInstance(ctx, "codex-runner-budget")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if agent.Status != models.AgentStatusPaused {
+		t.Errorf("agent status = %q, want %q (budget policy must apply to the session-fallback profile)",
+			agent.Status, models.AgentStatusPaused)
+	}
+}

--- a/apps/backend/internal/office/service/event_subscribers_cost_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_cost_test.go
@@ -259,6 +259,63 @@ func TestPromptUsage_CostSourceModelsDevList(t *testing.T) {
 	}
 }
 
+// TestPromptUsage_ThoughtTokensDoNotAffectCost is a regression test for the
+// triage correction on the card: reasoning_output_tokens is a SUBSET of
+// output_tokens (OpenAI's own accounting: last_total = last_in + last_out
+// held across all 22 Tetris-benchmark rows even though reasoning was
+// nonzero), not an addend. Folding ThoughtTokens into billable output would
+// have double-counted and inflated that turn's cost by ~22%. Pins the cost
+// for an identical usage sample with and without ThoughtTokens set.
+func TestPromptUsage_ThoughtTokensDoNotAffectCost(t *testing.T) {
+	pricing := &fakePricingLookup{
+		hit: true,
+		pricing: shared.ModelPricing{
+			InputPerMillion:  300000,
+			OutputPerMillion: 1500000,
+		},
+	}
+
+	costFor := func(taskID, sessionID string, thoughtTokens int) int64 {
+		svc, eb := newTestServiceWithBus(t)
+		svc.SetPricingLookup(pricing)
+		ctx := context.Background()
+		createTestAgent(t, svc, "ws-1", "worker-thought")
+		insertTestTask(t, svc, taskID, "ws-1")
+		setTestTaskAssignee(t, svc, taskID, "worker-thought")
+
+		usage := map[string]interface{}{
+			"input_tokens":  37616,
+			"output_tokens": 410,
+		}
+		if thoughtTokens > 0 {
+			usage["thought_tokens"] = thoughtTokens
+		}
+		event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+			"task_id":    taskID,
+			"session_id": sessionID,
+			"model":      "gpt-5.6-terra",
+			"usage":      usage,
+		})
+		if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject(sessionID), event); err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+		costs, err := svc.ListCostEvents(ctx, "ws-1")
+		if err != nil || len(costs) != 1 {
+			t.Fatalf("list costs: %v (len=%d)", err, len(costs))
+		}
+		return costs[0].CostSubcents
+	}
+
+	withoutReasoning := costFor("task-thought-a", "session-thought-a", 0)
+	withReasoning := costFor("task-thought-b", "session-thought-b", 238)
+	if withoutReasoning != withReasoning {
+		t.Fatalf(
+			"cost changed with ThoughtTokens present: without=%d with=%d, want equal (reasoning tokens are a subset of output, not billable separately)",
+			withoutReasoning, withReasoning,
+		)
+	}
+}
+
 // TestPromptUsage_CostSourceUnpriced confirms the "both layers miss" case
 // (no provider-reported cost, no pricing lookup wired) is tagged unpriced,
 // not silently left as a bare estimated=true with no source at all. It also
@@ -300,6 +357,82 @@ func TestPromptUsage_CostSourceUnpriced(t *testing.T) {
 	}
 	if row.Estimated {
 		t.Error("Estimated = true, want false: unpriced must not overwrite the adapter's own token-synthesis flag")
+	}
+}
+
+// TestPromptUsage_FallsBackToSessionAgentProfileWhenUnassigned is a
+// regression test for the codex cost-attribution gap: a task on a Kanban
+// step with no pinned runner (or, in general, no workflow_step_participants
+// 'runner' row) resolves RunnerProjection to "", so every cost event for it
+// attributed to no agent profile at all — measured at 421/639 opus and
+// 186/640 sonnet cost events store-wide. The session that actually ran the
+// turn still knows: task_sessions.agent_profile_id is populated. buildCostEvent
+// should fall back to it only when the workflow projection is blank.
+func TestPromptUsage_FallsBackToSessionAgentProfileWhenUnassigned(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "codex-runner")
+	insertTestTask(t, svc, "task-no-runner", "ws-1")
+	// Deliberately no setTestTaskAssignee call: the workflow step has no
+	// pinned runner, so RunnerProjection resolves to "".
+	insertTestTaskSession(t, svc, "session-no-runner", "task-no-runner", "codex-runner")
+
+	event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+		"task_id":    "task-no-runner",
+		"session_id": "session-no-runner",
+		"model":      "gpt-5.6-terra",
+		"usage": map[string]interface{}{
+			"input_tokens":  100,
+			"output_tokens": 10,
+		},
+	})
+	if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject("session-no-runner"), event); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	costs, err := svc.ListCostEvents(ctx, "ws-1")
+	if err != nil || len(costs) != 1 {
+		t.Fatalf("list costs: %v (len=%d)", err, len(costs))
+	}
+	if got := costs[0].AgentProfileID; got != "codex-runner" {
+		t.Errorf("AgentProfileID = %q, want %q (session fallback)", got, "codex-runner")
+	}
+}
+
+// TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile confirms the
+// session fallback strictly fills blanks: when RunnerProjection already
+// resolves an assignee, the session's own agent_profile_id (which could
+// differ, e.g. after a mid-task agent swap) must never override it.
+func TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "workflow-runner")
+	createTestAgent(t, svc, "ws-1", "session-runner")
+	insertTestTask(t, svc, "task-both-runners", "ws-1")
+	setTestTaskAssignee(t, svc, "task-both-runners", "workflow-runner")
+	insertTestTaskSession(t, svc, "session-both-runners", "task-both-runners", "session-runner")
+
+	event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+		"task_id":    "task-both-runners",
+		"session_id": "session-both-runners",
+		"model":      "sonnet",
+		"usage": map[string]interface{}{
+			"input_tokens":  100,
+			"output_tokens": 10,
+		},
+	})
+	if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject("session-both-runners"), event); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	costs, err := svc.ListCostEvents(ctx, "ws-1")
+	if err != nil || len(costs) != 1 {
+		t.Fatalf("list costs: %v (len=%d)", err, len(costs))
+	}
+	if got := costs[0].AgentProfileID; got != "workflow-runner" {
+		t.Errorf("AgentProfileID = %q, want %q (workflow projection must win)", got, "workflow-runner")
 	}
 }
 

--- a/apps/backend/internal/office/service/event_subscribers_cost_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_cost_test.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/office/models"
@@ -76,12 +81,17 @@ func TestPromptUsage_CacheSplitRecordedWhenNotEstimated(t *testing.T) {
 	}
 }
 
-// TestPromptUsage_CacheSplitNullWhenEstimated confirms the codex/no-usage-
-// frame caveat: when Usage.Estimated is true (context-occupancy synthesis,
-// adapter_prompt.go's fallback), the split columns must be NULL, never 0 —
-// a zero would falsely claim "no cache activity" for an adapter that never
-// reported cache tokens at all. tokens_cached_in still equals read+write
-// (both zero here), preserving the existing column's semantics.
+// TestPromptUsage_CacheSplitNullWhenEstimated confirms the context-occupancy
+// fallback caveat (adapter_prompt.go's fallbackUsageForNilTypedUsage, used
+// when an adapter emits no typed usage frame at all): when the usage sample
+// carries no cache counts at all (both fields absent/zero, as that fallback
+// always produces), the split columns must be NULL, never 0 — a zero would
+// falsely claim "no cache activity" for an adapter that never reported cache
+// tokens at all. The gate is cache-data availability, not Usage.Estimated
+// (see TestPromptUsage_CacheSplitPersistedWhenEstimatedWithCacheData for the
+// codex case: Estimated=true but real cache numbers present). tokens_cached_in
+// still equals read+write (both zero here), preserving the existing column's
+// semantics.
 func TestPromptUsage_CacheSplitNullWhenEstimated(t *testing.T) {
 	svc, eb := newTestServiceWithBus(t)
 	ctx := context.Background()
@@ -114,6 +124,59 @@ func TestPromptUsage_CacheSplitNullWhenEstimated(t *testing.T) {
 	}
 	if row.TokensCachedWrite != nil {
 		t.Errorf("TokensCachedWrite = %v, want nil (NULL, never 0)", *row.TokensCachedWrite)
+	}
+}
+
+// TestPromptUsage_CacheSplitPersistedWhenEstimatedWithCacheData is a
+// regression test for a Review round-1 finding: gating the cache split on
+// Usage.Estimated (rather than on whether cache data is actually present)
+// silently dropped codex's real cache numbers, because codex-acp's typed
+// per-request usage frame sets Estimated=true (it is scoped to the last
+// model request of the turn, not the whole turn) while still reporting
+// genuine cachedReadTokens/cachedWriteTokens — a live capture showed
+// cachedReadTokens=22272 on exactly such a frame. The split must survive
+// even though the row is (correctly) marked estimated.
+func TestPromptUsage_CacheSplitPersistedWhenEstimatedWithCacheData(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "worker-codex-cache")
+	insertTestTask(t, svc, "task-codex-cache", "ws-1")
+	setTestTaskAssignee(t, svc, "task-codex-cache", "worker-codex-cache")
+
+	event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+		"task_id":    "task-codex-cache",
+		"session_id": "session-codex-cache",
+		"agent_id":   "codex-acp",
+		"model":      "gpt-5.6-terra",
+		"usage": map[string]interface{}{
+			"input_tokens":        377,
+			"cached_read_tokens":  22272,
+			"cached_write_tokens": 0,
+			"output_tokens":       9,
+			"estimated":           true,
+		},
+	})
+	if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject("session-codex-cache"), event); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	costs, err := svc.ListCostEvents(ctx, "ws-1")
+	if err != nil || len(costs) != 1 {
+		t.Fatalf("list costs: %v (len=%d)", err, len(costs))
+	}
+	row := costs[0]
+	if !row.Estimated {
+		t.Fatalf("Estimated = false, want true (codex's typed frame is per-request, not per-turn)")
+	}
+	if row.TokensCachedRead == nil || *row.TokensCachedRead != 22272 {
+		t.Errorf("TokensCachedRead = %v, want 22272 (real cache data must survive Estimated=true)", row.TokensCachedRead)
+	}
+	if row.TokensCachedWrite == nil || *row.TokensCachedWrite != 0 {
+		t.Errorf("TokensCachedWrite = %v, want 0 (explicit, not nil)", row.TokensCachedWrite)
+	}
+	if row.TokensCachedIn != 22272 {
+		t.Errorf("TokensCachedIn = %d, want 22272 (read+write, unchanged semantics)", row.TokensCachedIn)
 	}
 }
 
@@ -433,6 +496,57 @@ func TestPromptUsage_WorkflowRunnerWinsOverSessionAgentProfile(t *testing.T) {
 	}
 	if got := costs[0].AgentProfileID; got != "workflow-runner" {
 		t.Errorf("AgentProfileID = %q, want %q (workflow projection must win)", got, "workflow-runner")
+	}
+}
+
+// TestPromptUsage_SessionAgentProfileLookupFailureLogsAndContinues is a
+// regression test for a Review round-1 finding: the session-agent-profile
+// fallback lookup's error was silently discarded, unlike every other error
+// path in handlePromptUsage (each of which records an explicit drop-reason
+// counter). A DB failure on that lookup would have silently reproduced the
+// exact "unattributed cost event" symptom this card was filed to fix, with
+// nothing in the logs to explain why. The fix logs the failure and — since
+// attribution is best-effort — still writes the cost event, unattributed,
+// rather than dropping it.
+func TestPromptUsage_SessionAgentProfileLookupFailureLogsAndContinues(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("create observer logger: %v", err)
+	}
+	svc, eb := newTestServiceWithBusLogger(t, log)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "codex-runner")
+	insertTestTask(t, svc, "task-broken-lookup", "ws-1")
+	// Deliberately no setTestTaskAssignee call, so RunnerProjection is ""
+	// and handlePromptUsage takes the session-fallback branch under test.
+	svc.ExecSQL(t, `DROP TABLE task_sessions`)
+
+	event := bus.NewEvent(events.SessionPromptUsageUpdated, "test", map[string]interface{}{
+		"task_id":    "task-broken-lookup",
+		"session_id": "session-broken-lookup",
+		"agent_id":   "codex-acp",
+		"model":      "gpt-5.6-terra",
+		"usage": map[string]interface{}{
+			"input_tokens":  100,
+			"output_tokens": 10,
+		},
+	})
+	if err := eb.Publish(ctx, events.BuildSessionPromptUsageSubject("session-broken-lookup"), event); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	if logs.FilterMessage("session agent profile lookup failed").Len() == 0 {
+		t.Fatal("session agent profile lookup failure was not logged")
+	}
+
+	costs, err := svc.ListCostEvents(ctx, "ws-1")
+	if err != nil || len(costs) != 1 {
+		t.Fatalf("list costs: %v (len=%d) — lookup failure must not drop the cost event", err, len(costs))
+	}
+	if got := costs[0].AgentProfileID; got != "" {
+		t.Errorf("AgentProfileID = %q, want \"\" (fallback lookup failed, no attribution to fall back to)", got)
 	}
 }
 

--- a/apps/backend/internal/office/service/event_subscribers_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_test.go
@@ -520,9 +520,9 @@ func TestPromptUsage_RecordsCostEvent(t *testing.T) {
 	// With no pricing lookup wired and no provider-reported cost, the row
 	// records 0 (Layer A miss + no Layer B), tagged cost_source=unpriced.
 	// Estimated tracks data.Usage.Estimated verbatim (unset here, so false)
-	// — it is a token-synthesis flag, distinct from cost_source, which is
+	// — it is a usage-authority flag, distinct from cost_source, which is
 	// what actually carries the "we could not resolve a price" signal. See
-	// costContractVersion's v1->v2 doc comment in prompt_usage_cost.go.
+	// costContractVersion's version history in prompt_usage_cost.go.
 	if costs[0].CostSubcents != 0 {
 		t.Fatalf("cost_subcents = %d, want 0 (no pricing lookup wired)", costs[0].CostSubcents)
 	}

--- a/apps/backend/internal/office/service/prompt_usage_cost.go
+++ b/apps/backend/internal/office/service/prompt_usage_cost.go
@@ -122,14 +122,18 @@ func (s *Service) lookupPricingWithVersion(
 // strictly fills blanks and never overrides an existing attribution.
 //
 // The cache split (TokensCachedRead / TokensCachedWrite) is recorded only
-// when data.Usage.Estimated is false. codex-acp's ACP bridge (and any
-// future adapter with no per-turn usage frame) synthesises InputTokens from
-// context-occupancy growth with Estimated=true and never sets the cache
-// fields — a NULL split there is honest; 0 would silently claim "no cache
-// activity" for an agent that never reported one. TokensCachedIn keeps its
-// original read+write sum on every row regardless, so existing consumers
-// (the tree-holds rollup, card 2faa29da's task_sessions fix) are
-// unaffected.
+// when the usage frame actually carries cache data (either field nonzero).
+// The context-occupancy fallback (fallbackUsageForNilTypedUsage in
+// adapter_prompt.go) never populates either field, so a NULL split there is
+// honest — it is a "no data reported" absence, not a claimed zero. Gating on
+// Estimated instead would be wrong: codex-acp's per-request typed frame sets
+// Estimated=true (it's scoped to the last model request of the turn, not
+// the whole turn — see normalizeCodexPromptUsage in dialect_codex.go) but
+// does carry real cache numbers, and discarding them would silently NULL a
+// value we actually have. TokensCachedIn keeps its original read+write sum
+// on every row regardless — a definite total whether or not the split is
+// known — so existing consumers (the tree-holds rollup, card 2faa29da's
+// task_sessions fix) are unaffected.
 func buildCostEvent(
 	data PromptUsageData, fields *sqlite.TaskExecutionFields, projectID, provider string,
 	resolution costResolution, sessionAgentProfileID string,
@@ -156,7 +160,7 @@ func buildCostEvent(
 	contractVersion := costContractVersion
 	event.CostContractVersion = &contractVersion
 
-	if !data.Usage.Estimated {
+	if data.Usage.CachedReadTokens != 0 || data.Usage.CachedWriteTokens != 0 {
 		cachedRead := data.Usage.CachedReadTokens
 		cachedWrite := data.Usage.CachedWriteTokens
 		event.TokensCachedRead = &cachedRead

--- a/apps/backend/internal/office/service/prompt_usage_cost.go
+++ b/apps/backend/internal/office/service/prompt_usage_cost.go
@@ -115,6 +115,12 @@ func (s *Service) lookupPricingWithVersion(
 // buildCostEvent assembles the office_cost_events row for a prompt-usage
 // update.
 //
+// AgentProfileID prefers RunnerProjection's workflow-configured runner
+// (fields.AssigneeAgentProfileID) and falls back to sessionAgentProfileID —
+// the session's own task_sessions.agent_profile_id — only when that
+// projection is empty (e.g. a Kanban step with no pinned runner). This
+// strictly fills blanks and never overrides an existing attribution.
+//
 // The cache split (TokensCachedRead / TokensCachedWrite) is recorded only
 // when data.Usage.Estimated is false. codex-acp's ACP bridge (and any
 // future adapter with no per-turn usage frame) synthesises InputTokens from
@@ -126,12 +132,16 @@ func (s *Service) lookupPricingWithVersion(
 // unaffected.
 func buildCostEvent(
 	data PromptUsageData, fields *sqlite.TaskExecutionFields, projectID, provider string,
-	resolution costResolution,
+	resolution costResolution, sessionAgentProfileID string,
 ) *models.CostEvent {
+	agentProfileID := fields.AssigneeAgentProfileID
+	if agentProfileID == "" {
+		agentProfileID = sessionAgentProfileID
+	}
 	event := &models.CostEvent{
 		SessionID:      data.SessionID,
 		TaskID:         data.TaskID,
-		AgentProfileID: fields.AssigneeAgentProfileID,
+		AgentProfileID: agentProfileID,
 		ProjectID:      projectID,
 		Model:          data.Model,
 		Provider:       provider,

--- a/apps/backend/internal/office/service/prompt_usage_cost.go
+++ b/apps/backend/internal/office/service/prompt_usage_cost.go
@@ -15,7 +15,7 @@ import (
 // The Rill cost extract has no schema versioning of its own, so a row
 // written under a prior contract is distinguished by comparing
 // cost_contract_version, not by a date an analyst has to be told out of
-// band. Bump only if the contract's meaning changes again.
+// band. Bump whenever the contract's meaning changes.
 //
 // v1 → v2: on the CostSourceUnpriced path, v1 forced Estimated=true
 // regardless of data.Usage.Estimated, conflating "we could not resolve a
@@ -24,7 +24,10 @@ import (
 // to keep separate. v2 preserves data.Usage.Estimated verbatim on every
 // path (see resolveCostForUsage); cost_source=unpriced alone now carries
 // the pricing-failure signal.
-const costContractVersion int64 = 2
+//
+// v2 → v3: Estimated also marks typed usage frames that cover only part of a
+// turn, such as Codex's last model request in a multi-request turn.
+const costContractVersion int64 = 3
 
 // costResolution is resolveCostForUsage's output: the priced cost plus
 // everything needed to record provenance on the row. Kept separate from
@@ -40,7 +43,7 @@ type costResolution struct {
 
 // resolveCostForUsage applies the Layer A / Layer B lookup and records
 // which layer produced the dollar amount — CostSource, distinct from
-// Estimated (a token-synthesis flag, not cost provenance). Layer A wins
+// Estimated (a usage-authority flag, not cost provenance). Layer A wins
 // when the adapter forwarded a provider-reported cost sample, including an
 // explicit zero
 // (claude-acp's usage_update.cost.amount). Layer B (models.dev) is queried
@@ -48,8 +51,8 @@ type costResolution struct {
 // configured the row is unpriced. Estimated is data.Usage.Estimated
 // verbatim on every branch, including unpriced: whether the tokens were
 // synthesised and whether a price could be resolved are independent facts,
-// and cost_source=unpriced already carries the second one — see
-// costContractVersion's v1→v2 doc comment.
+// and cost_source=unpriced already carries the second one — see the
+// costContractVersion history above.
 func (s *Service) resolveCostForUsage(ctx context.Context, data PromptUsageData) costResolution {
 	if data.Usage.ProviderReportedCostPresent || data.Usage.ProviderReportedCostSubcents > 0 {
 		return costResolution{
@@ -115,11 +118,11 @@ func (s *Service) lookupPricingWithVersion(
 // buildCostEvent assembles the office_cost_events row for a prompt-usage
 // update.
 //
-// AgentProfileID prefers RunnerProjection's workflow-configured runner
-// (fields.AssigneeAgentProfileID) and falls back to sessionAgentProfileID —
-// the session's own task_sessions.agent_profile_id — only when that
-// projection is empty (e.g. a Kanban step with no pinned runner). This
-// strictly fills blanks and never overrides an existing attribution.
+// AgentProfileID prefers sessionAgentProfileID — the stable
+// task_sessions.agent_profile_id captured when the session ran. It falls back
+// to RunnerProjection's workflow-configured runner only for legacy events that
+// have no session identity. This prevents a later workflow reassignment from
+// moving an earlier session's usage to a different profile.
 //
 // The cache split (TokensCachedRead / TokensCachedWrite) is recorded only
 // when the usage frame actually carries cache data (either field nonzero).
@@ -138,9 +141,9 @@ func buildCostEvent(
 	data PromptUsageData, fields *sqlite.TaskExecutionFields, projectID, provider string,
 	resolution costResolution, sessionAgentProfileID string,
 ) *models.CostEvent {
-	agentProfileID := fields.AssigneeAgentProfileID
+	agentProfileID := sessionAgentProfileID
 	if agentProfileID == "" {
-		agentProfileID = sessionAgentProfileID
+		agentProfileID = fields.AssigneeAgentProfileID
 	}
 	event := &models.CostEvent{
 		SessionID:      data.SessionID,

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -2567,6 +2567,8 @@ func usageEventIDFor(sessionID, executionID string, promptGeneration uint64) str
 // case — CurrentModelID only travels on session_models frames) we fall back
 // to the session's AgentProfileSnapshot, populated at session creation and
 // refreshed by persistSessionModel on ACP model updates.
+// AgentProfileID always comes from the persistent task session. It must not
+// be resolved from the mutable workflow runner projection after publication.
 //
 // turnID is resolved by the caller (handleCompleteStreamEvent), not here:
 // the terminal-execution snapshot and the live active-turn lookup are both
@@ -2586,16 +2588,21 @@ func (s *Service) publishPromptUsage(
 	}
 
 	model, agentType := resolvePromptUsageLabels(payload, session)
+	agentProfileID := ""
+	if session != nil {
+		agentProfileID = session.AgentProfileID
+	}
 
 	eventPayload := lifecycle.SessionPromptUsageEventPayload{
-		TaskID:    payload.TaskID,
-		SessionID: sessionID,
-		AgentID:   payload.AgentID,
-		AgentType: agentType,
-		Model:     model,
-		Usage:     payload.Data.Usage,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		TurnID:    turnID,
+		TaskID:         payload.TaskID,
+		SessionID:      sessionID,
+		AgentID:        payload.AgentID,
+		AgentProfileID: agentProfileID,
+		AgentType:      agentType,
+		Model:          model,
+		Usage:          payload.Data.Usage,
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+		TurnID:         turnID,
 		UsageEventID: usageEventIDFor(
 			sessionID, payload.ExecutionID, payload.Data.PromptGeneration,
 		),

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -1365,6 +1365,10 @@ func TestPublishPromptUsage_NonTerminalCompletionUsesReadyTurnSnapshot(t *testin
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
+	session, err := repo.GetTaskSession(ctx, "s1")
+	require.NoError(t, err)
+	session.AgentProfileID = "session-agent"
+	require.NoError(t, repo.UpdateTaskSession(ctx, session))
 
 	stepGetter := newMockStepGetter()
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
@@ -1408,6 +1412,8 @@ func TestPublishPromptUsage_NonTerminalCompletionUsesReadyTurnSnapshot(t *testin
 	require.NotNil(t, usageEvent, "expected a session_prompt_usage.updated event to be published")
 	require.Equal(t, turn.ID, usageEvent.TurnID,
 		"non-terminal completion must carry the turn id the ready event just closed, not NULL")
+	require.Equal(t, "session-agent", usageEvent.AgentProfileID,
+		"prompt usage must carry the stable profile recorded on the task session")
 }
 
 // TestPublishPromptUsage_CompletionPayloadTurnIDOwnsTurn verifies that a

--- a/docs/specs/office/costs.md
+++ b/docs/specs/office/costs.md
@@ -1,7 +1,7 @@
 ---
 status: in-progress
 created: 2026-04-25
-updated: 2026-08-14
+updated: 2026-08-18
 owner: cfl
 ---
 
@@ -43,17 +43,17 @@ Office adds per-session cost estimation, aggregated views by agent/project/model
 | `provider` | string | e.g. `anthropic`, `openai` |
 | `tokens_in` | int64 | input token count |
 | `tokens_cached_in` | int64 | cached input tokens (prompt caching). Always `= tokens_cached_read + tokens_cached_write` when the split is known; kept for existing rollup consumers (see `TaskSession additions` below) |
-| `tokens_cached_read` | int64, nullable | cached-read portion of `tokens_cached_in`. NULL for legacy rows (pre-contract-v2) and for adapters with no per-turn usage frame (`estimated=true`, e.g. codex-acp) - never `0`, since a merged column cannot be decomposed after the fact |
+| `tokens_cached_read` | int64, nullable | cached-read portion of `tokens_cached_in`. NULL for legacy rows (pre-contract-v2) and when no cache data was reported - never `0`, since a missing split is not proof of zero cache usage |
 | `tokens_cached_write` | int64, nullable | cached-write portion of `tokens_cached_in`. Same NULL rule as `tokens_cached_read` - cache write and cache read price at different per-million rates, so the split matters |
 | `tokens_out` | int64 | output token count |
 | `cost_subcents` | int64 | hundredths of a cent (renamed from `cost_cents`). UI divides by 10000 |
-| `estimated` | bool | true when token counts were synthesised (e.g. codex-acp's cumulative-delta inference). A token-synthesis flag ONLY - independent of `cost_source` below. An unpriced row (list-price lookup miss) does not force this true; it reflects whatever the usage payload reported |
+| `estimated` | bool | true when token counts are not authoritative for a complete turn: the adapter synthesised them (for example, codex-acp cumulative-delta inference), or the provider frame covers only part of the turn (for example, Codex's last request). Independent of `cost_source` |
 | `turn_id` | string, nullable | the turn this event was recorded at completion of. NULL when no turn could be resolved (e.g. an error/interrupt completion outside the normal ready path) |
 | `usage_event_id` | string, nullable | idempotency key derived from `(session_id, execution_id, prompt_generation)` at the publish site; unique when non-NULL (partial index) so a redelivered prompt-usage event does not double-insert or double-count the session rollup. NULL for legacy rows. Generation-less transports receive a random per-publish key, so those rows are intentionally not deduplicated |
 | `cost_source` | enum, nullable | `provider_reported` \| `models_dev_list` \| `unpriced`. Records which layer of the two-layer lookup below actually produced `cost_subcents` - distinct from `estimated`. NULL for legacy rows |
 | `rate_input_per_million` / `rate_cached_read_per_million` / `rate_cached_write_per_million` / `rate_output_per_million` | int64, nullable | the four models.dev rates actually applied, in subcents-per-million-tokens. Populated only when `cost_source = models_dev_list`; NULL otherwise (including `provider_reported`, where no rate table applies) |
 | `pricing_catalog_version` | string, nullable | the models.dev cache's "as-of" identifier (RFC3339 load/fetch time - the dataset has no version field of its own) that produced the applied rates. Populated only when `cost_source = models_dev_list` |
-| `cost_contract_version` | int64, nullable | in-band activation marker for this row's column semantics, since the point-in-time Rill extract has no schema versioning of its own. Current value `2` (v1 -> v2: the unpriced path stopped forcing `estimated=true`, see the `estimated` row above). NULL for legacy pre-contract rows - never backfilled |
+| `cost_contract_version` | int64, nullable | in-band activation marker for this row's column semantics, since the point-in-time Rill extract has no schema versioning of its own. Current value `3` (v1 -> v2 separated pricing failure from token synthesis; v2 -> v3 also marks partial-turn typed usage as estimated). NULL for legacy pre-contract rows - never backfilled |
 | `provider_event_id` | string | null for wire-side rows; non-null for disk-runner rows. Format `ccusage:<provider>:<session_id>:<model>` |
 | `provider_credits` | int64 | amp `credits` field (null elsewhere) |
 | `occurred_at` | timestamp | when the cost was incurred |
@@ -61,6 +61,10 @@ Office adds per-session cost estimation, aggregated views by agent/project/model
 Disk-runner rows are upserted by `(session_id, provider_event_id)`. For codex, after a successful aggregate row lands, the wire-side `estimated=true` rows for the same session are deleted to avoid double-counting.
 
 **Contract v2 columns** (`tokens_cached_read`, `tokens_cached_write`, `turn_id`, `usage_event_id`, `cost_source`, the four `rate_*_per_million` columns, `pricing_catalog_version`, `cost_contract_version`) were added via an idempotent nullable-column migration (`migrateCostEventContract`); every legacy row reads NULL for all of them, never `0` - see the cross-cutting rule in `Persistence guarantees` below. Postgres parity follows the same migration shape per ADR 0027.
+
+**Contract v3 semantics** keep the v2 column layout and pricing-source rules. They
+define `estimated=true` for both synthesised totals and typed usage frames that
+cover only part of a turn.
 
 ### `office_budget_policies`
 
@@ -199,7 +203,7 @@ There is no per-field permission model. Conformance tests should assert that cos
 **Survives restart:**
 
 - `office_cost_events` rows (full history, never trimmed). Disk-runner rows keyed by `(session_id, provider_event_id)` survive re-ingestion without duplicating; wire-side rows are additionally deduplicated by the unique `usage_event_id` partial index (contract v2). The wire-side `estimated=true` rows for codex are deleted once the matching aggregate row lands.
-- **Contract v2 column semantics never change value mid-series.** Legacy rows (written before contract v2) read NULL, never `0`, for every new column - the downstream point-in-time extract has no schema versioning, so a column whose meaning flips from "not recorded" to "recorded as zero" partway through the series would be silently discontinuous. `cost_contract_version` on each row is the in-band marker a consumer checks instead of inferring from a date.
+- **Contract v2 column semantics never change value mid-series.** Legacy rows (written before contract v2) read NULL, never `0`, for every new column - the downstream point-in-time extract has no schema versioning, so a column whose meaning flips from "not recorded" to "recorded as zero" partway through the series would be silently discontinuous. `cost_contract_version` on each row is the in-band marker a consumer checks instead of inferring from a date. Contract v3 changes the meaning of `estimated` for new rows only; legacy rows keep their recorded value.
 - `office_budget_policies` rows.
 - `TaskSession.cost_subcents` / `tokens_in` / `tokens_out` / `tokens_cached_in` running totals, kept in sync with `office_cost_events` so per-session totals are correct without a re-scan - written atomically with the ledger insert (see `Failure modes` above), so the two can never diverge on a partial write.
 - Per-agent `budget_monthly_cents` stored on the agent instance row.

--- a/docs/specs/office/costs.md
+++ b/docs/specs/office/costs.md
@@ -102,7 +102,7 @@ replaced successfully.
 - **claude-acp**: `result.usage` (camelCase, `cachedRead`/`cachedWriteTokens`), plus cumulative `usage_update.cost.amount` in USD; the adapter emits its nonnegative turn delta when present. claude-acp uses logical aliases (`sonnet`, `haiku`); provider-reported cost is the only accurate signal.
 - **opencode-acp**: `result.usage` with `inputTokens`/`outputTokens`/`thoughtTokens` (no cached tokens). Optional `usage_update.cost.amount` (often `0` on BYOK).
 - **gemini**: `result._meta.quota.token_count.{input_tokens, output_tokens}` (snake_case, no cached, no cost).
-- **codex-acp**: current context occupancy in `usage_update.used`; adapter uses nonnegative occupancy growth as a per-turn estimate and flags rows `estimated=true`. Input vs output cannot be split on the wire. Compaction or other decreases reset the estimate baseline.
+- **codex-acp**: 1.4.0+ emits a typed `result.usage` block on the prompt response, but its three response-construction sites (normal end_turn, cancelled, terminal failure) all hardcode it to the session's last model request, not a per-turn total — a turn making N requests reports only request N's counts. The adapter accepts this typed frame (input/output/cache split, when present) but always flags rows `estimated=true` until codex-acp emits a genuine per-turn total upstream. Prior to 1.4.0 (or if the frame is absent), the adapter falls back to nonnegative context-occupancy growth from `usage_update.used` as a per-turn estimate; that fallback cannot split input vs output and compaction or other decreases reset its baseline.
 - **auggie**, **copilot-acp**: not tracked. `_meta.copilotUsage` is a billing multiplier; Copilot `/usage` would require scraping.
 
 ### Disk-runner provider coverage
@@ -227,7 +227,9 @@ No TTL or retention is applied to `office_cost_events`; rows accumulate for the 
 
 - **GIVEN** a claude-acp turn that reports both cached-read and cached-write tokens, **WHEN** the cost event is recorded, **THEN** `tokens_cached_read` and `tokens_cached_write` are stored as the separate values reported (not merged), `tokens_cached_in` equals their sum, and `cost_subcents` reflects each portion priced at its own per-million rate.
 
-- **GIVEN** a codex-acp turn (no per-turn usage frame; tokens synthesised from context-occupancy growth, `estimated=true`), **WHEN** the cost event is recorded, **THEN** `tokens_cached_read` and `tokens_cached_write` are NULL (never `0`) because the split was never observed, while `tokens_cached_in` and `cost_subcents` are still recorded from the synthesised totals.
+- **GIVEN** a codex-acp turn using the context-occupancy-growth fallback (no typed usage frame available; tokens synthesised from `usage_update.used` growth, `estimated=true`), **WHEN** the cost event is recorded, **THEN** `tokens_cached_read` and `tokens_cached_write` are NULL (never `0`) because the split was never observed, while `tokens_cached_in` and `cost_subcents` are still recorded from the synthesised totals.
+
+- **GIVEN** a codex-acp 1.4.0+ turn whose typed usage frame reports a nonzero cache split, **WHEN** the cost event is recorded, **THEN** `estimated=true` (the frame is the last request only, not a per-turn total) and `tokens_cached_read`/`tokens_cached_write` are stored as the reported split. When the frame's cache fields are both zero, the split is stored as NULL rather than `0/0`, matching the "split never observed" rule above rather than distinguishing a reported zero from an absent field.
 
 - **GIVEN** a turn priced via the models.dev lookup, **WHEN** the cost event is recorded, **THEN** `cost_source=models_dev_list` and the row carries the four `rate_*_per_million` values and `pricing_catalog_version` actually applied, distinguishable from a provider-reported row (`cost_source=provider_reported`, no rate columns) and an unpriced row (`cost_source=unpriced`, `cost_subcents=0`).
 


### PR DESCRIPTION
Codex cost events were recorded from `codex-acp`'s per-request usage frame while being presented as measured whole-turn totals (confirmed by direct capture and codex's own rollout logs: a 22-request Tetris-build turn recorded only its final request, undercounting output tokens 21.5x and cost 24.8x), and ~30% of cost events across all agents land with no `agent_profile_id` because the workflow-configured runner projection is empty on unpinned steps even when the session itself knows who ran.

## Important Changes

- codex's typed usage frame is now marked `Estimated=true` — codex-acp 1.4.0 never puts the turn total on the wire (confirmed against its source), so presenting a per-request number as measured was wrong; the flag now tells that story honestly instead of silently.
- `buildCostEvent` falls back to the session's `task_sessions.agent_profile_id` only when the workflow-projected assignee is empty, strictly filling blanks without overriding an existing attribution.
- The cache-token split (`TokensCachedRead`/`TokensCachedWrite`) now gates on whether cache data is actually present rather than on `Estimated`, so codex's genuine per-request cache numbers keep persisting instead of being NULLed alongside the new `Estimated=true` flag.
- A previously-swallowed session agent-profile lookup error is now logged (matching this function's existing best-effort-failure convention) instead of failing silently with no trace.
- Two stale comments claiming codex-acp emits no per-turn usage frame are corrected, and a dangling doc path (`docs/specs/office-costs/spec.md` → `docs/specs/office/costs.md`) is fixed.

Explicitly not touched: the pricing boundary (reasoning/thought tokens stay out of billable output — they are a subset of output tokens, not an addend, confirmed against codex's own totals), and the 6 historical codex cost rows (no backfill/restatement).

## Validation

- `go test -count=1 ./internal/agentctl/server/adapter/transport/acp/... ./internal/office/service/... ./internal/office/repository/sqlite/... ./internal/agentctl/types/streams/...` — all pass.
- `make fmt` — clean.
- `make typecheck` — clean.
- `make lint` — 0 issues (backend, web, harness, architecture).
- `make lint-format` — clean.
- `cd apps/web && pnpm run i18n:ratchet` — clean, no UI source touched.
- `make test` (full backend suite) — failures confined to `internal/agent/managedruntime`, `internal/agent/settings/controller`, `internal/agentctl/server/config`, `internal/repoclone`, `internal/system/storage/workspaces`; each reproduced identically against the merge-base in a scratch worktree (sandbox filesystem restrictions and full-suite-load timing flakiness), none in a package touched by this change.
- E2E not required: no path under `apps/web/`, no new UI or controls — recorded values and one boolean flag only.

## Possible Improvements

Low risk — internal recording/pricing logic only, no UI or API surface change; the upstream root cause (codex-acp 1.4.0 puts only the last model request's usage on the wire, not the turn total) is not fixable in this repo and is not fixed here — this PR only stops misrepresenting that partial number as measured. Follow-up: file against `@agentclientprotocol/codex-acp` to emit a per-turn total.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->