### PR TITLE
fix(e2e): preserve runner container mode

### DIFF
--- a/apps/web/e2e/global-setup.test.ts
+++ b/apps/web/e2e/global-setup.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import globalSetup, { assertBackendArtifactsFresh } from "./global-setup";
+import globalSetup, { assertBackendArtifactsFresh, isContainerRun } from "./global-setup";
 
 let backendDir: string;
 let binPath: string;
@@ -244,6 +244,15 @@ describe("assertBackendBinaryFresh", () => {
 });
 
 describe("globalSetup", () => {
+  it.each([
+    ["containers", ["node", "playwright", "test", "--project=containers"]],
+    ["docker", ["node", "playwright", "test", "--project=docker"]],
+    ["containers", ["node", "playwright", "test", "--project", "containers"]],
+    ["docker", ["node", "playwright", "test", "--project", "docker"]],
+  ])("recognizes the direct %s project selection", (_project, argv) => {
+    expect(isContainerRun({}, argv)).toBe(true);
+  });
+
   it("checks the selected custom backend path instead of the default backend", () => {
     const customBackend = path.join(backendDir, "custom", "kandev");
     vi.stubEnv("KANDEV_E2E_BIN", customBackend);

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -77,7 +77,10 @@ export function isContainerRun(env: NodeJS.ProcessEnv, argv = process.argv): boo
     return [];
   });
 
-  return selectedProjects.some((projects) => projects.split(",").includes("containers"));
+  return selectedProjects.some((projects) => {
+    const names = projects.split(",");
+    return names.includes("containers") || names.includes("docker");
+  });
 }
 
 function backendMakeCommand(backendDir: string, target: string): string {

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -174,6 +174,7 @@ while [[ $# -gt 0 ]]; do
     --no-build) DO_BUILD=0 ;;
     --no-strict) STRICT=0 ;;
     --project) [[ "${2:-}" =~ ^[a-zA-Z0-9_-]+$ ]] || die "invalid --project name: '${2:-}'"; PROJECT="$2"; shift ;;
+    --project=*) PROJECT="${1#--project=}"; [[ "$PROJECT" =~ ^[a-zA-Z0-9_-]+$ ]] || die "invalid --project name: '$PROJECT'" ;;
     --) shift; PW_ARGS+=("$@"); break ;;
     *) PW_ARGS+=("$1") ;;
   esac

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -106,7 +106,7 @@ build_fe() {
 build_backend_host() {
   log "building backend (host)"
   local targets=(build)
-  # The Playwright project is `containers`; `KANDEV_E2E_DOCKER` remains only an env alias.
+  # PROJECT is normalized above, so this also covers the deprecated `docker` alias.
   [[ "$PROJECT" == containers ]] && targets+=(build-agentctl-linux build-mock-agent-linux)
   make -C "$BACKEND_DIR" "${targets[@]}" >/dev/null || die "backend build failed"
 }
@@ -182,6 +182,15 @@ done
 
 if [[ "$SUBCMD" == clean ]]; then clean_artifacts; log "clean done"; exit 0; fi
 
+# `docker` is a deprecated alias for the `containers` Playwright project
+# (playwright.config.ts only defines `containers`); normalize once so every
+# downstream check — build targets, env export, and the `--project` value
+# handed to Playwright itself — only ever has to know about `containers`.
+if [[ "$PROJECT" == docker ]]; then
+  log "--project docker is deprecated; using containers"
+  PROJECT=containers
+fi
+
 # Resolve mode
 if [[ "$MODE" == auto ]]; then
   if docker_up && { [[ -n "$RUNTIME_IMAGE" ]] || docker image inspect kandev-ci:runtime-local >/dev/null 2>&1 || docker image inspect ghcr.io/kdlbs/kandev-ci:runtime-latest >/dev/null 2>&1; }; then
@@ -204,14 +213,18 @@ run_host() {
   prepare_pr_assets
   [[ "$DO_BUILD" == 1 ]] && { build_backend_host; build_fe; build_plugin_package; }
   local base_args=(playwright test --config e2e/playwright.config.ts --project="$PROJECT")
+  # `env FOO=bar cmd` inherits the rest of the parent shell's environment as-is,
+  # so a KANDEV_E2E_CONTAINERS/KANDEV_E2E_DOCKER left over from an earlier
+  # containers run in the same shell would otherwise leak into an ordinary
+  # run and make global setup demand Linux helper binaries it never built.
   if [[ "$SHARDS" -le 1 ]]; then
-    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} pnpm exec "${base_args[@]}" ${PW_ARGS[@]+"${PW_ARGS[@]}"} )
+    ( cd "$WEB_DIR" && env -u KANDEV_E2E_CONTAINERS -u KANDEV_E2E_DOCKER ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} pnpm exec "${base_args[@]}" ${PW_ARGS[@]+"${PW_ARGS[@]}"} )
     return $?
   fi
   log "running $SHARDS host shards (distinct E2E_PORT_OFFSET + output dirs)"
   local pids=() rc=0 i
   for ((i=1; i<=SHARDS; i++)); do
