### PR TITLE
fix(office): stop agent-created subtasks from losing their project and cost tracking

### DIFF
--- a/apps/backend/internal/office/runtime/actions.go
+++ b/apps/backend/internal/office/runtime/actions.go
@@ -100,6 +100,11 @@ func (a *Actions) CreateTask(ctx context.Context, runCtx RunContext, input Creat
 	if a.deps.Tasks == nil {
 		return "", fmt.Errorf("%w: tasks", ErrRuntimeDependencyMissing)
 	}
+	if input.ParentTaskID == "" {
+		if err := a.resolveRootTaskProject(ctx, runCtx, &input); err != nil {
+			return "", err
+		}
+	}
 	if err := a.validateTaskRelations(ctx, runCtx.WorkspaceID, input); err != nil {
 		return "", err
 	}
@@ -111,6 +116,39 @@ func (a *Actions) CreateTask(ctx context.Context, runCtx RunContext, input Creat
 	return a.deps.Tasks.CreateOfficeTaskAsAgent(
 		ctx, runCtx.AgentID, runCtx.WorkspaceID, input.ProjectID, input.AssigneeAgentID, input.Title, input.Description,
 	)
+}
+
+// resolveRootTaskProject fills input.ProjectID for a root task (no parent)
+// when the caller omitted it: first from the run's current task project,
+// then — only if the workspace has projects to choose from — a
+// caller-correctable ErrProjectRequired naming them, instead of silently
+// creating a task whose office cost events can never roll up to a project
+// budget. A workspace with no projects at all creates as before (nothing to
+// attribute to).
+func (a *Actions) resolveRootTaskProject(ctx context.Context, runCtx RunContext, input *CreateTaskInput) error {
+	if input.ProjectID != "" {
+		return nil
+	}
+	if taskID := strings.TrimSpace(runCtx.TaskID); taskID != "" {
+		if projectID, err := a.deps.Tasks.GetTaskProjectID(ctx, taskID); err == nil && projectID != "" {
+			input.ProjectID = projectID
+			return nil
+		}
+	}
+	if a.deps.Projects == nil {
+		return nil
+	}
+	projects, err := a.deps.Projects.ListProjects(ctx, runCtx.WorkspaceID)
+	if err != nil || len(projects) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		if project != nil {
+			ids = append(ids, project.ID)
+		}
+	}
+	return fmt.Errorf("%w: workspace has projects [%s], specify project_id", ErrProjectRequired, strings.Join(ids, ", "))
 }
 
 func (a *Actions) validateTaskRelations(ctx context.Context, workspaceID string, input CreateTaskInput) error {
@@ -125,7 +163,12 @@ func (a *Actions) validateTaskRelations(ctx context.Context, workspaceID string,
 			return ErrWorkspaceOutOfScope
 		}
 		parentProjectID, err := a.deps.Tasks.GetTaskProjectID(ctx, input.ParentTaskID)
-		if err != nil || input.ProjectID != "" && input.ProjectID != parentProjectID {
+		if err != nil {
+			return ErrWorkspaceOutOfScope
+		}
+		// Only a mismatch against a non-empty parent project is rejected, so a
+		// subtask may still carry its own project when the parent has none.
+		if input.ProjectID != "" && parentProjectID != "" && input.ProjectID != parentProjectID {
 			return ErrWorkspaceOutOfScope
 		}
 	}

--- a/apps/backend/internal/office/runtime/actions.go
+++ b/apps/backend/internal/office/runtime/actions.go
@@ -139,7 +139,10 @@ func (a *Actions) resolveRootTaskProject(ctx context.Context, runCtx RunContext,
 		return nil
 	}
 	projects, err := a.deps.Projects.ListProjects(ctx, runCtx.WorkspaceID)
-	if err != nil || len(projects) == 0 {
+	if err != nil {
+		return err
+	}
+	if len(projects) == 0 {
 		return nil
 	}
 	ids := make([]string, 0, len(projects))
@@ -166,9 +169,7 @@ func (a *Actions) validateTaskRelations(ctx context.Context, workspaceID string,
 		if err != nil {
 			return ErrWorkspaceOutOfScope
 		}
-		// Only a mismatch against a non-empty parent project is rejected, so a
-		// subtask may still carry its own project when the parent has none.
-		if input.ProjectID != "" && parentProjectID != "" && input.ProjectID != parentProjectID {
+		if input.ProjectID != "" && input.ProjectID != parentProjectID {
 			return ErrWorkspaceOutOfScope
 		}
 	}

--- a/apps/backend/internal/office/runtime/actions.go
+++ b/apps/backend/internal/office/runtime/actions.go
@@ -130,7 +130,11 @@ func (a *Actions) resolveRootTaskProject(ctx context.Context, runCtx RunContext,
 		return nil
 	}
 	if taskID := strings.TrimSpace(runCtx.TaskID); taskID != "" {
-		if projectID, err := a.deps.Tasks.GetTaskProjectID(ctx, taskID); err == nil && projectID != "" {
+		projectID, err := a.deps.Tasks.GetTaskProjectID(ctx, taskID)
+		if err != nil {
+			return err
+		}
+		if projectID != "" {
 			input.ProjectID = projectID
 			return nil
 		}

--- a/apps/backend/internal/office/runtime/actions_test.go
+++ b/apps/backend/internal/office/runtime/actions_test.go
@@ -545,6 +545,29 @@ func TestActionsCreateTaskRootFailsClosedWhenProjectLookupErrors(t *testing.T) {
 	}
 }
 
+func TestActionsCreateTaskRootFailsClosedWhenRunTaskProjectLookupErrors(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "created-task"}
+	lookupErr := errors.New("get task project: transient repository failure")
+	creator.projectLookupErr = lookupErr
+	projects := &recordingProjectManager{projects: []*models.Project{
+		{ID: "project-1", WorkspaceID: "ws-1"},
+	}}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1", TaskID: "task-1",
+		Capabilities: Capabilities{CanCreateTasks: true},
+	}
+
+	_, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{Title: "Root task"})
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error = %v, want the GetTaskProjectID lookup error surfaced rather than treated as "+
+			"'run task has no project'", err)
+	}
+	if len(creator.calls) != 0 {
+		t.Fatalf("creator called despite run-task project lookup error: %#v", creator.calls)
+	}
+}
+
 func TestActionsCreateTaskDeniesMissingCapabilityBeforePersistence(t *testing.T) {
 	creator := &recordingTaskCreator{}
 	actions := NewActions(ActionDependencies{Tasks: creator})
@@ -1025,6 +1048,7 @@ type recordingTaskCreator struct {
 	taskScopes       map[string]taskScope
 	workspaceLookups []string
 	projectLookups   []string
+	projectLookupErr error
 }
 
 type taskScope struct {
@@ -1069,6 +1093,9 @@ func (c *recordingTaskCreator) GetTaskWorkspaceID(_ context.Context, taskID stri
 
 func (c *recordingTaskCreator) GetTaskProjectID(_ context.Context, taskID string) (string, error) {
 	c.projectLookups = append(c.projectLookups, taskID)
+	if c.projectLookupErr != nil {
+		return "", c.projectLookupErr
+	}
 	return c.taskScopes[taskID].ProjectID, nil
 }
 

--- a/apps/backend/internal/office/runtime/actions_test.go
+++ b/apps/backend/internal/office/runtime/actions_test.go
@@ -433,6 +433,97 @@ func TestActionsCreateTaskDeniesParentProjectMismatchBeforePersistence(t *testin
 	}
 }
 
+func TestActionsCreateTaskRootDefaultsToRunTaskProject(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "created-task", taskScopes: map[string]taskScope{
+		"task-1": {WorkspaceID: "ws-1", ProjectID: "project-1"},
+	}}
+	projects := &recordingProjectManager{projects: []*models.Project{
+		{ID: "project-1", WorkspaceID: "ws-1"},
+	}}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1", TaskID: "task-1",
+		Capabilities: Capabilities{CanCreateTasks: true},
+	}
+
+	taskID, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{Title: "Root task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if taskID != "created-task" || len(creator.calls) != 1 {
+		t.Fatalf("task id/calls = %q/%d", taskID, len(creator.calls))
+	}
+	if creator.calls[0].ProjectID != "project-1" {
+		t.Fatalf("project_id = %q, want defaulted from run task's project", creator.calls[0].ProjectID)
+	}
+}
+
+func TestActionsCreateTaskSubtaskMaySupplyProjectWhenParentHasNone(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "child-1", taskScopes: map[string]taskScope{
+		"parent-1": {WorkspaceID: "ws-1"},
+	}}
+	projects := &recordingProjectManager{projects: []*models.Project{
+		{ID: "project-1", WorkspaceID: "ws-1"},
+	}}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1",
+		Capabilities: Capabilities{
+			CanCreateSubtasks: true,
+			AllowedTaskIDs:    []string{"parent-1"},
+		},
+	}
+
+	taskID, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{
+		Title: "child", ParentTaskID: "parent-1", ProjectID: "project-1",
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if taskID != "child-1" || len(creator.calls) != 1 {
+		t.Fatalf("task id/calls = %q/%d", taskID, len(creator.calls))
+	}
+}
+
+func TestActionsCreateTaskRootErrorsWhenProjectUnresolvedAndWorkspaceHasProjects(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "created-task"}
+	projects := &recordingProjectManager{projects: []*models.Project{
+		{ID: "project-1", WorkspaceID: "ws-1"},
+		{ID: "project-2", WorkspaceID: "ws-1"},
+	}}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1",
+		Capabilities: Capabilities{CanCreateTasks: true},
+	}
+
+	_, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{Title: "Root task"})
+	if !errors.Is(err, ErrProjectRequired) {
+		t.Fatalf("error = %v, want ErrProjectRequired", err)
+	}
+	if len(creator.calls) != 0 {
+		t.Fatalf("creator called for unresolvable project: %#v", creator.calls)
+	}
+}
+
+func TestActionsCreateTaskRootAllowsEmptyProjectWhenWorkspaceHasNone(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "created-task"}
+	projects := &recordingProjectManager{}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1",
+		Capabilities: Capabilities{CanCreateTasks: true},
+	}
+
+	taskID, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{Title: "Root task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if taskID != "created-task" || len(creator.calls) != 1 || creator.calls[0].ProjectID != "" {
+		t.Fatalf("task id/calls = %q/%#v, want empty project_id preserved", taskID, creator.calls)
+	}
+}
+
 func TestActionsCreateTaskDeniesMissingCapabilityBeforePersistence(t *testing.T) {
 	creator := &recordingTaskCreator{}
 	actions := NewActions(ActionDependencies{Tasks: creator})

--- a/apps/backend/internal/office/runtime/actions_test.go
+++ b/apps/backend/internal/office/runtime/actions_test.go
@@ -458,7 +458,7 @@ func TestActionsCreateTaskRootDefaultsToRunTaskProject(t *testing.T) {
 	}
 }
 
