### PR TITLE
fix(chat): paste browser links as plain text so URLs survive

### DIFF
--- a/apps/web/components/task/chat/tiptap-helpers.test.ts
+++ b/apps/web/components/task/chat/tiptap-helpers.test.ts
@@ -338,28 +338,85 @@ describe("handleEditorPaste", () => {
     expect(onImagePaste).toHaveBeenCalledWith([], "unreadable-image");
     expect(preventDefault).toHaveBeenCalledOnce();
   });
+});
 
-  it("leaves rich HTML with visible text to the editor", () => {
-    const onImagePaste = vi.fn();
-    const preventDefault = vi.fn();
-    const event = {
+describe("handleEditorPaste formatting", () => {
+  function htmlPasteEvent(html: string, plain: string, preventDefault = vi.fn()): ClipboardEvent {
+    return {
       clipboardData: {
         files: [],
-        items: [{ kind: "string", type: "text/html" }],
-        getData: (type: string) =>
-          type === "text/html"
-            ? '<p>Visible caption <img src="https://images.example.test/image.png"></p>'
-            : "Visible caption",
+        items: [],
+        getData: (type: string) => (type === "text/html" ? html : plain),
       },
       preventDefault,
     } as unknown as ClipboardEvent;
+  }
 
-    const handled = handleEditorPaste({} as EditorView, event, {
+  function runPaste(event: ClipboardEvent, pasteText: () => void, onImagePaste = vi.fn()): boolean {
+    return handleEditorPaste({ pasteText } as unknown as EditorView, event, {
       current: onImagePaste,
     });
+  }
 
-    expect(handled).toBe(false);
+  it("strips formatting from rich HTML with visible text instead of attaching it", () => {
+    const pasteText = vi.fn();
+    const onImagePaste = vi.fn();
+    const preventDefault = vi.fn();
+    const event = htmlPasteEvent(
+      '<p>Visible caption <img src="https://images.example.test/image.png"></p>',
+      "Visible caption",
+      preventDefault,
+    );
+
+    expect(runPaste(event, pasteText, onImagePaste)).toBe(true);
     expect(onImagePaste).not.toHaveBeenCalled();
+    expect(pasteText).toHaveBeenCalledWith("Visible caption");
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("pastes the plain-text URL when the clipboard holds a formatted browser link", () => {
+    const pasteText = vi.fn();
+    const preventDefault = vi.fn();
+    const url =
+      "https://dev.azure.com/ptbcp/IT.DIT/_sprints/taskboard/ATMOffer/IT.DIT/DIT/2026/2Weeks/2W.2026.17?workitem=1103594";
+    const event = htmlPasteEvent(
+      `<a href="${url}">ATMOffer 2W.2026.17 Taskboard - Boards</a>`,
+      url,
+      preventDefault,
+    );
+
+    expect(runPaste(event, pasteText)).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(pasteText).toHaveBeenCalledWith(url);
+  });
+
+  it("strips formatting from external rich HTML, pasting only the plain text", () => {
+    const pasteText = vi.fn();
+    const event = htmlPasteEvent("<b>Bold</b> and <i>italic</i> text", "Bold and italic text");
+
+    expect(runPaste(event, pasteText)).toBe(true);
+    expect(pasteText).toHaveBeenCalledWith("Bold and italic text");
+  });
+
+  it("leaves internal editor copies marked with data-pm-slice to the default handler", () => {
+    const pasteText = vi.fn();
+    const preventDefault = vi.fn();
+    const event = htmlPasteEvent(
+      '<p data-pm-slice="1 1 []">reference</p>',
+      "reference",
+      preventDefault,
+    );
+
+    expect(runPaste(event, pasteText)).toBe(false);
+    expect(pasteText).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("leaves plain-text-only pastes to the default handler", () => {
+    const pasteText = vi.fn();
+    const event = htmlPasteEvent("", "plain text only");
+
+    expect(runPaste(event, pasteText)).toBe(false);
+    expect(pasteText).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task/chat/tiptap-helpers.ts
+++ b/apps/web/components/task/chat/tiptap-helpers.ts
@@ -319,6 +319,20 @@ function insertCodeFenceNodes(
   }
 }
 
+/**
+ * Rich content pasted from outside the editor should paste as plain text, the
+ * way Ctrl+Shift+V does. The chat composer has no link or styling marks, so the
+ * default HTML parse keeps a browser hyperlink's visible title and silently
+ * drops its URL. Copies made inside the editor (mentions, code blocks) carry
+ * ProseMirror's `data-pm-slice` marker; those are left to the default handler
+ * so their nodes round-trip.
+ */
+function shouldStripPastedFormatting(clipboardData: DataTransfer): boolean {
+  const html = clipboardData.getData("text/html");
+  if (!html) return false;
+  return !html.includes("data-pm-slice");
+}
+
 export function handleEditorPaste(
   view: import("@tiptap/pm/view").EditorView,
   event: ClipboardEvent,
@@ -349,6 +363,17 @@ export function handleEditorPaste(
       insertCodeFenceNodes(view, segments);
       return true;
     }
+  }
+
+  // 3. Strip formatting from externally pasted rich content. Re-running the
+  // paste with just the plain text keeps a hyperlink's URL instead of the
+  // default parse's visible title. `pasteText` fires a synthetic empty-clipboard
+  // paste, so this handler re-enters once, no-ops, and ProseMirror inserts the
+  // text with its own inline/block handling.
+  if (text && clipboardData && shouldStripPastedFormatting(clipboardData)) {
+    event.preventDefault();
+    view.pasteText(text);
+    return true;
   }
 
   return false;

--- a/apps/web/e2e/tests/chat/paste-strip-formatting.spec.ts
+++ b/apps/web/e2e/tests/chat/paste-strip-formatting.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "../../fixtures/test-base";
+import { openTaskSession, waitForLatestSessionDone } from "../../helpers/session";
+
+test.describe("paste strips rich text formatting", () => {
+  test("keeps a copied hyperlink's URL instead of its visible title", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Paste hyperlink keeps URL",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for paste-formatting task");
+    const session = await openTaskSession(testPage, task.id);
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    const editor = session.activeChat().locator(".tiptap.ProseMirror").first();
+    await expect(editor).toBeEditable();
+    await editor.click();
+
+    const url =
+      "https://dev.azure.com/ptbcp/IT.DIT/_sprints/taskboard/ATMOffer/IT.DIT/DIT/2026/2Weeks/2W.2026.17?workitem=1103594";
+    await editor.evaluate((element, pastedUrl) => {
+      const clipboardData = new DataTransfer();
+      clipboardData.setData("text/plain", pastedUrl);
+      clipboardData.setData(
+        "text/html",
+        `<a href="${pastedUrl}">ATMOffer 2W.2026.17 Taskboard - Boards</a>`,
+      );
+      const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+      Object.defineProperty(pasteEvent, "clipboardData", { value: clipboardData });
+      element.dispatchEvent(pasteEvent);
+    }, url);
+
+    await expect(editor).toContainText(url);
+    await expect(editor).not.toContainText("Taskboard - Boards");
+  });
+});


### PR DESCRIPTION
## What & why

Pasting a URL copied from a browser into the chat composer inserted the link's **visible title** instead of the URL, so the agent only ever saw the title, never the URL.

**Root cause:** the chat composer is a TipTap/ProseMirror editor with no `Link` mark. A browser hyperlink arrives on the clipboard as `text/html` (`<a href="URL">Title</a>`); ProseMirror's default paste parsed that HTML, kept the anchor text, and dropped the `href`.

## Change

`handleEditorPaste` (`apps/web/components/task/chat/tiptap-helpers.ts`) now, for externally pasted rich content, re-runs the paste as plain text via `view.pasteText(text)` (the Ctrl+Shift+V "paste without formatting" behavior):

- External rich content (browser links, styled text): pastes the plain text, so the URL survives and formatting is stripped.
- Plain-text pastes (no HTML): unchanged, handled by ProseMirror's default.
- Internal editor copies (mentions, code blocks): detected via ProseMirror's `data-pm-slice` marker and left to the default handler, so their nodes round-trip.

`view.pasteText` fires a synthetic empty-clipboard paste, so the handler re-enters once, no-ops, and ProseMirror performs the inline/block-aware insertion itself (no reimplementation, no recursion).

## Testing

- **Unit** (`tiptap-helpers.test.ts`): added cases for a formatted browser link, generic external rich HTML, an internal `data-pm-slice` copy, and plain-text-only paste; updated the test that encoded the old drop-the-URL behavior. 21/21 pass; full `components/task/chat` suite 819/819 across 84 files.
- **E2E** (`e2e/tests/chat/paste-strip-formatting.spec.ts`): pastes a formatted link and asserts the URL lands, not the title.
- `make fmt`, web `typecheck`, and web `lint` clean.
- Manually verified in a side-by-side dev instance built from this branch.

Task: **Strip rich text formatting on paste**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
