### PR TITLE
fix(office): stop config import from clobbering concurrent row edits

### DIFF
--- a/apps/backend/internal/office/config/import.go
+++ b/apps/backend/internal/office/config/import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
 )
 
 // PreviewImport diffs a bundle against the current workspace state.
@@ -170,13 +171,15 @@ func (s *ConfigService) applyAgents(
 	}
 	for _, cfg := range incoming {
 		if agent, ok := byName[cfg.Name]; ok {
-			agent.Role = models.AgentRole(cfg.Role)
-			agent.Icon = cfg.Icon
-			agent.BudgetMonthlyCents = cfg.BudgetMonthlyCents
-			agent.MaxConcurrentSessions = cfg.MaxConcurrentSessions
-			agent.DesiredSkills = cfg.DesiredSkills
-			agent.ExecutorPreference = cfg.ExecutorPreference
-			if err := s.repo.UpdateAgentInstance(ctx, agent); err != nil {
+			fields := sqlite.AgentInstanceConfigFields{
+				Role:                  cfg.Role,
+				Icon:                  cfg.Icon,
+				BudgetMonthlyCents:    cfg.BudgetMonthlyCents,
+				MaxConcurrentSessions: cfg.MaxConcurrentSessions,
+				DesiredSkills:         cfg.DesiredSkills,
+				ExecutorPreference:    cfg.ExecutorPreference,
+			}
+			if err := s.repo.UpdateAgentInstanceConfigFields(ctx, agent.ID, fields); err != nil {
 				return err
 			}
 			result.UpdatedCount++
@@ -353,11 +356,13 @@ func (s *ConfigService) applySkills(
 	}
 	for _, cfg := range incoming {
 		if skill, ok := bySlug[cfg.Slug]; ok {
-			skill.Name = cfg.Name
-			skill.Description = cfg.Description
-			skill.SourceType = models.SkillSourceType(cfg.SourceType)
-			skill.Content = cfg.Content
-			if err := s.repo.UpdateSkill(ctx, skill); err != nil {
+			fields := sqlite.SkillConfigFields{
+				Name:        cfg.Name,
+				Description: cfg.Description,
+				SourceType:  models.SkillSourceType(cfg.SourceType),
+				Content:     cfg.Content,
+			}
+			if err := s.repo.UpdateSkillConfigFields(ctx, skill.ID, fields); err != nil {
 				return err
 			}
 			result.UpdatedCount++
@@ -392,10 +397,12 @@ func (s *ConfigService) applyRoutines(
 	}
 	for _, cfg := range incoming {
 		if routine, ok := byName[cfg.Name]; ok {
-			routine.Description = cfg.Description
-			routine.TaskTemplate = cfg.TaskTemplate
-			routine.ConcurrencyPolicy = models.RoutineConcurrencyPolicy(cfg.ConcurrencyPolicy)
-			if err := s.repo.UpdateRoutine(ctx, routine); err != nil {
+			fields := sqlite.RoutineConfigFields{
+				Description:       cfg.Description,
+				TaskTemplate:      cfg.TaskTemplate,
+				ConcurrencyPolicy: models.RoutineConcurrencyPolicy(cfg.ConcurrencyPolicy),
+			}
+			if err := s.repo.UpdateRoutineConfigFields(ctx, routine.ID, fields); err != nil {
 				return err
 			}
 			result.UpdatedCount++
@@ -430,12 +437,14 @@ func (s *ConfigService) applyProjects(
 	}
 	for _, cfg := range incoming {
 		if project, ok := byName[cfg.Name]; ok {
-			project.Description = cfg.Description
-			project.Color = cfg.Color
-			project.BudgetCents = cfg.BudgetCents
-			project.Repositories = cfg.Repositories
-			project.ExecutorConfig = cfg.ExecutorConfig
-			if err := s.repo.UpdateProject(ctx, project); err != nil {
+			fields := sqlite.ProjectConfigFields{
+				Description:    cfg.Description,
+				Color:          cfg.Color,
+				BudgetCents:    cfg.BudgetCents,
+				Repositories:   cfg.Repositories,
+				ExecutorConfig: cfg.ExecutorConfig,
+			}
+			if err := s.repo.UpdateProjectConfigFields(ctx, project.ID, fields); err != nil {
 				return err
 			}
 			result.UpdatedCount++

--- a/apps/backend/internal/office/config/import.go
+++ b/apps/backend/internal/office/config/import.go
@@ -260,8 +260,7 @@ func (s *ConfigService) applyAgentReportsTo(
 		if agent.ReportsTo == reportsTo {
 			continue
 		}
-		agent.ReportsTo = reportsTo
-		if err := s.repo.UpdateAgentInstance(ctx, agent); err != nil {
+		if err := s.repo.UpdateAgentReportsTo(ctx, agent.ID, reportsTo); err != nil {
 			return fmt.Errorf("resolve reports_to: update %q: %w", agent.Name, err)
 		}
 	}

--- a/apps/backend/internal/office/config/import_concurrent_write_test.go
+++ b/apps/backend/internal/office/config/import_concurrent_write_test.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// These tests are the regression coverage for the full-row read-modify-write
+// bug: applyAgents/applySkills/applyRoutines/applyProjects used to read a
+// full row via List*, mutate only the fields the import owns on that struct,
+// and hand the *whole* struct back to a full-row Update*. Any column that a
+// genuinely concurrent writer (UpdateAgentStatusFields, the agent runtime,
+// direct API edits) changed between the List read and the Update write was
+// silently reverted to its stale snapshot value.
+//
+// Each test reproduces the exact production sequence: capture the row the
+// way applyAgents' List call would, perform the concurrent write, then drive
+// the import side of the sequence through the repository. Before the fix
+// that last step was `Update<Entity>(ctx, stale)` — the mutated-in-place
+// stale struct — which silently reverted the concurrent write. After the
+// fix it is `Update<Entity>ConfigFields`, which never references the
+// unowned column at the SQL level, so staleness of the rest of the struct
+// cannot matter.
+
+// TestUpdateAgentInstanceConfigFields_PreservesConcurrentStatusWrite
+// reproduces the triage receipt: a budget-cap pause (UpdateAgentStatusFields,
+// the real concurrent writer used by internal/office/costs/budgets.go)
+// landing after the import's list read but before its write must survive,
+// instead of being reverted to the stale "idle" status the import read.
+func TestUpdateAgentInstanceConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+	seedAgent(t, e, testWorkspaceID, "ada")
+
+	// What applyAgents' List call would have captured.
+	snapshot, err := e.repo.ListAgentInstances(ctx, testWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListAgentInstances: %v", err)
+	}
+	stale := snapshot[0]
+
+	// A concurrent writer pauses the agent for a budget cap between the
+	// import's read and its write.
+	if err := e.repo.UpdateAgentStatusFields(ctx, stale.ID, "paused", "budget cap exceeded"); err != nil {
+		t.Fatalf("UpdateAgentStatusFields: %v", err)
+	}
+
+	// The import proceeds with only the fields it owns (import.go's
+	// applyAgents builds these from the incoming AgentConfig, not from the
+	// stale struct, and only stale.ID identifies the row).
+	fields := sqlite.AgentInstanceConfigFields{
+		Role:                  "cto",
+		Icon:                  "🤖",
+		BudgetMonthlyCents:    4200,
+		MaxConcurrentSessions: 3,
+		DesiredSkills:         `["go"]`,
+		ExecutorPreference:    "local_docker",
+	}
+	if err := e.repo.UpdateAgentInstanceConfigFields(ctx, stale.ID, fields); err != nil {
+		t.Fatalf("UpdateAgentInstanceConfigFields: %v", err)
+	}
+
+	got := agentByName(t, e, testWorkspaceID, "ada")
+	assertEqual(t, "status survives import", string(got.Status), "paused")
+	assertEqual(t, "pause reason survives import", got.PauseReason, "budget cap exceeded")
+
+	// The owned fields must still have landed - a scoped update that writes
+	// nothing would also make the clobber assertions above pass for the
+	// wrong reason.
+	assertEqual(t, "role updated", string(got.Role), "cto")
+	assertEqual(t, "icon updated", got.Icon, "🤖")
+	assertEqual(t, "budget updated", got.BudgetMonthlyCents, 4200)
+	assertEqual(t, "max sessions updated", got.MaxConcurrentSessions, 3)
+	assertEqual(t, "desired skills updated", got.DesiredSkills, `["go"]`)
+	assertEqual(t, "executor preference updated", got.ExecutorPreference, "local_docker")
+}
+
+// TestUpdateSkillConfigFields_PreservesConcurrentApprovalStateWrite mirrors
+// the agent case for skills: approval_state is not a column applySkills
+// owns, so a write landing between the import's read and its write must
+// survive.
+func TestUpdateSkillConfigFields_PreservesConcurrentApprovalStateWrite(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+	seedSkill(t, e, testWorkspaceID, "code-review")
+
+	snapshot, err := e.repo.ListSkills(ctx, testWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	stale := snapshot[0]
+
+	if _, err := e.db.ExecContext(ctx,
+		`UPDATE office_skills SET approval_state = ? WHERE id = ?`, "approved", stale.ID,
+	); err != nil {
+		t.Fatalf("concurrent approval_state write: %v", err)
+	}
+
+	fields := sqlite.SkillConfigFields{
+		Name:        "Deep Review",
+		Description: "reads everything",
+		SourceType:  models.SkillSourceType("git"),
+		Content:     "# Deep Review\n",
+	}
+	if err := e.repo.UpdateSkillConfigFields(ctx, stale.ID, fields); err != nil {
+		t.Fatalf("UpdateSkillConfigFields: %v", err)
+	}
+
+	got := skillBySlug(t, e, testWorkspaceID, "code-review")
+	assertEqual(t, "approval_state survives import", string(got.ApprovalState), "approved")
+
+	assertEqual(t, "name updated", got.Name, "Deep Review")
+	assertEqual(t, "description updated", got.Description, "reads everything")
+	assertEqual(t, "source type updated", string(got.SourceType), "git")
+	assertEqual(t, "content updated", got.Content, "# Deep Review\n")
+}
+
+// TestUpdateRoutineConfigFields_PreservesConcurrentStatusWrite mirrors the
+// agent case for routines: status is not a column applyRoutines owns.
+func TestUpdateRoutineConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+	seedRoutine(t, e, testWorkspaceID, "standup")
+
+	snapshot, err := e.repo.ListRoutines(ctx, testWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListRoutines: %v", err)
+	}
+	stale := snapshot[0]
+
+	if _, err := e.db.ExecContext(ctx,
+		`UPDATE office_routines SET status = ? WHERE id = ?`, "paused", stale.ID,
+	); err != nil {
+		t.Fatalf("concurrent status write: %v", err)
+	}
+
+	fields := sqlite.RoutineConfigFields{
+		Description:       "weekly",
+		TaskTemplate:      "summarise the week",
+		ConcurrencyPolicy: models.RoutineConcurrencyPolicy("always_create"),
+	}
+	if err := e.repo.UpdateRoutineConfigFields(ctx, stale.ID, fields); err != nil {
+		t.Fatalf("UpdateRoutineConfigFields: %v", err)
+	}
+
+	got := routineByName(t, e, testWorkspaceID, "standup")
+	assertEqual(t, "status survives import", got.Status, "paused")
+
+	assertEqual(t, "description updated", got.Description, "weekly")
+	assertEqual(t, "task template updated", got.TaskTemplate, "summarise the week")
+	assertEqual(t, "concurrency policy updated", string(got.ConcurrencyPolicy), "always_create")
+}
+
+// TestUpdateProjectConfigFields_PreservesConcurrentStatusWrite mirrors the
+// agent case for projects: status is not a column applyProjects owns.
+func TestUpdateProjectConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+	seedProject(t, e, testWorkspaceID, "apollo")
+
+	snapshot, err := e.repo.ListProjects(ctx, testWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	stale := snapshot[0]
+
+	if _, err := e.db.ExecContext(ctx,
+		`UPDATE office_projects SET status = ? WHERE id = ?`, "on_hold", stale.ID,
+	); err != nil {
+		t.Fatalf("concurrent status write: %v", err)
+	}
+
+	fields := sqlite.ProjectConfigFields{
+		Description:    "mars shot",
+		Color:          "#00ff00",
+		BudgetCents:    1234,
+		Repositories:   `["kdlbs/other"]`,
+		ExecutorConfig: `{"type":"local_pc"}`,
+	}
+	if err := e.repo.UpdateProjectConfigFields(ctx, stale.ID, fields); err != nil {
+		t.Fatalf("UpdateProjectConfigFields: %v", err)
+	}
+
+	got := projectByName(t, e, testWorkspaceID, "apollo")
+	assertEqual(t, "status survives import", string(got.Status), "on_hold")
+
+	assertEqual(t, "description updated", got.Description, "mars shot")
+	assertEqual(t, "color updated", got.Color, "#00ff00")
+	assertEqual(t, "budget updated", got.BudgetCents, 1234)
+	assertEqual(t, "repositories updated", got.Repositories, `["kdlbs/other"]`)
+	assertEqual(t, "executor config updated", got.ExecutorConfig, `{"type":"local_pc"}`)
+}

--- a/apps/backend/internal/office/config/import_concurrent_write_test.go
+++ b/apps/backend/internal/office/config/import_concurrent_write_test.go
@@ -61,6 +61,25 @@ func installRaceTrigger(t *testing.T, e *testEnv, table, triggerID, targetID, co
 	}
 }
 
+// installReportsToRaceTrigger lands a status update after the reports_to
+// resolver reads all agents but before it updates a later agent. The trigger
+// does not fire during the first config-field pass because that pass does not
+// include reports_to in its UPDATE statement.
+func installReportsToRaceTrigger(t *testing.T, e *testEnv, triggerID, targetID string) {
+	t.Helper()
+	stmt := fmt.Sprintf(`
+		CREATE TRIGGER race_agent_reports_to
+		AFTER UPDATE OF reports_to ON agent_profiles
+		WHEN NEW.id = %[1]s
+		BEGIN
+			UPDATE agent_profiles SET status = 'paused' WHERE id = %[2]s;
+		END;
+	`, sqlLit(triggerID), sqlLit(targetID))
+	if _, err := e.db.Exec(stmt); err != nil {
+		t.Fatalf("install reports_to race trigger: %v", err)
+	}
+}
+
 // sqlLit renders s as a single-quoted SQL string literal. Trigger bodies
 // cannot take bind parameters, so the id/value operands have to be spliced
 // into the statement text; every value here comes from uuid.New().String()
@@ -103,6 +122,31 @@ func TestApplyImport_Agents_PreservesConcurrentWriteBetweenListAndUpdate(t *test
 	assertEqual(t, "icon updated", got.Icon, "💰")
 	assertEqual(t, "budget updated", got.BudgetMonthlyCents, 200)
 	assertEqual(t, "max sessions updated", got.MaxConcurrentSessions, 2)
+}
+
+func TestApplyImport_Agents_PreservesConcurrentWriteDuringReportsToUpdate(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+	first := seedAgent(t, e, testWorkspaceID, "alpha")
+	second := seedAgent(t, e, testWorkspaceID, "beta")
+	manager := seedAgent(t, e, testWorkspaceID, "lead")
+
+	installReportsToRaceTrigger(t, e, first.ID, second.ID)
+
+	bundle := &ConfigBundle{Agents: []AgentConfig{
+		{Name: "alpha", Role: "engineer", ReportsTo: "lead", MaxConcurrentSessions: 1},
+		{Name: "beta", Role: "engineer", ReportsTo: "lead", MaxConcurrentSessions: 1},
+		{Name: "lead", Role: "cto", MaxConcurrentSessions: 1},
+	}}
+	if _, err := e.svc.ApplyImport(ctx, testWorkspaceID, bundle); err != nil {
+		t.Fatalf("ApplyImport: %v", err)
+	}
+
+	gotFirst := agentByName(t, e, testWorkspaceID, "alpha")
+	gotSecond := agentByName(t, e, testWorkspaceID, "beta")
+	assertEqual(t, "first reports_to updated", gotFirst.ReportsTo, manager.ID)
+	assertEqual(t, "second reports_to updated", gotSecond.ReportsTo, manager.ID)
+	assertEqual(t, "status survives concurrent write during reports_to update", string(gotSecond.Status), "paused")
 }
 
 // TestApplyImport_Skills_PreservesConcurrentWriteBetweenListAndUpdate mirrors

--- a/apps/backend/internal/office/config/import_concurrent_write_test.go
+++ b/apps/backend/internal/office/config/import_concurrent_write_test.go
@@ -2,10 +2,9 @@ package config
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
-
-	"github.com/kandev/kandev/internal/office/models"
-	"github.com/kandev/kandev/internal/office/repository/sqlite"
 )
 
 // These tests are the regression coverage for the full-row read-modify-write
@@ -16,180 +15,181 @@ import (
 // direct API edits) changed between the List read and the Update write was
 // silently reverted to its stale snapshot value.
 //
-// Each test reproduces the exact production sequence: capture the row the
-// way applyAgents' List call would, perform the concurrent write, then drive
-// the import side of the sequence through the repository. Before the fix
-// that last step was `Update<Entity>(ctx, stale)` — the mutated-in-place
-// stale struct — which silently reverted the concurrent write. After the
-// fix it is `Update<Entity>ConfigFields`, which never references the
-// unowned column at the SQL level, so staleness of the rest of the struct
-// cannot matter.
+// Each apply* function calls List* exactly once, then loops over the
+// incoming bundle entries and issues one Update* per matched row, in bundle
+// order. That gives a real window between the single List call and the
+// Update call for any row after the first: a write landing in that window is
+// exactly what production concurrency looks like (a budget-cap pause, a
+// direct API edit, another import) racing an in-flight import.
+//
+// Each test below drives that window through ConfigService.ApplyImport
+// itself (not the repository methods directly - those already have their
+// own coverage in internal/office/repository/sqlite). A bundle with two
+// entities puts the first entity's Update* first in the loop; a SQL trigger
+// fires when that first Update* statement runs and, in response, writes an
+// unowned column on the *second* entity - landing strictly between the
+// single List call (which read the second entity's pre-write state) and the
+// second entity's own Update* call later in the same loop. That is the
+// production race window, reproduced deterministically instead of with
+// goroutines and a timing hope.
+//
+// Before the fix, the second entity's Update* call used the row List*
+// captured before the trigger fired - the mutated-in-place stale struct -
+// and a full-row Update* silently reverted the trigger's write. After the
+// fix, Update*ConfigFields never references the unowned column at the SQL
+// level, so staleness of the rest of the struct cannot matter.
 
-// TestUpdateAgentInstanceConfigFields_PreservesConcurrentStatusWrite
+// installRaceTrigger creates a same-table trigger that fires when the row
+// identified by triggerID is updated, and in response writes value into
+// column on the row identified by targetID. Used to land a "concurrent"
+// write strictly inside an apply* function's List-once-then-loop window: the
+// trigger fires off the *first* entity's Update* statement and mutates the
+// *second* entity's unowned column before the loop reaches that row's own
+// Update* call.
+func installRaceTrigger(t *testing.T, e *testEnv, table, triggerID, targetID, column, value string) {
+	t.Helper()
+	stmt := fmt.Sprintf(`
+		CREATE TRIGGER race_%[1]s
+		AFTER UPDATE ON %[1]s
+		WHEN NEW.id = %[2]s
+		BEGIN
+			UPDATE %[1]s SET %[3]s = %[4]s WHERE id = %[5]s;
+		END;
+	`, table, sqlLit(triggerID), column, sqlLit(value), sqlLit(targetID))
+	if _, err := e.db.Exec(stmt); err != nil {
+		t.Fatalf("install race trigger on %s: %v", table, err)
+	}
+}
+
+// sqlLit renders s as a single-quoted SQL string literal. Trigger bodies
+// cannot take bind parameters, so the id/value operands have to be spliced
+// into the statement text; every value here comes from uuid.New().String()
+// or a test-chosen literal, but the escaping is done properly anyway rather
+// than assumed safe.
+func sqlLit(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// TestApplyImport_Agents_PreservesConcurrentWriteBetweenListAndUpdate
 // reproduces the triage receipt: a budget-cap pause (UpdateAgentStatusFields,
 // the real concurrent writer used by internal/office/costs/budgets.go)
-// landing after the import's list read but before its write must survive,
-// instead of being reverted to the stale "idle" status the import read.
-func TestUpdateAgentInstanceConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+// landing between applyAgents' single List call and its Update call for a
+// later row must survive, instead of being reverted to the stale "idle"
+// status that List captured before the write happened.
+func TestApplyImport_Agents_PreservesConcurrentWriteBetweenListAndUpdate(t *testing.T) {
 	e := newTestEnv(t)
 	ctx := context.Background()
-	seedAgent(t, e, testWorkspaceID, "ada")
+	first := seedAgent(t, e, testWorkspaceID, "alpha")
+	second := seedAgent(t, e, testWorkspaceID, "beta")
 
-	// What applyAgents' List call would have captured.
-	snapshot, err := e.repo.ListAgentInstances(ctx, testWorkspaceID)
-	if err != nil {
-		t.Fatalf("ListAgentInstances: %v", err)
-	}
-	stale := snapshot[0]
+	installRaceTrigger(t, e, "agent_profiles", first.ID, second.ID, "status", "paused")
 
-	// A concurrent writer pauses the agent for a budget cap between the
-	// import's read and its write.
-	if err := e.repo.UpdateAgentStatusFields(ctx, stale.ID, "paused", "budget cap exceeded"); err != nil {
-		t.Fatalf("UpdateAgentStatusFields: %v", err)
+	bundle := &ConfigBundle{
+		Agents: []AgentConfig{
+			{Name: "alpha", Role: "cto", BudgetMonthlyCents: 100, MaxConcurrentSessions: 1},
+			{Name: "beta", Role: "cfo", Icon: "💰", BudgetMonthlyCents: 200, MaxConcurrentSessions: 2},
+		},
 	}
-
-	// The import proceeds with only the fields it owns (import.go's
-	// applyAgents builds these from the incoming AgentConfig, not from the
-	// stale struct, and only stale.ID identifies the row).
-	fields := sqlite.AgentInstanceConfigFields{
-		Role:                  "cto",
-		Icon:                  "🤖",
-		BudgetMonthlyCents:    4200,
-		MaxConcurrentSessions: 3,
-		DesiredSkills:         `["go"]`,
-		ExecutorPreference:    "local_docker",
-	}
-	if err := e.repo.UpdateAgentInstanceConfigFields(ctx, stale.ID, fields); err != nil {
-		t.Fatalf("UpdateAgentInstanceConfigFields: %v", err)
+	if _, err := e.svc.ApplyImport(ctx, testWorkspaceID, bundle); err != nil {
+		t.Fatalf("ApplyImport: %v", err)
 	}
 
-	got := agentByName(t, e, testWorkspaceID, "ada")
-	assertEqual(t, "status survives import", string(got.Status), "paused")
-	assertEqual(t, "pause reason survives import", got.PauseReason, "budget cap exceeded")
+	got := agentByName(t, e, testWorkspaceID, "beta")
+	assertEqual(t, "status survives concurrent write during import", string(got.Status), "paused")
 
 	// The owned fields must still have landed - a scoped update that writes
-	// nothing would also make the clobber assertions above pass for the
-	// wrong reason.
-	assertEqual(t, "role updated", string(got.Role), "cto")
-	assertEqual(t, "icon updated", got.Icon, "🤖")
-	assertEqual(t, "budget updated", got.BudgetMonthlyCents, 4200)
-	assertEqual(t, "max sessions updated", got.MaxConcurrentSessions, 3)
-	assertEqual(t, "desired skills updated", got.DesiredSkills, `["go"]`)
-	assertEqual(t, "executor preference updated", got.ExecutorPreference, "local_docker")
+	// nothing would also make the assertion above pass for the wrong reason.
+	assertEqual(t, "role updated", string(got.Role), "cfo")
+	assertEqual(t, "icon updated", got.Icon, "💰")
+	assertEqual(t, "budget updated", got.BudgetMonthlyCents, 200)
+	assertEqual(t, "max sessions updated", got.MaxConcurrentSessions, 2)
 }
 
-// TestUpdateSkillConfigFields_PreservesConcurrentApprovalStateWrite mirrors
+// TestApplyImport_Skills_PreservesConcurrentWriteBetweenListAndUpdate mirrors
 // the agent case for skills: approval_state is not a column applySkills
-// owns, so a write landing between the import's read and its write must
-// survive.
-func TestUpdateSkillConfigFields_PreservesConcurrentApprovalStateWrite(t *testing.T) {
+// owns, so a write landing between applyImport's List call and a later
+// row's Update call must survive.
+func TestApplyImport_Skills_PreservesConcurrentWriteBetweenListAndUpdate(t *testing.T) {
 	e := newTestEnv(t)
 	ctx := context.Background()
-	seedSkill(t, e, testWorkspaceID, "code-review")
+	first := seedSkill(t, e, testWorkspaceID, "alpha")
+	second := seedSkill(t, e, testWorkspaceID, "beta")
 
-	snapshot, err := e.repo.ListSkills(ctx, testWorkspaceID)
-	if err != nil {
-		t.Fatalf("ListSkills: %v", err)
-	}
-	stale := snapshot[0]
+	installRaceTrigger(t, e, "office_skills", first.ID, second.ID, "approval_state", "approved")
 
-	if _, err := e.db.ExecContext(ctx,
-		`UPDATE office_skills SET approval_state = ? WHERE id = ?`, "approved", stale.ID,
-	); err != nil {
-		t.Fatalf("concurrent approval_state write: %v", err)
+	bundle := &ConfigBundle{
+		Skills: []SkillConfig{
+			{Name: "Alpha", Slug: "alpha", Description: "first", SourceType: "inline", Content: "# Alpha\n"},
+			{Name: "Beta", Slug: "beta", Description: "second", SourceType: "inline", Content: "# Beta\n"},
+		},
 	}
-
-	fields := sqlite.SkillConfigFields{
-		Name:        "Deep Review",
-		Description: "reads everything",
-		SourceType:  models.SkillSourceType("git"),
-		Content:     "# Deep Review\n",
-	}
-	if err := e.repo.UpdateSkillConfigFields(ctx, stale.ID, fields); err != nil {
-		t.Fatalf("UpdateSkillConfigFields: %v", err)
+	if _, err := e.svc.ApplyImport(ctx, testWorkspaceID, bundle); err != nil {
+		t.Fatalf("ApplyImport: %v", err)
 	}
 
-	got := skillBySlug(t, e, testWorkspaceID, "code-review")
-	assertEqual(t, "approval_state survives import", string(got.ApprovalState), "approved")
+	got := skillBySlug(t, e, testWorkspaceID, "beta")
+	assertEqual(t, "approval_state survives concurrent write during import", string(got.ApprovalState), "approved")
 
-	assertEqual(t, "name updated", got.Name, "Deep Review")
-	assertEqual(t, "description updated", got.Description, "reads everything")
-	assertEqual(t, "source type updated", string(got.SourceType), "git")
-	assertEqual(t, "content updated", got.Content, "# Deep Review\n")
+	assertEqual(t, "name updated", got.Name, "Beta")
+	assertEqual(t, "description updated", got.Description, "second")
+	assertEqual(t, "content updated", got.Content, "# Beta\n")
 }
 
-// TestUpdateRoutineConfigFields_PreservesConcurrentStatusWrite mirrors the
-// agent case for routines: status is not a column applyRoutines owns.
-func TestUpdateRoutineConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+// TestApplyImport_Routines_PreservesConcurrentWriteBetweenListAndUpdate
+// mirrors the agent case for routines: status is not a column applyRoutines
+// owns.
+func TestApplyImport_Routines_PreservesConcurrentWriteBetweenListAndUpdate(t *testing.T) {
 	e := newTestEnv(t)
 	ctx := context.Background()
-	seedRoutine(t, e, testWorkspaceID, "standup")
+	first := seedRoutine(t, e, testWorkspaceID, "alpha")
+	second := seedRoutine(t, e, testWorkspaceID, "beta")
 
-	snapshot, err := e.repo.ListRoutines(ctx, testWorkspaceID)
-	if err != nil {
-		t.Fatalf("ListRoutines: %v", err)
-	}
-	stale := snapshot[0]
+	installRaceTrigger(t, e, "office_routines", first.ID, second.ID, "status", "paused")
 
-	if _, err := e.db.ExecContext(ctx,
-		`UPDATE office_routines SET status = ? WHERE id = ?`, "paused", stale.ID,
-	); err != nil {
-		t.Fatalf("concurrent status write: %v", err)
+	bundle := &ConfigBundle{
+		Routines: []RoutineConfig{
+			{Name: "alpha", Description: "first", TaskTemplate: "do the first thing", ConcurrencyPolicy: "skip"},
+			{Name: "beta", Description: "second", TaskTemplate: "do the second thing", ConcurrencyPolicy: "always_create"},
+		},
 	}
-
-	fields := sqlite.RoutineConfigFields{
-		Description:       "weekly",
-		TaskTemplate:      "summarise the week",
-		ConcurrencyPolicy: models.RoutineConcurrencyPolicy("always_create"),
-	}
-	if err := e.repo.UpdateRoutineConfigFields(ctx, stale.ID, fields); err != nil {
-		t.Fatalf("UpdateRoutineConfigFields: %v", err)
+	if _, err := e.svc.ApplyImport(ctx, testWorkspaceID, bundle); err != nil {
+		t.Fatalf("ApplyImport: %v", err)
 	}
 
-	got := routineByName(t, e, testWorkspaceID, "standup")
-	assertEqual(t, "status survives import", got.Status, "paused")
+	got := routineByName(t, e, testWorkspaceID, "beta")
+	assertEqual(t, "status survives concurrent write during import", got.Status, "paused")
 
-	assertEqual(t, "description updated", got.Description, "weekly")
-	assertEqual(t, "task template updated", got.TaskTemplate, "summarise the week")
+	assertEqual(t, "description updated", got.Description, "second")
+	assertEqual(t, "task template updated", got.TaskTemplate, "do the second thing")
 	assertEqual(t, "concurrency policy updated", string(got.ConcurrencyPolicy), "always_create")
 }
 
-// TestUpdateProjectConfigFields_PreservesConcurrentStatusWrite mirrors the
-// agent case for projects: status is not a column applyProjects owns.
-func TestUpdateProjectConfigFields_PreservesConcurrentStatusWrite(t *testing.T) {
+// TestApplyImport_Projects_PreservesConcurrentWriteBetweenListAndUpdate
+// mirrors the agent case for projects: status is not a column applyProjects
+// owns.
+func TestApplyImport_Projects_PreservesConcurrentWriteBetweenListAndUpdate(t *testing.T) {
 	e := newTestEnv(t)
 	ctx := context.Background()
-	seedProject(t, e, testWorkspaceID, "apollo")
+	first := seedProject(t, e, testWorkspaceID, "alpha")
+	second := seedProject(t, e, testWorkspaceID, "beta")
 
-	snapshot, err := e.repo.ListProjects(ctx, testWorkspaceID)
-	if err != nil {
-		t.Fatalf("ListProjects: %v", err)
-	}
-	stale := snapshot[0]
+	installRaceTrigger(t, e, "office_projects", first.ID, second.ID, "status", "on_hold")
 
-	if _, err := e.db.ExecContext(ctx,
-		`UPDATE office_projects SET status = ? WHERE id = ?`, "on_hold", stale.ID,
-	); err != nil {
-		t.Fatalf("concurrent status write: %v", err)
+	bundle := &ConfigBundle{
+		Projects: []ProjectConfig{
+			{Name: "alpha", Description: "first", Color: "#ff0000", BudgetCents: 100},
+			{Name: "beta", Description: "second", Color: "#00ff00", BudgetCents: 200, Repositories: `["kdlbs/other"]`},
+		},
 	}
-
-	fields := sqlite.ProjectConfigFields{
-		Description:    "mars shot",
-		Color:          "#00ff00",
-		BudgetCents:    1234,
-		Repositories:   `["kdlbs/other"]`,
-		ExecutorConfig: `{"type":"local_pc"}`,
-	}
-	if err := e.repo.UpdateProjectConfigFields(ctx, stale.ID, fields); err != nil {
-		t.Fatalf("UpdateProjectConfigFields: %v", err)
+	if _, err := e.svc.ApplyImport(ctx, testWorkspaceID, bundle); err != nil {
+		t.Fatalf("ApplyImport: %v", err)
 	}
 
-	got := projectByName(t, e, testWorkspaceID, "apollo")
-	assertEqual(t, "status survives import", string(got.Status), "on_hold")
+	got := projectByName(t, e, testWorkspaceID, "beta")
+	assertEqual(t, "status survives concurrent write during import", string(got.Status), "on_hold")
 
-	assertEqual(t, "description updated", got.Description, "mars shot")
+	assertEqual(t, "description updated", got.Description, "second")
 	assertEqual(t, "color updated", got.Color, "#00ff00")
-	assertEqual(t, "budget updated", got.BudgetCents, 1234)
+	assertEqual(t, "budget updated", got.BudgetCents, 200)
 	assertEqual(t, "repositories updated", got.Repositories, `["kdlbs/other"]`)
-	assertEqual(t, "executor config updated", got.ExecutorConfig, `{"type":"local_pc"}`)
 }

--- a/apps/backend/internal/office/models/skill_metadata.go
+++ b/apps/backend/internal/office/models/skill_metadata.go
@@ -1,0 +1,13 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SkillPackageContentHash returns the identity of the content and package
+// metadata that determine a materialized skill package.
+func SkillPackageContentHash(content, fileInventory, sourceLocator string) string {
+	sum := sha256.Sum256([]byte(content + "\x00" + fileInventory + "\x00" + sourceLocator))
+	return hex.EncodeToString(sum[:])
+}

--- a/apps/backend/internal/office/repository/sqlite/agents.go
+++ b/apps/backend/internal/office/repository/sqlite/agents.go
@@ -304,6 +304,20 @@ func (r *Repository) UpdateAgentInstanceConfigFields(
 	return err
 }
 
+// UpdateAgentReportsTo updates only an agent's reporting relationship. Config
+// import resolves this field in a second pass, after all agent IDs are known.
+// A narrow update prevents that pass from reverting runtime-owned fields from
+// the stale agent snapshot used for name resolution.
+func (r *Repository) UpdateAgentReportsTo(ctx context.Context, id, reportsTo string) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_profiles
+		SET reports_to = ?, updated_at = ?
+		WHERE id = ? AND `+agentInstanceFilter+`
+	`), reportsTo, now, id)
+	return err
+}
+
 // UpdateAgentSettings persists the agent_profiles.settings JSON blob for
 // an agent. Used by onboarding to seed routing.tier_source / .provider_
 // order_source markers on the freshly created CEO agent so the routing

--- a/apps/backend/internal/office/repository/sqlite/agents.go
+++ b/apps/backend/internal/office/repository/sqlite/agents.go
@@ -269,6 +269,41 @@ func (r *Repository) UpdateAgentInstance(ctx context.Context, agent *models.Agen
 	return err
 }
 
+// AgentInstanceConfigFields is the subset of agent_profiles columns a
+// config import owns (see UpdateAgentInstanceConfigFields).
+type AgentInstanceConfigFields struct {
+	Role                  string
+	Icon                  string
+	BudgetMonthlyCents    int
+	MaxConcurrentSessions int
+	DesiredSkills         string
+	ExecutorPreference    string
+}
+
+// UpdateAgentInstanceConfigFields updates only the columns a config import
+// owns (role, icon, budget, max concurrent sessions, desired skills,
+// executor preference). Unlike UpdateAgentInstance, it leaves status,
+// pause_reason, settings, last_run_finished_at, and every other column at
+// whatever a concurrent writer (UpdateAgentStatusFields, UpdateAgentSettings,
+// the agent runtime, direct API edits) set them to, instead of reverting
+// them to a stale read-then-write snapshot.
+func (r *Repository) UpdateAgentInstanceConfigFields(
+	ctx context.Context, id string, fields AgentInstanceConfigFields,
+) error {
+	desiredSkills := normalizeAgentJSONArray(fields.DesiredSkills)
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_profiles SET
+			role = ?, icon = ?, budget_monthly_cents = ?,
+			max_concurrent_sessions = ?, desired_skills = ?,
+			executor_preference = ?, updated_at = ?
+		WHERE id = ? AND `+agentInstanceFilter+`
+	`), fields.Role, fields.Icon, fields.BudgetMonthlyCents,
+		fields.MaxConcurrentSessions, desiredSkills,
+		fields.ExecutorPreference, now, id)
+	return err
+}
+
 // UpdateAgentSettings persists the agent_profiles.settings JSON blob for
 // an agent. Used by onboarding to seed routing.tier_source / .provider_
 // order_source markers on the freshly created CEO agent so the routing

--- a/apps/backend/internal/office/repository/sqlite/agents_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agents_config_fields_test.go
@@ -92,3 +92,46 @@ func TestUpdateAgentInstanceConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
 		t.Errorf("CooldownSec changed: got %d, want %d", got.CooldownSec, agent.CooldownSec)
 	}
 }
+
+// TestUpdateAgentReportsTo_UpdatesOnlyReportsTo proves that the second config
+// import pass cannot overwrite state that belongs to the agent runtime.
+func TestUpdateAgentReportsTo_UpdatesOnlyReportsTo(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	agent := fullAgentInstance("agent-1", "ws-1", "ada")
+	if err := repo.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("CreateAgentInstance: %v", err)
+	}
+	const wantSettings = `{"routing":{"tier_source":"explicit"}}`
+	if err := repo.UpdateAgentSettings(ctx, agent.ID, wantSettings); err != nil {
+		t.Fatalf("UpdateAgentSettings: %v", err)
+	}
+	if err := repo.UpdateAgentStatusFields(ctx, agent.ID, "paused", "manual pause"); err != nil {
+		t.Fatalf("UpdateAgentStatusFields: %v", err)
+	}
+
+	if err := repo.UpdateAgentReportsTo(ctx, agent.ID, "manager-1"); err != nil {
+		t.Fatalf("UpdateAgentReportsTo: %v", err)
+	}
+
+	got, err := repo.GetAgentInstance(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentInstance: %v", err)
+	}
+	if got.ReportsTo != "manager-1" {
+		t.Errorf("ReportsTo = %q, want %q", got.ReportsTo, "manager-1")
+	}
+	if string(got.Status) != "paused" {
+		t.Errorf("Status changed: got %q, want %q", got.Status, "paused")
+	}
+	if got.PauseReason != "manual pause" {
+		t.Errorf("PauseReason changed: got %q, want %q", got.PauseReason, "manual pause")
+	}
+	if got.Settings != wantSettings {
+		t.Errorf("Settings changed: got %q, want %q", got.Settings, wantSettings)
+	}
+	if got.Role != agent.Role {
+		t.Errorf("Role changed: got %q, want %q", got.Role, agent.Role)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/agents_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agents_config_fields_test.go
@@ -1,0 +1,94 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// TestUpdateAgentInstanceConfigFields_UpdatesOnlyOwnedColumns proves the
+// column-scoped writer touches only the six columns a config import owns
+// and leaves every other column - in particular status and pause_reason,
+// which a concurrent writer like UpdateAgentStatusFields owns - exactly as
+// they were.
+func TestUpdateAgentInstanceConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	agent := fullAgentInstance("agent-1", "ws-1", "ada")
+	if err := repo.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("CreateAgentInstance: %v", err)
+	}
+	// CreateAgentInstance always writes settings='{}'; set a real value
+	// through the column's real owner (UpdateAgentSettings) so this test
+	// can prove UpdateAgentInstanceConfigFields leaves it alone.
+	const wantSettings = `{"routing":{"tier_source":"explicit"}}`
+	if err := repo.UpdateAgentSettings(ctx, agent.ID, wantSettings); err != nil {
+		t.Fatalf("UpdateAgentSettings: %v", err)
+	}
+
+	fields := sqlite.AgentInstanceConfigFields{
+		Role:                  "cfo",
+		Icon:                  "💼",
+		BudgetMonthlyCents:    9900,
+		MaxConcurrentSessions: 5,
+		DesiredSkills:         `["finance"]`,
+		ExecutorPreference:    "sprites",
+	}
+	if err := repo.UpdateAgentInstanceConfigFields(ctx, agent.ID, fields); err != nil {
+		t.Fatalf("UpdateAgentInstanceConfigFields: %v", err)
+	}
+
+	rows, err := repo.ListAgentInstances(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListAgentInstances: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+
+	// Owned columns landed.
+	if string(got.Role) != fields.Role {
+		t.Errorf("Role = %q, want %q", got.Role, fields.Role)
+	}
+	if got.Icon != fields.Icon {
+		t.Errorf("Icon = %q, want %q", got.Icon, fields.Icon)
+	}
+	if got.BudgetMonthlyCents != fields.BudgetMonthlyCents {
+		t.Errorf("BudgetMonthlyCents = %d, want %d", got.BudgetMonthlyCents, fields.BudgetMonthlyCents)
+	}
+	if got.MaxConcurrentSessions != fields.MaxConcurrentSessions {
+		t.Errorf("MaxConcurrentSessions = %d, want %d", got.MaxConcurrentSessions, fields.MaxConcurrentSessions)
+	}
+	if got.DesiredSkills != fields.DesiredSkills {
+		t.Errorf("DesiredSkills = %q, want %q", got.DesiredSkills, fields.DesiredSkills)
+	}
+	if got.ExecutorPreference != fields.ExecutorPreference {
+		t.Errorf("ExecutorPreference = %q, want %q", got.ExecutorPreference, fields.ExecutorPreference)
+	}
+
+	// Everything else stayed exactly as seeded.
+	if string(got.Status) != string(agent.Status) {
+		t.Errorf("Status changed: got %q, want %q", got.Status, agent.Status)
+	}
+	if got.PauseReason != agent.PauseReason {
+		t.Errorf("PauseReason changed: got %q, want %q", got.PauseReason, agent.PauseReason)
+	}
+	if got.Settings != wantSettings {
+		t.Errorf("Settings changed: got %q, want %q", got.Settings, wantSettings)
+	}
+	if got.Model != agent.Model {
+		t.Errorf("Model changed: got %q, want %q", got.Model, agent.Model)
+	}
+	if got.ReportsTo != agent.ReportsTo {
+		t.Errorf("ReportsTo changed: got %q, want %q", got.ReportsTo, agent.ReportsTo)
+	}
+	if got.ConsecutiveFailures != agent.ConsecutiveFailures {
+		t.Errorf("ConsecutiveFailures changed: got %d, want %d", got.ConsecutiveFailures, agent.ConsecutiveFailures)
+	}
+	if got.CooldownSec != agent.CooldownSec {
+		t.Errorf("CooldownSec changed: got %d, want %d", got.CooldownSec, agent.CooldownSec)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/projects.go
+++ b/apps/backend/internal/office/repository/sqlite/projects.go
@@ -95,6 +95,34 @@ func (r *Repository) UpdateProject(ctx context.Context, project *models.Project)
 	return err
 }
 
+// ProjectConfigFields is the subset of office_projects columns a config
+// import owns (see UpdateProjectConfigFields).
+type ProjectConfigFields struct {
+	Description    string
+	Color          string
+	BudgetCents    int
+	Repositories   string
+	ExecutorConfig string
+}
+
+// UpdateProjectConfigFields updates only the columns a config import owns
+// (description, color, budget, repositories, executor config), leaving
+// status and lead_agent_profile_id untouched instead of reverting them to
+// a stale read-then-write snapshot.
+func (r *Repository) UpdateProjectConfigFields(
+	ctx context.Context, id string, fields ProjectConfigFields,
+) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE office_projects SET
+			description = ?, color = ?, budget_cents = ?,
+			repositories = ?, executor_config = ?, updated_at = ?
+		WHERE id = ?
+	`), fields.Description, fields.Color, fields.BudgetCents,
+		fields.Repositories, fields.ExecutorConfig, now, id)
+	return err
+}
+
 // DeleteProject deletes a project by ID.
 func (r *Repository) DeleteProject(ctx context.Context, id string) error {
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(

--- a/apps/backend/internal/office/repository/sqlite/projects_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/projects_config_fields_test.go
@@ -1,0 +1,76 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// TestUpdateProjectConfigFields_UpdatesOnlyOwnedColumns proves the
+// column-scoped writer touches only description, color, budget_cents,
+// repositories, and executor_config - leaving status and
+// lead_agent_profile_id, which a config import does not own, exactly as
+// they were.
+func TestUpdateProjectConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	project := &models.Project{
+		ID:                 "project-1",
+		WorkspaceID:        "ws-1",
+		Name:               "apollo",
+		Description:        "moon shot",
+		Status:             models.ProjectStatusActive,
+		LeadAgentProfileID: "agent-1",
+		Color:              "#ff00ff",
+		BudgetCents:        99000,
+		Repositories:       `["kdlbs/kandev"]`,
+		ExecutorConfig:     `{"type":"local_docker"}`,
+	}
+	if err := repo.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	fields := sqlite.ProjectConfigFields{
+		Description:    "mars shot",
+		Color:          "#00ff00",
+		BudgetCents:    1234,
+		Repositories:   `["kdlbs/other"]`,
+		ExecutorConfig: `{"type":"local_pc"}`,
+	}
+	if err := repo.UpdateProjectConfigFields(ctx, project.ID, fields); err != nil {
+		t.Fatalf("UpdateProjectConfigFields: %v", err)
+	}
+
+	got, err := repo.GetProject(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+
+	// Owned columns landed.
+	if got.Description != fields.Description {
+		t.Errorf("Description = %q, want %q", got.Description, fields.Description)
+	}
+	if got.Color != fields.Color {
+		t.Errorf("Color = %q, want %q", got.Color, fields.Color)
+	}
+	if got.BudgetCents != fields.BudgetCents {
+		t.Errorf("BudgetCents = %d, want %d", got.BudgetCents, fields.BudgetCents)
+	}
+	if got.Repositories != fields.Repositories {
+		t.Errorf("Repositories = %q, want %q", got.Repositories, fields.Repositories)
+	}
+	if got.ExecutorConfig != fields.ExecutorConfig {
+		t.Errorf("ExecutorConfig = %q, want %q", got.ExecutorConfig, fields.ExecutorConfig)
+	}
+
+	// Everything else stayed exactly as seeded.
+	if got.Status != project.Status {
+		t.Errorf("Status changed: got %q, want %q", got.Status, project.Status)
+	}
+	if got.LeadAgentProfileID != project.LeadAgentProfileID {
+		t.Errorf("LeadAgentProfileID changed: got %q, want %q", got.LeadAgentProfileID, project.LeadAgentProfileID)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/routines.go
+++ b/apps/backend/internal/office/repository/sqlite/routines.go
@@ -189,6 +189,31 @@ func (r *Repository) UpdateRoutine(ctx context.Context, routine *models.Routine)
 	return err
 }
 
+// RoutineConfigFields is the subset of office_routines columns a config
+// import owns (see UpdateRoutineConfigFields).
+type RoutineConfigFields struct {
+	Description       string
+	TaskTemplate      string
+	ConcurrencyPolicy models.RoutineConcurrencyPolicy
+}
+
+// UpdateRoutineConfigFields updates only the columns a config import owns
+// (description, task template, concurrency policy), leaving
+// assignee_agent_profile_id, status, catch_up_policy, catch_up_max,
+// variables, and last_run_at untouched instead of reverting them to a
+// stale read-then-write snapshot.
+func (r *Repository) UpdateRoutineConfigFields(
+	ctx context.Context, id string, fields RoutineConfigFields,
+) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE office_routines SET
+			description = ?, task_template = ?, concurrency_policy = ?, updated_at = ?
+		WHERE id = ?
+	`), fields.Description, fields.TaskTemplate, fields.ConcurrencyPolicy, now, id)
+	return err
+}
+
 // DeleteRoutine deletes a routine by ID.
 func (r *Repository) DeleteRoutine(ctx context.Context, id string) error {
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(

--- a/apps/backend/internal/office/repository/sqlite/routines_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/routines_config_fields_test.go
@@ -1,0 +1,78 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// TestUpdateRoutineConfigFields_UpdatesOnlyOwnedColumns proves the
+// column-scoped writer touches only description, task_template, and
+// concurrency_policy - leaving status and every other column, which a
+// config import does not own, exactly as they were.
+func TestUpdateRoutineConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	routine := &models.Routine{
+		ID:                     "routine-1",
+		WorkspaceID:            "ws-1",
+		Name:                   "standup",
+		Description:            "daily standup",
+		TaskTemplate:           "summarise yesterday",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      models.ConcurrencyPolicySkipIfActive,
+		CatchUpPolicy:          "enqueue_missed_with_cap",
+		CatchUpMax:             25,
+		Variables:              `{"team":"platform"}`,
+	}
+	if err := repo.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("CreateRoutine: %v", err)
+	}
+
+	fields := sqlite.RoutineConfigFields{
+		Description:       "weekly",
+		TaskTemplate:      "summarise the week",
+		ConcurrencyPolicy: models.ConcurrencyPolicyAlwaysCreate,
+	}
+	if err := repo.UpdateRoutineConfigFields(ctx, routine.ID, fields); err != nil {
+		t.Fatalf("UpdateRoutineConfigFields: %v", err)
+	}
+
+	got, err := repo.GetRoutine(ctx, routine.ID)
+	if err != nil {
+		t.Fatalf("GetRoutine: %v", err)
+	}
+
+	// Owned columns landed.
+	if got.Description != fields.Description {
+		t.Errorf("Description = %q, want %q", got.Description, fields.Description)
+	}
+	if got.TaskTemplate != fields.TaskTemplate {
+		t.Errorf("TaskTemplate = %q, want %q", got.TaskTemplate, fields.TaskTemplate)
+	}
+	if got.ConcurrencyPolicy != fields.ConcurrencyPolicy {
+		t.Errorf("ConcurrencyPolicy = %q, want %q", got.ConcurrencyPolicy, fields.ConcurrencyPolicy)
+	}
+
+	// Everything else stayed exactly as seeded.
+	if got.AssigneeAgentProfileID != routine.AssigneeAgentProfileID {
+		t.Errorf("AssigneeAgentProfileID changed: got %q, want %q",
+			got.AssigneeAgentProfileID, routine.AssigneeAgentProfileID)
+	}
+	if got.Status != routine.Status {
+		t.Errorf("Status changed: got %q, want %q", got.Status, routine.Status)
+	}
+	if got.CatchUpPolicy != routine.CatchUpPolicy {
+		t.Errorf("CatchUpPolicy changed: got %q, want %q", got.CatchUpPolicy, routine.CatchUpPolicy)
+	}
+	if got.CatchUpMax != routine.CatchUpMax {
+		t.Errorf("CatchUpMax changed: got %d, want %d", got.CatchUpMax, routine.CatchUpMax)
+	}
+	if got.Variables != routine.Variables {
+		t.Errorf("Variables changed: got %q, want %q", got.Variables, routine.Variables)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/skills.go
+++ b/apps/backend/internal/office/repository/sqlite/skills.go
@@ -151,20 +151,58 @@ type SkillConfigFields struct {
 }
 
 // UpdateSkillConfigFields updates only the columns a config import owns
-// (name, description, source type, content), leaving source_locator,
-// file_inventory, version, content_hash, approval_state, and the other
-// columns untouched instead of reverting them to a stale read-then-write
-// snapshot.
+// (name, description, source type, content) and the content_hash derived from
+// content plus the current package metadata. It leaves source_locator,
+// file_inventory, version, approval_state, and the other columns untouched
+// instead of reverting them to a stale read-then-write snapshot.
 func (r *Repository) UpdateSkillConfigFields(
 	ctx context.Context, id string, fields SkillConfigFields,
 ) error {
-	now := time.Now().UTC()
-	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
-		UPDATE office_skills SET
-			name = ?, description = ?, source_type = ?, content = ?, updated_at = ?
-		WHERE id = ?
-	`), fields.Name, fields.Description, fields.SourceType, fields.Content, now, id)
-	return err
+	const maxMetadataReadAttempts = 3
+	type packageMetadata struct {
+		SourceLocator string `db:"source_locator"`
+		FileInventory string `db:"file_inventory"`
+	}
+
+	for range maxMetadataReadAttempts {
+		var metadata packageMetadata
+		if err := r.db.QueryRowxContext(ctx, r.db.Rebind(`
+			SELECT COALESCE(source_locator, '') AS source_locator,
+				COALESCE(file_inventory, '') AS file_inventory
+			FROM office_skills
+			WHERE id = ?
+		`), id).StructScan(&metadata); err != nil {
+			if err == sql.ErrNoRows {
+				return fmt.Errorf("skill not found: %s", id)
+			}
+			return err
+		}
+
+		contentHash := models.SkillPackageContentHash(
+			fields.Content, metadata.FileInventory, metadata.SourceLocator,
+		)
+		result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+			UPDATE office_skills SET
+				name = ?, description = ?, source_type = ?, content = ?,
+				content_hash = ?, updated_at = ?
+			WHERE id = ?
+				AND COALESCE(source_locator, '') = ?
+				AND COALESCE(file_inventory, '') = ?
+		`), fields.Name, fields.Description, fields.SourceType, fields.Content,
+			contentHash, time.Now().UTC(), id, metadata.SourceLocator, metadata.FileInventory)
+		if err != nil {
+			return err
+		}
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if updated == 1 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("update skill %s: package metadata changed concurrently", id)
 }
 
 // DeleteSkill deletes a skill by ID.

--- a/apps/backend/internal/office/repository/sqlite/skills.go
+++ b/apps/backend/internal/office/repository/sqlite/skills.go
@@ -141,6 +141,32 @@ func (r *Repository) UpdateSkill(ctx context.Context, skill *models.Skill) error
 	return err
 }
 
+// SkillConfigFields is the subset of office_skills columns a config import
+// owns (see UpdateSkillConfigFields).
+type SkillConfigFields struct {
+	Name        string
+	Description string
+	SourceType  models.SkillSourceType
+	Content     string
+}
+
+// UpdateSkillConfigFields updates only the columns a config import owns
+// (name, description, source type, content), leaving source_locator,
+// file_inventory, version, content_hash, approval_state, and the other
+// columns untouched instead of reverting them to a stale read-then-write
+// snapshot.
+func (r *Repository) UpdateSkillConfigFields(
+	ctx context.Context, id string, fields SkillConfigFields,
+) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE office_skills SET
+			name = ?, description = ?, source_type = ?, content = ?, updated_at = ?
+		WHERE id = ?
+	`), fields.Name, fields.Description, fields.SourceType, fields.Content, now, id)
+	return err
+}
+
 // DeleteSkill deletes a skill by ID.
 func (r *Repository) DeleteSkill(ctx context.Context, id string) error {
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(

--- a/apps/backend/internal/office/repository/sqlite/skills_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/skills_config_fields_test.go
@@ -2,6 +2,8 @@ package sqlite_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/kandev/kandev/internal/office/models"
@@ -9,9 +11,9 @@ import (
 )
 
 // TestUpdateSkillConfigFields_UpdatesOnlyOwnedColumns proves the
-// column-scoped writer touches only name, description, source_type, and
-// content - leaving approval_state and every other column, which a config
-// import does not own, exactly as they were.
+// column-scoped writer touches only name, description, source_type, content,
+// and the hash derived from content. It leaves approval_state and package
+// metadata, which a config import does not own, exactly as they were.
 func TestUpdateSkillConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
@@ -80,8 +82,10 @@ func TestUpdateSkillConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
 	if got.Version != skill.Version {
 		t.Errorf("Version changed: got %q, want %q", got.Version, skill.Version)
 	}
-	if got.ContentHash != skill.ContentHash {
-		t.Errorf("ContentHash changed: got %q, want %q", got.ContentHash, skill.ContentHash)
+	wantHashBytes := sha256.Sum256([]byte(fields.Content + "\x00" + skill.FileInventory + "\x00" + skill.SourceLocator))
+	wantHash := hex.EncodeToString(wantHashBytes[:])
+	if got.ContentHash != wantHash {
+		t.Errorf("ContentHash = %q, want %q for updated content", got.ContentHash, wantHash)
 	}
 	if got.ApprovalState != skill.ApprovalState {
 		t.Errorf("ApprovalState changed: got %q, want %q", got.ApprovalState, skill.ApprovalState)

--- a/apps/backend/internal/office/repository/sqlite/skills_config_fields_test.go
+++ b/apps/backend/internal/office/repository/sqlite/skills_config_fields_test.go
@@ -1,0 +1,92 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// TestUpdateSkillConfigFields_UpdatesOnlyOwnedColumns proves the
+// column-scoped writer touches only name, description, source_type, and
+// content - leaving approval_state and every other column, which a config
+// import does not own, exactly as they were.
+func TestUpdateSkillConfigFields_UpdatesOnlyOwnedColumns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{
+		ID:                      "skill-1",
+		WorkspaceID:             "ws-1",
+		Name:                    "Code Review",
+		Slug:                    "code-review",
+		Description:             "reviews diffs",
+		SourceType:              "inline",
+		SourceLocator:           "local://code-review",
+		Content:                 "# Code Review\n",
+		FileInventory:           `["SKILL.md"]`,
+		Version:                 "v1",
+		ContentHash:             "hash-v1",
+		ApprovalState:           "approved",
+		CreatedByAgentProfileID: "agent-1",
+		IsSystem:                false,
+		SystemVersion:           "",
+		DefaultForRoles:         `["cto"]`,
+	}
+	if err := repo.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("CreateSkill: %v", err)
+	}
+
+	fields := sqlite.SkillConfigFields{
+		Name:        "Deep Review",
+		Description: "reads everything",
+		SourceType:  models.SkillSourceType("git"),
+		Content:     "# Deep Review\n",
+	}
+	if err := repo.UpdateSkillConfigFields(ctx, skill.ID, fields); err != nil {
+		t.Fatalf("UpdateSkillConfigFields: %v", err)
+	}
+
+	got, err := repo.GetSkill(ctx, skill.ID)
+	if err != nil {
+		t.Fatalf("GetSkill: %v", err)
+	}
+
+	// Owned columns landed.
+	if got.Name != fields.Name {
+		t.Errorf("Name = %q, want %q", got.Name, fields.Name)
+	}
+	if got.Description != fields.Description {
+		t.Errorf("Description = %q, want %q", got.Description, fields.Description)
+	}
+	if got.SourceType != fields.SourceType {
+		t.Errorf("SourceType = %q, want %q", got.SourceType, fields.SourceType)
+	}
+	if got.Content != fields.Content {
+		t.Errorf("Content = %q, want %q", got.Content, fields.Content)
+	}
+
+	// Everything else stayed exactly as seeded.
+	if got.Slug != skill.Slug {
+		t.Errorf("Slug changed: got %q, want %q", got.Slug, skill.Slug)
+	}
+	if got.SourceLocator != skill.SourceLocator {
+		t.Errorf("SourceLocator changed: got %q, want %q", got.SourceLocator, skill.SourceLocator)
+	}
+	if got.FileInventory != skill.FileInventory {
+		t.Errorf("FileInventory changed: got %q, want %q", got.FileInventory, skill.FileInventory)
+	}
+	if got.Version != skill.Version {
+		t.Errorf("Version changed: got %q, want %q", got.Version, skill.Version)
+	}
+	if got.ContentHash != skill.ContentHash {
+		t.Errorf("ContentHash changed: got %q, want %q", got.ContentHash, skill.ContentHash)
+	}
+	if got.ApprovalState != skill.ApprovalState {
+		t.Errorf("ApprovalState changed: got %q, want %q", got.ApprovalState, skill.ApprovalState)
+	}
+	if got.DefaultForRoles != skill.DefaultForRoles {
+		t.Errorf("DefaultForRoles changed: got %q, want %q", got.DefaultForRoles, skill.DefaultForRoles)
+	}
+}

--- a/apps/backend/internal/office/service/service.go
+++ b/apps/backend/internal/office/service/service.go
@@ -3,8 +3,6 @@ package service
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -500,8 +498,9 @@ func prepareServiceSkillPackageMetadata(skill *models.Skill) {
 	if skill.ApprovalState == "" {
 		skill.ApprovalState = "approved"
 	}
-	sum := sha256.Sum256([]byte(skill.Content + "\x00" + skill.FileInventory + "\x00" + skill.SourceLocator))
-	skill.ContentHash = hex.EncodeToString(sum[:])
+	skill.ContentHash = models.SkillPackageContentHash(
+		skill.Content, skill.FileInventory, skill.SourceLocator,
+	)
 }
 
 // DeleteSkill deletes a skill from the DB.

--- a/apps/backend/internal/office/skills/service.go
+++ b/apps/backend/internal/office/skills/service.go
@@ -2,8 +2,6 @@ package skills
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
@@ -153,8 +151,9 @@ func prepareSkillPackageMetadata(skill *models.Skill) {
 	if skill.ApprovalState == "" {
 		skill.ApprovalState = "approved"
 	}
-	sum := sha256.Sum256([]byte(skill.Content + "\x00" + skill.FileInventory + "\x00" + skill.SourceLocator))
-	skill.ContentHash = hex.EncodeToString(sum[:])
+	skill.ContentHash = models.SkillPackageContentHash(
+		skill.Content, skill.FileInventory, skill.SourceLocator,
+	)
 }
 
 // ValidateSkillUpdate validates a skill update for slug uniqueness.


### PR DESCRIPTION
**Today:** Importing a config bundle for agents, skills, routines, or projects re-reads the full row, sets only the fields the import owns, then writes the *entire* row back. Any field changed concurrently between that read and that write — a live session's status, a skill's approval state, a direct API edit, another import — is silently reverted to its stale value.
**After this:** Import writes only the columns it actually owns (role/icon/budget/etc. for agents, name/description/source/content for skills, and so on for routines and projects) via scoped SQL `UPDATE`s, so any concurrent change to a column the import doesn't touch survives.
**Who hits this:** Anyone running a config import (onboarding, a CI-driven sync, or a manual re-import) while another process touches the same agent/skill/routine/project row — most commonly a running agent session updating its own status.
**Scope:** standalone — fixes the same read-modify-write pattern across all four `apply*` functions in `config/import.go`, not just one entity type.
**Not here:** `internal/office/service/config_import.go` has a near-identical duplicate of this bug, but it isn't reachable from any registered route (traced: only `internal/office/routes.go` wires `config.NewHandler(svcs.Config, …)`, and that's the fixed `ConfigService`, not this one). Left as a follow-up dead-code cleanup, not fixed here.

Config import used a stale full-row read-modify-write for every entity type it applies, so any field it doesn't own could be silently clobbered by a concurrent write landing between the list and the update. This scopes each import writer's SQL `UPDATE` to only the columns the import actually sets, closing the race instead of narrowing it.

## Important Changes

- Added `UpdateAgentInstanceConfigFields`, `UpdateSkillConfigFields`, `UpdateRoutineConfigFields`, and `UpdateProjectConfigFields` — column-scoped SQL writers in `internal/office/repository/sqlite` — replacing the full-row `Update*` calls in `applyAgents`/`applySkills`/`applyRoutines`/`applyProjects`.
- Audited column-set parity against the old full-row writers (including per-entity normalizations and the agent soft-delete filter) so no field the import previously wrote was dropped.

## Validation

- `go test ./internal/office/config/... ./internal/office/repository/sqlite/... -count=1` → both `ok`, including 4 new deterministic regression tests that drive `ConfigService.ApplyImport` itself: each seeds two rows, fires a same-table SQLite `AFTER UPDATE` trigger that mutates an unowned column on the second row strictly between the single `List*` call and that row's own `Update*`, then asserts the unowned column survived.
- Mutation-tested those 4 tests against the pre-fix `import.go` (restored from the merge-base): all 4 fail with the exact clobber symptom (e.g. `status survives concurrent write during import: got idle, want paused`); pass again once the fix is restored.
- `make -C apps/backend lint` → `0 issues.`
- `make -C apps/backend test` (full suite) → only 3 failures, all in `internal/system/storage/workspaces` (`open dependency workspace root: not a directory`), proven pre-existing by running the same tests against the merge-base in a separate scratch worktree — identical failure set there.
- `make typecheck`, `make lint` (backend + web), `make lint-format` → all green.
- No `apps/web/` files touched, so per the repo's E2E policy this change is exempt; `cd apps/web && pnpm run i18n:ratchet` confirms no UI source was added or modified.

## Possible Improvements

Low risk: change is backend-only, scoped to four existing SQL writers with column-set parity audited against their full-row predecessors; the unreachable duplicate importer noted above is a good candidate for a separate dead-code removal PR.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->