### PR TITLE
fix: preserve ACP runtime configuration across reset

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -562,27 +563,35 @@ func (m *Manager) captureSessionRuntimeConfigForReset(
 	execution *AgentExecution,
 ) models.SessionRuntimeConfig {
 	profileModel, profileMode, profileOptions := m.resolveProfileSessionConfig(ctx, execution.AgentProfileID)
-	model, mode, options, optionsSet := m.effectiveSessionRuntimeConfigWithPresence(
-		ctx, execution, profileModel, profileMode, profileOptions,
-	)
 	modelState := execution.GetModelState()
-	if model == "" && modelState != nil {
-		model = modelState.CurrentModelID
+	liveModel := profileModel
+	if modelState != nil && strings.TrimSpace(modelState.CurrentModelID) != "" {
+		liveModel = modelState.CurrentModelID
 	}
-	if mode == "" {
-		if modeState := execution.GetModeState(); modeState != nil {
-			mode = modeState.CurrentModeID
+	liveMode := profileMode
+	if modeState := execution.GetModeState(); modeState != nil && strings.TrimSpace(modeState.CurrentModeID) != "" {
+		liveMode = modeState.CurrentModeID
+	}
+	liveOptions := maps.Clone(profileOptions)
+	if liveStateOptions, liveOptionsKnown := liveSessionRuntimeConfigOptions(modelState); liveOptionsKnown {
+		// A settled provider snapshot is the live layer, including an empty
+		// snapshot. Keep an allocated empty map so the effective-config helper
+		// preserves that presence while persisted state can still overlay it.
+		liveOptions = make(map[string]string, len(liveStateOptions))
+		for id, value := range liveStateOptions {
+			liveOptions[id] = value
 		}
 	}
-	if liveOptions, liveOptionsKnown := liveSessionRuntimeConfigOptions(modelState); liveOptionsKnown {
-		options = liveOptions
-	} else if !optionsSet {
+	model, mode, options, optionsSet := m.effectiveSessionRuntimeConfigWithPresence(
+		ctx, execution, liveModel, liveMode, liveOptions,
+	)
+	if !optionsSet {
 		options = selectedRuntimeConfigOptions(modelState)
 	}
 	return models.SessionRuntimeConfig{
 		Model:         model,
 		Mode:          mode,
-		ConfigOptions: sanitizeRuntimeConfigOptions(options),
+		ConfigOptions: sanitizeRuntimeConfigOptionsWithCatalog(options, modelState),
 	}
 }
 
@@ -612,16 +621,49 @@ func selectedRuntimeConfigOptions(state *CachedModelState) map[string]string {
 }
 
 func sanitizeRuntimeConfigOptions(options map[string]string) map[string]string {
+	return sanitizeRuntimeConfigOptionsWithCatalog(options, nil)
+}
+
+func sanitizeRuntimeConfigOptionsWithCatalog(options map[string]string, state *CachedModelState) map[string]string {
 	if options == nil {
 		return nil
 	}
+	catalog, catalogKnown := capturedRuntimeConfigOptionCatalog(state)
 	cleaned := make(map[string]string, len(options))
 	for id, value := range options {
-		if isRestorableRuntimeConfigOption(id, "", value) {
-			cleaned[strings.TrimSpace(id)] = strings.TrimSpace(value)
+		trimmedID := strings.TrimSpace(id)
+		category := ""
+		if catalogKnown {
+			var ok bool
+			category, ok = catalog[trimmedID]
+			if !ok {
+				continue
+			}
+		}
+		if isRestorableRuntimeConfigOption(trimmedID, category, value) {
+			cleaned[trimmedID] = strings.TrimSpace(value)
 		}
 	}
 	return cleaned
+}
+
+func capturedRuntimeConfigOptionCatalog(state *CachedModelState) (map[string]string, bool) {
+	if state == nil || (!state.ConfigOptionsSettled && len(state.ConfigOptions) == 0) {
+		return nil, false
+	}
+	catalog := make(map[string]string, len(state.ConfigOptions))
+	for _, option := range state.ConfigOptions {
+		id := strings.TrimSpace(option.ID)
+		if id == "" {
+			continue
+		}
+		category := strings.TrimSpace(option.Category)
+		if previous, exists := catalog[id]; exists && previous != "" {
+			continue
+		}
+		catalog[id] = category
+	}
+	return catalog, true
 }
 
 func isRestorableRuntimeConfigOption(id, category, value string) bool {
@@ -651,7 +693,7 @@ func (m *Manager) restoreSessionRuntimeConfig(
 	if err := m.applySessionModeAfterReset(ctx, execution, sessionID, config.Mode); err != nil {
 		return fmt.Errorf("restore session runtime mode: %w", err)
 	}
-	options := sanitizeRuntimeConfigOptions(config.ConfigOptions)
+	options := sanitizeRuntimeConfigOptionsWithCatalog(config.ConfigOptions, execution.GetModelState())
 	optionIDs := make([]string, 0, len(options))
 	for id := range options {
 		optionIDs = append(optionIDs, id)
@@ -701,14 +743,14 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 	if err != nil {
 		m.logger.Info("cannot resolve agent config for session reset, falling back to process restart",
 			zap.String("execution_id", executionID), zap.Error(err))
-		return m.RestartAgentProcess(ctx, executionID)
+		return m.restartAgentProcess(ctx, executionID, &runtimeConfig)
 	}
 
 	mcpServers, err := m.resolveMcpServers(ctx, execution, agentConfig)
 	if err != nil {
 		m.logger.Warn("cannot resolve MCP servers for session reset, falling back to process restart",
 			zap.String("execution_id", executionID), zap.Error(err))
-		return m.RestartAgentProcess(ctx, executionID)
+		return m.restartAgentProcess(ctx, executionID, &runtimeConfig)
 	}
 
 	// Try session-level reset (only ACP adapters support this)
@@ -716,7 +758,7 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 	if err != nil {
 		m.logger.Info("session reset not supported, falling back to process restart",
 			zap.String("execution_id", executionID), zap.Error(err))
-		return m.RestartAgentProcess(ctx, executionID)
+		return m.restartAgentProcess(ctx, executionID, &runtimeConfig)
 	}
 
 	// Success — update execution state without restarting process
@@ -896,6 +938,17 @@ func (m *Manager) StopBySessionID(ctx context.Context, sessionID string, force b
 // conversation context. For ACP agents this restarts via agentctl with a new ACP session.
 // For passthrough (TUI) agents this kills the PTY process and relaunches without --resume.
 func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) error {
+	return m.restartAgentProcess(ctx, executionID, nil)
+}
+
+// restartAgentProcess restarts an ACP process. When runtimeConfigOverride is
+// supplied, it is the immutable pre-reset snapshot and must be used instead of
+// reading state again after ResetAgentContext has cleared the old catalog.
+func (m *Manager) restartAgentProcess(
+	ctx context.Context,
+	executionID string,
+	runtimeConfigOverride *models.SessionRuntimeConfig,
+) error {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
 		return fmt.Errorf("execution %q not found: %w", executionID, ErrExecutionNotFound)
@@ -910,7 +963,7 @@ func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) e
 		return fmt.Errorf("execution %q has no agentctl client", executionID)
 	}
 
-	preparation, err := m.prepareAgentRestart(ctx, execution)
+	preparation, err := m.prepareAgentRestart(ctx, execution, runtimeConfigOverride)
 	if err != nil {
 		return err
 	}
@@ -924,12 +977,7 @@ func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) e
 	execution.agentctl.CloseWorkspaceStream()
 
 	// 2. Stop the agent subprocess via agentctl (keeps agentctl server alive)
-	if err := execution.agentctl.Stop(ctx); err != nil {
-		m.logger.Warn("failed to stop agent subprocess during restart",
-			zap.String("execution_id", executionID),
-			zap.Error(err))
-		// Continue — the process may already be stopped
-	}
+	m.stopAgentProcessForRestart(ctx, execution)
 
 	// 3. Reset execution state after the replacement command has been validated.
 	m.resetAgentRestartState(executionID, preparation.commands)
@@ -987,6 +1035,15 @@ func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) e
 	return nil
 }
 
+func (m *Manager) stopAgentProcessForRestart(ctx context.Context, execution *AgentExecution) {
+	if err := execution.agentctl.Stop(ctx); err != nil {
+		m.logger.Warn("failed to stop agent subprocess during restart",
+			zap.String("execution_id", execution.ID),
+			zap.Error(err))
+		// Continue — the process may already be stopped
+	}
+}
+
 type agentRestartPreparation struct {
 	agentConfig   agents.Agent
 	commands      agentCommands
@@ -994,7 +1051,11 @@ type agentRestartPreparation struct {
 }
 
 // prepareAgentRestart builds and validates the replacement before touching the current process.
-func (m *Manager) prepareAgentRestart(ctx context.Context, execution *AgentExecution) (agentRestartPreparation, error) {
+func (m *Manager) prepareAgentRestart(
+	ctx context.Context,
+	execution *AgentExecution,
+	runtimeConfigOverride *models.SessionRuntimeConfig,
+) (agentRestartPreparation, error) {
 	m.logger.Info("restarting agent process for context reset",
 		zap.String("execution_id", execution.ID),
 		zap.String("task_id", execution.TaskID),
@@ -1008,11 +1069,25 @@ func (m *Manager) prepareAgentRestart(ctx context.Context, execution *AgentExecu
 	if err != nil {
 		return agentRestartPreparation{}, fmt.Errorf("failed to rebuild agent command for restart: %w", err)
 	}
+	var runtimeConfig models.SessionRuntimeConfig
+	if runtimeConfigOverride == nil {
+		runtimeConfig = m.captureSessionRuntimeConfigForReset(ctx, execution)
+	} else {
+		runtimeConfig = cloneSessionRuntimeConfig(*runtimeConfigOverride)
+	}
 	return agentRestartPreparation{
 		agentConfig:   agentConfig,
 		commands:      commands,
-		runtimeConfig: m.captureSessionRuntimeConfigForReset(ctx, execution),
+		runtimeConfig: runtimeConfig,
 	}, nil
+}
+
+func cloneSessionRuntimeConfig(config models.SessionRuntimeConfig) models.SessionRuntimeConfig {
+	return models.SessionRuntimeConfig{
+		Model:         config.Model,
+		Mode:          config.Mode,
+		ConfigOptions: maps.Clone(config.ConfigOptions),
+	}
 }
 
 func (m *Manager) resetAgentRestartState(executionID string, commands agentCommands) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -550,7 +550,7 @@ func waitForFreshSessionModelState(ctx context.Context, log *logger.Logger, exec
 }
 
 func freshSessionModelCatalogReady(state *CachedModelState) bool {
-	return state != nil && len(state.Models) > 0
+	return state != nil && (len(state.Models) > 0 || len(state.ConfigOptions) > 0 || state.ConfigOptionsSettled)
 }
 
 func (m *Manager) effectiveSessionModelForReset(ctx context.Context, execution *AgentExecution) string {
@@ -574,7 +574,9 @@ func (m *Manager) captureSessionRuntimeConfigForReset(
 			mode = modeState.CurrentModeID
 		}
 	}
-	if !optionsSet {
+	if liveOptions, liveOptionsKnown := liveSessionRuntimeConfigOptions(modelState); liveOptionsKnown {
+		options = liveOptions
+	} else if !optionsSet {
 		options = selectedRuntimeConfigOptions(modelState)
 	}
 	return models.SessionRuntimeConfig{
@@ -582,6 +584,13 @@ func (m *Manager) captureSessionRuntimeConfigForReset(
 		Mode:          mode,
 		ConfigOptions: sanitizeRuntimeConfigOptions(options),
 	}
+}
+
+func liveSessionRuntimeConfigOptions(state *CachedModelState) (map[string]string, bool) {
+	if state == nil || (!state.ConfigOptionsSettled && len(state.ConfigOptions) == 0) {
+		return nil, false
+	}
+	return selectedRuntimeConfigOptions(state), true
 }
 
 func selectedRuntimeConfigOptions(state *CachedModelState) map[string]string {
@@ -733,15 +742,16 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 		waitForFreshSessionModelState(ctx, m.logger, execution)
 	}
 	if err := m.restoreSessionRuntimeConfig(ctx, execution, newSessionID, runtimeConfig); err != nil {
-		_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
-			exec.Status = v1.AgentStatusFailed
-			exec.ErrorMessage = err.Error()
-		})
-		return err
+		restoreErr := fmt.Errorf("failed to restore session runtime configuration after reset: %w", err)
+		m.updateExecutionError(executionID, restoreErr.Error())
+		m.persistExecutorRunning(context.WithoutCancel(ctx), execution)
+		return restoreErr
 	}
-	_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
-		exec.Status = v1.AgentStatusReady
-	})
+	if err := m.updateStatusAndPersist(ctx, executionID, v1.AgentStatusReady); err != nil {
+		m.updateExecutionError(executionID, "failed to mark reset agent ready: "+err.Error())
+		m.persistExecutorRunning(context.WithoutCancel(ctx), execution)
+		return fmt.Errorf("failed to mark reset agent ready: %w", err)
+	}
 
 	m.logger.Info("agent context reset via session (no process restart)",
 		zap.String("execution_id", executionID),

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -415,25 +417,33 @@ func (m *Manager) AuthenticateBySessionID(ctx context.Context, sessionID, method
 // before its agent mode event updated modeState. A nil/empty resolved mode is a
 // no-op. Addresses issue #1183.
 func (m *Manager) reapplySessionModeAfterReset(ctx context.Context, execution *AgentExecution, newSessionID string, prev *CachedModeState) {
-	if execution.agentctl == nil {
-		return
-	}
 	fallback := ""
-	var availableModes []streams.SessionModeInfo
 	if prev != nil {
 		fallback = prev.CurrentModeID
-		availableModes = prev.AvailableModes
 	}
 	mode := m.effectiveSessionMode(ctx, execution, fallback)
-	if mode == "" {
-		return
-	}
-	if err := execution.agentctl.SetMode(ctx, newSessionID, mode); err != nil {
+	if err := m.applySessionModeAfterReset(ctx, execution, newSessionID, mode); err != nil {
 		m.logger.Warn("failed to re-apply session mode after context reset",
 			zap.String("execution_id", execution.ID),
 			zap.String("mode", mode),
 			zap.Error(err))
-		return
+	}
+}
+
+func (m *Manager) applySessionModeAfterReset(
+	ctx context.Context,
+	execution *AgentExecution,
+	newSessionID, mode string,
+) error {
+	if execution.agentctl == nil || mode == "" {
+		return nil
+	}
+	if err := execution.agentctl.SetMode(ctx, newSessionID, mode); err != nil {
+		return fmt.Errorf("failed to restore session mode %q: %w", mode, err)
+	}
+	availableModes := []streams.SessionModeInfo(nil)
+	if current := execution.GetModeState(); current != nil {
+		availableModes = current.AvailableModes
 	}
 	// Restore the cache too: the fresh session would otherwise report the agent's
 	// default mode, leaving modeState stale relative to what we just re-applied.
@@ -445,6 +455,7 @@ func (m *Manager) reapplySessionModeAfterReset(ctx context.Context, execution *A
 		zap.String("execution_id", execution.ID),
 		zap.String("session_id", execution.SessionID),
 		zap.String("mode", mode))
+	return nil
 }
 
 // reapplySessionModelAfterReset applies the executor-authoritative model
@@ -543,16 +554,107 @@ func freshSessionModelCatalogReady(state *CachedModelState) bool {
 }
 
 func (m *Manager) effectiveSessionModelForReset(ctx context.Context, execution *AgentExecution) string {
-	modelFallback := ""
-	if previous := execution.GetModelState(); previous != nil {
-		modelFallback = previous.CurrentModelID
+	return m.captureSessionRuntimeConfigForReset(ctx, execution).Model
+}
+
+func (m *Manager) captureSessionRuntimeConfigForReset(
+	ctx context.Context,
+	execution *AgentExecution,
+) models.SessionRuntimeConfig {
+	profileModel, profileMode, profileOptions := m.resolveProfileSessionConfig(ctx, execution.AgentProfileID)
+	model, mode, options, optionsSet := m.effectiveSessionRuntimeConfigWithPresence(
+		ctx, execution, profileModel, profileMode, profileOptions,
+	)
+	modelState := execution.GetModelState()
+	if model == "" && modelState != nil {
+		model = modelState.CurrentModelID
 	}
-	if modelFallback == "" {
-		profileModel, _, _ := m.resolveProfileSessionConfig(ctx, execution.AgentProfileID)
-		modelFallback = profileModel
+	if mode == "" {
+		if modeState := execution.GetModeState(); modeState != nil {
+			mode = modeState.CurrentModeID
+		}
 	}
-	model, _, _ := m.effectiveSessionRuntimeConfig(ctx, execution, modelFallback, "", nil)
-	return model
+	if !optionsSet {
+		options = selectedRuntimeConfigOptions(modelState)
+	}
+	return models.SessionRuntimeConfig{
+		Model:         model,
+		Mode:          mode,
+		ConfigOptions: sanitizeRuntimeConfigOptions(options),
+	}
+}
+
+func selectedRuntimeConfigOptions(state *CachedModelState) map[string]string {
+	if state == nil {
+		return nil
+	}
+	options := make(map[string]string, len(state.ConfigOptions))
+	for _, option := range state.ConfigOptions {
+		id := strings.TrimSpace(option.ID)
+		value := strings.TrimSpace(option.CurrentValue)
+		if isRestorableRuntimeConfigOption(id, option.Category, value) {
+			options[id] = value
+		}
+	}
+	if len(options) == 0 {
+		return nil
+	}
+	return options
+}
+
+func sanitizeRuntimeConfigOptions(options map[string]string) map[string]string {
+	if options == nil {
+		return nil
+	}
+	cleaned := make(map[string]string, len(options))
+	for id, value := range options {
+		if isRestorableRuntimeConfigOption(id, "", value) {
+			cleaned[strings.TrimSpace(id)] = strings.TrimSpace(value)
+		}
+	}
+	return cleaned
+}
+
+func isRestorableRuntimeConfigOption(id, category, value string) bool {
+	id = strings.TrimSpace(id)
+	value = strings.TrimSpace(value)
+	if id == "" || value == "" {
+		return false
+	}
+	if strings.EqualFold(id, "model") || strings.EqualFold(id, "mode") {
+		return false
+	}
+	return !strings.EqualFold(category, "model") && !strings.EqualFold(category, "mode")
+}
+
+func (m *Manager) restoreSessionRuntimeConfig(
+	ctx context.Context,
+	execution *AgentExecution,
+	sessionID string,
+	config models.SessionRuntimeConfig,
+) error {
+	if execution == nil || execution.agentctl == nil {
+		return fmt.Errorf("cannot restore session runtime configuration without an agentctl client")
+	}
+	if err := m.reapplySessionModelAfterReset(ctx, execution, sessionID, config.Model); err != nil {
+		return fmt.Errorf("restore session runtime model: %w", err)
+	}
+	if err := m.applySessionModeAfterReset(ctx, execution, sessionID, config.Mode); err != nil {
+		return fmt.Errorf("restore session runtime mode: %w", err)
+	}
+	options := sanitizeRuntimeConfigOptions(config.ConfigOptions)
+	optionIDs := make([]string, 0, len(options))
+	for id := range options {
+		optionIDs = append(optionIDs, id)
+	}
+	sort.Strings(optionIDs)
+	for _, id := range optionIDs {
+		value := options[id]
+		if err := execution.agentctl.SetConfigOption(ctx, id, value); err != nil {
+			return fmt.Errorf("restore session runtime option %q: %w", id, err)
+		}
+	}
+	return nil
 }
 
 // ResetAgentContext resets the agent's conversation context. For ACP agents that support
@@ -573,11 +675,10 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 		return fmt.Errorf("execution %q has no agentctl client", executionID)
 	}
 
-	// Capture active session state before the reset. The fresh ACP session starts
-	// at provider defaults, so asynchronous model/mode events from it must not
-	// replace the task's effective pre-reset configuration.
-	prevMode := execution.GetModeState()
-	effectiveModel := m.effectiveSessionModelForReset(ctx, execution)
+	// Capture the complete effective session configuration before the reset. The
+	// fresh ACP session starts at provider defaults, so asynchronous events from
+	// it must not replace the task's pre-reset restoration intent.
+	runtimeConfig := m.captureSessionRuntimeConfigForReset(ctx, execution)
 
 	// Clear the old catalog before creating the fresh session. The new
 	// session_models event is delivered asynchronously and must be the only
@@ -612,7 +713,6 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 	// Success — update execution state without restarting process
 	_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
 		exec.ACPSessionID = newSessionID
-		exec.Status = v1.AgentStatusReady
 		exec.needsResumeContext = false
 		exec.resumeContextInjected = false
 
@@ -625,24 +725,23 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 		}
 	})
 
-	// Restore the task's effective model and the user's session permission mode
-	// onto the fresh ACP session. A strict-mode model that is gone in the new
-	// session fails the reset explicitly instead of silently dropping to the
-	// provider default.
-	if !cacheFreshSessionModelState(execution) && effectiveModel != "" {
+	// Restore the complete captured configuration. A strict-mode model that is
+	// rejected by the fresh session fails the reset explicitly instead of
+	// silently dropping to the provider default.
+	if !cacheFreshSessionModelState(execution) &&
+		(runtimeConfig.Model != "" || len(runtimeConfig.ConfigOptions) > 0) {
 		waitForFreshSessionModelState(ctx, m.logger, execution)
 	}
-	if err := m.reapplySessionModelAfterReset(ctx, execution, newSessionID, effectiveModel); err != nil {
-		// The reset already committed the execution as Ready; a model
-		// re-application failure must not leave it there, or later prompts
-		// would run on the fresh session with provider-default model state.
+	if err := m.restoreSessionRuntimeConfig(ctx, execution, newSessionID, runtimeConfig); err != nil {
 		_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
 			exec.Status = v1.AgentStatusFailed
 			exec.ErrorMessage = err.Error()
 		})
 		return err
 	}
-	m.reapplySessionModeAfterReset(ctx, execution, newSessionID, prevMode)
+	_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
+		exec.Status = v1.AgentStatusReady
+	})
 
 	m.logger.Info("agent context reset via session (no process restart)",
 		zap.String("execution_id", executionID),
@@ -855,16 +954,19 @@ func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) e
 		return fmt.Errorf("failed to initialize ACP session after restart: %w", err)
 	}
 
-	if !cacheFreshSessionModelState(execution) && preparation.previousModel != "" {
+	if !cacheFreshSessionModelState(execution) &&
+		(preparation.runtimeConfig.Model != "" || len(preparation.runtimeConfig.ConfigOptions) > 0) {
 		waitForFreshSessionModelState(ctx, m.logger, execution)
-		if err := m.reapplySessionModelAfterReset(ctx, execution, execution.ACPSessionID, preparation.previousModel); err != nil {
-			m.updateExecutionError(executionID, "failed to restore session model after restart: "+err.Error())
-			return fmt.Errorf("failed to restore session model after restart: %w", err)
-		}
 	}
-
-	// Restore the user's session permission mode onto the fresh ACP session.
-	m.reapplySessionModeAfterReset(ctx, execution, execution.ACPSessionID, preparation.previousMode)
+	if err := m.restoreSessionRuntimeConfig(ctx, execution, execution.ACPSessionID, preparation.runtimeConfig); err != nil {
+		m.updateExecutionError(executionID, "failed to restore session runtime configuration after restart: "+err.Error())
+		return fmt.Errorf("failed to restore session runtime configuration after restart: %w", err)
+	}
+	if err := m.updateStatusAndPersist(ctx, execution.ID, v1.AgentStatusReady); err != nil {
+		m.updateExecutionError(executionID, "failed to mark restarted agent ready: "+err.Error())
+		return fmt.Errorf("failed to mark restarted agent ready: %w", err)
+	}
+	m.eventPublisher.PublishAgentEvent(ctx, events.AgentBootReady, execution)
 
 	m.logger.Info("agent process restarted with fresh context",
 		zap.String("execution_id", executionID),
@@ -878,8 +980,7 @@ func (m *Manager) RestartAgentProcess(ctx context.Context, executionID string) e
 type agentRestartPreparation struct {
 	agentConfig   agents.Agent
 	commands      agentCommands
-	previousModel string
-	previousMode  *CachedModeState
+	runtimeConfig models.SessionRuntimeConfig
 }
 
 // prepareAgentRestart builds and validates the replacement before touching the current process.
@@ -900,8 +1001,7 @@ func (m *Manager) prepareAgentRestart(ctx context.Context, execution *AgentExecu
 	return agentRestartPreparation{
 		agentConfig:   agentConfig,
 		commands:      commands,
-		previousModel: m.effectiveSessionModelForReset(ctx, execution),
-		previousMode:  execution.GetModeState(),
+		runtimeConfig: m.captureSessionRuntimeConfigForReset(ctx, execution),
 	}, nil
 }
 
@@ -965,14 +1065,6 @@ func (m *Manager) initializeACPSessionForRestart(
 	if m.sessionManager.eventPublisher != nil {
 		m.sessionManager.eventPublisher.PublishACPSessionCreated(execution, result.SessionID)
 	}
-
-	// Mark execution as ready. This is a *boot* signal — initializeACPSessionForRestart
-	// is the post-restart init path and no turn has run yet, so AgentBootReady (not
-	// AgentReady) is what subscribers want to route on.
-	if err := m.updateStatusAndPersist(ctx, execution.ID, v1.AgentStatusReady); err != nil {
-		return err
-	}
-	m.eventPublisher.PublishAgentEvent(ctx, events.AgentBootReady, execution)
 
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
@@ -327,7 +327,7 @@ func TestSanitizeRuntimeConfigOptionsFiltersInvalidEntries(t *testing.T) {
 	require.Equal(t, map[string]string{"effort": "max"}, options)
 }
 
-func TestManager_CaptureSessionRuntimeConfigPrefersLiveProviderOptions(t *testing.T) {
+func TestManager_CaptureSessionRuntimeConfigOverlaysPersistedStateAfterLiveState(t *testing.T) {
 	mgr := newTestManager(t)
 	mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
 		infos: map[string]*WorkspaceInfo{
@@ -350,5 +350,106 @@ func TestManager_CaptureSessionRuntimeConfigPrefersLiveProviderOptions(t *testin
 
 	config := mgr.captureSessionRuntimeConfigForReset(context.Background(), exec)
 
+	require.Equal(t, map[string]string{"effort": "low"}, config.ConfigOptions)
+}
+
+func TestManager_CaptureSessionRuntimeConfigLayersLiveStateOverProfileDefaults(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.profileResolver = &restartProfileResolver{profile: &AgentProfileInfo{
+		Model:         "mock-fast",
+		Mode:          "default",
+		ConfigOptions: map[string]string{"effort": "low"},
+	}}
+	exec := runtimeConfigResetExecution(nil, true)
+	exec.SetModelState(&CachedModelState{
+		CurrentModelID: "mock-smart",
+		ConfigOptions:  []streams.ConfigOption{{ID: "effort", CurrentValue: "max"}},
+	})
+	exec.SetModeState(&CachedModeState{CurrentModeID: "acceptEdits"})
+
+	config := mgr.captureSessionRuntimeConfigForReset(context.Background(), exec)
+
+	require.Equal(t, "mock-smart", config.Model)
+	require.Equal(t, "acceptEdits", config.Mode)
 	require.Equal(t, map[string]string{"effort": "max"}, config.ConfigOptions)
+}
+
+func TestManager_ResetAgentContext_FallbackReusesCapturedRuntimeConfig(t *testing.T) {
+	mgr := newTestManager(t)
+	provider := runtimeConfigResetWorkspaceInfo()
+	mgr.workspaceInfoProvider = provider
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.failSessionReset = true
+	mock.newModelState = runtimeConfigResetModelState()
+	mock.onReset = func() {
+		provider.infos["session-1"].RuntimeModel = "mock-fast"
+		provider.infos["session-1"].SessionMode = "default"
+		provider.infos["session-1"].RuntimeConfigOptions = map[string]string{
+			"effort": "low",
+		}
+	}
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	exec := runtimeConfigResetExecution(client, true)
+	exec.SetModelState(&CachedModelState{CurrentModelID: "mock-smart"})
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	require.NoError(t, mgr.ResetAgentContext(ctx, exec.ID))
+
+	require.Equal(t, []string{"mock-smart"}, mock.getSetModelIDs())
+	require.Equal(t, []string{"acceptEdits"}, mock.getSetModeIDs())
+	require.Equal(t, []restartConfigOption{
+		{ID: "alpha", Value: "enabled"},
+		{ID: "zeta", Value: "max"},
+	}, mock.getSetOptions())
+}
+
+func TestManager_CaptureSessionRuntimeConfigFiltersPersistedCategorizedOptions(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-1": {
+				SessionID: "session-1",
+				RuntimeConfigOptions: map[string]string{
+					"primary_model":   "mock-smart",
+					"permission_mode": "acceptEdits",
+					"effort":          "max",
+				},
+				RuntimeConfigOptionsSet: true,
+			},
+		},
+	}
+	exec := runtimeConfigResetExecution(nil, true)
+	exec.SetModelState(&CachedModelState{
+		CurrentModelID: "mock-smart",
+		ConfigOptions: []streams.ConfigOption{
+			{ID: "primary_model", Category: "model", CurrentValue: "mock-smart"},
+			{ID: "permission_mode", Category: "mode", CurrentValue: "acceptEdits"},
+			{ID: "effort", CurrentValue: "max"},
+		},
+	})
+
+	config := mgr.captureSessionRuntimeConfigForReset(context.Background(), exec)
+
+	require.Equal(t, map[string]string{"effort": "max"}, config.ConfigOptions)
+}
+
+func TestSanitizeRuntimeConfigOptionsUsesCapturedOptionCategories(t *testing.T) {
+	options := sanitizeRuntimeConfigOptionsWithCatalog(map[string]string{
+		"primary_model":   "mock-smart",
+		"permission_mode": "acceptEdits",
+		"effort":          "max",
+	}, &CachedModelState{
+		ConfigOptions: []streams.ConfigOption{
+			{ID: "primary_model", Category: "model"},
+			{ID: "permission_mode", Category: "mode"},
+			{ID: "effort", Category: ""},
+		},
+	})
+
+	require.Equal(t, map[string]string{"effort": "max"}, options)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
@@ -11,6 +11,7 @@ import (
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -145,6 +146,8 @@ func TestManager_RestartAgentProcess_ReappliesSessionRuntimeConfig(t *testing.T)
 
 func TestManager_ResetAgentContext_FailsClosedOnRuntimeConfigRestore(t *testing.T) {
 	mgr := newTestManager(t)
+	writer := &captureExecutorRunningWriter{}
+	mgr.SetExecutorRunningWriter(writer)
 	provider := runtimeConfigResetWorkspaceInfo()
 	mgr.workspaceInfoProvider = provider
 	mock := newRestartMockAgentctlServer(t, false, false)
@@ -164,7 +167,39 @@ func TestManager_ResetAgentContext_FailsClosedOnRuntimeConfigRestore(t *testing.
 	require.Error(t, err)
 	require.Equal(t, v1.AgentStatusFailed, exec.Status)
 	require.NotEmpty(t, exec.ErrorMessage)
+	require.NotNil(t, writer.running)
+	require.Equal(t, models.ExecutorRunningStatusFailed, writer.running.Status)
 	require.Equal(t, []string{"agent.session.reset", "agent.session.set_model", "agent.session.set_mode", "agent.session.set_config_option"}, mock.getWSActions())
+
+	bus := mgr.eventBus.(*MockEventBus)
+	for _, event := range bus.PublishedEvents {
+		require.NotEqual(t, events.AgentBootReady, event.Type)
+		require.NotEqual(t, events.AgentContextReset, event.Type)
+	}
+}
+
+func TestManager_ResetAgentContext_FailsClosedOnSessionModelRestore(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.workspaceInfoProvider = runtimeConfigResetWorkspaceInfo()
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.modelState = runtimeConfigResetModelState()
+	mock.failModel = true
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, client.StreamUpdates(ctx, func(agentctl.AgentEvent) {}, nil, nil))
+
+	exec := runtimeConfigResetExecution(client, true)
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	err := mgr.ResetAgentContext(ctx, exec.ID)
+	require.Error(t, err)
+	require.Equal(t, v1.AgentStatusFailed, exec.Status)
+	require.Equal(t, []string{"agent.session.reset", "agent.session.set_model"}, mock.getWSActions())
+	require.Empty(t, mock.getSetModeIDs())
+	require.Empty(t, mock.getSetOptions())
 
 	bus := mgr.eventBus.(*MockEventBus)
 	for _, event := range bus.PublishedEvents {
@@ -290,4 +325,30 @@ func TestSanitizeRuntimeConfigOptionsFiltersInvalidEntries(t *testing.T) {
 	})
 
 	require.Equal(t, map[string]string{"effort": "max"}, options)
+}
+
+func TestManager_CaptureSessionRuntimeConfigPrefersLiveProviderOptions(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-1": {
+				SessionID:               "session-1",
+				RuntimeModel:            "mock-smart",
+				SessionMode:             "acceptEdits",
+				RuntimeConfigOptions:    map[string]string{"effort": "low", "removed": "stale"},
+				RuntimeConfigOptionsSet: true,
+			},
+		},
+	}
+	exec := runtimeConfigResetExecution(nil, true)
+	exec.SetModelState(&CachedModelState{
+		CurrentModelID: "mock-smart",
+		ConfigOptions: []streams.ConfigOption{
+			{ID: "effort", CurrentValue: "max"},
+		},
+	})
+
+	config := mgr.captureSessionRuntimeConfigForReset(context.Background(), exec)
+
+	require.Equal(t, map[string]string{"effort": "max"}, config.ConfigOptions)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go
@@ -1,0 +1,293 @@
+package lifecycle
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func runtimeConfigResetModelState() *streams.SessionModelState {
+	return &streams.SessionModelState{
+		CurrentModelID: "mock-fast",
+		Models: []streams.SessionModelInfo{
+			{ModelID: "mock-fast"},
+			{ModelID: "mock-smart"},
+		},
+	}
+}
+
+func runtimeConfigResetWorkspaceInfo() *mockWorkspaceInfoProvider {
+	return &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-1": {
+				SessionID:               "session-1",
+				RuntimeModel:            "mock-smart",
+				SessionMode:             "acceptEdits",
+				RuntimeConfigOptions:    map[string]string{"zeta": "max", "alpha": "enabled"},
+				RuntimeConfigOptionsSet: true,
+			},
+		},
+	}
+}
+
+func runtimeConfigResetExecution(client *agentctl.Client, initialized bool) *AgentExecution {
+	return &AgentExecution{
+		ID:                 "exec-runtime-config",
+		TaskID:             "task-1",
+		SessionID:          "session-1",
+		AgentProfileID:     "profile-1",
+		ACPSessionID:       "old-session",
+		AgentCommand:       "auggie --model test",
+		Status:             v1.AgentStatusRunning,
+		WorkspacePath:      "/workspace",
+		sessionInitialized: initialized,
+		agentctl:           client,
+		promptDoneCh:       make(chan PromptCompletionSignal, 1),
+	}
+}
+
+func TestManager_ResetAgentContext_ReappliesSessionRuntimeConfig(t *testing.T) {
+	mgr := newTestManager(t)
+	provider := runtimeConfigResetWorkspaceInfo()
+	mgr.workspaceInfoProvider = provider
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.modelState = runtimeConfigResetModelState()
+	mock.onReset = func() {
+		provider.infos["session-1"].RuntimeModel = "mock-fast"
+		provider.infos["session-1"].SessionMode = "default"
+		provider.infos["session-1"].RuntimeConfigOptions = map[string]string{
+			"zeta":  "low",
+			"alpha": "disabled",
+		}
+	}
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, client.StreamUpdates(ctx, func(agentctl.AgentEvent) {}, nil, nil))
+
+	exec := runtimeConfigResetExecution(client, true)
+	exec.SetModelState(&CachedModelState{CurrentModelID: "mock-smart"})
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	require.NoError(t, mgr.ResetAgentContext(ctx, exec.ID))
+
+	actions := mock.getWSActions()
+	require.Equal(t, []string{
+		"agent.session.reset",
+		"agent.session.set_model",
+		"agent.session.set_mode",
+		"agent.session.set_config_option",
+		"agent.session.set_config_option",
+	}, actions)
+	require.Equal(t, []string{"mock-smart"}, mock.getSetModelIDs())
+	require.Equal(t, []string{"acceptEdits"}, mock.getSetModeIDs())
+	require.Equal(t, []restartConfigOption{
+		{ID: "alpha", Value: "enabled"},
+		{ID: "zeta", Value: "max"},
+	}, mock.getSetOptions())
+	require.Equal(t, v1.AgentStatusReady, exec.Status)
+}
+
+func TestManager_RestartAgentProcess_ReappliesSessionRuntimeConfig(t *testing.T) {
+	mgr := newTestManager(t)
+	provider := runtimeConfigResetWorkspaceInfo()
+	mgr.workspaceInfoProvider = provider
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.newModelState = runtimeConfigResetModelState()
+	mock.onSessionNew = func() {
+		provider.infos["session-1"].RuntimeModel = "mock-fast"
+		provider.infos["session-1"].SessionMode = "default"
+		provider.infos["session-1"].RuntimeConfigOptions = map[string]string{
+			"zeta":  "low",
+			"alpha": "disabled",
+		}
+	}
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	exec := runtimeConfigResetExecution(client, false)
+	exec.SetModeState(&CachedModeState{CurrentModeID: "acceptEdits"})
+	exec.SetModelState(&CachedModelState{CurrentModelID: "mock-smart"})
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	require.NoError(t, mgr.RestartAgentProcess(ctx, exec.ID))
+
+	actions := mock.getWSActions()
+	require.Equal(t, []string{
+		"agent.initialize",
+		"agent.session.new",
+		"agent.session.set_model",
+		"agent.session.set_mode",
+		"agent.session.set_config_option",
+		"agent.session.set_config_option",
+	}, actions)
+	require.Equal(t, []string{"mock-smart"}, mock.getSetModelIDs())
+	require.Equal(t, []string{"acceptEdits"}, mock.getSetModeIDs())
+	require.Equal(t, []restartConfigOption{
+		{ID: "alpha", Value: "enabled"},
+		{ID: "zeta", Value: "max"},
+	}, mock.getSetOptions())
+	require.Equal(t, v1.AgentStatusReady, exec.Status)
+}
+
+func TestManager_ResetAgentContext_FailsClosedOnRuntimeConfigRestore(t *testing.T) {
+	mgr := newTestManager(t)
+	provider := runtimeConfigResetWorkspaceInfo()
+	mgr.workspaceInfoProvider = provider
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.modelState = runtimeConfigResetModelState()
+	mock.failConfigOptionID = "alpha"
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, client.StreamUpdates(ctx, func(agentctl.AgentEvent) {}, nil, nil))
+
+	exec := runtimeConfigResetExecution(client, true)
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	err := mgr.ResetAgentContext(ctx, exec.ID)
+	require.Error(t, err)
+	require.Equal(t, v1.AgentStatusFailed, exec.Status)
+	require.NotEmpty(t, exec.ErrorMessage)
+	require.Equal(t, []string{"agent.session.reset", "agent.session.set_model", "agent.session.set_mode", "agent.session.set_config_option"}, mock.getWSActions())
+
+	bus := mgr.eventBus.(*MockEventBus)
+	for _, event := range bus.PublishedEvents {
+		require.NotEqual(t, events.AgentBootReady, event.Type)
+		require.NotEqual(t, events.AgentContextReset, event.Type)
+	}
+}
+
+func TestManager_RestartAgentProcess_FailsClosedOnRuntimeConfigRestore(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.workspaceInfoProvider = runtimeConfigResetWorkspaceInfo()
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.newModelState = runtimeConfigResetModelState()
+	mock.failConfigOptionID = "alpha"
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	exec := runtimeConfigResetExecution(client, false)
+	exec.SetModeState(&CachedModeState{CurrentModeID: "acceptEdits"})
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	err := mgr.RestartAgentProcess(ctx, exec.ID)
+	require.Error(t, err)
+	require.Equal(t, v1.AgentStatusFailed, exec.Status)
+	require.NotEmpty(t, exec.ErrorMessage)
+
+	bus := mgr.eventBus.(*MockEventBus)
+	for _, event := range bus.PublishedEvents {
+		require.NotEqual(t, events.AgentBootReady, event.Type)
+		require.NotEqual(t, events.AgentContextReset, event.Type)
+	}
+}
+
+func TestManager_ResetAgentContext_FailsClosedOnSessionModeRestore(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.workspaceInfoProvider = runtimeConfigResetWorkspaceInfo()
+	mock := newRestartMockAgentctlServer(t, false, false)
+	mock.modelState = runtimeConfigResetModelState()
+	mock.failMode = true
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, client.StreamUpdates(ctx, func(agentctl.AgentEvent) {}, nil, nil))
+
+	exec := runtimeConfigResetExecution(client, true)
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	err := mgr.ResetAgentContext(ctx, exec.ID)
+	require.Error(t, err)
+	require.Equal(t, v1.AgentStatusFailed, exec.Status)
+	require.Equal(t, []string{
+		"agent.session.reset",
+		"agent.session.set_model",
+		"agent.session.set_mode",
+	}, mock.getWSActions())
+
+	bus := mgr.eventBus.(*MockEventBus)
+	for _, event := range bus.PublishedEvents {
+		require.NotEqual(t, events.AgentBootReady, event.Type)
+		require.NotEqual(t, events.AgentContextReset, event.Type)
+	}
+}
+
+func TestRuntimeConfigResetModelStateHelperUsesStableValues(t *testing.T) {
+	state := runtimeConfigResetModelState()
+	require.True(t, slices.ContainsFunc(state.Models, func(model streams.SessionModelInfo) bool {
+		return model.ModelID == "mock-smart"
+	}))
+}
+
+func TestSelectedRuntimeConfigOptionsFiltersInvalidEntries(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *CachedModelState
+		want  map[string]string
+	}{
+		{name: "nil state"},
+		{name: "empty state", state: &CachedModelState{}},
+		{
+			name: "model-shaped entries",
+			state: &CachedModelState{ConfigOptions: []streams.ConfigOption{
+				{ID: "model", Category: "model", CurrentValue: "mock-smart"},
+				{ID: "primary", Category: "model", CurrentValue: "mock-smart"},
+			}},
+		},
+		{
+			name: "mode-shaped entries",
+			state: &CachedModelState{ConfigOptions: []streams.ConfigOption{
+				{ID: "mode", Category: "mode", CurrentValue: "acceptEdits"},
+				{ID: "permission", Category: "mode", CurrentValue: "acceptEdits"},
+			}},
+		},
+		{
+			name: "provider entries",
+			state: &CachedModelState{ConfigOptions: []streams.ConfigOption{
+				{ID: "effort", CurrentValue: "high"},
+				{ID: "effort", CurrentValue: "max"},
+				{ID: "blank", CurrentValue: " "},
+			}},
+			want: map[string]string{"effort": "max"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, selectedRuntimeConfigOptions(test.state))
+		})
+	}
+}
+
+func TestSanitizeRuntimeConfigOptionsFiltersInvalidEntries(t *testing.T) {
+	options := sanitizeRuntimeConfigOptions(map[string]string{
+		"":       "value",
+		"model":  "mock-fast",
+		"mode":   "default",
+		"effort": " max ",
+		"blank":  " ",
+	})
+
+	require.Equal(t, map[string]string{"effort": "max"}, options)
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -48,6 +48,7 @@ type restartMockAgentctlServer struct {
 
 	failStop           bool
 	failSessionNew     bool
+	failSessionReset   bool
 	failMode           bool
 	failModel          bool
 	failConfigOptionID string
@@ -182,6 +183,13 @@ func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *
 			case "agent.session.reset":
 				if m.onReset != nil {
 					m.onReset()
+				}
+				if m.failSessionReset {
+					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+						"success": false,
+						"error":   "session reset failed",
+					})
+					break
 				}
 				payload := map[string]interface{}{
 					"success":    true,

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -49,6 +49,7 @@ type restartMockAgentctlServer struct {
 	failStop           bool
 	failSessionNew     bool
 	failMode           bool
+	failModel          bool
 	failConfigOptionID string
 	modelState         *streams.SessionModelState
 	newModelState      *streams.SessionModelState
@@ -82,6 +83,15 @@ func TestWaitForFreshSessionModelStateWaitsForAdvertisedCatalog(t *testing.T) {
 	}()
 
 	require.True(t, waitForFreshSessionModelState(context.Background(), newTestLogger(), execution))
+}
+
+func TestFreshSessionModelCatalogReadyAcceptsConfigOptionsWithoutModels(t *testing.T) {
+	require.True(t, freshSessionModelCatalogReady(&CachedModelState{
+		ConfigOptions: []streams.ConfigOption{{ID: "effort", CurrentValue: "max"}},
+	}))
+	require.True(t, freshSessionModelCatalogReady(&CachedModelState{
+		ConfigOptionsSettled: true,
+	}))
 }
 
 func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *restartMockAgentctlServer {
@@ -190,9 +200,13 @@ func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *
 					})
 				}
 			case "agent.session.set_model":
