### PR TITLE
fix(integrations): render action component on plugin integration cards

### DIFF
--- a/apps/packages/plugin-sdk/src/index.ts
+++ b/apps/packages/plugin-sdk/src/index.ts
@@ -603,6 +603,14 @@ export interface PluginHostApi {
   storage: PluginStorageApi;
 }
 
+export type IntegrationSettingsActionSurface = "detail" | "index";
+
+export interface IntegrationSettingsActionProps {
+  workspaceId?: string;
+  /** Identifies the native integration surface that mounted the action. */
+  surface: IntegrationSettingsActionSurface;
+}
+
 export interface PluginRegistry {
   registerTranslations(catalogs: PluginTranslationCatalogs): void;
   registerRoute(path: string, component: Component, options?: PluginRouteOptions): void;
@@ -623,10 +631,9 @@ export interface PluginRegistry {
     description: string;
     icon?: PluginIcon;
     Component: Component<{ workspaceId?: string }>;
-    /** Optional header action (e.g. an enable toggle) rendered in the host
-     * section header's action slot, mirroring built-in integrations.
-     * Receives `{ workspaceId?: string }` so it can operate per-workspace. */
-    action?: Component<{ workspaceId?: string }>;
+    /** Optional action rendered in the detail section header and index card.
+     * Receives the routed workspace and the native surface that mounted it. */
+    action?: Component<IntegrationSettingsActionProps>;
   }): void;
   registerRepositoryProvider(provider: RepositoryProviderRegistration): void;
   registerTaskAction(action: {

--- a/apps/web/app/settings/integrations/page.test.tsx
+++ b/apps/web/app/settings/integrations/page.test.tsx
@@ -1,5 +1,6 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Component, IntegrationSettingsActionProps } from "@kandev/plugin-sdk";
 import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
 import { IntegrationsIndexPage } from "@/components/integrations/integrations-index-page";
 import { pluginRegistry } from "@/lib/plugins/registry";
@@ -46,14 +47,35 @@ vi.mock("@/hooks/domains/sentry/use-sentry-enabled", () => ({
 }));
 
 const PLUGIN_ID = "plugin-source-control";
+const SOURCE_CONTROL_ID = "source-control";
+const SOURCE_CONTROL_DESCRIPTION = "Connect a source-control provider.";
 
 function registerIntegration() {
   pluginRegistry.forPlugin(PLUGIN_ID).registerIntegrationSettings({
-    id: "source-control",
+    id: SOURCE_CONTROL_ID,
     label: "Source Control",
-    description: "Connect a source-control provider.",
+    description: SOURCE_CONTROL_DESCRIPTION,
     icon: "cloud",
     Component: () => null,
+  });
+}
+
+function registerIntegrationWithAction(
+  pluginId = PLUGIN_ID,
+  id = SOURCE_CONTROL_ID,
+  action?: Component<IntegrationSettingsActionProps>,
+) {
+  const labels: Record<string, string> = {
+    "source-control": "Source Control",
+    "throwing-provider": "Throwing Provider",
+  };
+  pluginRegistry.forPlugin(pluginId).registerIntegrationSettings({
+    id,
+    label: labels[id] ?? "Healthy Provider",
+    description: SOURCE_CONTROL_DESCRIPTION,
+    icon: "cloud",
+    Component: () => null,
+    action,
   });
 }
 
@@ -158,8 +180,51 @@ describe("IntegrationsIndexPage plugin contributions", () => {
     renderPage();
 
     const link = screen.getByRole("link", { name: /source control/i });
-    expect(link.getAttribute("href")).toBe("/settings/integrations/source-control");
-    expect(screen.getByText("Connect a source-control provider.")).not.toBeNull();
+    expect(link.getAttribute("href")).toBe(`/settings/integrations/${SOURCE_CONTROL_ID}`);
+    expect(screen.getByText(SOURCE_CONTROL_DESCRIPTION)).not.toBeNull();
+  });
+
+  it("renders the plugin action with the index surface and routed workspace", () => {
+    const actionCalls: Array<{ workspaceId?: string; surface: "detail" | "index" }> = [];
+    const Action = ({ workspaceId, surface }: IntegrationSettingsActionProps) => {
+      actionCalls.push({ workspaceId, surface });
+      return <span data-testid="plugin-index-action">Action</span>;
+    };
+    registerIntegrationWithAction(PLUGIN_ID, SOURCE_CONTROL_ID, Action);
+
+    renderPage("workspace-42");
+
+    expect(screen.getByTestId("plugin-index-action")).not.toBeNull();
+    expect(actionCalls).toEqual([{ workspaceId: "workspace-42", surface: "index" }]);
+  });
+
+  it("passes an undefined workspace to a plugin action on the global index route", () => {
+    const actionCalls: Array<{ workspaceId?: string; surface: "detail" | "index" }> = [];
+    const Action = ({ workspaceId, surface }: IntegrationSettingsActionProps) => {
+      actionCalls.push({ workspaceId, surface });
+      return null;
+    };
+    registerIntegrationWithAction(PLUGIN_ID, SOURCE_CONTROL_ID, Action);
+
+    renderPage();
+
+    expect(actionCalls).toEqual([{ workspaceId: undefined, surface: "index" }]);
+  });
+
+  it("contains a throwing plugin action without removing other integration cards", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ThrowingAction = () => {
+      throw new Error("plugin action failed");
+    };
+    const HealthyAction = () => <span data-testid="healthy-plugin-action">Healthy</span>;
+    registerIntegrationWithAction(PLUGIN_ID, "throwing-provider", ThrowingAction);
+    registerIntegrationWithAction("plugin-healthy", "healthy-provider", HealthyAction);
+
+    renderPage();
+
+    expect(screen.getByRole("link", { name: /throwing provider/i })).not.toBeNull();
+    expect(screen.getByRole("link", { name: /healthy provider/i })).not.toBeNull();
+    expect(screen.getByTestId("healthy-plugin-action")).not.toBeNull();
   });
 
   it("uses the workspace-scoped plugin integration path", () => {
@@ -168,7 +233,7 @@ describe("IntegrationsIndexPage plugin contributions", () => {
     renderPage("workspace one");
 
     expect(screen.getByRole("link", { name: /source control/i }).getAttribute("href")).toBe(
-      "/settings/workspaces/workspace%20one/integrations/source-control",
+      `/settings/workspaces/workspace%20one/integrations/${SOURCE_CONTROL_ID}`,
     );
   });
 

--- a/apps/web/components/integrations/integrations-index-page.tsx
+++ b/apps/web/components/integrations/integrations-index-page.tsx
@@ -177,7 +177,7 @@ export function IntegrationsIndexPage({ workspaceId }: IntegrationsIndexPageProp
             </Card>
           );
         })}