-func TestActionsCreateTaskSubtaskMaySupplyProjectWhenParentHasNone(t *testing.T) {
+func TestActionsCreateTaskSubtaskRejectsProjectMismatchWhenParentHasNone(t *testing.T) {
 	creator := &recordingTaskCreator{taskID: "child-1", taskScopes: map[string]taskScope{
 		"parent-1": {WorkspaceID: "ws-1"},
 	}}
@@ -474,14 +474,15 @@ func TestActionsCreateTaskSubtaskMaySupplyProjectWhenParentHasNone(t *testing.T)
 		},
 	}
 
-	taskID, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{
+	_, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{
 		Title: "child", ParentTaskID: "parent-1", ProjectID: "project-1",
 	})
-	if err != nil {
-		t.Fatalf("create task: %v", err)
+	if !errors.Is(err, ErrWorkspaceOutOfScope) {
+		t.Fatalf("error = %v, want ErrWorkspaceOutOfScope: a caller-supplied project_id is unreachable on the "+
+			"subtask path and must not be silently dropped", err)
 	}
-	if taskID != "child-1" || len(creator.calls) != 1 {
-		t.Fatalf("task id/calls = %q/%d", taskID, len(creator.calls))
+	if len(creator.calls) != 0 {
+		t.Fatalf("creator called on rejected project mismatch: %#v", creator.calls)
 	}
 }
 
@@ -521,6 +522,26 @@ func TestActionsCreateTaskRootAllowsEmptyProjectWhenWorkspaceHasNone(t *testing.
 	}
 	if taskID != "created-task" || len(creator.calls) != 1 || creator.calls[0].ProjectID != "" {
 		t.Fatalf("task id/calls = %q/%#v, want empty project_id preserved", taskID, creator.calls)
+	}
+}
+
+func TestActionsCreateTaskRootFailsClosedWhenProjectLookupErrors(t *testing.T) {
+	creator := &recordingTaskCreator{taskID: "created-task"}
+	lookupErr := errors.New("list projects: transient repository failure")
+	projects := &recordingProjectManager{listErr: lookupErr}
+	actions := NewActions(ActionDependencies{Tasks: creator, Projects: projects})
+	runCtx := RunContext{
+		AgentID: "agent-1", WorkspaceID: "ws-1",
+		Capabilities: Capabilities{CanCreateTasks: true},
+	}
+
+	_, err := actions.CreateTask(context.Background(), runCtx, CreateTaskInput{Title: "Root task"})
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error = %v, want the ListProjects lookup error surfaced rather than treated as "+
+			"'workspace has no projects'", err)
+	}
+	if len(creator.calls) != 0 {
+		t.Fatalf("creator called despite project lookup error: %#v", creator.calls)
 	}
 }
 
