### PR TITLE
fix(web): register prompt history in layout editor

### DIFF
--- a/apps/web/components/settings/layouts/layout-editor.test.ts
+++ b/apps/web/components/settings/layouts/layout-editor.test.ts
@@ -5,10 +5,11 @@ import { placeholderComponents } from "./layout-editor";
 describe("layout editor placeholder components", () => {
   it("renders every reusable panel the Add panel menu offers", () => {
     for (const id of REUSABLE_PANEL_IDS) {
-      const component = PANEL_REGISTRY[id].component;
+      const entry = PANEL_REGISTRY[id];
+      expect(entry, `PANEL_REGISTRY missing entry for reusable panel ${id}`).toBeDefined();
       expect(
-        placeholderComponents[component],
-        `placeholder for reusable panel ${id} (component ${component})`,
+        placeholderComponents[entry?.component],
+        `placeholder for reusable panel ${id} (component ${entry?.component})`,
       ).toBeDefined();
     }
   });

--- a/apps/web/components/settings/layouts/layout-editor.test.ts
+++ b/apps/web/components/settings/layouts/layout-editor.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { PANEL_REGISTRY, REUSABLE_PANEL_IDS } from "@/lib/state/layout-manager";
+import { placeholderComponents } from "./layout-editor";
+
+describe("layout editor placeholder components", () => {
+  it("renders every reusable panel the Add panel menu offers", () => {
+    for (const id of REUSABLE_PANEL_IDS) {
+      const component = PANEL_REGISTRY[id].component;
+      expect(
+        placeholderComponents[component],
+        `placeholder for reusable panel ${id} (component ${component})`,
+      ).toBeDefined();
+    }
+  });
+});

--- a/apps/web/components/settings/layouts/layout-editor.tsx
+++ b/apps/web/components/settings/layouts/layout-editor.tsx
@@ -39,7 +39,7 @@ function EditorTab(props: IDockviewPanelHeaderProps) {
   return <DockviewDefaultTab {...props} hideClose />;
 }
 
-const placeholderComponents = {
+export const placeholderComponents: Record<string, React.FunctionComponent<IDockviewPanelProps>> = {
   chat: PlaceholderPanel,
   files: PlaceholderPanel,
   changes: PlaceholderPanel,
@@ -52,6 +52,8 @@ const placeholderComponents = {
   // so Settings > Layouts renders a generic box instead of throwing on an
   // unknown tabComponent (AC8), regardless of which plugin registered it.
   "plugin-panel": PlaceholderPanel,
+  // Reusable panels rendered through the same placeholder box in the editor.
+  "prompt-history": PlaceholderPanel,
   todos: PlaceholderPanel,
 };
 

--- a/apps/web/e2e/tests/settings/layout-profiles.spec.ts
+++ b/apps/web/e2e/tests/settings/layout-profiles.spec.ts
@@ -399,12 +399,30 @@ test.describe("Task layout profile defaults", () => {
     expect((await apiClient.getUserSettings()).settings.saved_layouts).toHaveLength(1);
   });
 
-  test("adds Prompt History through the layout editor", async ({ testPage }) => {
+  test("adds Prompt History through the layout editor and restores it into a task", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
     const layouts = new LayoutSettingsPage(testPage);
     await layouts.open();
 
     await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toHaveCount(0);
     await layouts.addPanel("Prompt History");
-    await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toBeVisible();
+
+    // The added panel survives save and is persisted in the default profile.
+    await layouts.save();
+    const saved = (await apiClient.getUserSettings()).settings.saved_layouts;
+    expect(saved).toHaveLength(1);
+    expect(JSON.stringify(saved[0].layout)).toContain("prompt-history");
+
+    // A new task opens with the edited default layout; the panel restores and renders.
+    const task = await createTaskWithSession(apiClient, seedData, "Prompt History Layout Task");
+    await openTask(testPage, task.id);
+    const tab = testPage.locator(".dv-tab", { hasText: "Prompt History" });
+    await expect(tab).toBeVisible({ timeout: 15_000 });
+    await tab.click();
+    await expect(testPage.getByTestId("prompt-history-panel")).toBeVisible();
   });
 });

--- a/apps/web/e2e/tests/settings/layout-profiles.spec.ts
+++ b/apps/web/e2e/tests/settings/layout-profiles.spec.ts
@@ -398,4 +398,13 @@ test.describe("Task layout profile defaults", () => {
     await testPage.getByRole("button", { name: "Cancel" }).click();
     expect((await apiClient.getUserSettings()).settings.saved_layouts).toHaveLength(1);
   });
+
+  test("adds Prompt History through the layout editor", async ({ testPage }) => {
+    const layouts = new LayoutSettingsPage(testPage);
+    await layouts.open();
+
+    await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toHaveCount(0);
+    await layouts.addPanel("Prompt History");
+    await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toBeVisible();
+  });
 });

--- a/apps/web/e2e/tests/settings/mobile-layout-profiles.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-layout-profiles.spec.ts
@@ -104,4 +104,13 @@ test.describe("Mobile layout profiles", () => {
     await assertNoDocumentHorizontalOverflow(testPage, "edited layouts page");
     await assertNoDescendantOverflowsRight(layouts.root, "edited layouts settings");
   });
+
+  test("adds Prompt History through the touch layout editor", async ({ testPage }) => {
+    const layouts = new LayoutSettingsPage(testPage);
+    await layouts.openFromSettingsIndex();
+
+    await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toHaveCount(0);
+    await layouts.addPanel("Prompt History", true);
+    await expect(layouts.editor.locator(".dv-tab", { hasText: "Prompt History" })).toBeVisible();
+  });
 });


### PR DESCRIPTION
Adding Prompt History in Settings > Preferences > Layouts crashed the layout editor because its placeholder renderer map lacked a `prompt-history` entry; the editor now registers the panel, with unit and desktop/mobile E2E coverage guarding the add → save → restore flow.

## Validation

- `pnpm --filter @kandev/web test -- components/settings/layouts/ lib/state/layout-manager/` — 103 tests passed, incl. the new invariant test (every `REUSABLE_PANEL_IDS` panel has an editor placeholder renderer).
- E2E desktop `e2e/tests/settings/layout-profiles.spec.ts` — 5 passed (fresh build): add Prompt History → save → persisted default profile contains `prompt-history` → fresh task restores the tab → real workbench renders `prompt-history-panel`.
- E2E mobile-chrome `e2e/tests/settings/mobile-layout-profiles.spec.ts` — 4 passed (touch add through the layout editor).
- `make fmt-web`, `make typecheck`, `make lint` — clean.
- Adversarial review (3 consecutive clean rounds): APPROVE.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.