-				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-					"success": true,
-				})
+				if m.failModel {
+					resp, _ = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "model rejected", nil)
+				} else {
+					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+						"success": true,
+					})
+				}
 			case "agent.session.set_config_option":
 				var payload struct {
 					ConfigID string `json:"config_id"`

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -43,10 +43,22 @@ type restartMockAgentctlServer struct {
 	httpActions []string
 	wsActions   []string
 	setModelIDs []string
+	setModeIDs  []string
+	setOptions  []restartConfigOption
 
-	failStop       bool
-	failSessionNew bool
-	modelState     *streams.SessionModelState
+	failStop           bool
+	failSessionNew     bool
+	failMode           bool
+	failConfigOptionID string
+	modelState         *streams.SessionModelState
+	newModelState      *streams.SessionModelState
+	onReset            func()
+	onSessionNew       func()
+}
+
+type restartConfigOption struct {
+	ID    string `json:"config_id"`
+	Value string `json:"value"`
 }
 
 func TestStopAgentWithReason_MissingExecutionIsClassified(t *testing.T) {
@@ -139,18 +151,28 @@ func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *
 					},
 				})
 			case "agent.session.new":
+				if m.onSessionNew != nil {
+					m.onSessionNew()
+				}
 				if m.failSessionNew {
 					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 						"success": false,
 						"error":   "session new failed",
 					})
 				} else {
-					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+					payload := map[string]interface{}{
 						"success":    true,
 						"session_id": "new-session-123",
-					})
+					}
+					if m.newModelState != nil {
+						payload["model_state"] = m.newModelState
+					}
+					resp, _ = ws.NewResponse(msg.ID, msg.Action, payload)
 				}
 			case "agent.session.reset":