@@ -1093,6 +1114,7 @@ type recordingProjectManager struct {
 	projects         []*models.Project
 	listWorkspaceIDs []string
 	created          []*models.Project
+	listErr          error
 }
 
 func (m *recordingProjectManager) ListProjects(
@@ -1100,6 +1122,9 @@ func (m *recordingProjectManager) ListProjects(
 	workspaceID string,
 ) ([]*models.Project, error) {
 	m.listWorkspaceIDs = append(m.listWorkspaceIDs, workspaceID)
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	return m.projects, nil
 }
 

--- a/apps/backend/internal/office/runtime/errors.go
+++ b/apps/backend/internal/office/runtime/errors.go
@@ -15,4 +15,9 @@ var (
 	ErrWorkspaceOutOfScope = fmt.Errorf("%w: workspace out of scope", shared.ErrForbidden)
 	// ErrRuntimeDependencyMissing indicates that a runtime action was not fully wired.
 	ErrRuntimeDependencyMissing = fmt.Errorf("runtime dependency missing")
+	// ErrProjectRequired is returned when a root task has no resolvable
+	// project (no explicit project_id, and the run's current task has none
+	// either) in a workspace that has at least one project to choose from.
+	// Caller-correctable: the caller should retry with an explicit project_id.
+	ErrProjectRequired = fmt.Errorf("project_id is required")
 )

--- a/apps/backend/internal/office/runtime/handler.go
+++ b/apps/backend/internal/office/runtime/handler.go
@@ -408,7 +408,7 @@ func (h *Handler) respondRuntimeError(
 	targetID string,
 	err error,
 ) {
-	if errors.Is(err, errTaskTitleRequired) {
+	if errors.Is(err, errTaskTitleRequired) || errors.Is(err, ErrProjectRequired) {
 		h.appendDeniedRunEvent(c.Request.Context(), runCtx, action, targetType, targetID, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/apps/backend/internal/office/runtime/handler_test.go
+++ b/apps/backend/internal/office/runtime/handler_test.go
@@ -357,6 +357,23 @@ func TestRuntimeHandler_CreateTaskUsesRuntimeToken(t *testing.T) {
 	}
 }
 
+func TestRuntimeHandler_CreateTaskRequiresProjectWhenWorkspaceHasProjects(t *testing.T) {
+	h := newRuntimeHandlerHarness(t, Capabilities{CanCreateTasks: true})
+	h.projects.projects = []*models.Project{{ID: "project-1", WorkspaceID: "ws-1"}}
+
+	resp := h.request(t, http.MethodPost, "/runtime/tasks", map[string]interface{}{
+		"title": "Runtime task",
+	})
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+	if h.tasks.calls != 0 {
+		t.Fatalf("task creator called without a project selection: %d", h.tasks.calls)
+	}
+	assertDeniedRunEvent(t, h.runEvents, "create_task", "task", "")
+}
+
 func TestRuntimeHandler_CreateTaskWithParentRequiresSubtaskCapability(t *testing.T) {
 	h := newRuntimeHandlerHarness(t, Capabilities{CanCreateTasks: true}.WithTaskScope("task-1"))
 

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -451,3 +451,63 @@ func TestCreateTask_SubtaskOfSubtask_Office_Allowed(t *testing.T) {
 		t.Errorf("parent_id = %q, want %q", got.ParentID, child.ID)
 	}
 }
+
+// Regression: a caller authorized only for req.WorkspaceID must not have a
+// foreign workspace's project silently attributed to a subtask it creates.
+// Explicit cross-workspace subtask creation is itself a supported MCP flow
+// (TestHandleCreateTask_SubtaskHonorsExplicitWorkspaceAndWorkflow), so this
+// must not reject the create outright — only project inheritance is at
+// stake. Without this guard, POST /tasks with a foreign parent_id and no
+// project_id landed a task in the caller's workspace carrying another
+// workspace's project id: cost attribution leaking across a workspace
+// boundary, the same class of bug this card exists to close, pointed
+// sideways instead of down the tree.
+func TestCreateTask_Subtask_CrossWorkspaceParentDoesNotInheritForeignProject(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	ws, err := repo.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	officeWorkflowID := ws.OfficeWorkflowID
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-2", Name: "Other Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace ws-2: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-2", WorkspaceID: "ws-2", Name: "Board"}); err != nil {
+		t.Fatalf("CreateWorkflow wf-2: %v", err)
+	}
+
+	foreignParentResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-2",
+		WorkflowID:  "wf-2",
+		Title:       "Foreign parent",
+		ProjectID:   "proj-ws2",
+	})
+	if err != nil {
+		t.Fatalf("create foreign parent: %v", err)
+	}
+	foreignParent := foreignParentResult.Task
+
+	childResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  officeWorkflowID,
+		ParentID:    foreignParent.ID,
+		Title:       "Child",
+		Origin:      models.TaskOriginAgentCreated,
+	})
+	if err != nil {
+		t.Fatalf("create child with cross-workspace parent: %v", err)
+	}
+	child := childResult.Task
+	if child.WorkspaceID != "ws-1" {
+		t.Errorf("workspace_id = %q, want ws-1 (the requested, authorized workspace)", child.WorkspaceID)
+	}
+	if child.ProjectID == "proj-ws2" {
+		t.Fatalf("project_id = %q: leaked workspace ws-2's project into a ws-1 task", child.ProjectID)
+	}
+	if child.ProjectID != "" {
+		t.Errorf("project_id = %q, want empty (no same-workspace project to inherit)", child.ProjectID)
+	}
+}

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -248,6 +248,61 @@ func TestCreateTask_Subtask_ExplicitProjectNotOverridden(t *testing.T) {
 	}
 }
 
