### PR TITLE
fix(e2e): restore managed container-run preflights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ test-scripts:
 	@node --test scripts/validate-public-docs.test.mjs
 
 .PHONY: test-e2e
-test-e2e: build-backend build-web-e2e build-e2e-plugin-package
+test-e2e: build-backend build-backend-linux-helpers build-web-e2e build-e2e-plugin-package
 	@printf "$(CYAN)Running E2E tests (headless, parallel, managed runner)...$(RESET)\n"
 	@cd $(WEB_DIR) && status=0; for project in routing auth chromium mobile-chrome containers; do \
 		printf "$(CYAN)-- project: $$project --$(RESET)\n"; \

--- a/apps/web/e2e/global-setup.test.ts
+++ b/apps/web/e2e/global-setup.test.ts
@@ -248,7 +248,7 @@ describe("globalSetup", () => {
     vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
     const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
 
-    (globalSetup as (config: unknown) => void)({ projects: [] });
+    (globalSetup as () => void)();
 
     expect(existsSync).toHaveBeenCalledWith(customBackend);
     expect(existsSync).not.toHaveBeenCalledWith(path.join(backendDirForTest(), "bin", "kandev"));
@@ -261,22 +261,41 @@ describe("globalSetup", () => {
       .spyOn(fs, "existsSync")
       .mockImplementation((artifactPath) => artifactPath !== customBackend);
 
-    expect(() => (globalSetup as (config: unknown) => void)({ projects: [] })).toThrow(
-      /KANDEV_E2E_BIN file does not exist/,
-    );
+    expect(() => (globalSetup as () => void)()).toThrow(/KANDEV_E2E_BIN file does not exist/);
     expect(existsSync).toHaveBeenCalledWith(customBackend);
   });
 
-  it("checks Linux helper binaries when the containers project is selected", () => {
+  // Regression: `globalSetup` used to derive "is this a container run" from
+  // Playwright's `FullConfig.projects`, which always lists every project
+  // declared in playwright.config.ts regardless of `--project=` selection —
+  // so an ordinary `--project=chromium` run was indistinguishable from
+  // `--project=containers` and wrongly demanded Linux-only helper binaries
+  // that `make build` does not produce. See global-setup.ts's isContainerRun.
+  it("checks Linux helper binaries only when a container run is requested via env", () => {
     vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
+    vi.stubEnv("KANDEV_E2E_CONTAINERS", "1");
     const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
 
-    (globalSetup as (config: unknown) => void)({ projects: [{ name: "containers" }] });
+    (globalSetup as () => void)();
 
     expect(existsSync).toHaveBeenCalledWith(
       path.join(backendDirForTest(), "bin", "mock-agent-linux-amd64"),
     );
     expect(existsSync).toHaveBeenCalledWith(
+      path.join(backendDirForTest(), "bin", "agentctl-linux-amd64"),
+    );
+  });
+
+  it("does not require Linux helper binaries for an ordinary run", () => {
+    vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
+    const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+
+    (globalSetup as () => void)();
+
+    expect(existsSync).not.toHaveBeenCalledWith(
+      path.join(backendDirForTest(), "bin", "mock-agent-linux-amd64"),
+    );
+    expect(existsSync).not.toHaveBeenCalledWith(
       path.join(backendDirForTest(), "bin", "agentctl-linux-amd64"),
     );
   });

--- a/apps/web/e2e/global-setup.test.ts
+++ b/apps/web/e2e/global-setup.test.ts
@@ -6,6 +6,7 @@ import globalSetup, { assertBackendArtifactsFresh } from "./global-setup";
 
 let backendDir: string;
 let binPath: string;
+const originalArgv = [...process.argv];
 
 beforeEach(() => {
   backendDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-backend-fixture-"));
@@ -25,6 +26,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  process.argv = [...originalArgv];
   fs.rmSync(backendDir, { recursive: true, force: true });
 });
 
@@ -271,9 +273,29 @@ describe("globalSetup", () => {
   // so an ordinary `--project=chromium` run was indistinguishable from
   // `--project=containers` and wrongly demanded Linux-only helper binaries
   // that `make build` does not produce. See global-setup.ts's isContainerRun.
-  it("checks Linux helper binaries only when a container run is requested via env", () => {
+  it.each([
+    ["KANDEV_E2E_CONTAINERS", "1"],
+    ["KANDEV_E2E_DOCKER", "1"],
+  ])("checks Linux helper binaries for the %s marker", (marker, value) => {
     vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
-    vi.stubEnv("KANDEV_E2E_CONTAINERS", "1");
+    vi.stubEnv(marker, value);
+    const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+
+    (globalSetup as () => void)();
+
+    expect(existsSync).toHaveBeenCalledWith(
+      path.join(backendDirForTest(), "bin", "mock-agent-linux-amd64"),
+    );
+    expect(existsSync).toHaveBeenCalledWith(
+      path.join(backendDirForTest(), "bin", "agentctl-linux-amd64"),
+    );
+  });
+
+  it("checks Linux helper binaries for a direct containers project selection", () => {
+    vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
+    vi.stubEnv("KANDEV_E2E_CONTAINERS", "");
+    vi.stubEnv("KANDEV_E2E_DOCKER", "");
+    process.argv = [...originalArgv, "--project=containers"];
     const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
 
     (globalSetup as () => void)();
@@ -288,6 +310,8 @@ describe("globalSetup", () => {
 
   it("does not require Linux helper binaries for an ordinary run", () => {
     vi.stubEnv("KANDEV_E2E_SKIP_FRESHNESS", "1");
+    vi.stubEnv("KANDEV_E2E_CONTAINERS", "");
+    vi.stubEnv("KANDEV_E2E_DOCKER", "");
     const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
 
     (globalSetup as () => void)();

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { FullConfig } from "@playwright/test";
 
 const BACKEND_DIR = path.resolve(__dirname, "../../../apps/backend");
 const WEB_DIR = path.resolve(__dirname, "..");
@@ -10,7 +9,7 @@ export type BackendArtifact = {
   rebuildTarget: string;
 };
 
-export default function globalSetup(config: FullConfig) {
+export default function globalSetup() {
   const customKandevBin = process.env.KANDEV_E2E_BIN;
   const kandevBin = customKandevBin ?? path.join(BACKEND_DIR, "bin", "kandev");
   const artifacts: BackendArtifact[] = [
@@ -24,7 +23,7 @@ export default function globalSetup(config: FullConfig) {
   if (!customKandevBin) {
     artifacts.unshift({ path: kandevBin, rebuildTarget: "build" });
   }
-  if (isContainerRun(config, process.env)) {
+  if (isContainerRun(process.env)) {
     artifacts.push(
       {
         path: path.join(BACKEND_DIR, "bin", "mock-agent-linux-amd64"),
@@ -53,12 +52,24 @@ export default function globalSetup(config: FullConfig) {
   assertPseudoCatalogBundled();
 }
 
-function isContainerRun(config: FullConfig, env: NodeJS.ProcessEnv): boolean {
-  return (
-    config.projects.some(({ name }) => name === "containers" || name === "docker") ||
-    env.KANDEV_E2E_CONTAINERS === "1" ||
-    env.KANDEV_E2E_DOCKER === "1"
-  );
+/**
+ * Playwright's `globalSetup` receives the fully resolved `FullConfig`, whose
+ * `projects` array always lists every project declared in
+ * `playwright.config.ts` — it is not filtered down to the project(s) selected
+ * via `--project=`. `config.projects.some((p) => p.name === "containers")` is
+ * therefore always true and cannot distinguish a `--project=chromium` run
+ * from a `--project=containers` one; verified empirically, not just by
+ * reading the types.
+ *
+ * The env vars are the actual source of truth: CI's `e2e-containers` job sets
+ * `KANDEV_E2E_CONTAINERS=1` (and nowhere else does), and the README's only
+ * documented way to run `--project=containers` locally also sets it. Mirrors
+ * `fixtures/backend.ts`'s `isContainerProjectActive`, whose own
+ * `projectName === "containers"` branch is safe only because it reads
+ * `testInfo.project.name` — the per-test resolved project — not `FullConfig`.
+ */
+function isContainerRun(env: NodeJS.ProcessEnv): boolean {
+  return env.KANDEV_E2E_CONTAINERS === "1" || env.KANDEV_E2E_DOCKER === "1";
 }
 
 function backendMakeCommand(backendDir: string, target: string): string {

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -61,15 +61,23 @@ export default function globalSetup() {
  * from a `--project=containers` one; verified empirically, not just by
  * reading the types.
  *
- * The env vars are the actual source of truth: CI's `e2e-containers` job sets
- * `KANDEV_E2E_CONTAINERS=1` (and nowhere else does), and the README's only
- * documented way to run `--project=containers` locally also sets it. Mirrors
- * `fixtures/backend.ts`'s `isContainerProjectActive`, whose own
- * `projectName === "containers"` branch is safe only because it reads
- * `testInfo.project.name` — the per-test resolved project — not `FullConfig`.
+ * Managed runs and CI pass an explicit environment marker. Direct Playwright
+ * runs keep the selected project in `process.argv`, so this function reads the
+ * CLI value as well. This mirrors `fixtures/backend.ts`'s
+ * `isContainerProjectActive`, whose project-name branch reads
+ * `testInfo.project.name` — the per-test resolved project — instead of
+ * `FullConfig`.
  */
-function isContainerRun(env: NodeJS.ProcessEnv): boolean {
-  return env.KANDEV_E2E_CONTAINERS === "1" || env.KANDEV_E2E_DOCKER === "1";
+export function isContainerRun(env: NodeJS.ProcessEnv, argv = process.argv): boolean {
+  if (env.KANDEV_E2E_CONTAINERS === "1" || env.KANDEV_E2E_DOCKER === "1") return true;
+
+  const selectedProjects = argv.flatMap((arg, index) => {
+    if (arg === "--project") return argv[index + 1] ? [argv[index + 1]!] : [];
+    if (arg.startsWith("--project=")) return [arg.slice("--project=".length)];
+    return [];
+  });
+
+  return selectedProjects.some((projects) => projects.split(",").includes("containers"));
 }
 
 function backendMakeCommand(backendDir: string, target: string): string {

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -193,6 +193,8 @@ log "mode=$MODE  shards=$SHARDS  project=$PROJECT  strict=$STRICT"
 
 STRICT_ENV=()
 [[ "$STRICT" == 1 ]] && STRICT_ENV=(KANDEV_E2E_WS_ASSERT=1)
+CONTAINER_ENV=()
+[[ "$PROJECT" == containers || "$PROJECT" == docker ]] && CONTAINER_ENV=(KANDEV_E2E_CONTAINERS=1)
 
 # ---------------------------------------------------------------------------
 # HOST mode
@@ -202,13 +204,13 @@ run_host() {
   [[ "$DO_BUILD" == 1 ]] && { build_backend_host; build_fe; build_plugin_package; }
   local base_args=(playwright test --config e2e/playwright.config.ts --project="$PROJECT")
   if [[ "$SHARDS" -le 1 ]]; then
-    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} pnpm exec "${base_args[@]}" ${PW_ARGS[@]+"${PW_ARGS[@]}"} )
+    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} pnpm exec "${base_args[@]}" ${PW_ARGS[@]+"${PW_ARGS[@]}"} )
     return $?
   fi
   log "running $SHARDS host shards (distinct E2E_PORT_OFFSET + output dirs)"
   local pids=() rc=0 i
   for ((i=1; i<=SHARDS; i++)); do
-    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} E2E_PORT_OFFSET=$((i-1)) \
+    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} E2E_PORT_OFFSET=$((i-1)) \
         pnpm exec "${base_args[@]}" --shard="$i/$SHARDS" --output="e2e/test-results-shard-$i" ${PW_ARGS[@]+"${PW_ARGS[@]}"} \
         > "/tmp/e2e-host-shard-$i.log" 2>&1 ) &
     pids+=("$!")
@@ -234,6 +236,8 @@ run_docker() {
 
   local strict_flag=()
   [[ "$STRICT" == 1 ]] && strict_flag=(-e KANDEV_E2E_WS_ASSERT=1)
+  local container_flag=()
+  [[ "$PROJECT" == containers || "$PROJECT" == docker ]] && container_flag=(-e KANDEV_E2E_CONTAINERS=1)
   local capture_flag=()
   [[ -n "${CAPTURE_PR_ASSETS:-}" ]] && capture_flag=(-e CAPTURE_PR_ASSETS)
   local pw="git config --global --add safe.directory /work 2>/dev/null; cd /work/apps/web && pnpm exec playwright test --config e2e/playwright.config.ts --project=\"$PROJECT\""
@@ -244,6 +248,7 @@ run_docker() {
     docker run --rm --ipc=host \
       -v "$REPO_ROOT":/work -w /work/apps/web \
       ${strict_flag[@]+"${strict_flag[@]}"} \
+      ${container_flag[@]+"${container_flag[@]}"} \
       ${capture_flag[@]+"${capture_flag[@]}"} \
       -e NODE_OPTIONS=--dns-result-order=ipv4first \
       -e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -106,6 +106,7 @@ build_fe() {
 build_backend_host() {
   log "building backend (host)"
   local targets=(build)
+  # The Playwright project is `containers`; `KANDEV_E2E_DOCKER` remains only an env alias.
   [[ "$PROJECT" == containers ]] && targets+=(build-agentctl-linux build-mock-agent-linux)
   make -C "$BACKEND_DIR" "${targets[@]}" >/dev/null || die "backend build failed"
 }
@@ -194,7 +195,7 @@ log "mode=$MODE  shards=$SHARDS  project=$PROJECT  strict=$STRICT"
 STRICT_ENV=()
 [[ "$STRICT" == 1 ]] && STRICT_ENV=(KANDEV_E2E_WS_ASSERT=1)
 CONTAINER_ENV=()
-[[ "$PROJECT" == containers || "$PROJECT" == docker ]] && CONTAINER_ENV=(KANDEV_E2E_CONTAINERS=1)
+[[ "$PROJECT" == containers ]] && CONTAINER_ENV=(KANDEV_E2E_CONTAINERS=1)
 
 # ---------------------------------------------------------------------------
 # HOST mode
@@ -237,7 +238,7 @@ run_docker() {
   local strict_flag=()
   [[ "$STRICT" == 1 ]] && strict_flag=(-e KANDEV_E2E_WS_ASSERT=1)
   local container_flag=()
-  [[ "$PROJECT" == containers || "$PROJECT" == docker ]] && container_flag=(-e KANDEV_E2E_CONTAINERS=1)
+  [[ "$PROJECT" == containers ]] && container_flag=(-e KANDEV_E2E_CONTAINERS=1)
   local capture_flag=()
   [[ -n "${CAPTURE_PR_ASSETS:-}" ]] && capture_flag=(-e CAPTURE_PR_ASSETS)
   local pw="git config --global --add safe.directory /work 2>/dev/null; cd /work/apps/web && pnpm exec playwright test --config e2e/playwright.config.ts --project=\"$PROJECT\""

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const scriptPath = path.resolve(__dirname, "run-e2e.sh");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("run-e2e.sh", () => {
+  it("marks a managed containers run before invoking Playwright", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nprintf '%s' \"${KANDEV_E2E_CONTAINERS:-}\"\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project", "containers", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("1");
+  });
+});

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -6,10 +6,24 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const scriptPath = path.resolve(__dirname, "run-e2e.sh");
 const tempDirs: string[] = [];
+const tempFiles: string[] = [];
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  for (const file of tempFiles.splice(0)) fs.rmSync(file, { force: true });
 });
+
+function runnerEnv(binDir: string, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+  const env = {
+    ...process.env,
+    ...extra,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+  };
+  delete env.KANDEV_E2E_CONTAINERS;
+  delete env.KANDEV_E2E_DOCKER;
+  delete env.CAPTURE_PR_ASSETS;
+  return env;
+}
 
 describe("run-e2e.sh", () => {
   it("marks a managed containers run before invoking Playwright", () => {
@@ -24,11 +38,74 @@ describe("run-e2e.sh", () => {
       [scriptPath, "--host", "--no-build", "--project", "containers", "--", "--help"],
       {
         encoding: "utf8",
-        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+        env: runnerEnv(binDir),
       },
     );
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("1");
+  });
+
+  it("passes the marker to every host shard", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    const resultFile = path.join(binDir, "marker.txt");
+    tempDirs.push(binDir);
+    tempFiles.push("/tmp/e2e-host-shard-1.log", "/tmp/e2e-host-shard-2.log");
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(
+      pnpmPath,
+      '#!/usr/bin/env sh\nprintf \'%s\\n\' "${KANDEV_E2E_CONTAINERS:-}" >> "$KANDEV_RUNNER_RESULT_FILE"\n',
+    );
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [
+        scriptPath,
+        "--host",
+        "--no-build",
+        "--shards",
+        "2",
+        "--project",
+        "containers",
+        "--",
+        "--help",
+      ],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_RUNNER_RESULT_FILE: resultFile }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(resultFile, "utf8").trim().split("\n")).toEqual(["1", "1"]);
+  });
+
+  it("passes the marker to the outer Docker runner", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    const resultFile = path.join(binDir, "docker-args.txt");
+    tempDirs.push(binDir);
+    tempFiles.push("/tmp/e2e-docker-shard-1.log");
+    const dockerPath = path.join(binDir, "docker");
+    fs.writeFileSync(
+      dockerPath,
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then exit 1; fi\nif [ "$1" = "run" ]; then printf \'%s\\n\' "$*" >> "$KANDEV_RUNNER_RESULT_FILE"; exit 0; fi\nexit 1\n',
+    );
+    fs.chmodSync(dockerPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--docker", "--no-build", "--project", "containers", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_RUNNER_RESULT_FILE: resultFile }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const dockerInvocations = fs.readFileSync(resultFile, "utf8").trim().split("\n");
+    expect(dockerInvocations.some((args) => args.includes("-e KANDEV_E2E_CONTAINERS=1"))).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
The merged stale-backend guard from PR #2694 stopped short of the two follow-up fixes that keep default chromium/mobile runs from demanding Linux container helpers and ensure managed container runs still do demand them. This follow-up reapplies those missing harness guards on current `main` so local E2E failures stay attributable to the right artifact set.

## Important Changes

- scope container-only helper checks in `global-setup.ts` to explicit `KANDEV_E2E_CONTAINERS` / `KANDEV_E2E_DOCKER` opt-in, so ordinary chromium and mobile runs do not require Linux helper binaries
- propagate `KANDEV_E2E_CONTAINERS=1` from the managed runner when `--project containers` is selected, so container-backed runs still fail fast on missing Linux helper artifacts before specs execute

## Validation

- `corepack pnpm --dir apps/web exec vitest run e2e/global-setup.test.ts`
- `corepack pnpm --dir apps/web exec vitest run e2e/scripts/run-e2e.test.ts`
- `corepack pnpm --dir apps --filter @kandev/web lint`
- `corepack pnpm --dir apps/web run typecheck`
- `bash -n apps/web/e2e/scripts/run-e2e.sh`
- `bash apps/web/e2e/scripts/run-e2e.sh --host --no-build -- --list` (with a temporary `pnpm` PATH shim) listed chromium tests in the isolated follow-up worktree
- `bash apps/web/e2e/scripts/run-e2e.sh --host --no-build --project containers -- tests/ssh/launch-task.spec.ts --workers=1 --retries=0` (with a temporary `pnpm` PATH shim and copied default backend artifacts) failed fast on missing `mock-agent-linux-amd64`, confirming the managed container marker still triggers Linux-helper preflight

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->