-        {pluginIntegrations.map(({ pluginId, id, label, description, icon }) => {
+        {pluginIntegrations.map(({ pluginId, id, label, description, icon, action: Action }) => {
           const href = `${rootHref}/${id}`;
           const Icon = resolvePluginIcon(icon);
           return (
@@ -187,13 +187,18 @@ export function IntegrationsIndexPage({ workspaceId }: IntegrationsIndexPageProp
               className="h-full w-full transition-colors hover:border-primary/40"
             >
               <CardContent className="space-y-2">
-                <Link
-                  href={href}
-                  className="flex min-w-0 items-center gap-2 text-base font-semibold hover:underline cursor-pointer"
-                >
-                  <Icon className="h-5 w-5 shrink-0" />
-                  <span className="truncate">{label}</span>
-                </Link>
+                <div className="flex items-center justify-between gap-2">
+                  <Link
+                    href={href}
+                    className="flex min-w-0 items-center gap-2 text-base font-semibold hover:underline cursor-pointer"
+                  >
+                    <Icon className="h-5 w-5 shrink-0" />
+                    <span className="truncate">{label}</span>
+                  </Link>
+                  <div className="shrink-0">
+                    {Action ? <Action workspaceId={workspaceId} /> : null}
+                  </div>
+                </div>
                 <Link href={href} className="text-sm text-muted-foreground cursor-pointer">
                   {description}
                 </Link>

--- a/apps/web/components/integrations/integrations-index-page.tsx
+++ b/apps/web/components/integrations/integrations-index-page.tsx
@@ -28,6 +28,7 @@ import { LinearEnabledControl } from "@/components/linear/linear-enabled-control
 import { SentryEnabledControl } from "@/components/sentry/sentry-enabled-control";
 import { resolvePluginIcon } from "@/lib/plugins/icons";
 import { usePluginRegistry } from "@/lib/plugins/registry";
+import { PluginErrorBoundary } from "@/components/plugins/plugin-error-boundary";
 
 type IntegrationSlug = "azure-devops" | "github" | "gitlab" | "jira" | "linear" | "sentry";
 
@@ -196,7 +197,11 @@ export function IntegrationsIndexPage({ workspaceId }: IntegrationsIndexPageProp
                     <span className="truncate">{label}</span>
                   </Link>
                   <div className="shrink-0">
-                    {Action ? <Action workspaceId={workspaceId} /> : null}
+                    {Action ? (
+                      <PluginErrorBoundary context={`integration card action "${pluginId}:${id}"`}>
+                        <Action workspaceId={workspaceId} surface="index" />
+                      </PluginErrorBoundary>
+                    ) : null}
                   </div>
                 </div>
                 <Link href={href} className="text-sm text-muted-foreground cursor-pointer">

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -10,6 +10,8 @@ import type { AppState } from "@/lib/state/store";
 import type * as PluginSDK from "@kandev/plugin-sdk";
 import type { PluginUIApi } from "@kandev/plugin-sdk";
 export type {
+  IntegrationSettingsActionProps,
+  IntegrationSettingsActionSurface,
   PluginContextApi,
   PluginHostRepository,
   PluginNavSection,
@@ -101,10 +103,9 @@ export interface IntegrationSettingsRegistration {
   /** Curated icon name or plugin-owned component. */
   icon?: PluginSDK.PluginIcon;
   Component: ReactType.ComponentType<PluginIntegrationSettingsProps>;
-  /** Optional header action (e.g. an enable toggle) rendered in the host's
-   * SettingsSection header action slot, mirroring built-in integrations.
-   * Receives `{ workspaceId?: string }` so it can operate per-workspace. */
-  action?: ReactType.ComponentType<{ workspaceId?: string }>;
+  /** Optional action rendered in the detail section header and index card.
+   * Receives the routed workspace and the native surface that mounted it. */
+  action?: ReactType.ComponentType<PluginSDK.IntegrationSettingsActionProps>;
 }
 
 /**

--- a/apps/web/src/plugin-integration-settings-route.test.tsx
+++ b/apps/web/src/plugin-integration-settings-route.test.tsx
@@ -31,7 +31,10 @@ describe("plugin integration settings route", () => {
     const page = renderPluginIntegrationSettings(INTEGRATION_ID, "workspace-from-route");
     render(page);
 
-    expect(Action.mock.calls[0]?.[0]).toEqual({ workspaceId: "workspace-from-route" });
+    expect(Action.mock.calls[0]?.[0]).toEqual({
+      workspaceId: "workspace-from-route",
+      surface: "detail",
+    });
     expect(actionWorkspaceIds).toEqual(["workspace-from-route"]);
   });
 });

--- a/apps/web/src/plugin-integration-settings-route.tsx
+++ b/apps/web/src/plugin-integration-settings-route.tsx
@@ -22,7 +22,7 @@ export function renderPluginIntegrationSettings(integrationId: string, workspace
         title={registration.label}
         description={registration.description}
         icon={<Icon className="h-5 w-5" />}
-        action={Action ? <Action workspaceId={workspaceId} /> : undefined}
+        action={Action ? <Action workspaceId={workspaceId} surface="detail" /> : undefined}
       >
         <Component workspaceId={workspaceId} />
       </SettingsSection>

--- a/docs/decisions/2026-08-05-plugin-native-integration-settings.md
+++ b/docs/decisions/2026-08-05-plugin-native-integration-settings.md
@@ -16,8 +16,11 @@ to the host.
 ## Decision
 
 The frontend plugin registry adds
-`registerIntegrationSettings({ id, label, description, icon?, Component })`.
-`Component` receives `{ workspaceId?: string }`; the host renders it in the existing
+`registerIntegrationSettings({ id, label, description, icon?, Component, action? })`.
+`Component` receives `{ workspaceId?: string }`. An optional `action` receives the
+routed workspace and a `surface` value. The host renders the action in the detail
+section header and the native integrations index card. The host renders the main
+component in the existing
 settings shell at both `/settings/integrations/{id}` and
 `/settings/workspace/{workspaceId}/integrations/{id}`, and adds the contribution to
 the native integrations index and workspace settings navigation. The host wraps the
@@ -39,10 +42,10 @@ and watch configuration use the native integration settings contribution.
 
 Official and third-party integrations can feel first-party in Settings while retaining
 independent release ownership. Plugins must choose a stable non-reserved slug and make
-their settings component work with either an explicit workspace or the legacy global
-route; it returns the section body rather than duplicating the host heading. The host
-owns navigation, responsive settings chrome, error containment, and
-lifecycle; the plugin owns all provider-specific fields and behavior.
+their settings component and action work with either an explicit workspace or the
+legacy global route. Actions must tolerate the detail and index surfaces. The host
+owns navigation, responsive settings chrome, error containment, and lifecycle. The
+plugin owns all provider-specific fields and behavior.
 
 ## Alternatives Considered
 

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -512,10 +512,11 @@ These are functions, so they sit beside `navigate`/`openModal` rather than in
 
 ### Native integration settings state
 
-`registerIntegrationSettings` may provide an `action` component. The host passes
-the routed `workspaceId` to both the page component and the action. Use that
-value for workspace-scoped reads and writes. Do not use
-`getActiveWorkspaceId()` for a routed settings page.
+`registerIntegrationSettings` may provide an `action` component. The host mounts
+the action in the detail `SettingsSection` header and in the native integrations
+index card. The host passes the routed `workspaceId` and a `surface` value of
+`"detail"` or `"index"`. Use the workspace value for workspace-scoped reads and
+writes. Do not use `getActiveWorkspaceId()` for a routed settings page.
 
 `host.setIntegrationEnabled(integrationId, workspaceId, enabled)` publishes a
 live value for one registration and workspace. The host checks that the
@@ -808,9 +809,17 @@ interface IntegrationSettingsRegistration {
   description: string;
   icon?: PluginIcon;
   Component: React.ComponentType<{ workspaceId?: string }>;
-  // Optional native header action. It receives the same routed workspace id
-  // as Component, so it never needs to infer the target from the active one.
-  action?: React.ComponentType<{ workspaceId?: string }>;
+  // Optional action for the detail section header and integrations index card.
+  // The surface identifies the host location and the workspace id identifies
+  // the settings target.
+  action?: React.ComponentType<IntegrationSettingsActionProps>;
+}
+
+type IntegrationSettingsActionSurface = "detail" | "index";
+
+interface IntegrationSettingsActionProps {
+  workspaceId?: string;
+  surface: IntegrationSettingsActionSurface;
 }
 
 // Integration settings render at /settings/integrations/{id} and

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -256,7 +256,7 @@ slice shapes in a released plugin.
 | registerComponent           | registerComponent(slot, Component); component receives { slotProps?: unknown }                                                                                                                                                                                                                         | Active ui.bundle                                                       | Every registration is owner-tracked, error-isolated, and bulk-revoked                                                                                                                                           | registry.registerComponent("task-sidebar", Panel)                                                                   |
 | registerWsHandler           | registerWsHandler(action, handler(payload)); receives actions bridged from lib/ws                                                                                                                                                                                                                      | Active ui.bundle                                                       | Handler is removed on disable/uninstall; tolerate duplicate/replayed actions                                                                                                                                    | registry.registerWsHandler("acme.updated", renderUpdate)                                                            |
 | registerKeybinding          | registerKeybinding(id, handler(event)); id must be declared in ui.keybindings; users can override the effective combo                                                                                                                                                                                  | ui.bundle and ui.keybindings[]                                         | Handler is removed on disable/uninstall; core shortcuts win, and editable targets are skipped unless that entry set ui.keybindings[].allow_in_editor                                                            | registry.registerKeybinding("open-panel", () => host.openModal(...))                                                |
-| registerIntegrationSettings | One provider-owned settings component with an optional header action mounted inside Settings > Integrations                                                                                                                                                                                       | Active ui.bundle                                                       | Registration is exclusive by id and revoked on unload; host owns workspace selection and settings navigation; both component and action receive the routed `workspaceId`                                                               | registry.registerIntegrationSettings({ id: "acme", Component, action: Toggle }) |
+| registerIntegrationSettings | One provider-owned settings component with an optional action mounted in the detail header and the integrations index card                                                                                                                                    | Active ui.bundle                                                       | Registration is exclusive by id and revoked on unload; host owns workspace selection and settings navigation; component and action receive the routed `workspaceId`, and action receives its `surface`                                                               | registry.registerIntegrationSettings({ id: "acme", Component, action: Toggle }) |
 | registerTranslations        | Flat English fallback plus optional Kandev locale catalogs, isolated to this plugin's namespace                                                                                                                                                                                                        | Active ui.bundle                                                       | Catalogs are replaced atomically, removed on unload, and registry consumers invalidate when the host locale changes                                                                                             | registry.registerTranslations({ en: { settings: "Settings" }, "pt-pt": { settings: "Definições" } })                |
 | registerRepositoryProvider  | Provider-owned paged/searchable repository list, URL match/inspect, branches, and optional native `createChangeRequest` transport                                                                                                                                                                      | ui.bundle and matching `repository_providers[]` id                     | Registration and in-flight callbacks are result-fenced on unload; host owns native task and Create PR UI                                                                                                        | registry.registerRepositoryProvider({ id: "acme", ...provider })                                                    |
 | registerTaskAction          | Child action inside the task menu's native Link section                                                                                                                                                                                                                                                | Active ui.bundle                                                       | Action is revoked on unload; host supplies current task/workspace and desktop/mobile presentation                                                                                                               | registry.registerTaskAction({ id: "link-pr", placement: "link", ... })                                              |
@@ -1063,9 +1063,16 @@ interface IntegrationSettingsRegistration {
   description: string;
   icon?: PluginIcon;
   Component: React.ComponentType<{ workspaceId?: string }>;
-  // Optional native header action. It receives the same routed workspace id
-  // as Component.
-  action?: React.ComponentType<{ workspaceId?: string }>;
+  // Optional action in the detail section header and integrations index card.
+  // The surface identifies the host location.
+  action?: React.ComponentType<IntegrationSettingsActionProps>;
+}
+
+type IntegrationSettingsActionSurface = "detail" | "index";
+
+interface IntegrationSettingsActionProps {
+  workspaceId?: string;
+  surface: IntegrationSettingsActionSurface;
 }
 
 interface PluginRouteOptions {
@@ -1398,8 +1405,10 @@ owned until unload.
 ### Workspace integration state and native save bar
 
 The optional `action` component and the main integration component both receive
-the `workspaceId` from the URL. Use this value for the workspace that the user
-is editing. Do not replace it with `host.context.getActiveWorkspaceId()`.
+the `workspaceId` from the URL. The action also receives `surface`, with the
+value `"detail"` for the settings header or `"index"` for the integrations card.
+Use the workspace value for the workspace that the user is editing. Do not
+replace it with `host.context.getActiveWorkspaceId()`.
 
 `host.setIntegrationEnabled(integrationId, workspaceId, enabled)` updates the
 live **Enabled** badge for one registration. The host checks the registration

--- a/docs/specs/plugins/spec.md
+++ b/docs/specs/plugins/spec.md
@@ -671,8 +671,10 @@ Mattermost-webapp model), not iframes. The full contract lives in
   `registerComponent(slot, C)` (including `app-status-bar-left` and
   `app-status-bar-right`), and `registerWsHandler(action, fn)`. Integration-settings
   contributions appear in the native global integrations index, workspace settings
-  navigation, and global/workspace settings routes. IDs are URL-safe, unique among
-  active plugins, and cannot shadow host integrations; unload revokes the contribution.
+  navigation, and global/workspace settings routes. An optional integration action
+  receives the routed workspace and a `surface` value for the detail header or index
+  card. IDs are URL-safe, unique among active plugins, and cannot shadow host
+  integrations; unload revokes the contribution.
   Status-slot components receive the exact `AppStatusBarSlotProps` contract in
   `PLUGIN-API.md`: current path/context plus placement and presentation. The host
   renders one responsive presentation at once — 24 px bar on tablet/desktop or


### PR DESCRIPTION
## Summary

Plugin integration cards on the integrations index page (`/settings/.../integrations`) were missing the enable/disable switch that built-in integrations (Jira, GitHub, Linear, etc.) have in their card header.

## Problem

Built-in integration cards render an `EnabledControl` component (e.g. `JiraEnabledControl`) in the card's top-right corner:

```tsx
<div className="shrink-0">
  <EnabledControl workspaceId={workspaceId} />
</div>
```

But plugin integration cards only rendered the icon + label and description — no switch:

```tsx
// Before: no action rendered
<Link href={href} ...>
  <Icon /> <span>{label}</span>
</Link>
<Link href={href}>{description}</Link>
```

## Fix

Destructure `action` from the plugin integration registration and render it in the card header, matching the built-in layout:

```tsx
const { pluginId, id, label, description, icon, action: Action } = entry;
// ...
<div className="flex items-center justify-between gap-2">
  <Link href={href} ...>
    <Icon /> <span>{label}</span>
  </Link>
  <div className="shrink-0">
    {Action ? <Action workspaceId={workspaceId} /> : null}
  </div>
</div>
```

This makes plugin integration cards visually identical to built-in ones — the enable toggle appears in the top-right of each card.

## Test plan

- [ ] Open `/settings/workspaces/{id}/integrations` with a plugin that registers `action` in `registerIntegrationSettings`
- [ ] Verify the switch appears in the top-right of the plugin's card
- [ ] Toggle the switch — it should participate in the floating Save/Reset bar (via `useSettingsSaveContributor`)
- [ ] Verify built-in integration cards still render their switches correctly

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