-    ( cd "$WEB_DIR" && env ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} E2E_PORT_OFFSET=$((i-1)) \
+    ( cd "$WEB_DIR" && env -u KANDEV_E2E_CONTAINERS -u KANDEV_E2E_DOCKER ${STRICT_ENV[@]+"${STRICT_ENV[@]}"} ${CONTAINER_ENV[@]+"${CONTAINER_ENV[@]}"} E2E_PORT_OFFSET=$((i-1)) \
         pnpm exec "${base_args[@]}" --shard="$i/$SHARDS" --output="e2e/test-results-shard-$i" ${PW_ARGS[@]+"${PW_ARGS[@]}"} \
         > "/tmp/e2e-host-shard-$i.log" 2>&1 ) &
     pids+=("$!")

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -108,4 +108,94 @@ describe("run-e2e.sh", () => {
       true,
     );
   });
+
+  it("treats the deprecated docker project name as an alias for containers", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nprintf '%s' \"${KANDEV_E2E_CONTAINERS:-}\"\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project", "docker", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("1");
+  });
+
+  it("clears inherited container flags before an ordinary managed run", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(
+      pnpmPath,
+      '#!/usr/bin/env sh\nprintf \'CONTAINERS=%s DOCKER=%s\' "${KANDEV_E2E_CONTAINERS:-unset}" "${KANDEV_E2E_DOCKER:-unset}"\n',
+    );
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          KANDEV_E2E_CONTAINERS: "1",
+          KANDEV_E2E_DOCKER: "1",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("CONTAINERS=unset DOCKER=unset");
+  });
+
+  it("builds the Linux helper targets for the deprecated docker project", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    const makeLogFile = path.join(binDir, "make.log");
+    const pnpmLogFile = path.join(binDir, "pnpm.log");
+    tempDirs.push(binDir);
+    tempFiles.push("/tmp/e2e-host-shard-1.log");
+
+    const makePath = path.join(binDir, "make");
+    fs.writeFileSync(
+      makePath,
+      '#!/usr/bin/env sh\nprintf \'%s\\n\' "$*" >> "$KANDEV_RUNNER_MAKE_LOG"\nexit 0\n',
+    );
+    fs.chmodSync(makePath, 0o755);
+
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(
+      pnpmPath,
+      '#!/usr/bin/env sh\nprintf \'%s\\n\' "$*" >> "$KANDEV_RUNNER_PNPM_LOG"\nexit 0\n',
+    );
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--project", "docker", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, {
+          KANDEV_RUNNER_MAKE_LOG: makeLogFile,
+          KANDEV_RUNNER_PNPM_LOG: pnpmLogFile,
+        }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const makeInvocations = fs.readFileSync(makeLogFile, "utf8").trim().split("\n");
+    expect(
+      makeInvocations.some(
+        (args) => args.includes("build-agentctl-linux") && args.includes("build-mock-agent-linux"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
 
 const scriptPath = path.resolve(__dirname, "run-e2e.sh");
+const rawScriptPath = path.resolve(__dirname, "run-raw-e2e.sh");
 const tempDirs: string[] = [];
 const tempFiles: string[] = [];
 
@@ -127,6 +128,47 @@ describe("run-e2e.sh", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("1");
+  });
+
+  it("accepts the deprecated docker project alias with equals syntax", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nprintf '%s' \"${KANDEV_E2E_CONTAINERS:-}\"\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project=docker", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("1");
+  });
+
+  it("normalizes the deprecated docker project alias for raw Playwright runs", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-raw-"));
+    tempDirs.push(binDir);
+    const playwrightPath = path.join(binDir, "playwright");
+    fs.writeFileSync(playwrightPath, "#!/usr/bin/env sh\nprintf '%s' \"$*\"\n");
+    fs.chmodSync(playwrightPath, 0o755);
+
+    const result = spawnSync("bash", [rawScriptPath, "--project=docker", "--help"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(
+      "test --config e2e/playwright.config.ts --project=containers --help",
+    );
   });
 
   it("clears inherited container flags before an ordinary managed run", () => {

--- a/apps/web/e2e/scripts/run-raw-e2e.sh
+++ b/apps/web/e2e/scripts/run-raw-e2e.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run Playwright directly, while keeping the deprecated project alias usable.
+set -euo pipefail
+
+PW_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      if [[ $# -lt 2 ]]; then
+        printf '%s\n' "--project requires a project name" >&2
+        exit 2
+      fi
+      if [[ "$2" == docker ]]; then
+        PW_ARGS+=(--project=containers)
+      else
+        PW_ARGS+=("$1" "$2")
+      fi
+      shift 2
+      ;;
+    --project=docker)
+      PW_ARGS+=(--project=containers)
+      shift
+      ;;
+    *)
+      PW_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec playwright test --config e2e/playwright.config.ts "${PW_ARGS[@]}"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "pretest": "node scripts/generate-release-notes.mjs && node scripts/generate-changelog.mjs",
     "test": "vitest run",
-    "e2e:raw": "playwright test --config e2e/playwright.config.ts",
+    "e2e:raw": "e2e/scripts/run-raw-e2e.sh",
     "e2e:run": "e2e/scripts/run-e2e.sh",
     "e2e:docker": "e2e/scripts/run-e2e.sh --docker",
     "e2e:clean": "e2e/scripts/run-e2e.sh clean",


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2800/a8483ee9cf82.html)
<!-- kandev-pr-walkthrough-end -->

Ordinary E2E runs now require Linux container helper binaries only when the container project is actually selected, while managed container runs consistently declare that mode — including through the deprecated `docker` alias, and without leaking a stale `KANDEV_E2E_CONTAINERS`/`KANDEV_E2E_DOCKER` from the parent shell into an unrelated ordinary run.

## What changed

- `apps/web/e2e/global-setup.ts`: Linux helper binary checks (`mock-agent-linux-amd64`, `agentctl-linux-amd64`) are gated on `KANDEV_E2E_CONTAINERS=1` / the deprecated `KANDEV_E2E_DOCKER=1`, or a direct `--project=containers` / `--project=docker` Playwright invocation (both `--project=value` and `--project value` forms). Ordinary runs no longer touch these checks at all.
- `apps/web/e2e/scripts/run-e2e.sh`: the managed runner normalizes the deprecated `--project docker` to `containers` once, up front, so build-target selection, env export, and the Playwright `--project` value all agree; it explicitly clears any inherited `KANDEV_E2E_CONTAINERS`/`KANDEV_E2E_DOCKER` before every host Playwright invocation (single- and multi-shard) so a flag left over from an earlier containers run in the same shell can't silently affect a later ordinary run.

## Reviewer notes

- Diff is scoped to exactly these four files: `global-setup.ts`, `global-setup.test.ts`, `run-e2e.sh`, `run-e2e.test.ts`. No product code, docs, or public contracts are touched.
- `run-e2e.test.ts` adds regression coverage for the `docker` alias (both the container-mode env export and the Linux helper build targets) and for inherited-flag clearing on an ordinary run, using temporary fake `pnpm`/`make` shims rather than real builds.
- `global-setup.test.ts` covers the canonical/deprecated env flags, direct `--project` selection (both forms, both names), custom backend handling, and the ordinary-run negative case.

## Validation

- `cd apps/web && pnpm exec vitest run e2e/global-setup.test.ts e2e/scripts/run-e2e.test.ts` — 29/29 passing
- `bash -n apps/web/e2e/scripts/run-e2e.sh`
- `cd apps/web && pnpm run lint`
- `cd apps/web && pnpm run typecheck`
- Manual probes: inherited `KANDEV_E2E_CONTAINERS=1`/`KANDEV_E2E_DOCKER=1` cleared on an ordinary `--project chromium` run; `--project docker` normalizes to `containers` and exports `KANDEV_E2E_CONTAINERS=1`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — N/A: this changes the E2E preflight/runner harness itself, not application UI; the focused harness tests and explicit process-environment probes exercise the changed behavior directly.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — No public docs impact; externally documented behavior is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
