### PR TITLE
fix(desktop): preserve inherited KANDEV_SERVER_HOST for embedded backend

### DIFF
--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -371,15 +371,10 @@ pub fn desktop_environment(
         !key.to_string_lossy()
             .eq_ignore_ascii_case(DESKTOP_NATIVE_NOTIFICATIONS_ENV)
     });
-    // KANDEV_SERVER_HOST is conditionally injected: a caller (CI smoke harness,
-    // integration test) that already set it must see the value pass through
-    // unchanged. Only the un-set case falls back to the loopback default.
-    if !env.contains_key(OsStr::new("KANDEV_SERVER_HOST")) {
-        env.insert(
-            OsString::from("KANDEV_SERVER_HOST"),
-            OsString::from(LOOPBACK_HOST),
-        );
-    }
+    env.insert(
+        OsString::from("KANDEV_SERVER_HOST"),
+        OsString::from(LOOPBACK_HOST),
+    );
     env.insert(
         OsString::from("KANDEV_BUNDLE_DIR"),
         runtime_dir.as_os_str().to_os_string(),
@@ -855,10 +850,8 @@ mod tests {
     }
 
     #[test]
-    fn desktop_environment_preserves_inherited_server_host() {
-        // CI smoke harness / integration tests can pre-set KANDEV_SERVER_HOST
-        // to point at a non-loopback backend. desktop_environment must pass
-        // the value through unchanged.
+    fn desktop_environment_overrides_inherited_server_host_with_loopback() {
+        // Desktop launches must keep the embedded backend on the loopback host.
         let mut inherited = BTreeMap::new();
         inherited.insert(
             OsString::from("KANDEV_SERVER_HOST"),
@@ -869,8 +862,8 @@ mod tests {
 
         assert_eq!(
             env.get(OsStr::new("KANDEV_SERVER_HOST")),
-            Some(&OsString::from("10.0.0.42")),
-            "inherited KANDEV_SERVER_HOST must pass through desktop_environment",
+            Some(&OsString::from(LOOPBACK_HOST)),
+            "desktop_environment must force the loopback server host",
         );
     }
 

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -371,10 +371,15 @@ pub fn desktop_environment(
         !key.to_string_lossy()
             .eq_ignore_ascii_case(DESKTOP_NATIVE_NOTIFICATIONS_ENV)
     });
-    env.insert(
-        OsString::from("KANDEV_SERVER_HOST"),
-        OsString::from(LOOPBACK_HOST),
-    );
+    // KANDEV_SERVER_HOST is conditionally injected: a caller (CI smoke harness,
+    // integration test) that already set it must see the value pass through
+    // unchanged. Only the un-set case falls back to the loopback default.
+    if !env.contains_key(OsStr::new("KANDEV_SERVER_HOST")) {
+        env.insert(
+            OsString::from("KANDEV_SERVER_HOST"),
+            OsString::from(LOOPBACK_HOST),
+        );
+    }
     env.insert(
         OsString::from("KANDEV_BUNDLE_DIR"),
         runtime_dir.as_os_str().to_os_string(),
@@ -847,6 +852,38 @@ mod tests {
             Some(&OsString::from("true"))
         );
         assert!(!env.contains_key(OsStr::new("kandev_desktop_native_notifications")));
+    }
+
+    #[test]
+    fn desktop_environment_preserves_inherited_server_host() {
+        // CI smoke harness / integration tests can pre-set KANDEV_SERVER_HOST
+        // to point at a non-loopback backend. desktop_environment must pass
+        // the value through unchanged.
+        let mut inherited = BTreeMap::new();
+        inherited.insert(
+            OsString::from("KANDEV_SERVER_HOST"),
+            OsString::from("10.0.0.42"),
+        );
+
+        let env = desktop_environment(Path::new("/opt/kandev"), inherited, None);
+
+        assert_eq!(
+            env.get(OsStr::new("KANDEV_SERVER_HOST")),
+            Some(&OsString::from("10.0.0.42")),
+            "inherited KANDEV_SERVER_HOST must pass through desktop_environment",
+        );
+    }
+
+    #[test]
+    fn desktop_environment_falls_back_to_loopback_when_server_host_unset() {
+        // The default production path: no inherited KANDEV_SERVER_HOST,
+        // desktop_environment must inject the loopback default.
+        let env = desktop_environment(Path::new("/opt/kandev"), BTreeMap::new(), None);
+
+        assert_eq!(
+            env.get(OsStr::new("KANDEV_SERVER_HOST")),
+            Some(&OsString::from(LOOPBACK_HOST))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`desktop_environment` unconditionally overwrote `KANDEV_SERVER_HOST` with the loopback default (`127.0.0.1`). Any caller that pre-set the variable — e.g. a CI smoke harness or an integration test pointing the desktop shell at a non-loopback backend — had its value silently discarded.

The injection is now conditional: an inherited `KANDEV_SERVER_HOST` passes through unchanged; only when it is unset does the embedded backend fall back to the loopback default. No behavior change for the default production path.

## Changes

- `apps/desktop/src-tauri/src/backend.rs` — skip the `KANDEV_SERVER_HOST` insert when the key is already present in the inherited environment (`41 insertions / 4 deletions`, comment explains the contract).

## Tests

Two new unit tests in `backend::tests`:

- `desktop_environment_preserves_inherited_server_host` — a pre-set value (`10.0.0.42`) passes through unchanged.
- `desktop_environment_falls_back_to_loopback_when_server_host_unset` — the unset case still injects the loopback default.

## Verification

- `cargo build --features desktop-runtime` — clean
- `cargo test --features desktop-runtime` — 59 passed, 0 failed
- `cargo clippy --features desktop-runtime` — exit 0 (3 pre-existing warnings outside this diff)
- `git diff --check` — clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->