### PR TITLE
fix(ui): show clarification submit spinner

### DIFF
--- a/apps/web/components/task/chat/clarification-overlay-header.tsx
+++ b/apps/web/components/task/chat/clarification-overlay-header.tsx
@@ -2,6 +2,7 @@
 
 import { IconChevronDown, IconCheck, IconX } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
+import { Spinner } from "@kandev/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { KeyboardShortcutTooltip } from "@/components/keyboard-shortcut-tooltip";
 import { SHORTCUTS } from "@/lib/keyboard/constants";
@@ -88,7 +89,7 @@ export function ClarificationHeaderActions({
               )}
             >
               {isSubmitting ? t("task:submitting") : t("task:submit")}
-              <IconCheck className="h-3 w-3" />
+              {isSubmitting ? <Spinner className="size-3" /> : <IconCheck className="h-3 w-3" />}
             </button>
           </span>
         </KeyboardShortcutTooltip>

--- a/apps/web/components/task/chat/clarification-overlay-header.tsx
+++ b/apps/web/components/task/chat/clarification-overlay-header.tsx
@@ -89,7 +89,11 @@ export function ClarificationHeaderActions({
               )}
             >
               {isSubmitting ? t("task:submitting") : t("task:submit")}
-              {isSubmitting ? <Spinner className="size-3" /> : <IconCheck className="h-3 w-3" />}
+              {isSubmitting ? (
+                <Spinner aria-hidden="true" className="size-3" />
+              ) : (
+                <IconCheck className="h-3 w-3" />
+              )}
             </button>
           </span>
         </KeyboardShortcutTooltip>

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -902,6 +902,7 @@ test.describe("Multi-question clarification carousel", () => {
     await expect(submit).toContainText("Submitting");
     await expect(submit).toBeDisabled();
     await expect(submit.locator('[role="status"]')).toBeVisible();
+    await expect(submit.locator('[role="status"]')).toHaveAttribute("aria-hidden", "true");
     await expect(submit.locator("svg.tabler-icon-check")).toHaveCount(0);
 
     await testPage.keyboard.press("ArrowLeft");

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -898,7 +898,11 @@ test.describe("Multi-question clarification carousel", () => {
 
     await session.chat.focus();
     await testPage.keyboard.press("ControlOrMeta+Enter");
-    await expect(session.clarificationSubmit()).toContainText("Submitting");
+    const submit = session.clarificationSubmit();
+    await expect(submit).toContainText("Submitting");
+    await expect(submit).toBeDisabled();
+    await expect(submit.locator('[role="status"]')).toBeVisible();
+    await expect(submit.locator("svg.tabler-icon-check")).toHaveCount(0);
 
     await testPage.keyboard.press("ArrowLeft");
     await expect(session.clarificationStep(2)).toHaveAttribute("data-active", "true");

--- a/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
@@ -171,6 +171,7 @@ test.describe("Mobile clarification multiline answer", () => {
     await expect(submit).toContainText("Submitting");
     await expect(submit).toBeDisabled();
     await expect(submit.locator('[role="status"]')).toBeVisible();
+    await expect(submit.locator('[role="status"]')).toHaveAttribute("aria-hidden", "true");
     await expect(submit.locator("svg.tabler-icon-check")).toHaveCount(0);
     await expect(
       testPage.evaluate(

--- a/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
@@ -137,4 +137,48 @@ test.describe("Mobile clarification multiline answer", () => {
     await expect(session.clarificationStep(1)).toHaveAttribute("data-active", "true");
     await expect(context).toHaveCount(1);
   });
+
+  test("shows a loading spinner while batch answers submit on mobile", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedClarificationSession(
+      testPage,
+      apiClient,
+      seedData,
+      "Mobile Clarify Submit Feedback",
+      { scenario: "clarification-multi" },
+    );
+
+    await expect(session.clarificationOverlay()).toBeVisible({ timeout: 30_000 });
+    await session.clarificationOption("PostgreSQL").tap();
+    await session.clarificationOption("Go").tap();
+    await session.clarificationOption("Docker").tap();
+
+    let releaseResponse = () => undefined;
+    const heldResponse = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    await testPage.route("**/api/v1/clarification/*/respond", async (route) => {
+      await heldResponse;
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    const submit = session.clarificationSubmit();
+    await expect(submit).toBeEnabled();
+    await submit.tap();
+    await expect(submit).toContainText("Submitting");
+    await expect(submit).toBeDisabled();
+    await expect(submit.locator('[role="status"]')).toBeVisible();
+    await expect(submit.locator("svg.tabler-icon-check")).toHaveCount(0);
+    await expect(
+      testPage.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).resolves.toBe(true);
+
+    releaseResponse();
+    await expect(session.clarificationOverlay()).not.toBeVisible({ timeout: 30_000 });
+  });
 });

--- a/docs/plans/clarification-submit-feedback/plan.md
+++ b/docs/plans/clarification-submit-feedback/plan.md
@@ -21,6 +21,9 @@ responsive composition changes are required.
 - `apps/web/components/task/chat/clarification-overlay-header.tsx`
   - Import `Spinner` from `@kandev/ui/spinner`.
   - Render the spinner instead of `IconCheck` when `isSubmitting` is true.
+  - Mark the decorative spinner `aria-hidden` so the translated submitting
+    label remains the accessible status without exposing the shared English
+    `Loading` label.
   - Preserve the existing translated labels, disabled state, tooltip gating,
     button dimensions, and idle check icon.
 - The component is shared by task chat and Quick Chat, so both surfaces inherit
@@ -79,6 +82,8 @@ Passed.
 - `cd ../.. && git diff --check` passed.
 - The managed E2E runs rebuilt the backend and pseudo-locale Vite assets and cleaned their isolated test artifacts. No blockers remain.
 - Fresh phone and desktop pending-state screenshots were captured with synthetic E2E data, visually inspected, compressed, and validated through `apps/web/.pr-assets/manifest.json`; the disposable capture specs were removed afterward.
+- Fixup: addressed the P2 accessibility review by hiding the decorative spinner from assistive technology; the translated `Submitting...` button text remains exposed.
+- Fixup verification: `cd apps/web && pnpm run typecheck`, `cd apps/web && pnpm run lint`, and the focused desktop/mobile E2E commands above all passed.
 
 ## Implementation Waves And Parallel Candidates
 

--- a/docs/plans/clarification-submit-feedback/plan.md
+++ b/docs/plans/clarification-submit-feedback/plan.md
@@ -1,0 +1,94 @@
+---
+spec: docs/specs/ui/clarification-submit-feedback.md
+created: 2026-08-20
+status: done
+---
+
+# Implementation Plan: Clarification submit feedback
+
+## Overview
+
+Update the shared clarification overlay header to use the existing design-system
+`Spinner` while a multi-question answer submission is pending. Extend the
+existing desktop clarification E2E coverage and add the same pending-state
+assertion to the mobile clarification flow. No backend, state, translation, or
+responsive composition changes are required.
+
+## Frontend
+
+### Shared clarification submit button
+
+- `apps/web/components/task/chat/clarification-overlay-header.tsx`
+  - Import `Spinner` from `@kandev/ui/spinner`.
+  - Render the spinner instead of `IconCheck` when `isSubmitting` is true.
+  - Preserve the existing translated labels, disabled state, tooltip gating,
+    button dimensions, and idle check icon.
+- The component is shared by task chat and Quick Chat, so both surfaces inherit
+  the same behavior. No `useResponsiveBreakpoint` branch is needed because the
+  change is an inline status indicator inside an existing control.
+
+### Mobile parity contract
+
+- Desktop outcome: the operator can see that the batch answer request is still
+  in flight and cannot submit it again.
+- Mobile entry point: the existing clarification overlay Submit button in the
+  shared chat panel; no new navigation or surface is introduced.
+- Nearest shipped exemplar: existing `Spinner` usage inside submit controls in
+  `apps/web/components/settings/system/bundle-customizer.tsx`.
+- Mobile hierarchy, scroll owner, safe area, and touch target remain unchanged;
+  the status icon stays inside the existing reachable button.
+- Shared state and handler logic remain in `useClarificationGroup` and the
+  existing `ClarificationHeaderActions` props.
+
+## Tests
+
+- **What:** The shared submit button shows an animated loading status, keeps the
+  `Submitting...` label, remains disabled, and hides the idle check icon while a
+  response is held.
+  **File:** `apps/web/e2e/tests/chat/clarification.spec.ts`
+  **How:** Extend the existing “question shortcuts stay disabled while answers
+  are submitting” test, which already holds the response route open, to assert
+  a `role="status"` spinner inside `clarification-submit`.
+- **What:** The same loading status is reachable and contained on a phone.
+  **File:** `apps/web/e2e/tests/chat/mobile-clarification.spec.ts`
+  **How:** Add a focused multi-question mobile scenario that answers the
+  bundle, holds the response route, and asserts the spinner inside the Submit
+  button before releasing the response.
+
+## E2E Tests
+
+- **Scenario:** GIVEN a multi-question clarification is fully answered on
+  desktop, WHEN its response is held in flight, THEN the Submit button shows
+  `Submitting...`, is disabled, and contains the loading status.
+  **File:** `apps/web/e2e/tests/chat/clarification.spec.ts`
+- **Scenario:** GIVEN the same fully answered clarification is shown on a
+  Pixel 5 viewport, WHEN its response is held in flight, THEN the Submit button
+  remains visible and contains the loading status without page overflow.
+  **File:** `apps/web/e2e/tests/chat/mobile-clarification.spec.ts`
+
+## Verification Results
+
+Passed.
+
+- `cd apps && pnpm install --frozen-lockfile` passed.
+- `cd apps/web && pnpm run typecheck` passed.
+- `cd apps/web && pnpm run lint` passed with no errors or warnings.
+- `cd apps/web && pnpm exec prettier --check components/task/chat/clarification-overlay-header.tsx e2e/tests/chat/clarification.spec.ts e2e/tests/chat/mobile-clarification.spec.ts` passed.
+- `cd apps/web && pnpm e2e:run --project chromium tests/chat/clarification.spec.ts -- --grep "question shortcuts stay disabled while answers are submitting"` passed (1 test).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-clarification.spec.ts -- --grep "loading spinner"` passed (1 test).
+- `cd ../.. && git diff --check` passed.
+- The managed E2E runs rebuilt the backend and pseudo-locale Vite assets and cleaned their isolated test artifacts. No blockers remain.
+- Fresh phone and desktop pending-state screenshots were captured with synthetic E2E data, visually inspected, compressed, and validated through `apps/web/.pr-assets/manifest.json`; the disposable capture specs were removed afterward.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [task-01-submit-feedback](task-01-submit-feedback.md)
+
+The task is sequential because the component and both E2E assertions form one
+small vertical slice.
+
+## Open Questions
+
+None.

--- a/docs/plans/clarification-submit-feedback/task-01-submit-feedback.md
+++ b/docs/plans/clarification-submit-feedback/task-01-submit-feedback.md
@@ -76,3 +76,5 @@ vertical slice.
 - Final files: `apps/web/components/task/chat/clarification-overlay-header.tsx`, `apps/web/e2e/tests/chat/clarification.spec.ts`, `apps/web/e2e/tests/chat/mobile-clarification.spec.ts`, `docs/specs/ui/clarification-submit-feedback.md`, `docs/plans/clarification-submit-feedback/plan.md`, and this task file.
 - The managed E2E runs rebuilt the backend and pseudo-locale Vite assets and cleaned their isolated test artifacts. No E2E blockers or failure artifacts remain.
 - Fresh phone and desktop pending-state screenshots were captured with synthetic E2E data, visually inspected, compressed, and validated through `apps/web/.pr-assets/manifest.json`; the disposable capture specs were removed afterward.
+- Fixup: addressed the P2 accessibility review by adding `aria-hidden="true"` to the decorative spinner and asserting that attribute in both desktop and mobile E2E coverage.
+- Fixup verification passed: `cd apps/web && pnpm run typecheck`, `cd apps/web && pnpm run lint`, and the focused desktop/mobile E2E commands above.

--- a/docs/plans/clarification-submit-feedback/task-01-submit-feedback.md
+++ b/docs/plans/clarification-submit-feedback/task-01-submit-feedback.md
@@ -1,0 +1,78 @@
+---
+id: "01-submit-feedback"
+title: "Add clarification submit spinner"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/clarification-submit-feedback.md"
+---
+
+# Task 01: Add clarification submit spinner
+
+## Acceptance
+
+- The shared multi-question clarification Submit button shows the existing
+  translated `Submitting...` label and an animated `Spinner` while its response
+  request is pending; it remains disabled and does not show the idle check
+  icon.
+- Idle and failed submissions retain the current retryable behavior, and the
+  shared change works in task chat and Quick Chat without changing the mobile
+  composition.
+- Desktop and mobile Playwright coverage proves the pending loading state.
+
+## Verification
+
+Run from the repository root in one sequential block:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm e2e:run --project chromium tests/chat/clarification.spec.ts -- --grep "question shortcuts stay disabled while answers are submitting"
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-clarification.spec.ts -- --grep "loading spinner"
+cd ../.. && git diff --check
+```
+
+## Files likely touched
+
+- `apps/web/components/task/chat/clarification-overlay-header.tsx`
+- `apps/web/e2e/tests/chat/clarification.spec.ts`
+- `apps/web/e2e/tests/chat/mobile-clarification.spec.ts`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. The shared component and its desktop/mobile proof must stay in one
+vertical slice.
+
+## Inputs
+
+- `docs/specs/ui/clarification-submit-feedback.md`
+- `docs/plans/clarification-submit-feedback/plan.md`
+- `apps/web/hooks/domains/session/use-clarification-group.ts`
+- `apps/web/components/task/chat/clarification-overlay-header.tsx`
+- Existing `Spinner` usage in `apps/web/components/settings/system/bundle-customizer.tsx`
+
+## Risks
+
+- The design-system spinner exposes an accessible status label; tests should
+  scope that status to the submit button so unrelated loading indicators cannot
+  satisfy the assertion.
+- The mobile test must use the configured `mobile-chrome` project and the
+  existing causal response-hold pattern, not a fixed sleep.
+
+## Results
+
+- `cd apps && pnpm install --frozen-lockfile` passed.
+- `cd apps/web && pnpm run typecheck` passed.
+- `cd apps/web && pnpm run lint` passed with no errors or warnings.
+- `cd apps/web && pnpm exec prettier --check components/task/chat/clarification-overlay-header.tsx e2e/tests/chat/clarification.spec.ts e2e/tests/chat/mobile-clarification.spec.ts` passed.
+- `cd apps/web && pnpm e2e:run --project chromium tests/chat/clarification.spec.ts -- --grep "question shortcuts stay disabled while answers are submitting"` passed (1 test).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-clarification.spec.ts -- --grep "loading spinner"` passed (1 test).
+- `cd ../.. && git diff --check` passed.
+- Final files: `apps/web/components/task/chat/clarification-overlay-header.tsx`, `apps/web/e2e/tests/chat/clarification.spec.ts`, `apps/web/e2e/tests/chat/mobile-clarification.spec.ts`, `docs/specs/ui/clarification-submit-feedback.md`, `docs/plans/clarification-submit-feedback/plan.md`, and this task file.
+- The managed E2E runs rebuilt the backend and pseudo-locale Vite assets and cleaned their isolated test artifacts. No E2E blockers or failure artifacts remain.
+- Fresh phone and desktop pending-state screenshots were captured with synthetic E2E data, visually inspected, compressed, and validated through `apps/web/.pr-assets/manifest.json`; the disposable capture specs were removed afterward.

--- a/docs/specs/ui/clarification-submit-feedback.md
+++ b/docs/specs/ui/clarification-submit-feedback.md
@@ -1,0 +1,54 @@
+---
+status: implemented
+created: 2026-08-20
+owner: kandev
+---
+
+# Clarification submit feedback
+
+## Why
+
+When a multi-question clarification is submitted, the chat button changes to
+`Submitting...` and becomes disabled, but its completion check icon remains.
+The button needs a clear in-flight signal while the response is pending.
+
+## What
+
+- The shared clarification overlay keeps the translated `Submitting...` label
+  while its answer request is in flight.
+- While submitting, the multi-question Submit button is disabled and shows the
+  shared animated loading spinner in place of the completion check icon.
+- When the overlay is idle and answerable, the button keeps its existing
+  translated Submit label and completion check icon.
+- The same behavior applies to task chat and Quick Chat on desktop and mobile,
+  because they share the clarification overlay header.
+- If submission fails and the clarification remains visible, the spinner stops,
+  the button returns to its existing retryable Submit state, and no new error
+  behavior is introduced.
+
+## Scenarios
+
+- **GIVEN** every question in a multi-question clarification has an answer,
+  **WHEN** the operator submits the answers and the response request remains
+  pending, **THEN** the Submit button is disabled, retains the `Submitting...`
+  label, shows an animated loading status, and does not show the completion
+  check icon.
+- **GIVEN** a pending submission succeeds, **WHEN** the response is accepted,
+  **THEN** the clarification resolves as it does today and the submitting
+  indicator is no longer rendered.
+- **GIVEN** a pending submission fails, **WHEN** the response returns an error,
+  **THEN** the clarification remains available, the spinner is removed, and
+  the existing Submit action is available for retry.
+- **GIVEN** the same multi-question clarification is rendered in a phone
+  viewport, **WHEN** its answer request is pending, **THEN** the loading status
+  remains visible inside the reachable Submit button without changing the
+  mobile layout or introducing horizontal overflow.
+
+## Out of scope
+
+- Changing the clarification response API, submission lifecycle, or duplicate
+  request guard.
+- Changing the existing `Submitting...` translation or adding new copy.
+- Adding a header Submit button to single-question clarifications.
+- Changing custom-answer Send behavior, skip behavior, button placement, or
+  other loading states.


### PR DESCRIPTION
When clarification answers are submitted, the button stays disabled but the completion check makes the in-flight state unclear. The shared overlay now swaps that check for the existing animated spinner while preserving translated copy and mobile layout.

## Validation

- `cd apps && pnpm install --frozen-lockfile`
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm run lint`
- `cd apps/web && pnpm e2e:run --project chromium tests/chat/clarification.spec.ts -- --grep "question shortcuts stay disabled while answers are submitting"`
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-clarification.spec.ts -- --grep "loading spinner"`
- `cd ../.. && git diff --check`
- Captured and visually inspected fresh phone and desktop screenshots of the pending state.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop pending clarification submit](https://raw.githubusercontent.com/kdlbs/kandev/b376281ee7b6008a3e27ac3363a356a90d6eb2f6/clarification-submit-desktop.png)

![Phone pending clarification submit](https://raw.githubusercontent.com/kdlbs/kandev/b376281ee7b6008a3e27ac3363a356a90d6eb2f6/clarification-submit-mobile.png)
<!-- kandev-screenshots-end -->