### PR TITLE
fix(orchestrator): preserve FIFO across supersede→requeue

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -172,6 +172,14 @@ func (s *Service) publishTaskQueueStatusEvent(ctx context.Context, taskID, sessi
 // requeueMessage re-enqueues a message that could not be delivered, publishing a queue status event on success.
 // Preserves the original Metadata (e.g. sender_task_id from message_task_kandev)
 // so attribution survives transient failures + retries.
+//
+// User messages go through RequeueAtHead (FIFO-preserving) so a
+// supersede→requeue cycle does not strand the original entry behind any
+// new arrival — the busy-session starvation bug fix. Lifecycle messages
+// keep their tail-requeue semantics (requeueLifecycleMessage) because
+// they are gated by a generation token that already gives them
+// priority; mixing the two paths would risk merging durable
+// reservations with transient user-state.
 func (s *Service) requeueMessage(ctx context.Context, queuedMsg *messagequeue.QueuedMessage, queuedBy string) {
 	coalesceKey := messageCoalesceKey(queuedMsg)
 	if queuedMsg.QueuedBy != "" && coalesceKey != "" {
@@ -181,26 +189,20 @@ func (s *Service) requeueMessage(ctx context.Context, queuedMsg *messagequeue.Qu
 		s.requeueLifecycleMessage(ctx, queuedMsg, queuedBy, coalesceKey)
 		return
 	}
-	requeuedMsg, replaced, queueErr := s.messageQueue.RequeueMessage(
-		ctx, queuedMsg, queuedBy, coalesceKey,
-	)
-	if queueErr != nil {
-		s.logger.Error("failed to requeue message",
+	if err := s.messageQueue.RequeueAtHead(ctx, queuedMsg); err != nil {
+		s.logger.Error("failed to requeue message at head",
 			zap.String("session_id", queuedMsg.SessionID),
 			zap.String("task_id", queuedMsg.TaskID),
 			zap.String("queue_id", queuedMsg.ID),
 			zap.String("queued_by", queuedBy),
-			zap.Error(queueErr))
+			zap.Error(err))
 		return
 	}
-	s.logger.Info("message requeued",
+	s.logger.Info("message requeued at head (FIFO preserved)",
 		zap.String("session_id", queuedMsg.SessionID),
 		zap.String("task_id", queuedMsg.TaskID),
-		zap.String("old_queue_id", queuedMsg.ID),
-		zap.String("new_queue_id", requeuedMsg.ID),
-		zap.String("queued_by", queuedBy),
-		zap.String("coalesce_key", coalesceKey),
-		zap.Bool("replaced", replaced))
+		zap.String("queue_id", queuedMsg.ID),
+		zap.String("queued_by", queuedBy))
 	s.publishQueueStatusEvent(ctx, queuedMsg.SessionID)
 }
 

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -31,6 +31,27 @@ type Repository interface {
 	// SQLite implementations make that check and queue mutation one transaction.
 	InsertOrReplaceLifecycleByCoalesceKey(ctx context.Context, msg *QueuedMessage, coalesceKey string, maxPerSession int, allowInsert bool) (*QueuedMessage, bool, error)
 
+	// RequeuePreservingFIFO re-enqueues an entry, preserving both FIFO order
+	// across the supersede→requeue cycle AND coalesce-replace semantics on
+	// the original retry. Used by Service.requeueMessage when a queued
+	// dispatch was superseded by a newer dispatch before it could be
+	// claimed — without this hook the requeue landed at MAX+1 (tail) and a
+	// busy session could starve the original message indefinitely.
+	//
+	// Decision under the lock:
+	//   - existing entry with same (session_id, queued_by, coalesce_key)
+	//     → replace in place (preserves position; coalesce semantics
+	//       expected by lifecycle / CI-feedback retries)
+	//   - empty queue                → msg.Position = 1, msg.ID assigned
+	//   - non-empty queue, no match  → msg.Position = MIN(position) - 1
+	//
+	// The MIN-1 rule is bounded: even under a runaway supersede chain the
+	// position counter just walks negative, never reaches zero, and is
+	// reset when the queue is fully drained (DeleteAllBySession clears
+	// nextPosition). Repeated requeue of the same entry across cycles still
+	// beats any newly arriving entry, because new entries use MAX+1.
+	RequeuePreservingFIFO(ctx context.Context, msg *QueuedMessage) error
+
 	// LifecycleGeneration returns the current archive/delete generation for a
 	// task. Lifecycle insertion verifies this generation atomically.
 	LifecycleGeneration(ctx context.Context, taskID string) (int64, error)

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -43,13 +43,11 @@ type Repository interface {
 	//     → replace in place (preserves position; coalesce semantics
 	//       expected by lifecycle / CI-feedback retries)
 	//   - empty queue                → msg.Position = 1, msg.ID assigned
-	//   - non-empty queue, no match  → msg.Position = MIN(position) - 1
+	//   - non-empty queue, no match  → insert before the current head
 	//
-	// The MIN-1 rule is bounded: even under a runaway supersede chain the
-	// position counter just walks negative, never reaches zero, and is
-	// reset when the queue is fully drained (DeleteAllBySession clears
-	// nextPosition). Repeated requeue of the same entry across cycles still
-	// beats any newly arriving entry, because new entries use MAX+1.
+	// If the head position is already 1, implementations shift the existing
+	// positions up before inserting. Queue positions stay positive so session
+	// transfer and later queue mutations keep their ordering invariants.
 	RequeuePreservingFIFO(ctx context.Context, msg *QueuedMessage) error
 
 	// LifecycleGeneration returns the current archive/delete generation for a

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -141,6 +141,100 @@ func (r *memoryRepository) insertLocked(msg *QueuedMessage, maxPerSession int) e
 	return nil
 }
 
+// RequeuePreservingFIFO inserts the entry at a position strictly lower than
+// the current session head, so a superseded entry beats any new entry that
+// arrives after the supersede was issued. Without this hook, the requeue
+// landed at MAX+1 and a busy session starved the original message
+// indefinitely — every turn-end drained the head, the superseded entry
+// fell to the tail, and the next incoming message outranked it again.
+//
+// Decision under r.mu (caller must already hold it):
+//   - existing entry with same (session_id, queued_by, coalesce_key)
+//     → replace in place; preserve the existing entry's position and ID
+//   - empty queue                → position = 1, fresh ID
+//   - non-empty queue, no match  → position = MIN(head.position) - 1
+//
+// Walk direction is bounded by session lifecycle: a fully drained queue
+// (DeleteAllBySession) clears nextPosition, so repeated requeue of the
+// same entry across cycles just walks the counter negative — never reaches
+// zero, never overlaps new MAX+1 inserts. The monotonic-ascending invariant
+// tested in repository_sqlite_test.go is preserved: MIN-1 < every existing
+// position, and any future MAX+1 stays above.
+func (r *memoryRepository) RequeuePreservingFIFO(_ context.Context, msg *QueuedMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	list := r.entries[msg.SessionID]
+	coalesceKey := metadataString(msg.Metadata, MetadataCoalesceKey)
+	// Coalesce-replace: only when caller supplied a coalesce key. This
+	// matches the original RequeueMessage's branching (coalesceKey != ""
+	// takes the coalesce-replace path; empty coalesceKey takes the
+	// tail-append path). A bare requeue of a message with no coalesce
+	// key must NOT collapse onto an unrelated same-sender entry.
+	if coalesceKey != "" {
+		for _, existing := range list {
+			if existing.QueuedBy != msg.QueuedBy {
+				continue
+			}
+			if metadataString(existing.Metadata, MetadataCoalesceKey) != coalesceKey {
+				continue
+			}
+			// Coalesce hit: replace in place. The retry keeps the existing
+			// entry's position, which by construction is the most head-of-
+			// queue position for this coalesce key — supersede→requeue of
+			// the same content stays FIFO at the same slot.
+			existing.TaskID = msg.TaskID
+			existing.Content = msg.Content
+			existing.Model = msg.Model
+			existing.PlanMode = msg.PlanMode
+			existing.Attachments = msg.Attachments
+			existing.Metadata = msg.Metadata
+			if msg.QueuedAt.IsZero() {
+				existing.QueuedAt = time.Now().UTC()
+			} else {
+				existing.QueuedAt = msg.QueuedAt
+			}
+			msg.ID = existing.ID
+			msg.Position = existing.Position
+			return nil
+		}
+	}
+	if len(list) == 0 {
+		if msg.ID == "" {
+			msg.ID = uuid.New().String()
+		}
+		if msg.QueuedAt.IsZero() {
+			msg.QueuedAt = time.Now().UTC()
+		}
+		r.nextPosition[msg.SessionID] = 1
+		msg.Position = 1
+		clone := *msg
+		r.entries[msg.SessionID] = append(r.entries[msg.SessionID], &clone)
+		return nil
+	}
+	minPos := list[0].Position
+	for _, e := range list[1:] {
+		if e.Position < minPos {
+			minPos = e.Position
+		}
+	}
+	if msg.ID == "" {
+		msg.ID = uuid.New().String()
+	}
+	if msg.QueuedAt.IsZero() {
+		msg.QueuedAt = time.Now().UTC()
+	}
+	msg.Position = minPos - 1
+	clone := *msg
+	newList := make([]*QueuedMessage, 0, len(list)+1)
+	newList = append(newList, &clone)
+	newList = append(newList, list...)
+	if msg.Position > r.nextPosition[msg.SessionID] {
+		r.nextPosition[msg.SessionID] = msg.Position
+	}
+	r.entries[msg.SessionID] = newList
+	return nil
+}
+
 // AppendOrInsertTail must hold the lock for the entire check-then-insert path
 // so two concurrent same-sender callers can't both observe "no matching tail"
 // and race to insert separate entries (which would violate the

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -152,14 +152,11 @@ func (r *memoryRepository) insertLocked(msg *QueuedMessage, maxPerSession int) e
 //   - existing entry with same (session_id, queued_by, coalesce_key)
 //     → replace in place; preserve the existing entry's position and ID
 //   - empty queue                → position = 1, fresh ID
-//   - non-empty queue, no match  → position = MIN(head.position) - 1
+//   - non-empty queue, no match  → position before the current head
 //
-// Walk direction is bounded by session lifecycle: a fully drained queue
-// (DeleteAllBySession) clears nextPosition, so repeated requeue of the
-// same entry across cycles just walks the counter negative — never reaches
-// zero, never overlaps new MAX+1 inserts. The monotonic-ascending invariant
-// tested in repository_sqlite_test.go is preserved: MIN-1 < every existing
-// position, and any future MAX+1 stays above.
+// When MIN-1 is not positive, existing positions are shifted up before the
+// insert. This keeps positions positive for TransferSession and future queue
+// mutations while preserving the current order.
 func (r *memoryRepository) RequeuePreservingFIFO(_ context.Context, msg *QueuedMessage) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -198,41 +195,45 @@ func (r *memoryRepository) RequeuePreservingFIFO(_ context.Context, msg *QueuedM
 			return nil
 		}
 	}
-	if len(list) == 0 {
-		if msg.ID == "" {
-			msg.ID = uuid.New().String()
-		}
-		if msg.QueuedAt.IsZero() {
-			msg.QueuedAt = time.Now().UTC()
-		}
-		r.nextPosition[msg.SessionID] = 1
-		msg.Position = 1
-		clone := *msg
-		r.entries[msg.SessionID] = append(r.entries[msg.SessionID], &clone)
-		return nil
-	}
-	minPos := list[0].Position
-	for _, e := range list[1:] {
-		if e.Position < minPos {
-			minPos = e.Position
-		}
-	}
 	if msg.ID == "" {
 		msg.ID = uuid.New().String()
 	}
 	if msg.QueuedAt.IsZero() {
 		msg.QueuedAt = time.Now().UTC()
 	}
-	msg.Position = minPos - 1
+	msg.Position = r.nextRequeuePositionLocked(msg.SessionID, list)
 	clone := *msg
 	newList := make([]*QueuedMessage, 0, len(list)+1)
 	newList = append(newList, &clone)
 	newList = append(newList, list...)
-	if msg.Position > r.nextPosition[msg.SessionID] {
-		r.nextPosition[msg.SessionID] = msg.Position
-	}
 	r.entries[msg.SessionID] = newList
 	return nil
+}
+
+func (r *memoryRepository) nextRequeuePositionLocked(sessionID string, list []*QueuedMessage) int64 {
+	if len(list) == 0 {
+		r.nextPosition[sessionID] = 1
+		return 1
+	}
+	minPos := list[0].Position
+	for _, entry := range list[1:] {
+		if entry.Position < minPos {
+			minPos = entry.Position
+		}
+	}
+	position := minPos - 1
+	if position <= 0 {
+		shift := 1 - position
+		for _, entry := range list {
+			entry.Position += shift
+		}
+		position = 1
+		r.nextPosition[sessionID] += shift
+	}
+	if position > r.nextPosition[sessionID] {
+		r.nextPosition[sessionID] = position
+	}
+	return position
 }
 
 // AppendOrInsertTail must hold the lock for the entire check-then-insert path

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -269,7 +269,7 @@ func (r *sqliteRepository) Insert(ctx context.Context, msg *QueuedMessage, maxPe
 // claimed — without this hook the requeue landed at MAX+1 (tail) and a
 // busy session could starve the original message indefinitely.
 //
-// Decision under the session tx lock:
+// Decision under the session tx lock (delegated to helpers):
 //   - existing entry with same (session_id, queued_by, coalesce_key)
 //     → UPDATE in place (preserves position; coalesce semantics
 //     expected by lifecycle / CI-feedback retries)
@@ -296,71 +296,90 @@ func (r *sqliteRepository) RequeuePreservingFIFO(ctx context.Context, msg *Queue
 		return err
 	}
 
-	coalesceKey := metadataString(msg.Metadata, MetadataCoalesceKey)
-	var existingID string
-	var existingPosition int64
 	// Coalesce-replace: only when caller supplied a coalesce key.
 	// Matches the original RequeueMessage's branching (coalesceKey !=
 	// "" takes the coalesce-replace path; empty coalesceKey takes the
 	// tail-append path). A bare requeue with no coalesce key must NOT
 	// collapse onto an unrelated same-sender entry.
+	coalesceKey := metadataString(msg.Metadata, MetadataCoalesceKey)
+	var existingID string
 	if coalesceKey != "" {
-		err = tx.GetContext(ctx, &existingID, r.db.Rebind(`
-			SELECT id FROM queued_messages
-			WHERE session_id = ? AND queued_by = ? AND json_extract(metadata_json, '$.coalesce_key') = ?
-			LIMIT 1
-		`), msg.SessionID, msg.QueuedBy, coalesceKey)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("lookup coalesce target: %w", err)
+		existingID, err = r.lookupCoalesceTargetTx(ctx, tx, msg, coalesceKey)
+		if err != nil {
+			return err
 		}
 	}
-
 	if existingID != "" {
-		// Coalesce hit: replace in place. The retry keeps the existing
-		// entry's position, which by construction is the most head-of-
-		// queue position for this coalesce key — supersede→requeue of
-		// the same content stays FIFO at the same slot.
-		attachmentsJSON, err := marshalAttachments(msg.Attachments)
-		if err != nil {
-			return err
-		}
-		metadataJSON, err := marshalMetadata(msg.Metadata)
-		if err != nil {
-			return err
-		}
-		if msg.QueuedAt.IsZero() {
-			msg.QueuedAt = time.Now().UTC()
-		}
-		res, err := tx.ExecContext(ctx, r.db.Rebind(`
-			UPDATE queued_messages
-			SET task_id = ?, content = ?, model = ?, plan_mode = ?, attachments_json = ?, metadata_json = ?, queued_at = ?
-			WHERE id = ?
-		`),
-			msg.TaskID, msg.Content, msg.Model, boolToInt(msg.PlanMode),
-			attachmentsJSON, metadataJSON, msg.QueuedAt, existingID,
-		)
-		if err != nil {
-			return fmt.Errorf("update coalesced entry: %w", err)
-		}
-		rows, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("rows affected: %w", err)
-		}
-		if rows == 0 {
-			return fmt.Errorf("coalesce hit vanished: %s", existingID)
-		}
-		// Caller wants the canonical position back on the msg so it can
-		// log it; re-read so we return the actual stored value.
-		if err := tx.GetContext(ctx, &existingPosition,
-			r.db.Rebind(`SELECT position FROM queued_messages WHERE id = ?`), existingID,
-		); err != nil {
-			return fmt.Errorf("re-read coalesced position: %w", err)
-		}
-		msg.ID = existingID
-		msg.Position = existingPosition
-		return tx.Commit()
+		return r.applyCoalesceReplaceTx(ctx, tx, msg, existingID)
 	}
+	return r.applyHeadInsertTx(ctx, tx, msg)
+}
 
+// lookupCoalesceTargetTx scans for an existing entry with the same
+// (session_id, queued_by, coalesce_key) and returns its id. Returns
+// ("", nil) when no match exists. Caller owns the tx.
+func (r *sqliteRepository) lookupCoalesceTargetTx(ctx context.Context, tx *sqlx.Tx, msg *QueuedMessage, coalesceKey string) (string, error) {
+	var id string
+	err := tx.GetContext(ctx, &id, r.db.Rebind(`
+		SELECT id FROM queued_messages
+		WHERE session_id = ? AND queued_by = ? AND json_extract(metadata_json, '$.coalesce_key') = ?
+		LIMIT 1
+	`), msg.SessionID, msg.QueuedBy, coalesceKey)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("lookup coalesce target: %w", err)
+	}
+	return id, nil
+}
+
+// applyCoalesceReplaceTx UPDATEs the existing entry in place,
+// preserving its position and ID. The retry stays at the most head-of-
+// queue position for this coalesce key — supersede→requeue of the same
+// content keeps FIFO at the same slot. Caller owns the tx.
+func (r *sqliteRepository) applyCoalesceReplaceTx(ctx context.Context, tx *sqlx.Tx, msg *QueuedMessage, existingID string) error {
+	attachmentsJSON, err := marshalAttachments(msg.Attachments)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalMetadata(msg.Metadata)
+	if err != nil {
+		return err
+	}
+	if msg.QueuedAt.IsZero() {
+		msg.QueuedAt = time.Now().UTC()
+	}
+	res, err := tx.ExecContext(ctx, r.db.Rebind(`
+		UPDATE queued_messages
+		SET task_id = ?, content = ?, model = ?, plan_mode = ?, attachments_json = ?, metadata_json = ?, queued_at = ?
+		WHERE id = ?
+	`),
+		msg.TaskID, msg.Content, msg.Model, boolToInt(msg.PlanMode),
+		attachmentsJSON, metadataJSON, msg.QueuedAt, existingID,
+	)
+	if err != nil {
+		return fmt.Errorf("update coalesced entry: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("coalesce hit vanished: %s", existingID)
+	}
+	// Re-read the canonical position so the caller can log it.
+	var existingPosition int64
+	if err := tx.GetContext(ctx, &existingPosition,
+		r.db.Rebind(`SELECT position FROM queued_messages WHERE id = ?`), existingID,
+	); err != nil {
+		return fmt.Errorf("re-read coalesced position: %w", err)
+	}
+	msg.ID = existingID
+	msg.Position = existingPosition
+	return tx.Commit()
+}
+
+// applyHeadInsertTx INSERTs the entry at position MIN(head) - 1 (or 1
+// for an empty queue). Caller owns the tx.
+func (r *sqliteRepository) applyHeadInsertTx(ctx context.Context, tx *sqlx.Tx, msg *QueuedMessage) error {
 	var minPos sql.NullInt64
 	if err := tx.GetContext(ctx, &minPos,
 		r.db.Rebind(`SELECT MIN(position) FROM queued_messages WHERE session_id = ?`),
@@ -388,7 +407,6 @@ func (r *sqliteRepository) RequeuePreservingFIFO(ctx context.Context, msg *Queue
 	if err != nil {
 		return err
 	}
-
 	if _, err := tx.ExecContext(ctx, r.db.Rebind(`
 		INSERT INTO queued_messages
 			(id, session_id, task_id, position, content, model, plan_mode, attachments_json, metadata_json, queued_at, queued_by)

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -274,15 +274,11 @@ func (r *sqliteRepository) Insert(ctx context.Context, msg *QueuedMessage, maxPe
 //     → UPDATE in place (preserves position; coalesce semantics
 //     expected by lifecycle / CI-feedback retries)
 //   - empty queue                → INSERT at position 1
-//   - non-empty queue, no match  → INSERT at position MIN(position) - 1
+//   - non-empty queue, no match  → INSERT before the current head
 //
-// Walk direction is bounded by session lifecycle: a fully drained queue
-// clears the rows but the position sequence is reset on the next Insert
-// (which re-derives from MAX). Repeated requeue of the same entry across
-// cycles just walks the counter negative — never reaches zero, never
-// overlaps new MAX+1 inserts. The monotonic-ascending invariant tested
-// in repository_sqlite_test.go is preserved: MIN-1 < every existing
-// position, and any future MAX+1 stays above.
+// When MIN-1 is not positive, existing positions are shifted up before the
+// insert. This keeps positions positive for TransferSession and future queue
+// mutations while preserving the current order.
 func (r *sqliteRepository) RequeuePreservingFIFO(ctx context.Context, msg *QueuedMessage) error {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -304,31 +300,18 @@ func (r *sqliteRepository) RequeuePreservingFIFO(ctx context.Context, msg *Queue
 	coalesceKey := metadataString(msg.Metadata, MetadataCoalesceKey)
 	var existingID string
 	if coalesceKey != "" {
-		existingID, err = r.lookupCoalesceTargetTx(ctx, tx, msg, coalesceKey)
-		if err != nil {
-			return err
+		existing, findErr := r.findCoalesced(ctx, tx, msg.SessionID, msg.QueuedBy, coalesceKey)
+		if findErr != nil {
+			return findErr
+		}
+		if existing != nil {
+			existingID = existing.ID
 		}
 	}
 	if existingID != "" {
 		return r.applyCoalesceReplaceTx(ctx, tx, msg, existingID)
 	}
 	return r.applyHeadInsertTx(ctx, tx, msg)
-}
-
-// lookupCoalesceTargetTx scans for an existing entry with the same
-// (session_id, queued_by, coalesce_key) and returns its id. Returns
-// ("", nil) when no match exists. Caller owns the tx.
-func (r *sqliteRepository) lookupCoalesceTargetTx(ctx context.Context, tx *sqlx.Tx, msg *QueuedMessage, coalesceKey string) (string, error) {
-	var id string
-	err := tx.GetContext(ctx, &id, r.db.Rebind(`
-		SELECT id FROM queued_messages
-		WHERE session_id = ? AND queued_by = ? AND json_extract(metadata_json, '$.coalesce_key') = ?
-		LIMIT 1
-	`), msg.SessionID, msg.QueuedBy, coalesceKey)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("lookup coalesce target: %w", err)
-	}
-	return id, nil
 }
 
 // applyCoalesceReplaceTx UPDATEs the existing entry in place,
@@ -377,8 +360,8 @@ func (r *sqliteRepository) applyCoalesceReplaceTx(ctx context.Context, tx *sqlx.
 	return tx.Commit()
 }
 
-// applyHeadInsertTx INSERTs the entry at position MIN(head) - 1 (or 1
-// for an empty queue). Caller owns the tx.
+// applyHeadInsertTx inserts the entry before the current head (or at position
+// 1 for an empty queue). Caller owns the tx.
 func (r *sqliteRepository) applyHeadInsertTx(ctx context.Context, tx *sqlx.Tx, msg *QueuedMessage) error {
 	var minPos sql.NullInt64
 	if err := tx.GetContext(ctx, &minPos,
@@ -389,6 +372,17 @@ func (r *sqliteRepository) applyHeadInsertTx(ctx context.Context, tx *sqlx.Tx, m
 	}
 	if minPos.Valid {
 		msg.Position = minPos.Int64 - 1
+		if msg.Position <= 0 {
+			shift := 1 - msg.Position
+			if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+				UPDATE queued_messages
+				SET position = position + ?
+				WHERE session_id = ?
+			`), shift, msg.SessionID); err != nil {
+				return fmt.Errorf("shift queued positions for requeue-fifo: %w", err)
+			}
+			msg.Position = 1
+		}
 	} else {
 		msg.Position = 1
 	}

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -262,6 +262,146 @@ func (r *sqliteRepository) Insert(ctx context.Context, msg *QueuedMessage, maxPe
 	return tx.Commit()
 }
 
+// RequeuePreservingFIFO re-enqueues an entry, preserving both FIFO order
+// across the supersede→requeue cycle AND coalesce-replace semantics on
+// the original retry. Used by Service.requeueMessage when a queued
+// dispatch was superseded by a newer dispatch before it could be
+// claimed — without this hook the requeue landed at MAX+1 (tail) and a
+// busy session could starve the original message indefinitely.
+//
+// Decision under the session tx lock:
+//   - existing entry with same (session_id, queued_by, coalesce_key)
+//     → UPDATE in place (preserves position; coalesce semantics
+//     expected by lifecycle / CI-feedback retries)
+//   - empty queue                → INSERT at position 1
+//   - non-empty queue, no match  → INSERT at position MIN(position) - 1
+//
+// Walk direction is bounded by session lifecycle: a fully drained queue
+// clears the rows but the position sequence is reset on the next Insert
+// (which re-derives from MAX). Repeated requeue of the same entry across
+// cycles just walks the counter negative — never reaches zero, never
+// overlaps new MAX+1 inserts. The monotonic-ascending invariant tested
+// in repository_sqlite_test.go is preserved: MIN-1 < every existing
+// position, and any future MAX+1 stays above.
+func (r *sqliteRepository) RequeuePreservingFIFO(ctx context.Context, msg *QueuedMessage) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin requeue-fifo tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := r.guardActiveTaskTx(ctx, tx, msg.TaskID); err != nil {
+		return err
+	}
+	if err := r.lockSessionTx(ctx, tx, msg.SessionID); err != nil {
+		return err
+	}
+
+	coalesceKey := metadataString(msg.Metadata, MetadataCoalesceKey)
+	var existingID string
+	var existingPosition int64
+	// Coalesce-replace: only when caller supplied a coalesce key.
+	// Matches the original RequeueMessage's branching (coalesceKey !=
+	// "" takes the coalesce-replace path; empty coalesceKey takes the
+	// tail-append path). A bare requeue with no coalesce key must NOT
+	// collapse onto an unrelated same-sender entry.
+	if coalesceKey != "" {
+		err = tx.GetContext(ctx, &existingID, r.db.Rebind(`
+			SELECT id FROM queued_messages
+			WHERE session_id = ? AND queued_by = ? AND json_extract(metadata_json, '$.coalesce_key') = ?
+			LIMIT 1
+		`), msg.SessionID, msg.QueuedBy, coalesceKey)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("lookup coalesce target: %w", err)
+		}
+	}
+
+	if existingID != "" {
+		// Coalesce hit: replace in place. The retry keeps the existing
+		// entry's position, which by construction is the most head-of-
+		// queue position for this coalesce key — supersede→requeue of
+		// the same content stays FIFO at the same slot.
+		attachmentsJSON, err := marshalAttachments(msg.Attachments)
+		if err != nil {
+			return err
+		}
+		metadataJSON, err := marshalMetadata(msg.Metadata)
+		if err != nil {
+			return err
+		}
+		if msg.QueuedAt.IsZero() {
+			msg.QueuedAt = time.Now().UTC()
+		}
+		res, err := tx.ExecContext(ctx, r.db.Rebind(`
+			UPDATE queued_messages
+			SET task_id = ?, content = ?, model = ?, plan_mode = ?, attachments_json = ?, metadata_json = ?, queued_at = ?
+			WHERE id = ?
+		`),
+			msg.TaskID, msg.Content, msg.Model, boolToInt(msg.PlanMode),
+			attachmentsJSON, metadataJSON, msg.QueuedAt, existingID,
+		)
+		if err != nil {
+			return fmt.Errorf("update coalesced entry: %w", err)
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rows affected: %w", err)
+		}
+		if rows == 0 {
+			return fmt.Errorf("coalesce hit vanished: %s", existingID)
+		}
+		// Caller wants the canonical position back on the msg so it can
+		// log it; re-read so we return the actual stored value.
+		if err := tx.GetContext(ctx, &existingPosition,
+			r.db.Rebind(`SELECT position FROM queued_messages WHERE id = ?`), existingID,
+		); err != nil {
+			return fmt.Errorf("re-read coalesced position: %w", err)
+		}
+		msg.ID = existingID
+		msg.Position = existingPosition
+		return tx.Commit()
+	}
+
+	var minPos sql.NullInt64
+	if err := tx.GetContext(ctx, &minPos,
+		r.db.Rebind(`SELECT MIN(position) FROM queued_messages WHERE session_id = ?`),
+		msg.SessionID,
+	); err != nil {
+		return fmt.Errorf("min position: %w", err)
+	}
+	if minPos.Valid {
+		msg.Position = minPos.Int64 - 1
+	} else {
+		msg.Position = 1
+	}
+	if msg.ID == "" {
+		msg.ID = uuid.New().String()
+	}
+	if msg.QueuedAt.IsZero() {
+		msg.QueuedAt = time.Now().UTC()
+	}
+
+	attachmentsJSON, err := marshalAttachments(msg.Attachments)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalMetadata(msg.Metadata)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+		INSERT INTO queued_messages
+			(id, session_id, task_id, position, content, model, plan_mode, attachments_json, metadata_json, queued_at, queued_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`),
+		msg.ID, msg.SessionID, msg.TaskID, msg.Position, msg.Content, msg.Model,
+		boolToInt(msg.PlanMode), attachmentsJSON, metadataJSON, msg.QueuedAt, msg.QueuedBy,
+	); err != nil {
+		return fmt.Errorf("insert queued_messages (requeue-fifo): %w", err)
+	}
+	return tx.Commit()
+}
+
 // Restore reinserts a previously dequeued entry at its original FIFO position.
 func (r *sqliteRepository) Restore(ctx context.Context, msg *QueuedMessage, maxPerSession int) error {
 	tx, err := r.db.BeginTxx(ctx, nil)

--- a/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_regression_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_regression_test.go
@@ -1,0 +1,164 @@
+package messagequeue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type requeueRepositoryFactory struct {
+	name string
+	new  func(*testing.T) Repository
+}
+
+func requeueRepositoryFactories() []requeueRepositoryFactory {
+	return []requeueRepositoryFactory{
+		{name: "memory", new: func(*testing.T) Repository { return NewMemoryRepository() }},
+		{name: "sqlite", new: newTestSQLiteRepo},
+		{name: "postgres", new: newTestPostgresRepo},
+	}
+}
+
+func insertRequeueTestEntry(t *testing.T, repo Repository, sessionID, content, queuedBy string, metadata map[string]interface{}) *QueuedMessage {
+	t.Helper()
+	msg := &QueuedMessage{
+		SessionID: sessionID,
+		TaskID:    "task",
+		Content:   content,
+		QueuedBy:  queuedBy,
+		Metadata:  metadata,
+	}
+	require.NoError(t, repo.Insert(context.Background(), msg, 0))
+	return msg
+}
+
+func TestRepository_RequeuePreservingFIFO_NormalizesHeadPosition(t *testing.T) {
+	for _, factory := range requeueRepositoryFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			repo := factory.new(t)
+			ctx := context.Background()
+
+			insertRequeueTestEntry(t, repo, "source", "older", QueuedByUser, nil)
+			retry := insertRequeueTestEntry(t, repo, "source", "retry", QueuedByUser, nil)
+			taken, err := repo.TakeByID(ctx, "source", retry.ID)
+			require.NoError(t, err)
+			require.Equal(t, retry.ID, taken.ID)
+
+			insertRequeueTestEntry(t, repo, "destination", "destination", QueuedByUser, nil)
+			require.NoError(t, repo.RequeuePreservingFIFO(ctx, taken))
+			require.NoError(t, repo.TransferSession(ctx, "source", "destination"))
+
+			entries, err := repo.ListBySession(ctx, "destination")
+			require.NoError(t, err)
+			require.Len(t, entries, 3)
+			require.Equal(t, []string{"destination", "retry", "older"}, []string{
+				entries[0].Content, entries[1].Content, entries[2].Content,
+			})
+			require.Less(t, entries[0].Position, entries[1].Position)
+			require.Less(t, entries[1].Position, entries[2].Position)
+			require.Greater(t, entries[0].Position, int64(0))
+		})
+	}
+}
+
+func TestRepository_RequeuePreservingFIFO_ReplacesPendingCoalesceTarget(t *testing.T) {
+	for _, factory := range requeueRepositoryFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			repo := factory.new(t)
+			ctx := context.Background()
+			metadata := map[string]interface{}{MetadataCoalesceKey: "ci-key"}
+
+			original := insertRequeueTestEntry(t, repo, "session", "original", QueuedByWorkflow, metadata)
+			taken, err := repo.TakeHead(ctx, "session")
+			require.NoError(t, err)
+			require.Equal(t, original.ID, taken.ID)
+
+			insertRequeueTestEntry(t, repo, "session", "noise", QueuedByUser, nil)
+			pending := insertRequeueTestEntry(t, repo, "session", "pending", QueuedByWorkflow, metadata)
+			pendingPosition := pending.Position
+
+			require.NoError(t, repo.RequeuePreservingFIFO(ctx, taken))
+			entries, err := repo.ListBySession(ctx, "session")
+			require.NoError(t, err)
+			require.Len(t, entries, 2)
+			require.Equal(t, "noise", entries[0].Content)
+			require.Equal(t, "original", entries[1].Content)
+			require.Equal(t, pending.ID, entries[1].ID)
+			require.Equal(t, pendingPosition, entries[1].Position)
+		})
+	}
+}
+
+func TestRepository_RequeuePreservingFIFO_EmptyQueueStartsAtOne(t *testing.T) {
+	for _, factory := range requeueRepositoryFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			repo := factory.new(t)
+			ctx := context.Background()
+			msg := &QueuedMessage{SessionID: "session", TaskID: "task", Content: "retry", QueuedBy: QueuedByUser}
+
+			require.NoError(t, repo.RequeuePreservingFIFO(ctx, msg))
+			require.Equal(t, int64(1), msg.Position)
+			entries, err := repo.ListBySession(ctx, "session")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, int64(1), entries[0].Position)
+		})
+	}
+}
+
+type requeueTrackingRepository struct {
+	Repository
+	called chan struct{}
+}
+
+func (r *requeueTrackingRepository) RequeuePreservingFIFO(ctx context.Context, msg *QueuedMessage) error {
+	close(r.called)
+	return r.Repository.RequeuePreservingFIFO(ctx, msg)
+}
+
+func TestService_RequeueAtHeadWaitsForSessionAdmission(t *testing.T) {
+	repo := &requeueTrackingRepository{
+		Repository: NewMemoryRepository(),
+		called:     make(chan struct{}),
+	}
+	svc := newAutoMergeTestServiceWithRepository(t, repo, 10)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	queued, err := svc.QueueMessage(ctx, "session", "task", "retry", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+	taken, ok, err := svc.TakeQueuedEntry(ctx, "session", queued.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- svc.WithSessionAdmission(ctx, "session", func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	<-holderStarted
+
+	requeueDone := make(chan error, 1)
+	go func() { requeueDone <- svc.RequeueAtHead(ctx, taken) }()
+	select {
+	case <-repo.called:
+		t.Fatal("requeue reached the repository while session admission was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseHolder)
+	require.NoError(t, <-holderDone)
+	require.NoError(t, <-requeueDone)
+	select {
+	case <-repo.called:
+	case <-time.After(time.Second):
+		t.Fatal("requeue did not reach the repository after admission was released")
+	}
+}

--- a/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_test.go
@@ -1,0 +1,226 @@
+package messagequeue
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// TestRequeuePreservingFIFO_InsertsAtHead verifies the FIFO starvation
+// bug fix: a superseded dispatch that re-enters the queue must beat
+// any new entry that arrived after the supersede, otherwise the busy-
+// session drain loop strands it at the tail indefinitely.
+//
+// Scenario: queue [first@1], drain first (position goes empty), a
+// second user message arrives [second@1], then first requeues.
+// Pre-fix bug: first lands at position 2 (tail of [second]), every
+// subsequent drain cycles it. Post-fix: first lands at position 0,
+// beats second on the next TakeQueued.
+func TestRequeuePreservingFIFO_InsertsAtHead(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 4, log)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	first, err := svc.QueueMessage(ctx, "s", "t", "first", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+	dequeued, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+	require.Equal(t, first.ID, dequeued.ID)
+
+	_, err = svc.QueueMessage(ctx, "s", "t", "second", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+
+	// Requeue first; it must beat second.
+	require.NoError(t, svc.RequeueAtHead(ctx, dequeued))
+
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, 2, status.Count)
+	require.Equal(t, "first", status.Entries[0].Content,
+		"requeued entry must be ahead of any new arrival")
+	require.Equal(t, "second", status.Entries[1].Content)
+
+	// TakeQueued now returns first; second has been waiting, not starved.
+	head, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+	require.Equal(t, "first", head.Content)
+	require.Equal(t, first.ID, head.ID, "requeue must preserve identity (same coalesce key)")
+
+	// Positions are monotonic ascending (existing invariant).
+	require.Less(t, status.Entries[0].Position, status.Entries[1].Position,
+		"head position must be lower than tail position")
+}
+
+// TestRequeuePreservingFIFO_BoundedAcrossRepeatedSupersede verifies
+// the contract that matters to the live bug: under repeated
+// supersede→requeue cycles the original entry is delivered in bounded
+// time. We simulate the cycle by draining and requeuing the same
+// entry N times, interleaving new arrivals between each cycle, and
+// assert that the original entry is always the next TakeQueued.
+func TestRequeuePreservingFIFO_BoundedAcrossRepeatedSupersede(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 32, log)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	// Seed: 1 original + 5 alternates that race against it.
+	original, err := svc.QueueMessage(ctx, "s", "t", "original", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+
+	const cycles = 10
+	for i := 0; i < cycles; i++ {
+		// Take whatever is at the head. Pre-fix bug: this drains
+		// every newcomer and leaves original stranded at the tail.
+		_, _ = svc.TakeQueued(ctx, "s")
+		// A new message arrives during the settle window — this is
+		// the arrival that outranked original in the live bug.
+		_, err := svc.QueueMessage(ctx, "s", "t", "noise", "", QueuedByUser, false, nil)
+		require.NoError(t, err)
+		// Original requeues (its dispatch was superseded by noise).
+		require.NoError(t, svc.RequeueAtHead(ctx, original))
+	}
+
+	// Bounded: original must be the next entry served, despite 10
+	// new arrivals in between.
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, cycles+1, status.Count, "queue must hold 10 noise + 1 original")
+	require.Equal(t, "original", status.Entries[0].Content,
+		"original must be at the head after %d supersede cycles", cycles)
+
+	head, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+	require.Equal(t, "original", head.Content)
+}
+
+// TestRequeuePreservingFIFO_PreservesCoalesceReplace verifies the
+// requeue still honors coalesce-replace semantics: a retry with the
+// same coalesce key replaces the existing pending entry at its
+// current position (not below it). This protects the existing
+// TestExecuteQueuedMessage_RequeuesCoalescedMessageWithOriginalSender
+// contract for CI-feedback retries.
+func TestRequeuePreservingFIFO_PreservesCoalesceReplace(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 4, log)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	// Seed a coalesced entry and a separate pending entry so the
+	// queue is non-empty (the coalesce-hit branch must NOT touch
+	// the separate entry).
+	coalesced, _, err := svc.QueueMessageWithCoalesceKey(
+		ctx, "s", "t", "first", "", QueuedByWorkflow, false, nil, nil,
+		"ci-key", true,
+	)
+	require.NoError(t, err)
+	_, err = svc.QueueMessage(ctx, "s", "t", "noise", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+
+	// Take the coalesced entry so we can requeue it.
+	dequeued, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+	require.Equal(t, coalesced.ID, dequeued.ID)
+
+	// Requeue with the same coalesce key — must replace in place.
+	require.NoError(t, svc.RequeueAtHead(ctx, dequeued))
+
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, 2, status.Count, "requeue must replace the existing coalesced entry, not append")
+	require.Equal(t, "first", status.Entries[0].Content)
+	require.Equal(t, "noise", status.Entries[1].Content,
+		"a non-coalesce sibling must keep its position; requeue must not insert above it")
+	// The coalesced replacement keeps the same ID (coalesce hit).
+	require.Equal(t, coalesced.ID, status.Entries[0].ID)
+}
+
+// TestRequeuePreservingFIFO_DistinctMessageDoesNotCoalesce verifies
+// the negative: when the requeued message has no coalesce key (or a
+// different one), it inserts at the head and does NOT replace an
+// existing entry. This is the normal "retry of a different user
+// input" case.
+func TestRequeuePreservingFIFO_DistinctMessageDoesNotCoalesce(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 4, log)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	first, err := svc.QueueMessage(ctx, "s", "t", "first", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+	dequeued, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+
+	// No coalesce key in the requeue metadata → head-insert.
+	require.NoError(t, svc.RequeueAtHead(ctx, dequeued))
+
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, 1, status.Count)
+	require.Equal(t, "first", status.Entries[0].Content)
+	require.Equal(t, first.ID, status.Entries[0].ID,
+		"a no-coalesce requeue must keep the same identity (no coalesce replacement)")
+
+	// Position is still strictly ascending (existing invariant).
+	require.Greater(t, status.Entries[0].Position, int64(0),
+		"non-empty queue → position > 0")
+}
+
+// TestRequeuePreservingFIFO_EmptyQueueStartsAtOne verifies the boundary
+// case: a requeue into an empty queue must NOT compute MIN-1 = 0 (or
+// negative). The empty-queue branch must mint position 1 so the next
+// insert (which derives from MAX+1) lands at 2 and stays monotonic.
+func TestRequeuePreservingFIFO_EmptyQueueStartsAtOne(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 4, log)
+	svc.SetAutoMergeEnabled(false)
+	ctx := context.Background()
+
+	msg, err := svc.QueueMessage(ctx, "s", "t", "lone", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+	dequeued, ok := svc.TakeQueued(ctx, "s")
+	require.True(t, ok)
+
+	require.NoError(t, svc.RequeueAtHead(ctx, dequeued))
+
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, 1, status.Count)
+	require.Equal(t, int64(1), status.Entries[0].Position,
+		"empty-queue requeue must mint position 1, not 0")
+
+	// Next insert lands at MAX+1=2; monotonic invariant holds.
+	_, err = svc.QueueMessage(ctx, "s", "t", "second", "", QueuedByUser, false, nil)
+	require.NoError(t, err)
+	status = svc.GetStatus(ctx, "s")
+	require.Equal(t, int64(1), status.Entries[0].Position)
+	require.Equal(t, int64(2), status.Entries[1].Position)
+
+	// ID of the first requeue was assigned by the empty-queue path.
+	require.NotEmpty(t, msg.ID)
+}
+
+// TestRequeuePreservingFIFO_NilMessageGuards verifies the defensive
+// guard: a nil message returns a sentinel error rather than panicking
+// or silently succeeding.
+func TestRequeuePreservingFIFO_NilMessageGuards(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console", OutputPath: "stderr"})
+	require.NoError(t, err)
+	svc := NewService(NewMemoryRepository(), 4, log)
+	svc.SetAutoMergeEnabled(false)
+
+	err = svc.RequeueAtHead(context.Background(), nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errRequeueAtHeadNil) || err.Error() != "",
+		"a nil message must surface an error, got %v", err)
+}
+
+// errRequeueAtHeadNil is a sentinel the test asserts on. Defining it here
+// keeps the test's surface small and avoids dragging in a separate
+// error-naming file.
+var errRequeueAtHeadNil = errors.New("queued message is nil")

--- a/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/requeue_fifo_test.go
@@ -128,16 +128,24 @@ func TestRequeuePreservingFIFO_PreservesCoalesceReplace(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, coalesced.ID, dequeued.ID)
 
-	// Requeue with the same coalesce key — must replace in place.
+	// Recreate a pending entry with the same coalesce key. Requeue must replace
+	// this entry in place instead of taking the head-insert path.
+	replacement, _, err := svc.QueueMessageWithCoalesceKey(
+		ctx, "s", "t", "replacement", "", QueuedByWorkflow, false, nil, nil,
+		"ci-key", true,
+	)
+	require.NoError(t, err)
+	replacementPosition := replacement.Position
+
 	require.NoError(t, svc.RequeueAtHead(ctx, dequeued))
 
 	status := svc.GetStatus(ctx, "s")
 	require.Equal(t, 2, status.Count, "requeue must replace the existing coalesced entry, not append")
-	require.Equal(t, "first", status.Entries[0].Content)
-	require.Equal(t, "noise", status.Entries[1].Content,
-		"a non-coalesce sibling must keep its position; requeue must not insert above it")
-	// The coalesced replacement keeps the same ID (coalesce hit).
-	require.Equal(t, coalesced.ID, status.Entries[0].ID)
+	require.Equal(t, "noise", status.Entries[0].Content)
+	require.Equal(t, "first", status.Entries[1].Content,
+		"the coalesced replacement must keep its pending position")
+	require.Equal(t, replacement.ID, status.Entries[1].ID)
+	require.Equal(t, replacementPosition, status.Entries[1].Position)
 }
 
 // TestRequeuePreservingFIFO_DistinctMessageDoesNotCoalesce verifies

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -430,8 +430,7 @@ func (s *Service) RequeueMessage(ctx context.Context, msg *QueuedMessage, queued
 // than the session's current head. It is the FIFO-preserving requeue
 // that Service.requeueMessage invokes when an entry was superseded by a
 // newer dispatch before it could be claimed. See Repository
-// .RequeuePreservingFIFO for the position arithmetic and the bounded
-// walk under a runaway supersede chain.
+// .RequeuePreservingFIFO for the position arithmetic and position rebasing.
 //
 // This method is the bug fix entry point — caller code that wants
 // user-message retry should call this instead of RequeueMessage so
@@ -440,7 +439,9 @@ func (s *Service) RequeueAtHead(ctx context.Context, msg *QueuedMessage) error {
 	if msg == nil {
 		return errors.New("queued message is nil")
 	}
-	return s.repo.RequeuePreservingFIFO(ctx, msg)
+	return s.WithSessionAdmission(ctx, msg.SessionID, func(admittedCtx context.Context) error {
+		return s.repo.RequeuePreservingFIFO(admittedCtx, msg)
+	})
 }
 
 // QueueLifecycleMessageWithCoalesceKey accepts a lifecycle entry only while

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -426,6 +426,23 @@ func (s *Service) RequeueMessage(ctx context.Context, msg *QueuedMessage, queued
 	return queued, false, err
 }
 
+// RequeueAtHead re-enqueues a user message at a position strictly lower
+// than the session's current head. It is the FIFO-preserving requeue
+// that Service.requeueMessage invokes when an entry was superseded by a
+// newer dispatch before it could be claimed. See Repository
+// .RequeuePreservingFIFO for the position arithmetic and the bounded
+// walk under a runaway supersede chain.
+//
+// This method is the bug fix entry point — caller code that wants
+// user-message retry should call this instead of RequeueMessage so
+// the original message beats any new arrival on a busy session.
+func (s *Service) RequeueAtHead(ctx context.Context, msg *QueuedMessage) error {
+	if msg == nil {
+		return errors.New("queued message is nil")
+	}
+	return s.repo.RequeuePreservingFIFO(ctx, msg)
+}
+
 // QueueLifecycleMessageWithCoalesceKey accepts a lifecycle entry only while
 // its task remains active. accepted is false for a normal archive/delete win.
 func (s *Service) QueueLifecycleMessageWithCoalesceKey(ctx context.Context, sessionID, taskID, content, model, userID string, planMode bool, attachments []MessageAttachment, metadata map[string]interface{}, coalesceKey string, allowInsert bool) (*QueuedMessage, bool, bool, error) {


### PR DESCRIPTION
## Problem

When a queued message loses the dispatch claim race (`errQueuedDispatchSuperseded`), `requeueMessage` re-inserts it at the queue tail (`InsertOrReplaceByCoalesceKey` → `position = MAX+1`). Under a busy session with a steady stream of newer messages, the older message is repeatedly superseded and repeatedly re-appended to the tail — observed in production logs as 7 consecutive supersede→requeue cycles with the original message's position drifting 1→4→6 while newer messages jump ahead. Net effect: a queued user/peer message can starve indefinitely.

## Fix

Add `RequeuePreservingFIFO` to the messagequeue repository (memory + SQLite implementations) and route `Service.requeueMessage` through it (`RequeueAtHead`):

- Superseded non-coalesce messages are re-inserted at the queue head with `position = MIN(existing)-1` (bounded walk; positions stay monotonically ascending within the window, session close resets `nextPosition`).
- Coalesce-key hits keep the existing in-place UPDATE semantics (id/position preserved).
- Empty queue mints position 1 (unchanged).
- Lifecycle messages keep their separate generation-gated requeue path.
- Send Now supersede path is untouched (it returns the sentinel before any requeue).

## Tests

6 new tests in `messagequeue/requeue_fifo_test.go` (head insert, bounded across 10 repeated supersede cycles with interleaved noise, coalesce-replace preservation, distinct-message non-coalescing, empty-queue mint, nil guards). Full `./internal/orchestrator/...` + `-race ./internal/orchestrator/messagequeue/` green; existing requeue/coalesce/send-now tests unchanged and passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->