+// TestCreateTask_Subtask_AutoTitleRejectedRegardlessOfProjectSource is the F3
+// regression: prepareTaskForCreation must classify office-ness once, from the
+// final req.ProjectID, so an inherited project reaches the same
+// ErrAutoTitleUnsupportedForOffice rejection an explicit project_id does.
+// Before the fix, inheritParentProject ran after prepareAutoTitle and
+// validateCreateTaskRequest, so a request with no explicit project_id sailed
+// past both — isOfficeRequest saw ProjectID still empty — then got
+// classified as an office task once the project was inherited, silently
+// creating a task with agent_title_pending set: exactly what the guard
+// exists to prevent.
+func TestCreateTask_Subtask_AutoTitleRejectedRegardlessOfProjectSource(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	ws, err := repo.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	officeWorkflowID := ws.OfficeWorkflowID
+
+	parentResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Parent",
+		ProjectID:   "proj-1",
+	})
+	parent := parentResult.Task
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	_, err = svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		ParentID:    parent.ID,
+		WorkflowID:  officeWorkflowID,
+		ProjectID:   "proj-1",
+		AutoTitle:   true,
+		Description: "please do the thing now",
+	})
+	if !errors.Is(err, ErrAutoTitleUnsupportedForOffice) {
+		t.Fatalf("explicit project: error = %v, want ErrAutoTitleUnsupportedForOffice", err)
+	}
+
+	_, err = svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		ParentID:    parent.ID,
+		WorkflowID:  officeWorkflowID,
+		AutoTitle:   true,
+		Description: "please do the thing now",
+	})
+	if !errors.Is(err, ErrAutoTitleUnsupportedForOffice) {
+		t.Fatalf("inherited project: error = %v, want the SAME ErrAutoTitleUnsupportedForOffice the explicit "+
+			"case gets, not a silently-created office task carrying agent_title_pending", err)
+	}
+}
+
 func TestCreateTask_Subtask_ExplicitRepositoriesNotOverridden(t *testing.T) {
 	svc, repo := setupOfficeTest(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -52,6 +52,37 @@ func TestCreateChildTask_HappyPath_InheritsWorkflow(t *testing.T) {
 	}
 }
 
+// Regression: CreateChildTask must keep inheriting the parent's project so
+// office cost events (which copy tasks.project_id verbatim) attribute to the
+// same project as the rest of the task tree.
+func TestCreateChildTask_InheritsParentProject(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	parentResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Parent",
+		ProjectID:   "proj-1",
+	})
+	parent := parentResult.Task
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	childID, err := svc.CreateChildTask(ctx, parent, ChildTaskSpec{Title: "Child"})
+	if err != nil {
+		t.Fatalf("CreateChildTask: %v", err)
+	}
+
+	got, err := repo.GetTask(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ProjectID != "proj-1" {
+		t.Errorf("project_id = %q, want inherited proj-1", got.ProjectID)
+	}
+}
+
 func TestCreateChildTask_OverridesWorkflow(t *testing.T) {
 	svc, repo := setupOfficeTest(t)
 	ctx := context.Background()
@@ -137,6 +168,83 @@ func TestCreateTask_Subtask_InheritsParentRepositories(t *testing.T) {
 	// CheckoutBranch is dropped: two worktrees can't share a working branch.
 	if childRepos[0].CheckoutBranch != "" {
 		t.Errorf("checkout_branch = %q, want empty (dropped on inherit)", childRepos[0].CheckoutBranch)
+	}
+}
+
+// TestCreateTask_Subtask_InheritsParentProject covers the generic create
+// path (mirrors MCP create_task_kandev / REST create with parent_id set): a
+// subtask created with a parent but no explicit project_id must inherit the
+// parent's project and, since that earns it office recognition, an
+// identifier — otherwise its office cost events leak (no project_id to roll
+// up to).
+func TestCreateTask_Subtask_InheritsParentProject(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	parentResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Parent",
+		ProjectID:   "proj-1",
+	})
+	parent := parentResult.Task
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	childResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Child",
+		ParentID:    parent.ID,
+		Origin:      models.TaskOriginAgentCreated,
+	})
+	child := childResult.Task
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	got, err := repo.GetTask(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ProjectID != "proj-1" {
+		t.Errorf("project_id = %q, want inherited proj-1", got.ProjectID)
+	}
+	if got.Identifier == "" {
+		t.Error("expected identifier once the task is recognized as an office task")
+	}
+}
+
+func TestCreateTask_Subtask_ExplicitProjectNotOverridden(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	parentResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Parent",
+		ProjectID:   "proj-1",
+	})
+	parent := parentResult.Task
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	childResult, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Child",
+		ParentID:    parent.ID,
+		ProjectID:   "proj-2",
+	})
+	child := childResult.Task
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	got, err := repo.GetTask(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ProjectID != "proj-2" {
+		t.Errorf("project_id = %q, want explicit proj-2 kept", got.ProjectID)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -552,6 +552,16 @@ func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTask
 // projectIDForTask) with no ancestry walk or fallback, so a subtask left
 // projectless never rolls up to its tree's budget even though its parent
 // has one.
+//
+// CreateTask authorizes only req.WorkspaceID, never the parent, and the MCP
+// create-task path deliberately allows an explicit req.WorkspaceID that
+// differs from the parent's (TestHandleCreateTask_SubtaskHonorsExplicitWorkspaceAndWorkflow) —
+// so a workspace mismatch cannot be rejected outright without breaking that
+// flow. Inheritance is skipped instead: a caller authorized only for
+// workspace A that passes a parent from workspace B gets a projectless
+// subtask in A, never B's project silently attributed to A. This mirrors
+// the pre-fix behavior for every subtask (blank project) rather than
+// introducing a new failure mode.
 func (s *Service) inheritParentProject(ctx context.Context, req *CreateTaskRequest) error {
 	if req.ParentID == "" || req.ProjectID != "" {
 		return nil
@@ -559,6 +569,9 @@ func (s *Service) inheritParentProject(ctx context.Context, req *CreateTaskReque
 	parent, err := s.tasks.GetTask(ctx, req.ParentID)
 	if err != nil {
 		return fmt.Errorf("get parent task for project inheritance: %w", err)
+	}
+	if parent.WorkspaceID != req.WorkspaceID {
+		return nil
 	}
 	req.ProjectID = parent.ProjectID
 	return nil

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -223,6 +223,17 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (Creat
 // required validation, workflow/step resolution, and office identifier
 // assignment, producing the in-memory task CreateTask is about to insert.
 func (s *Service) prepareTaskForCreation(ctx context.Context, req *CreateTaskRequest, externalID string) (*models.Task, error) {
+	// Subtasks created without an explicit project inherit the parent's, so
+	// office cost events (which copy tasks.project_id verbatim) attribute to
+	// the same project as the rest of the tree instead of leaking. Runs first
+	// so every isOfficeRequest check below — including prepareAutoTitle's —
+	// classifies office-ness from the same, final req.ProjectID: an inherited
+	// project must reach the same auto_title rejection an explicit one does,
+	// not silently create an office task carrying agent_title_pending.
+	if err := s.inheritParentProject(ctx, req); err != nil {
+		return nil, err
+	}
+
 	if err := prepareAutoTitle(req); err != nil {
 		return nil, err
 	}
@@ -238,15 +249,6 @@ func (s *Service) prepareTaskForCreation(ctx context.Context, req *CreateTaskReq
 	// parent's worktree (the UI omits repositories expecting this). Mirrors the
 	// MCP create_task path so UI- and agent-created subtasks behave identically.
 	if err := s.inheritParentRepositories(ctx, req); err != nil {
-		return nil, err
-	}
-
-	// Subtasks created without an explicit project inherit the parent's, so
-	// office cost events (which copy tasks.project_id verbatim) attribute to
-	// the same project as the rest of the tree instead of leaking. Runs before
-	// isOfficeRequest below so an inherited project also earns the office
-	// identifier and workflow resolution.
-	if err := s.inheritParentProject(ctx, req); err != nil {
 		return nil, err
 	}
 

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -241,6 +241,15 @@ func (s *Service) prepareTaskForCreation(ctx context.Context, req *CreateTaskReq
 		return nil, err
 	}
 
+	// Subtasks created without an explicit project inherit the parent's, so
+	// office cost events (which copy tasks.project_id verbatim) attribute to
+	// the same project as the rest of the tree instead of leaking. Runs before
+	// isOfficeRequest below so an inherited project also earns the office
+	// identifier and workflow resolution.
+	if err := s.inheritParentProject(ctx, req); err != nil {
+		return nil, err
+	}
+
 	// For office tasks, resolve workflow from workspace
 	if isOfficeRequest(req) && req.WorkflowID == "" {
 		if err := s.resolveOfficeWorkflow(ctx, req); err != nil {
@@ -532,6 +541,24 @@ func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTask
 	if len(inherited) > 0 {
 		req.Repositories = inherited
 	}
+	return nil
+}
+
+// inheritParentProject fills req.ProjectID from the parent task when a
+// subtask is created without an explicit project. Office cost events copy
+// tasks.project_id verbatim (see office/service/event_subscribers.go
+// projectIDForTask) with no ancestry walk or fallback, so a subtask left
+// projectless never rolls up to its tree's budget even though its parent
+// has one.
+func (s *Service) inheritParentProject(ctx context.Context, req *CreateTaskRequest) error {
+	if req.ParentID == "" || req.ProjectID != "" {
+		return nil
+	}
+	parent, err := s.tasks.GetTask(ctx, req.ParentID)
+	if err != nil {
+		return fmt.Errorf("get parent task for project inheritance: %w", err)
+	}
+	req.ProjectID = parent.ProjectID
 	return nil
 }
 


### PR DESCRIPTION
**Today:** Office agents auto-create subtasks (e.g. KAN-5, KAN-6, KAN-7) with no project assigned. Nothing tracks the cost of that work against any project — it just leaks off the books.
**After this:** A new subtask inherits its parent task's project automatically. If a root task's project genuinely can't be resolved, task creation is rejected outright instead of silently succeeding with a blank project that starts the leak.
**Who hits this:** Anyone running Office mode with per-project cost/spend tracking — every agent-spawned subtask shipped unattributed until now.
**Scope:** standalone fix, not part of a larger series.
**Not here:** root-level tasks created directly via the MCP `create_task` tool (no `parent_id`) still have no project-resolution step of their own — that's a separate, larger gap in office cost attribution, outside this card.

Office subtasks were classifying "is this an office task" before the parent's project had been copied onto the request, so an inherited project could sneak past the `auto_title` guard, and a task whose parent lived in a different workspace could inherit that workspace's project outright, misattributing cost across workspace boundaries. Both are closed now: office-ness is classified once, off the final resolved project, and inheritance only happens within the same workspace.

## Validation

Backend-only change (`apps/backend/internal/office/runtime/**`, `apps/backend/internal/task/service/**`) — no `apps/web/` paths touched, so no E2E run is required per the repo's mechanical E2E-scope rule.

- `make -C apps/backend lint` — `0 issues`
- `make lint` (root: backend + web eslint + harness + architecture) — clean
- `make fmt` / `make lint-format` — clean, no diffs
- `cd apps/web && pnpm run i18n:ratchet` — clean no-op (no web files touched)
- `go build ./...` — clean
- Targeted regression tests, all green:
  - `TestCreateTask_Subtask_AutoTitleRejectedRegardlessOfProjectSource`
  - `TestActionsCreateTaskRootFailsClosedWhenRunTaskProjectLookupErrors`
  - `TestCreateTask_Subtask_CrossWorkspaceParentDoesNotInheritForeignProject`
  - Full `internal/mcp/handlers` suite, including the two pre-existing explicit-cross-workspace-subtask tests this fix had to stay compatible with
- Full backend suite (`go test ./...`): only failures are the pre-existing/flaky set unrelated to this diff — `internal/agent/managedruntime`, `internal/agent/settings/controller`, `internal/agentctl/server/config`, `internal/system/storage/workspaces` (proven pre-existing against `origin/main`'s merge-base in a scratch worktree — same failure signatures, e.g. `open npm cache root: not a directory`), plus `internal/common/subproc` (one timing-sensitive test, passes cleanly in isolation — parallel-load flake in an untouched package)

## Possible Improvements

Low risk, backend-only. One residual gap, not a production bug: there's no handler-level test asserting `ErrProjectRequired` maps to HTTP 400 on `POST /runtime/tasks` — the mapping is correctly wired and covered at the action layer, just not at the route layer.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->