### PR TITLE
fix(build): make dev-prod-db honor env KANDEV_DATABASE_PATH / KANDEV_HOME_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,10 @@ dev: doctor
 #
 # $(if $(strip …),…) tests emptiness on the trimmed value but substitutes the
 # original, so a blank falls through to the next source while a real path keeps
-# the internal spaces $(strip …) would otherwise collapse. Values are forwarded
-# as-is; the launcher trims its own leading/trailing whitespace.
+# the internal spaces $(strip …) would otherwise collapse. Export the Make
+# variable so both environment and command-line assignments reach $(shell).
+# Trim only the outer padding before the database suffix is appended.
+export KANDEV_HOME_DIR
 KANDEV_PROD_HOME_DIR := $(if $(strip $(KANDEV_HOME_DIR)),$(shell printf '%s' "$$KANDEV_HOME_DIR" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//'),$(HOME)/.kandev)
 KANDEV_PROD_DB_PATH := $(if $(strip $(KANDEV_DATABASE_PATH)),$(KANDEV_DATABASE_PATH),$(KANDEV_PROD_HOME_DIR)/data/kandev.db)
 dev-prod-db: export KANDEV_DATABASE_PATH := $(KANDEV_PROD_DB_PATH)

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ dev: doctor
 # original, so a blank falls through to the next source while a real path keeps
 # the internal spaces $(strip …) would otherwise collapse. Values are forwarded
 # as-is; the launcher trims its own leading/trailing whitespace.
-KANDEV_PROD_HOME_DIR := $(if $(strip $(KANDEV_HOME_DIR)),$(KANDEV_HOME_DIR),$(HOME)/.kandev)
+KANDEV_PROD_HOME_DIR := $(if $(strip $(KANDEV_HOME_DIR)),$(shell printf '%s' "$$KANDEV_HOME_DIR" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$$//'),$(HOME)/.kandev)
 KANDEV_PROD_DB_PATH := $(if $(strip $(KANDEV_DATABASE_PATH)),$(KANDEV_DATABASE_PATH),$(KANDEV_PROD_HOME_DIR)/data/kandev.db)
 dev-prod-db: export KANDEV_DATABASE_PATH := $(KANDEV_PROD_DB_PATH)
 dev-prod-db:

--- a/Makefile
+++ b/Makefile
@@ -201,15 +201,28 @@ dev: doctor
 	@exec $(BACKEND_DIR)/bin/kandev-launcher$(EXE) dev $(DEV_FLAGS)
 
 .PHONY: dev-prod-db
-# `?=`, not `:=`: a makefile assignment outranks the environment in GNU Make, so
-# `:=` overwrote a relocated install's KANDEV_DATABASE_PATH and pointed dev mode
-# at the untouched $HOME/.kandev default while the launcher still reported that
-# it had backed up the production db. The fallback chain mirrors the launcher's
-# own resolveDatabasePath/resolveHomeDir (apps/backend/internal/launcher/constants.go),
-# which likewise trims a blank KANDEV_HOME_DIR before using it.
-dev-prod-db: export KANDEV_DATABASE_PATH ?= $(or $(strip $(KANDEV_HOME_DIR)),$(HOME)/.kandev)/data/kandev.db
+# Resolve the production db the way the launcher would
+# (resolveDatabasePath/resolveHomeDir in apps/backend/internal/launcher/constants.go):
+# an environment KANDEV_DATABASE_PATH wins, then KANDEV_HOME_DIR, then
+# $HOME/.kandev. A plain makefile assignment outranks the environment in GNU
+# Make, so the earlier `:=` of the $HOME default ignored a relocated install and
+# ran dev mode against the wrong db while the launcher still reported backing up
+# the production one.
+#
+# `?=` does not express this either: Make counts a variable the shell exported
+# blank as defined, so `?=` would forward that blank onward and the launcher —
+# which trims before testing for empty — would quietly fall back to the isolated
+# .kandev-dev db while this target announced production.
+#
+# $(if $(strip …),…) tests emptiness on the trimmed value but substitutes the
+# original, so a blank falls through to the next source while a real path keeps
+# the internal spaces $(strip …) would otherwise collapse. Values are forwarded
+# as-is; the launcher trims its own leading/trailing whitespace.
+KANDEV_PROD_HOME_DIR := $(if $(strip $(KANDEV_HOME_DIR)),$(KANDEV_HOME_DIR),$(HOME)/.kandev)
+KANDEV_PROD_DB_PATH := $(if $(strip $(KANDEV_DATABASE_PATH)),$(KANDEV_DATABASE_PATH),$(KANDEV_PROD_HOME_DIR)/data/kandev.db)
+dev-prod-db: export KANDEV_DATABASE_PATH := $(KANDEV_PROD_DB_PATH)
 dev-prod-db:
-	@echo "⚠  dev mode against PRODUCTION db at $(KANDEV_DATABASE_PATH)"
+	@echo "⚠  dev mode against PRODUCTION db at $(KANDEV_PROD_DB_PATH)"
 	@$(MAKE) dev
 
 .PHONY: dev-backend

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ help:
 	@echo "  dev              Run backend + web via the native Go launcher (auto ports)"
 	@echo "  dev PORT=38430 WEB_PORT=37430   PORT beats KANDEV_BACKEND_PORT/KANDEV_PORT, WEB_PORT beats KANDEV_WEB_PORT"
 	@echo "  dev DEV_ARGS='--verbose'        Pass extra flags through to the native launcher"
-	@echo "  dev-prod-db      Run dev mode against the production db at ~/.kandev"
+	@echo "  dev-prod-db      Run dev mode against the production db (KANDEV_DATABASE_PATH, else KANDEV_HOME_DIR, else ~/.kandev)"
 	@echo "  dev-backend      Run backend in development mode (port 38429)"
 	@echo "  dev-web          Run web app in development mode (port 37429)"
 	@echo "  desktop-dev      Run macOS Tauri app in dev mode with bundled runtime"
@@ -201,7 +201,13 @@ dev: doctor
 	@exec $(BACKEND_DIR)/bin/kandev-launcher$(EXE) dev $(DEV_FLAGS)
 
 .PHONY: dev-prod-db
-dev-prod-db: export KANDEV_DATABASE_PATH := $(HOME)/.kandev/data/kandev.db
+# `?=`, not `:=`: a makefile assignment outranks the environment in GNU Make, so
+# `:=` overwrote a relocated install's KANDEV_DATABASE_PATH and pointed dev mode
+# at the untouched $HOME/.kandev default while the launcher still reported that
+# it had backed up the production db. The fallback chain mirrors the launcher's
+# own resolveDatabasePath/resolveHomeDir (apps/backend/internal/launcher/constants.go),
+# which likewise trims a blank KANDEV_HOME_DIR before using it.
+dev-prod-db: export KANDEV_DATABASE_PATH ?= $(or $(strip $(KANDEV_HOME_DIR)),$(HOME)/.kandev)/data/kandev.db
 dev-prod-db:
 	@echo "⚠  dev mode against PRODUCTION db at $(KANDEV_DATABASE_PATH)"
 	@$(MAKE) dev
@@ -540,6 +546,7 @@ test-scripts:
 	@python3 .github/scripts/lint-action-pinning_test.py
 	@bash scripts/pr-state.test.sh
 	@bash scripts/run-quiet.test.sh
+	@bash scripts/dev-prod-db-path.test.sh
 	@bash scripts/opencode-code-review.test.sh
 	@python3 scripts/opencode-code-review.test.py
 	@python3 scripts/lint-harness-files.test.py

--- a/scripts/dev-prod-db-path.test.sh
+++ b/scripts/dev-prod-db-path.test.sh
@@ -93,6 +93,12 @@ expect_eq "blank KANDEV_DATABASE_PATH" 'D:\kandev-probe/data/kandev.db' \
 expect_eq "spaces inside KANDEV_HOME_DIR" 'D:\kandev  probe/data/kandev.db' \
 	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=D:\kandev  probe')"
 
+# 8. Leading and trailing padding around a nonblank home must be removed
+#    before the database suffix is appended. Otherwise the trailing spaces
+#    become internal path characters and survive the launcher's TrimSpace.
+expect_eq "padded KANDEV_HOME_DIR" 'D:\kandev-probe/data/kandev.db' \
+	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=  D:\kandev-probe   ')"
+
 if [ "$status" -eq 0 ]; then
 	echo "All dev-prod-db path checks passed (env db path > KANDEV_HOME_DIR > \$HOME/.kandev)."
 fi

--- a/scripts/dev-prod-db-path.test.sh
+++ b/scripts/dev-prod-db-path.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# dev-prod-db-path.test.sh — assert the root Makefile's `dev-prod-db` target
+# exports the same production database path the launcher would resolve on its
+# own: an environment-provided KANDEV_DATABASE_PATH wins, then KANDEV_HOME_DIR,
+# then $HOME/.kandev (resolveDatabasePath/resolveHomeDir in
+# apps/backend/internal/launcher/constants.go).
+#
+# The pre-fix target assigned with `:=`, which outranks the environment in GNU
+# Make. On an install whose KANDEV_HOME_DIR points outside $HOME, that silently
+# pointed dev mode at the untouched $HOME/.kandev default while the launcher
+# still printed "backed up production db", so the warning named a database the
+# run never opened.
+#
+# Each case is a dry run. `-n` alone is not enough: make executes any recipe
+# line mentioning $(MAKE) even under -n, so `@$(MAKE) dev` would recurse into a
+# real build. Overriding MAKE swaps that line for a probe that prints the
+# exported value and swallows the leftover `dev` argument on a `:` builtin. That
+# neutralises the recursion and asserts the variable as the child process
+# actually receives it rather than as the sibling echo renders it. `:` is used
+# rather than a trailing `#` so the value carries nothing a make implementation
+# might re-read as a comment.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROBE_MAKE='printenv KANDEV_DATABASE_PATH || echo UNSET; :'
+status=0
+
+# resolve <env-assignment>... — the KANDEV_DATABASE_PATH dev-prod-db exports.
+resolve() {
+	env "$@" make -C "$ROOT_DIR" --no-print-directory MAKE="$PROBE_MAKE" \
+		-n dev-prod-db 2>/dev/null | tail -n 1
+}
+
+expect_eq() {
+	local label=$1 want=$2 got=$3
+	if [ "$got" = "$want" ]; then
+		printf 'ok    %-21s %s\n' "$label" "$got"
+	else
+		printf 'FAIL  %-21s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+		status=1
+	fi
+}
+
+expect_suffix() {
+	local label=$1 want=$2 got=$3
+	# $HOME is asserted by suffix: Git Bash/MSYS rewrites HOME on its way to
+	# native make, so the absolute prefix is not reproducible across shells.
+	case "$got" in
+	UNSET | "") ;;
+	*"$want")
+		printf 'ok    %-21s %s\n' "$label" "$got"
+		return
+		;;
+	esac
+	printf 'FAIL  %-21s\n        want suffix: %s\n        got:         %s\n' \
+		"$label" "$want" "$got"
+	status=1
+}
+
+# 1. Clean environment — the historical default under $HOME.
+expect_suffix "default home" "/.kandev/data/kandev.db" \
+	"$(resolve -u KANDEV_DATABASE_PATH -u KANDEV_HOME_DIR)"
+
+# 2. Relocated home, no explicit db path — derived from KANDEV_HOME_DIR. The
+#    backslash value mirrors the Windows install that surfaced the bug; make
+#    joins with a forward slash, which Go accepts alongside backslashes.
+expect_eq "KANDEV_HOME_DIR" 'D:\kandev-probe/data/kandev.db' \
+	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=D:\kandev-probe')"
+
+# 3. Explicit db path — forwarded unchanged, and it outranks KANDEV_HOME_DIR.
+expect_eq "KANDEV_DATABASE_PATH" 'D:\kandev-probe\data\custom.db' \
+	"$(resolve 'KANDEV_DATABASE_PATH=D:\kandev-probe\data\custom.db' 'KANDEV_HOME_DIR=D:\other')"
+
+# 4. A whitespace-only KANDEV_HOME_DIR is not a relocated install. resolveHomeDir
+#    trims before testing for empty, so the Makefile must fall back to $HOME
+#    rather than derive "   /data/kandev.db" from it.
+expect_suffix "blank KANDEV_HOME_DIR" "/.kandev/data/kandev.db" \
+	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=   ')"
+
+if [ "$status" -eq 0 ]; then
+	echo "All dev-prod-db path checks passed (env db path > KANDEV_HOME_DIR > \$HOME/.kandev)."
+fi
+exit "$status"

--- a/scripts/dev-prod-db-path.test.sh
+++ b/scripts/dev-prod-db-path.test.sh
@@ -31,6 +31,11 @@ resolve() {
 		-n dev-prod-db 2>/dev/null | tail -n 1
 }
 
+resolve_make_home() {
+	env -u KANDEV_DATABASE_PATH make -C "$ROOT_DIR" --no-print-directory MAKE="$PROBE_MAKE" \
+		-n dev-prod-db "KANDEV_HOME_DIR=$1" 2>/dev/null | tail -n 1
+}
+
 expect_eq() {
 	local label=$1 want=$2 got=$3
 	if [ "$got" = "$want" ]; then
@@ -98,6 +103,11 @@ expect_eq "spaces inside KANDEV_HOME_DIR" 'D:\kandev  probe/data/kandev.db' \
 #    become internal path characters and survive the launcher's TrimSpace.
 expect_eq "padded KANDEV_HOME_DIR" 'D:\kandev-probe/data/kandev.db' \
 	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=  D:\kandev-probe   ')"
+
+# 9. A Make command-line assignment must use the same trimmed home path. The
+#    explicit environment database is cleared so the home remains the source.
+expect_eq "Make variable home" 'D:\kandev-probe/data/kandev.db' \
+	"$(resolve_make_home 'D:\kandev-probe   ')"
 
 if [ "$status" -eq 0 ]; then
 	echo "All dev-prod-db path checks passed (env db path > KANDEV_HOME_DIR > \$HOME/.kandev)."

--- a/scripts/dev-prod-db-path.test.sh
+++ b/scripts/dev-prod-db-path.test.sh
@@ -34,9 +34,9 @@ resolve() {
 expect_eq() {
 	local label=$1 want=$2 got=$3
 	if [ "$got" = "$want" ]; then
-		printf 'ok    %-21s %s\n' "$label" "$got"
+		printf 'ok    %-29s %s\n' "$label" "$got"
 	else
-		printf 'FAIL  %-21s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+		printf 'FAIL  %-29s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
 		status=1
 	fi
 }
@@ -48,11 +48,11 @@ expect_suffix() {
 	case "$got" in
 	UNSET | "") ;;
 	*"$want")
-		printf 'ok    %-21s %s\n' "$label" "$got"
+		printf 'ok    %-29s %s\n' "$label" "$got"
 		return
 		;;
 	esac
-	printf 'FAIL  %-21s\n        want suffix: %s\n        got:         %s\n' \
+	printf 'FAIL  %-29s\n        want suffix: %s\n        got:         %s\n' \
 		"$label" "$want" "$got"
 	status=1
 }
@@ -76,6 +76,22 @@ expect_eq "KANDEV_DATABASE_PATH" 'D:\kandev-probe\data\custom.db' \
 #    rather than derive "   /data/kandev.db" from it.
 expect_suffix "blank KANDEV_HOME_DIR" "/.kandev/data/kandev.db" \
 	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=   ')"
+
+# 5. An exported-but-empty KANDEV_DATABASE_PATH must not be forwarded. Make
+#    counts it as defined, so `?=` would keep the blank; the launcher trims it,
+#    finds nothing, and drops to the isolated .kandev-dev db — dev-prod-db would
+#    then announce production while opening the dev database.
+expect_eq "empty KANDEV_DATABASE_PATH" 'D:\kandev-probe/data/kandev.db' \
+	"$(resolve 'KANDEV_DATABASE_PATH=' 'KANDEV_HOME_DIR=D:\kandev-probe')"
+
+# 6. Same for a whitespace-only override, which the launcher also trims away.
+expect_eq "blank KANDEV_DATABASE_PATH" 'D:\kandev-probe/data/kandev.db' \
+	"$(resolve 'KANDEV_DATABASE_PATH=   ' 'KANDEV_HOME_DIR=D:\kandev-probe')"
+
+# 7. Internal whitespace is part of the path. $(strip …) collapses runs of
+#    spaces, so it may gate the emptiness test but must not supply the value.
+expect_eq "spaces inside KANDEV_HOME_DIR" 'D:\kandev  probe/data/kandev.db' \
+	"$(resolve -u KANDEV_DATABASE_PATH 'KANDEV_HOME_DIR=D:\kandev  probe')"
 
 if [ "$status" -eq 0 ]; then
 	echo "All dev-prod-db path checks passed (env db path > KANDEV_HOME_DIR > \$HOME/.kandev)."


### PR DESCRIPTION
> Task: **make dev-prod-db honor env KANDEV_DATABASE_PATH / KANDEV_HOME_DIR**

## Problem

`dev-prod-db` assigned `KANDEV_DATABASE_PATH` with `:=`, and a makefile assignment outranks the environment in GNU Make (env is lower precedence unless `make -e`). On an install whose data root is relocated via `KANDEV_HOME_DIR`, the target overwrote the inherited path and ran dev mode against the untouched `$HOME/.kandev` default — while the launcher still printed `backed up production db`, so the warning named a database the run never opened.

```make
dev-prod-db: export KANDEV_DATABASE_PATH := $(HOME)/.kandev/data/kandev.db
```

## Fix

```make
dev-prod-db: export KANDEV_DATABASE_PATH ?= $(or $(strip $(KANDEV_HOME_DIR)),$(HOME)/.kandev)/data/kandev.db
```

`?=` skips assignment when the variable already has an origin — including `environment` — so an inherited value survives. The chain mirrors the launcher's own `resolveDatabasePath`/`resolveHomeDir` (`apps/backend/internal/launcher/constants.go`), including the `$(strip …)` that matches its `strings.TrimSpace` on `KANDEV_HOME_DIR`:

1. env `KANDEV_DATABASE_PATH` — used unchanged
2. else `$(KANDEV_HOME_DIR)/data/kandev.db`
3. else `$(HOME)/.kandev/data/kandev.db` (unchanged default)

Help text updated to match.

## Test

`scripts/dev-prod-db-path.test.sh`, registered in the `test-scripts` target. Covers all three levels plus a whitespace-only `KANDEV_HOME_DIR`. Verified red→green: 2 failures against the old Makefile, 0 after.

Two details worth reviewing:

- It asserts the value the **child process** receives, not the sibling `echo`, so a target-specific `export` that renders correctly but exports wrongly would still fail.
- `-n` alone is insufficient — make executes any recipe line mentioning `$(MAKE)` even in dry-run mode, so `@$(MAKE) dev` would recurse into a real build. The test overrides `MAKE` with a probe that both neutralises the recursion and prints the exported variable. Runs in ~0.3s with no build.

## Verification

Dry runs:

| env | resolved |
|---|---|
| clean | `$HOME/.kandev/data/kandev.db` |
| `KANDEV_HOME_DIR=D:/x` | `D:/x/data/kandev.db` |
| `KANDEV_DATABASE_PATH=D:/y/kandev.db` | `D:/y/kandev.db` |

Also exercised end-to-end against throwaway home directories: the launcher's `[kandev] db:` line and `GET /api/v1/system/database` both reported the expected path for the `KANDEV_HOME_DIR` branch and for an explicit `KANDEV_DATABASE_PATH` that deliberately differed from the derivable one.

Gates: `check-make-shells`, harness lint, architecture lint, em-dash guard, and every `test-scripts` step that passes on `main`.

## Follow-up (not in this PR)

`backupProductionDb` (`apps/backend/internal/launcher/backup.go:59`) always writes to `<os.UserHomeDir()>/.kandev/data/backups/`, ignoring `KANDEV_HOME_DIR`. With this fix a relocated install now correctly targets its real database, but the safety snapshot still lands under `$HOME` — a different volume in the relocated case. The 5-deep retention also prunes across unrelated runs, so snapshots from one target can evict another's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->