+				if m.onReset != nil {
+					m.onReset()
+				}
 				payload := map[string]interface{}{
 					"success":    true,
 					"session_id": "reset-session-456",
@@ -160,17 +182,30 @@ func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *
 				}
 				resp, _ = ws.NewResponse(msg.ID, msg.Action, payload)
 			case "agent.session.set_mode":
-				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-					"success": true,
-				})
+				if m.failMode {
+					resp, _ = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "mode rejected", nil)
+				} else {
+					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+						"success": true,
+					})
+				}
 			case "agent.session.set_model":
 				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 					"success": true,
 				})
 			case "agent.session.set_config_option":
-				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-					"success": true,
-				})
+				var payload struct {
+					ConfigID string `json:"config_id"`
+					Value    string `json:"value"`
+				}
+				_ = json.Unmarshal(msg.Payload, &payload)
+				if payload.ConfigID == m.failConfigOptionID {
+					resp, _ = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "config option rejected", nil)
+				} else {
+					resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+						"success": true,
+					})
+				}
 			case "agent.stderr":
 				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 					"lines": []string{
@@ -221,14 +256,26 @@ func (m *restartMockAgentctlServer) recordWS(message ws.Message) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.wsActions = append(m.wsActions, message.Action)
-	if message.Action != "agent.session.set_model" {
-		return
-	}
-	var payload struct {
-		ModelID string `json:"model_id"`
-	}
-	if err := json.Unmarshal(message.Payload, &payload); err == nil {
-		m.setModelIDs = append(m.setModelIDs, payload.ModelID)
+	switch message.Action {
+	case "agent.session.set_model":
+		var payload struct {
+			ModelID string `json:"model_id"`
+		}
+		if err := json.Unmarshal(message.Payload, &payload); err == nil {
+			m.setModelIDs = append(m.setModelIDs, payload.ModelID)
+		}
+	case "agent.session.set_mode":
+		var payload struct {
+			ModeID string `json:"mode_id"`
+		}
+		if err := json.Unmarshal(message.Payload, &payload); err == nil {
+			m.setModeIDs = append(m.setModeIDs, payload.ModeID)
+		}
+	case "agent.session.set_config_option":
+		var payload restartConfigOption
+		if err := json.Unmarshal(message.Payload, &payload); err == nil {
+			m.setOptions = append(m.setOptions, payload)
+		}
 	}
 }
 
@@ -253,6 +300,22 @@ func (m *restartMockAgentctlServer) getSetModelIDs() []string {
 	defer m.mu.Unlock()
 	out := make([]string, len(m.setModelIDs))
 	copy(out, m.setModelIDs)
+	return out
+}
+
+func (m *restartMockAgentctlServer) getSetModeIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.setModeIDs))
+	copy(out, m.setModeIDs)
+	return out
+}
+
+func (m *restartMockAgentctlServer) getSetOptions() []restartConfigOption {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]restartConfigOption, len(m.setOptions))
+	copy(out, m.setOptions)
 	return out
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
@@ -234,12 +234,25 @@ func (m *Manager) sessionRuntimeOverrides(ctx context.Context, execution *AgentE
 }
 
 func (m *Manager) effectiveSessionRuntimeConfig(ctx context.Context, execution *AgentExecution, profileModel, profileMode string, profileConfigOptions map[string]string) (string, string, map[string]string) {
+	model, mode, configOptions, _ := m.effectiveSessionRuntimeConfigWithPresence(
+		ctx, execution, profileModel, profileMode, profileConfigOptions,
+	)
+	return model, mode, configOptions
+}
+
+func (m *Manager) effectiveSessionRuntimeConfigWithPresence(
+	ctx context.Context,
+	execution *AgentExecution,
+	profileModel, profileMode string,
+	profileConfigOptions map[string]string,
+) (string, string, map[string]string, bool) {
 	model := profileModel
 	mode := profileMode
 	configOptions := maps.Clone(profileConfigOptions)
+	configOptionsSet := profileConfigOptions != nil
 	info := m.sessionWorkspaceInfo(ctx, execution)
 	if info == nil {
-		return model, mode, configOptions
+		return model, mode, configOptions, configOptionsSet
 	}
 	if info.RuntimeModel != "" {
 		model = info.RuntimeModel
@@ -249,8 +262,12 @@ func (m *Manager) effectiveSessionRuntimeConfig(ctx context.Context, execution *
 	}
 	if info.RuntimeConfigOptionsSet {
 		configOptions = maps.Clone(info.RuntimeConfigOptions)
+		if configOptions == nil {
+			configOptions = make(map[string]string)
+		}
+		configOptionsSet = true
 	}
-	return model, mode, configOptions
+	return model, mode, configOptions, configOptionsSet
 }
 
 // effectiveSessionMode prefers a session-level permission mode persisted in the

--- a/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
@@ -96,7 +96,7 @@ test.describe("Manual proceed to next workflow step", () => {
     await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
   });
 
-  test("preserves selected model across context reset", async ({
+  test("preserves session settings across context reset", async ({
     testPage,
     apiClient,
     seedData,
@@ -104,13 +104,22 @@ test.describe("Manual proceed to next workflow step", () => {
     const { agents } = await apiClient.listAgents();
     const agent = agents.find((item) => item.name === "mock-agent");
     if (!agent) {
-      throw new Error("E2E mock agent is required for model-reset coverage");
+      throw new Error("E2E mock agent is required for runtime-config reset coverage");
     }
-    const smartProfile = await apiClient.createAgentProfile(agent.id, "Reset Model Profile", {
-      model: "mock-smart",
-    });
+    const smartProfile = await apiClient.createAgentProfile(
+      agent.id,
+      "Reset Runtime Config Profile",
+      {
+        model: "mock-smart",
+        mode: "plan-mock",
+        config_options: { effort: "max" },
+      },
+    );
 
-    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Reset Model Workflow");
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Reset Runtime Config Workflow",
+    );
     const startStep = await apiClient.createWorkflowStep(workflow.id, "Start", 0);
     const resetStep = await apiClient.createWorkflowStep(workflow.id, "Reset", 1);
 
@@ -125,7 +134,7 @@ test.describe("Manual proceed to next workflow step", () => {
       },
     });
 
-    const task = await apiClient.createTask(seedData.workspaceId, "Reset Model Task", {
+    const task = await apiClient.createTask(seedData.workspaceId, "Reset Runtime Config Task", {
       workflow_id: workflow.id,
       workflow_step_id: startStep.id,
       agent_profile_id: smartProfile.id,
@@ -138,19 +147,23 @@ test.describe("Manual proceed to next workflow step", () => {
     await session.waitForChatIdle({ timeout: 30_000 });
 
     const modelTrigger = testPage.getByRole("button", { name: "Session model settings" });
-    await expect(modelTrigger).toContainText("Mock Smart", { timeout: 15_000 });
+    const modeTrigger = testPage.getByTestId("session-mode-selector");
+    await expect(modelTrigger).toHaveText("Mock Smart / Max", { timeout: 15_000 });
+    await expect(modeTrigger).toHaveText("Plan Mock", { timeout: 15_000 });
 
     await session.proceedNextStepButton().click();
     await expect(session.stepperStep("Reset")).toHaveAttribute("aria-current", "step", {
       timeout: 15_000,
     });
     await session.waitForChatIdle({ timeout: 30_000 });
-    await expect(modelTrigger).toContainText("Mock Smart", { timeout: 15_000 });
+    await expect(modelTrigger).toHaveText("Mock Smart / Max", { timeout: 15_000 });
+    await expect(modeTrigger).toHaveText("Plan Mock", { timeout: 15_000 });
 
     await testPage.reload();
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 30_000 });
-    await expect(modelTrigger).toContainText("Mock Smart", { timeout: 15_000 });
+    await expect(modelTrigger).toHaveText("Mock Smart / Max", { timeout: 15_000 });
+    await expect(modeTrigger).toHaveText("Plan Mock", { timeout: 15_000 });
   });
 
   test("shows next step auto-start prompt when its message-added notification is missed", async ({

--- a/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
@@ -106,13 +106,13 @@ test.describe("Manual proceed to next workflow step", () => {
     if (!agent) {
       throw new Error("E2E mock agent is required for runtime-config reset coverage");
     }
-    const smartProfile = await apiClient.createAgentProfile(
+    const runtimeProfile = await apiClient.createAgentProfile(
       agent.id,
       "Reset Runtime Config Profile",
       {
-        model: "mock-smart",
-        mode: "plan-mock",
-        config_options: { effort: "max" },
+        model: "mock-fast",
+        mode: "default",
+        config_options: { effort: "medium" },
       },
     );
 
@@ -137,7 +137,7 @@ test.describe("Manual proceed to next workflow step", () => {
     const task = await apiClient.createTask(seedData.workspaceId, "Reset Runtime Config Task", {
       workflow_id: workflow.id,
       workflow_step_id: startStep.id,
-      agent_profile_id: smartProfile.id,
+      agent_profile_id: runtimeProfile.id,
       repository_ids: [seedData.repositoryId],
     });
 
@@ -148,8 +148,23 @@ test.describe("Manual proceed to next workflow step", () => {
 
     const modelTrigger = testPage.getByRole("button", { name: "Session model settings" });
     const modeTrigger = testPage.getByTestId("session-mode-selector");
-    await expect(modelTrigger).toHaveText("Mock Smart / Max", { timeout: 15_000 });
-    await expect(modeTrigger).toHaveText("Plan Mock", { timeout: 15_000 });
+    await expect(modelTrigger).toHaveText("Mock Fast", { timeout: 15_000 });
+    await expect(modeTrigger).toHaveText("Default", { timeout: 15_000 });
+
+    // Change the live session after launch. These values intentionally differ
+    // from the profile defaults so reset coverage exercises the live caches.
+    await modelTrigger.click();
+    await testPage.getByRole("option", { name: /Mock Smart/ }).click();
+    await expect(modelTrigger).toContainText("Mock Smart", { timeout: 5_000 });
+    await modelTrigger.click();
+    await testPage.getByTestId("config-option-trigger-effort").click();
+    await testPage.getByRole("button", { name: "Max", exact: true }).click();
+    await expect(modelTrigger).toHaveText("Mock Smart / Max", { timeout: 5_000 });
+    await testPage.keyboard.press("Escape");
+
+    await modeTrigger.click();
+    await testPage.getByRole("menuitem", { name: /^Plan Mock/ }).click();
+    await expect(modeTrigger).toHaveText("Plan Mock", { timeout: 5_000 });
 
     await session.proceedNextStepButton().click();
     await expect(session.stepperStep("Reset")).toHaveAttribute("aria-current", "step", {

--- a/docs/decisions/2026-08-18-context-reset-preserves-runtime-configuration.md
+++ b/docs/decisions/2026-08-18-context-reset-preserves-runtime-configuration.md
@@ -1,0 +1,51 @@
+# ADR-2026-08-18-context-reset-preserves-runtime-configuration: Preserve ACP Runtime Configuration Across Context Reset
+
+**Status:** accepted
+**Date:** 2026-08-18
+**Area:** backend, protocol, workflow
+
+## Context
+
+An ACP context reset creates a new provider session. The new session starts with provider defaults for its model, permission mode, and configuration options.
+
+Kandev restores the model and mode through separate paths. These paths read mutable state after session creation, and they do not restore configuration options.
+
+Fresh-session events can replace the persisted user selection before restoration reads it. A workflow can then continue with different runtime permissions or model configuration.
+
+## Decision
+
+A context reset changes conversation context only. It does not change the effective ACP runtime configuration of the task session.
+
+Before Kandev creates a provider session, the lifecycle captures one immutable `SessionRuntimeConfig` value. This value contains the effective model, permission mode, and all selected ACP configuration options.
+
+The capture uses profile state, live state, provider state, and explicit runtime overrides through the existing precedence rules. The capture completes before fresh-session events can publish provider defaults.
+
+Kandev restores the captured value in this order:
+
+1. Apply the model through the executor-owned model policy.
+2. Apply the permission mode.
+3. Apply each configuration option in stable option-ID order.
+
+The same rule applies to the ACP reset path and the process-restart fallback. Fresh provider catalogs remain authoritative for supported values, but they cannot redefine restoration intent.
+
+If one captured field cannot be restored, Kandev reports a restoration error. A workflow reset does not send its automatic prompt with a partial configuration.
+
+Provider convergence events remain authoritative for the state that the provider accepted. Kandev does not fabricate restored state and cannot roll back the completed conversation reset.
+
+MCP attachments remain session-construction inputs and use their existing resolution path. Authentication, credentials, CLI flags, environment values, executor selection, and profile identity are not ACP runtime configuration.
+
+## Consequences
+
+- Model, mode, and model-adjacent options have one reset lifecycle and one precedence model.
+- A context reset cannot silently reduce permissions or change reasoning and collaboration options.
+- The reset path must wait for model-aware option availability before it applies dependent options.
+- A restoration error blocks an automatic workflow prompt, but the new provider conversation can already exist.
+- Runtime state, explicit overrides, provider-default baselines, and original workflow snapshots keep their existing ownership rules.
+
+## Alternatives Considered
+
+- Restore only the model and mode: rejected because provider-defined options also change agent behavior.
+- Read persisted values after session creation: rejected because fresh default events can replace those values first.
+- Reapply the current agent profile: rejected because user and workflow changes can differ from the profile.
+- Continue after a partial restoration: rejected because the next prompt can run with different permissions or execution settings.
+- Suppress all fresh-session events during reset: rejected because Kandev still needs the fresh capability catalogs and accepted provider state.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -94,6 +94,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 2026-08-15-subagent-context-schema-boundary | [Start with the execution-aware subagent schema](2026-08-15-subagent-context-schema-boundary.md) | accepted | backend | 2026-08-15 |
 | 2026-08-15-portable-agent-configuration-bundles | [Use Explicit Portable Agent Configuration Bundles](2026-08-15-portable-agent-configuration-bundles.md) | accepted | backend, frontend, protocol, security | 2026-08-15 |
 | 2026-08-15-executor-authoritative-model-selection | [Let the Executor Own Model Selection](2026-08-15-executor-authoritative-model-selection.md) | accepted | backend, frontend, protocol, persistence | 2026-08-15 |
+| 2026-08-18-context-reset-preserves-runtime-configuration | [Preserve ACP Runtime Configuration Across Context Reset](2026-08-18-context-reset-preserves-runtime-configuration.md) | accepted | backend, protocol, workflow | 2026-08-18 |
 | 2026-07-28-coarse-running-busy-signal | [Restore Coarse Running Prompt Admission](2026-07-28-coarse-running-busy-signal.md) | accepted | backend, frontend, protocol | 2026-07-28 |
 | 2026-07-29-agent-stall-user-controlled-recovery | [Keep Agent Stall Recovery User Controlled](2026-07-29-agent-stall-user-controlled-recovery.md) | accepted | backend, frontend, protocol | 2026-07-29 |
 | 2026-07-29-quarantine-retention-override | [Make Quarantine Retention Overridable but Visible](2026-07-29-quarantine-retention-override.md) | accepted | backend, frontend | 2026-07-29 |

--- a/docs/plans/acp-context-reset-runtime-configuration/plan.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/plan.md
@@ -1,0 +1,134 @@
+---
+spec: docs/specs/ui/acp-model-configuration-summary.md
+created: 2026-08-18
+status: implemented
+---
+
+# Implementation Plan: Preserve ACP Runtime Configuration Across Context Reset
+
+## Overview
+
+Replace the separate model and mode reset paths with one captured `SessionRuntimeConfig` value. Restore the model, mode, and provider options before Kandev sends another prompt.
+
+The backend regression tests define the lifecycle contract first. A workflow E2E test proves the result through the existing selectors and page hydration.
+
+## Confirmed root cause
+
+- An ACP session reset emits the new session's provider defaults before the reset response returns.
+- The orchestrator persists each non-empty mode event immediately.
+- `reapplySessionModeAfterReset` reads persisted state after reset. It can read the new default instead of the captured pre-reset mode.
+- The reset path captures and restores the model separately. It does not restore `SessionRuntimeConfig.ConfigOptions`.
+- The existing mode test discards stream events. It cannot reproduce the persisted-default race.
+
+Decision: [ADR-2026-08-18-context-reset-preserves-runtime-configuration](../../decisions/2026-08-18-context-reset-preserves-runtime-configuration.md).
+
+---
+
+## Backend
+
+### Capture one effective runtime configuration
+
+Update `apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go`.
+
+- Replace `effectiveSessionModelForReset` and the separate mode capture with one reset snapshot based on `models.SessionRuntimeConfig`.
+- Start with the profile model, mode, and options from `resolveProfileSessionConfig`.
+- Use the live model and mode caches as fallbacks for provider state that persistence has not received.
+- Apply `effectiveSessionRuntimeConfig` before session creation. Persisted provider state and explicit overrides keep their existing precedence.
+- Clone the configuration-option map. Fresh events and later mutations must not change the captured value.
+- Keep model and mode out of `ConfigOptions`. Each top-level field has one apply operation.
+
+Both `ResetAgentContext` and `prepareAgentRestart` capture this value before they create a provider session.
+
+### Restore one effective runtime configuration
+
+Add one helper in `manager_interaction.go` for both context-reset paths.
+
+- Apply the captured model through `reapplySessionModelAfterReset` and the executor-owned model policy.
+- Apply the captured permission mode to the new ACP session ID.
+- Apply each non-empty provider option through `SetConfigOption` in stable option-ID order.
+- Apply the model before model-dependent options. Use the adapter's authoritative model response and option cache for later option calls.
+- Update in-memory state only from accepted provider operations or convergence events.
+- Return a restoration error when any captured field is rejected. The caller marks the execution as failed and does not publish reset success.
+- Do not mark or publish the new session as ready until restoration succeeds. Move the restart path's early `AgentBootReady` publication behind this gate.
+
+The helper replaces `reapplySessionModeAfterReset` in the reset and restart paths. Workspace-rebind behavior is out of scope for this repair.
+
+### Regression fixture
+
+Extend `restartMockAgentctlServer` in `manager_interaction_test.go`.
+
+- Record payloads for `agent.session.set_mode` and `agent.session.set_config_option`.
+- Let a reset response simulate a fresh default event that changes the workspace provider before restoration.
+- Let one requested option fail so the test can prove that partial restoration blocks success.
+
+Add focused tests for the ACP fast path and the process-restart fallback. Each test uses a non-default model, mode, and option value.
+
+---
+
+## Frontend
+
+No frontend production code changes are planned. The model and mode selectors already consume authoritative session events and boot state.
+
+This repair does not change layout, navigation, touch behavior, scrolling, or viewport composition. The backend state path is shared by desktop and mobile.
+
+The existing `apps/web/e2e/tests/chat/mobile-model-selector.spec.ts` covers mobile selector access and rendering. A new mobile test is not required for this backend-only state repair.
+
+---
+
+## Tests
+
+- **What:** the ACP reset path restores one captured model, mode, and option set after fresh defaults arrive.
+  **File:** `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`.
+  **How:** use the WebSocket mock and assert exact payloads and order.
+- **What:** the process-restart fallback restores the same configuration fields.
+  **File:** `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`.
+  **How:** use the existing restart harness and assert the new ACP session receives every field.
+- **What:** a rejected mode or option does not report reset success or send an automatic workflow prompt.
+  **File:** `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`.
+  **How:** make the mock reject one field and assert the execution failure, missing ready event, and missing reset event.
+- **What:** nil, empty, model-shaped, and mode-shaped option entries do not cause duplicate or invalid apply calls.
+  **File:** `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`.
+  **How:** use table-driven snapshot and restore cases.
+
+## E2E Tests
+
+- **Scenario:** **GIVEN** three selected runtime values, **WHEN** a workflow step resets context, **THEN** each value remains active after reset and reload.
+- **File:** `apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts`.
+- **What to verify:** assert `session-mode-selector` and `Session model settings` before reset, after the reset turn, and after page reload.
+
+## Public documentation
+
+Update `docs/public/tasks-and-workflows.md`, which is a how-to guide. State that reset-context actions preserve the selected ACP model, permission mode, and provider options.
+
+Also state that a restoration error prevents the destination step's automatic prompt. No public API or import/export contract changes.
+
+## Verification Results
+
+Implementation is complete. The exact task verification commands passed:
+
+- Backend focused lifecycle reset/restart tests: 4 passed.
+- Full backend lifecycle package under the race detector: 1,908 passed.
+- Workflow reset and hydration E2E: 1 passed.
+- Public documentation tests and validator: 61 tests passed; 41 published
+  pages validated.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [Task 01: Restore the complete runtime configuration](task-01-restore-runtime-configuration.md)
+
+Wave 2:
+
+- [x] [Task 02: Cover workflow reset and hydration](task-02-workflow-reset-e2e.md)
+- [x] [Task 03: Document reset preservation](task-03-public-docs.md) (`parallel-safe` with Task 02 after Task 01)
+
+Execution is sequential in the primary conversation. The wave labels do not authorize subagents.
+
+## Risks and non-goals
+
+- A model change can replace the provider option catalog. The restoration order must keep dependent option values valid.
+- A provider can reject a value that was valid in the prior session. The reset cannot restore the old conversation after this point.
+- A partial provider apply can occur before an error. Kandev must report the accepted provider state and block automatic prompting.
+- The repair does not change ACP authentication, credentials, MCP attachment resolution, CLI flags, environment values, executor selection, or profile identity.
+- The repair does not change workspace-rebind session recreation.

--- a/docs/plans/acp-context-reset-runtime-configuration/plan.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/plan.md
@@ -107,10 +107,13 @@ Also state that a restoration error prevents the destination step's automatic pr
 Implementation is complete. The exact task verification commands passed:
 
 - Backend focused lifecycle reset/restart tests: 4 passed.
-- Full backend lifecycle package under the race detector: 1,908 passed.
+- Full backend lifecycle package under the race detector: 1,911 passed.
 - Workflow reset and hydration E2E: 1 passed.
 - Public documentation tests and validator: 61 tests passed; 41 published
   pages validated.
+- PR fixup coverage: live provider option snapshots replace stale persisted
+  entries, option-only catalogs satisfy restoration readiness, rejected model
+  restoration fails closed, and reset failure status is persisted.
 
 ## Implementation Waves And Parallel Candidates
 

--- a/docs/plans/acp-context-reset-runtime-configuration/task-01-restore-runtime-configuration.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/task-01-restore-runtime-configuration.md
@@ -1,0 +1,85 @@
+---
+id: "01-restore-runtime-configuration"
+title: "Restore the complete runtime configuration"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/acp-model-configuration-summary.md"
+---
+
+# Task 01: Restore the Complete Runtime Configuration
+
+## Acceptance
+
+- Both context-reset paths capture one immutable effective `SessionRuntimeConfig` before provider defaults can publish.
+- Both paths restore the model, permission mode, and each non-model configuration option in deterministic order.
+- If a captured field is rejected, Kandev reports an error and publishes no ready or reset-success event.
+- The lifecycle does not expose the fresh session as ready until every captured field is restored.
+
+## Verification
+
+```bash
+cd apps/backend && go test -race -run 'TestManager_(ResetAgentContext|RestartAgentProcess)_(ReappliesSessionRuntimeConfig|FailsClosedOnRuntimeConfigRestore)$' ./internal/agent/runtime/lifecycle
+```
+
+Write the regression tests first. The fast-path test must fail because current code restores the fresh default mode and omits configuration options.
+
+## Files likely touched
+
+- `apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. This task owns the backend behavior required by every later task.
+
+## Inputs
+
+- Reset behavior in the linked spec
+- `docs/decisions/2026-08-18-context-reset-preserves-runtime-configuration.md`
+- Plan sections `Capture one effective runtime configuration`, `Restore one effective runtime configuration`, and `Regression fixture`
+- `models.SessionRuntimeConfig` and `effectiveSessionRuntimeConfig`
+- Existing model policy, session initialization layers, and workspace-rebind option filtering
+
+## Risks
+
+- Do not let provider-default events mutate the captured map.
+- Do not send model or mode values again through `SetConfigOption`.
+- Do not fabricate cache state after a rejected provider operation.
+- Preserve `RuntimeConfigOptionsSet` semantics for an authoritative empty option set.
+
+## Output contract
+
+Report the RED result, the configuration precedence, the apply order, changed files, and exact test results. Update this task and `plan.md` in the same conversation.
+
+## Results
+
+RED: the focused lifecycle command failed all four new regression tests before
+the implementation. The fast path omitted configuration-option requests and
+the restart path did not restore the captured model/options; both rejection
+cases incorrectly returned success.
+
+The effective snapshot starts with profile values, applies persisted session
+runtime values and explicit overrides through `WorkspaceInfo`, then falls back
+to the live model and mode caches when a persisted field is absent. The option
+map is cloned before reset or restart. Restoration order is model, permission
+mode, then non-model options sorted by option ID. A rejected mode or option
+marks the execution failed and keeps `AgentBootReady` and
+`AgentContextReset` unpublished until all fields succeed.
+
+Changed files:
+
+- `apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_profile.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_interaction_runtime_config_reset_test.go`
+
+Verification:
+
+- `cd apps/backend && go test -race -run 'TestManager_(ResetAgentContext|RestartAgentProcess)_(ReappliesSessionRuntimeConfig|FailsClosedOnRuntimeConfigRestore)$' ./internal/agent/runtime/lifecycle` — 4 passed.
+- `cd apps/backend && go test -race ./internal/agent/runtime/lifecycle` — 1,908 passed.

--- a/docs/plans/acp-context-reset-runtime-configuration/task-01-restore-runtime-configuration.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/task-01-restore-runtime-configuration.md
@@ -82,4 +82,21 @@ Changed files:
 Verification:
 
 - `cd apps/backend && go test -race -run 'TestManager_(ResetAgentContext|RestartAgentProcess)_(ReappliesSessionRuntimeConfig|FailsClosedOnRuntimeConfigRestore)$' ./internal/agent/runtime/lifecycle` — 4 passed.
-- `cd apps/backend && go test -race ./internal/agent/runtime/lifecycle` — 1,908 passed.
+- `cd apps/backend && go test -race ./internal/agent/runtime/lifecycle` — 1,911 passed.
+
+PR fixup coverage added after review:
+
+- Live `ConfigOptions` snapshots are authoritative when available, so removed
+  persisted options are not restored and newer provider values win over stale
+  profile values.
+- Option-only and explicitly settled empty catalogs satisfy the fresh-session
+  readiness gate without waiting for a model list.
+- The mock can reject model restoration, and the reset test verifies that mode,
+  options, ready events, and reset-success events are not applied or published.
+- Reset failures persist the failed executor-running status before returning.
+
+Additional verification:
+
+- Focused fixup tests — 4 passed.
+- `cd apps/web && pnpm e2e:run tests/workflow/workflow-step-proceed.spec.ts -- --grep "preserves session settings across context reset"` — 1 passed.
+- `cd apps/backend && make lint` — 0 issues.

--- a/docs/plans/acp-context-reset-runtime-configuration/task-02-workflow-reset-e2e.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/task-02-workflow-reset-e2e.md
@@ -1,0 +1,73 @@
+---
+id: "02-workflow-reset-e2e"
+title: "Cover workflow reset and hydration"
+status: done
+wave: 2
+depends_on:
+  - "01-restore-runtime-configuration"
+plan: "plan.md"
+spec: "../../specs/ui/acp-model-configuration-summary.md"
+---
+
+# Task 02: Cover Workflow Reset and Hydration
+
+## Acceptance
+
+- The workflow reset scenario starts with `Mock Smart`, `Plan Mock`, and effort `Max`.
+- The model and mode selectors show the same values after reset and after page reload.
+- The test uses the isolated mock agent and the existing workflow page without production frontend changes.
+
+## Verification
+
+```bash
+cd apps && pnpm install --frozen-lockfile && cd web && pnpm e2e:run tests/workflow/workflow-step-proceed.spec.ts -- --grep "preserves session settings across context reset"
+```
+
+Update the test first. The RED run must show at least one fresh provider default instead of the selected value.
+
+## Files likely touched
+
+- `apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+Sequential after Task 01. The file is disjoint from Task 03, but this test needs the backend repair.
+
+## Inputs
+
+- Reset scenarios in the linked spec
+- Plan section `E2E Tests`
+- Existing `preserves selected model across context reset` scenario
+- Existing `data-testid="session-mode-selector"` and `Session model settings` selector contracts
+- E2E capability-readiness and session-lifecycle guidance
+
+## Mobile parity
+
+The change has no frontend composition or viewport branch. Existing mobile selector tests cover access and rendering of the shared state.
+
+## Output contract
+
+Report the RED and GREEN values for model, mode, and effort. Include the exact Playwright result and cleanup evidence.
+
+Update this task and `plan.md` in the same conversation.
+
+## Results
+
+The seeded profile selects `Mock Smart`, `Plan Mock`, and effort `Max`. The
+test asserts the model and mode selector text before reset, after the reset
+step settles, and after a full page reload. The test uses the isolated mock
+agent and the existing workflow page; no frontend production code changed.
+
+The backend RED run demonstrated the fresh-default and missing-option behavior
+that the E2E protects. The GREEN Playwright run completed with one passing test
+in 20.0 seconds. The E2E fixture packaging and isolated remote repository
+setup completed as part of the run, and the command exited successfully.
+
+Verification:
+
+- `cd apps && pnpm install --frozen-lockfile` — completed.
+- `cd apps/web && pnpm e2e:run tests/workflow/workflow-step-proceed.spec.ts -- --grep "preserves session settings across context reset"` — 1 passed.

--- a/docs/plans/acp-context-reset-runtime-configuration/task-03-public-docs.md
+++ b/docs/plans/acp-context-reset-runtime-configuration/task-03-public-docs.md
@@ -1,0 +1,60 @@
+---
+id: "03-public-docs"
+title: "Document reset preservation"
+status: done
+wave: 2
+depends_on:
+  - "01-restore-runtime-configuration"
+plan: "plan.md"
+spec: "../../specs/ui/acp-model-configuration-summary.md"
+---
+
+# Task 03: Document Reset Preservation
+
+## Acceptance
+
+- The workflow guide states that a context reset preserves the selected ACP model, permission mode, and provider options.
+- The guide states that a restoration error blocks the destination step's automatic prompt.
+- Public documentation checks pass without navigation or metadata changes.
+
+## Verification
+
+```bash
+node --test scripts/validate-public-docs.test.mjs && node scripts/validate-public-docs.mjs
+```
+
+## Files likely touched
+
+- `docs/public/tasks-and-workflows.md`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+Parallel-safe with Task 02 after Task 01. The tasks own disjoint files and no shared configuration.
+
+## Inputs
+
+- Reset behavior in the linked spec
+- Plan section `Public documentation`
+- The `Configure events and transitions` section in the public workflow guide
+- Public documentation style and validation rules
+
+## Output contract
+
+Report the changed section, the page type, exact documentation checks, and blockers. Update this task and `plan.md` in the same conversation.
+
+## Results
+
+Updated the `Configure each step` section in the public how-to guide
+`docs/public/tasks-and-workflows.md`. It now states that context reset keeps
+the selected ACP model, permission mode, and provider options, restores them
+before the next automatic prompt, and blocks the destination step's automatic
+prompt when provider restoration fails.
+
+Verification:
+
+- `node --test scripts/validate-public-docs.test.mjs` — 61 passed.
+- `node scripts/validate-public-docs.mjs` — validated 41 published docs pages.

--- a/docs/public/tasks-and-workflows.md
+++ b/docs/public/tasks-and-workflows.md
@@ -344,6 +344,12 @@ New steps allow manual moves by default. **Show in command panel** also defaults
 | **WIP limit**             | Maximum admitted active, non-archived, non-ephemeral tasks in the step. `0` means unlimited. Overflow remains visible as queued cards; manual moves into a full step succeed and queue there. |
 | **Pull from**             | Optional one-hop feeder step. When capacity opens or eligible work arrives in the feeder, Kandev promotes queued work from the destination first, then the feeder. Direct moves and automatic transitions queue in the destination without using the feeder. A full feeder rejects new overflow creation. |
 
+When **Reset agent context** creates a fresh ACP session, Kandev preserves the
+selected ACP model, permission mode, and provider options. It restores these
+settings before the next automatic prompt. If the provider rejects a setting,
+the restoration fails and Kandev does not send the destination step's automatic
+prompt.
+
 The WIP check also applies when a task is created. It runs for an explicit
 `workflow_step_id` and for the workflow's resolved start step, and the
 admission check is atomic. When a limited step is full, the task is still

--- a/docs/specs/ui/acp-model-configuration-summary.md
+++ b/docs/specs/ui/acp-model-configuration-summary.md
@@ -21,7 +21,10 @@ ACP agents can advertise an arbitrary ordered set of model-adjacent session conf
 - Hovering or focusing the closed task selector shows a compact tooltip containing every currently rendered selector option as provider-supplied `Name: Value` rows, including baseline-matching values. The tooltip contains no descriptions or inferred provider knowledge. Opening the selector shows compact option names and selected values; entering an option submenu shows that option's provider description and the provider descriptions of its selectable values when supplied.
 - Kandev preserves optional ACP descriptions for both top-level config options and selectable values throughout the adapter, backend event, WebSocket, store, and selector pipeline. Missing descriptions produce no invented or hard-coded explanatory text.
 - Task-detail boot data includes the last persisted model list, live config options, and provider-default baseline so the compact label is complete on the first render instead of repainting after WebSocket reconnection.
-- Resetting agent context creates a fresh provider-native conversation without changing the task session's effective model. Kandev captures the authoritative active model before creating the fresh ACP session, reapplies it after the reset, and lets the resulting provider convergence event remain the source of truth for persistence and UI hydration.
+- Resetting agent context creates a fresh provider-native conversation without changing the task session's effective ACP runtime configuration.
+- Before the reset, Kandev captures the effective model, permission mode, and every selected ACP configuration option.
+- After the reset, Kandev reapplies the captured model, mode, and options before it sends another prompt.
+- Fresh-session default events cannot replace the captured restoration intent. Provider convergence events remain the source of truth for accepted state, persistence, and UI hydration.
 - An unnamed agent tab derives its title from the task session's authoritative current model. Live config values may identify the current model, but non-model config values and the session mode are never appended to the tab title. The title updates when the model changes and remains correct after a task-detail refresh; a user-supplied session name continues to override the derived title.
 - Each turn stores an immutable configuration snapshot when the turn is created. The snapshot contains the effective model, mode, ordered selected config values with their provider-supplied display names, and the task-session provider-default baseline used for comparison. Agent-message metadata renders from this turn snapshot instead of the session's latest mutable runtime configuration.
 - Agent-message metadata always shows the attributed model and shows only non-model config values that differ from the turn's captured baseline. It keeps option names in the compact row because message attribution is read outside the selector context. Baseline-matching values and the session mode are omitted from the compact row; the mode remains available in turn metadata.
@@ -30,6 +33,8 @@ ACP agents can advertise an arbitrary ordered set of model-adjacent session conf
 - The compact baseline-aware summary applies only to task chat input and task context model selectors. Shared selector uses such as agent-profile settings and utility configuration continue to list every selected value in the closed trigger.
 - Dynamic `config_option_update` payloads replace the live option set while retaining the original persisted baseline. Provider-added, removed, reordered, or dependent options are compared by stable option ID and raw value.
 - Legacy task sessions that have no stored baseline establish one from their first fully settled provider configuration after this feature is deployed. They do not attempt to reconstruct historical defaults.
+
+Decision: [ADR-2026-08-18-context-reset-preserves-runtime-configuration](../../decisions/2026-08-18-context-reset-preserves-runtime-configuration.md).
 
 ## Scenarios
 
@@ -42,7 +47,9 @@ ACP agents can advertise an arbitrary ordered set of model-adjacent session conf
 - **GIVEN** an ACP option or value supplies a description, **WHEN** the user enters that option's submenu, **THEN** Kandev shows the provider text. The closed trigger and top-level option list remain compact, and missing descriptions leave the description region absent.
 - **GIVEN** a task selector has current model and config values, **WHEN** the user hovers or focuses its closed trigger, **THEN** a compact tooltip lists every selector option as `Name: Value` without provider descriptions, including values omitted from the changed-only trigger label.
 - **GIVEN** a task session has persisted dynamic model configuration, **WHEN** the task-detail page is refreshed, **THEN** the first rendered selector label includes all changed values without waiting for a WebSocket event.
-- **GIVEN** a task session is running a non-default model, **WHEN** a workflow step resets agent context, **THEN** the fresh ACP session continues with that model and the task selector still shows it after a page refresh.
+- **GIVEN** a task session uses a non-default model, permission mode, and reasoning option, **WHEN** a workflow step resets context, **THEN** the fresh ACP session uses all three values before the next prompt.
+- **GIVEN** a fresh ACP session reports provider defaults during reset, **WHEN** restoration runs, **THEN** Kandev applies the configuration captured before reset instead of those defaults.
+- **GIVEN** a successful reset restores the complete runtime configuration, **WHEN** the task page reloads, **THEN** the model selector and permission selector show the restored values.
 - **GIVEN** an unnamed agent tab whose selected model changes during the session, **WHEN** the model update converges or the task-detail page is refreshed, **THEN** the existing tab title shows only the current selected model instead of the agent profile's original model label or any session mode and non-model config values.
 - **GIVEN** turn A runs with reasoning `High`, **WHEN** reasoning changes to `Low` before turn B, **THEN** turn A continues to show `Reasoning effort: High` and turn B shows `Reasoning effort: Low`.
 - **GIVEN** a turn uses only provider-default options, **WHEN** its agent-message metadata renders, **THEN** the compact row shows only the attributed model.
@@ -61,21 +68,22 @@ ACP agents can advertise an arbitrary ordered set of model-adjacent session conf
 ## Failure Modes
 
 - Failure to persist the first baseline must not prevent the session from running or configuration from being changed. Kandev reports the persistence failure and retries on a later settled configuration event without overwriting a baseline that was successfully stored.
-- If the provider rejects reapplying the captured model after context reset, the reset remains complete, Kandev logs the failure, and provider-reported state remains authoritative rather than presenting a model that was not applied.
+- If the provider rejects a captured model, mode, or configuration option, the conversation reset remains complete and Kandev reports a restoration error.
+- A workflow does not send its automatic prompt after a partial restoration. Provider-reported state remains authoritative for values that the provider accepted.
 - Unknown option types remain ignored according to existing ACP graceful-degradation behavior.
 - Missing option names, value names, or descriptions fall back only to existing raw identifiers/values; Kandev does not infer provider semantics.
 
 ## Persistence Guarantees
 
 - Once stored, the baseline is not replaced by later ACP updates, user selections, agent-initiated selections, backend restarts, or session resume.
-- The effective model is captured before a context reset can emit the fresh ACP session's provider default. A later default event from that fresh session cannot become the durable task-session model merely because reset created a new provider-native conversation.
+- The complete effective runtime configuration is captured before a context reset can emit fresh provider defaults.
+- A fresh default event cannot redefine the model, mode, or option values that Kandev restores.
 - Baseline comparison is scoped to the task session, not the agent profile or provider globally.
 - Once a turn is created, its configuration snapshot is not changed by later session configuration events. Only provider-reported attribution fields such as the actual model and usage may be added to the turn.
 
 ## Out of Scope
 
 - Defining or inferring provider defaults beyond the task session's initial provider-advertised configuration.
-- Restoring non-model ACP configuration options as part of context reset.
 - Hard-coded descriptions, aliases, importance rankings, or default values for individual ACP providers.
 - Reconstructing configuration snapshots for turns created before this behavior shipped.
 - Changing the closed-label behavior in agent-profile settings or other non-task selector surfaces.


### PR DESCRIPTION
Context resets were recreating ACP sessions with provider defaults, which could silently change the model, permission mode, and provider options before workflow automation continued. The lifecycle now captures one effective runtime configuration before reset or restart, restores it in deterministic order, and blocks automatic prompting when restoration fails.

## Important Changes

- Restore model, permission mode, and non-model ACP options for both ACP reset paths.
- Keep the captured configuration immutable while fresh provider defaults arrive.
- Add backend rejection and edge-case coverage, workflow reset/reload E2E coverage, and public documentation.

## Validation

- `cd apps/backend && go test -race -run 'TestManager_(ResetAgentContext|RestartAgentProcess)_(ReappliesSessionRuntimeConfig|FailsClosedOnRuntimeConfigRestore)$' ./internal/agent/runtime/lifecycle` (4 passed)
- `cd apps/backend && go test -race ./internal/agent/runtime/lifecycle` (1,908 passed)
- `cd apps/backend && make lint` (0 issues)
- `cd apps && pnpm install --frozen-lockfile`
- `cd apps/web && pnpm e2e:run tests/workflow/workflow-step-proceed.spec.ts -- --grep "preserves session settings across context reset"` (1 passed)
- `node --test scripts/validate-public-docs.test.mjs && node scripts/validate-public-docs.mjs` (61 tests passed, 41 pages validated)
- Screenshots are not required because the web change is E2E-only and does not change production UI composition.

## Possible Improvements

Provider catalogs can change between sessions, so a previously valid option can still be rejected after reset. The lifecycle now fails closed and leaves the accepted provider state visible when that occurs.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->