### PR TITLE
fix(office): persist workspace name and description edits on save

### DIFF
--- a/apps/backend/internal/office/dashboard/dto.go
+++ b/apps/backend/internal/office/dashboard/dto.go
@@ -449,8 +449,6 @@ type CreateCommentRequest struct {
 
 // UpdateWorkspaceSettingsRequest is the request body for updating workspace settings.
 type UpdateWorkspaceSettingsRequest struct {
-	Name                             *string `json:"name"`
-	Description                      *string `json:"description"`
 	PermissionHandlingMode           *string `json:"permission_handling_mode"`
 	RecoveryLookbackHours            *int    `json:"recovery_lookback_hours"`
 	RequireApprovalForNewAgents      *bool   `json:"require_approval_for_new_agents"`

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -137,6 +137,32 @@ describe("useSettingsState appearance save", () => {
     expect(setWorkspaces).not.toHaveBeenCalled();
   });
 
+  // A newer keystroke landing before the PATCH from an older one resolves
+  // must survive that response, not get overwritten by the stale echo.
+  it("keeps a draft typed during an in-flight save instead of reverting it", async () => {
+    const ws = workspace();
+    const { storeApi } = makeStoreApi([ws]);
+    let resolveUpdate!: (value: Workspace) => void;
+    mockUpdateWorkspaceAction.mockImplementation(
+      () => new Promise<Workspace>((resolve) => (resolveUpdate = resolve)) as never,
+    );
+
+    const { result } = renderSettings(ws, storeApi);
+    act(() => result.current.setName("Alpha"));
+    let savePromise!: Promise<void>;
+    act(() => {
+      savePromise = result.current.handleSaveAppearance();
+    });
+    act(() => result.current.setName("Alpha2"));
+
+    await act(async () => {
+      resolveUpdate({ ...ws, name: "Alpha" });
+      await savePromise;
+    });
+
+    expect(result.current.name).toBe("Alpha2");
+  });
+
   it("does not clobber a workspace added to the store while the save was in flight", async () => {
     const ws = workspace();
     const concurrent = workspace({ id: "ws-2", name: "Concurrent Workspace" });

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -34,16 +34,34 @@ function workspace(overrides: Partial<Workspace> = {}): Workspace {
   };
 }
 
+// Mirrors the slice of `StoreApi<AppState>` the appearance-save handler
+// reads: a live `getState()` accessor, not a snapshot passed at render time.
+// This is what lets the test below prove a concurrent store write survives.
+function makeStoreApi(initialItems: Workspace[], onSetWorkspaces?: (items: Workspace[]) => void) {
+  let items = initialItems;
+  const setWorkspaces = vi.fn((next: Workspace[]) => {
+    items = next;
+    onSetWorkspaces?.(next);
+  });
+  return {
+    storeApi: {
+      getState: () => ({ workspaces: { items, activeId: items[0]?.id ?? null }, setWorkspaces }),
+    },
+    setWorkspaces,
+    getItems: () => items,
+    setItems: (next: Workspace[]) => {
+      items = next;
+    },
+  };
+}
+
 function renderSettings(
   activeWorkspace: Workspace,
-  workspaces: Workspace[],
-  setWorkspaces: (items: Workspace[]) => void,
+  storeApi: ReturnType<typeof makeStoreApi>["storeApi"],
 ) {
-  return renderHook(
-    ({ ws, list }: { ws: Workspace; list: Workspace[] }) =>
-      useSettingsState(ws, list, setWorkspaces),
-    { initialProps: { ws: activeWorkspace, list: workspaces } },
-  );
+  return renderHook(({ ws }: { ws: Workspace }) => useSettingsState(ws, storeApi), {
+    initialProps: { ws: activeWorkspace },
+  });
 }
 
 describe("useSettingsState appearance save", () => {
@@ -55,14 +73,14 @@ describe("useSettingsState appearance save", () => {
 
   it("saves the trimmed name and description through updateWorkspaceAction and syncs the store", async () => {
     const ws = workspace();
-    const setWorkspaces = vi.fn();
+    const { storeApi, setWorkspaces } = makeStoreApi([ws]);
     mockUpdateWorkspaceAction.mockResolvedValue({
       ...ws,
       name: "Renamed",
       description: NEW_DESCRIPTION,
     } as never);
 
-    const { result } = renderSettings(ws, [ws], setWorkspaces);
+    const { result } = renderSettings(ws, storeApi);
 
     act(() => {
       result.current.setName("  Renamed  ");
@@ -84,13 +102,10 @@ describe("useSettingsState appearance save", () => {
 
   it("clears the dirty flag once the store reflects the saved workspace", async () => {
     const ws = workspace();
-    let stored: Workspace[] = [ws];
-    const setWorkspaces = vi.fn((items: Workspace[]) => {
-      stored = items;
-    });
+    const { storeApi, getItems } = makeStoreApi([ws]);
     mockUpdateWorkspaceAction.mockResolvedValue({ ...ws, name: "Renamed" } as never);
 
-    const { result, rerender } = renderSettings(ws, [ws], setWorkspaces);
+    const { result, rerender } = renderSettings(ws, storeApi);
 
     act(() => result.current.setName("Renamed"));
     expect(result.current.appearanceDirty).toBe(true);
@@ -102,15 +117,15 @@ describe("useSettingsState appearance save", () => {
     // Simulate the Zustand store propagating the update back into
     // `activeWorkspace`, the way SettingsContent's subscription would on the
     // next render.
-    rerender({ ws: stored[0], list: stored });
+    rerender({ ws: getItems()[0] });
 
     expect(result.current.appearanceDirty).toBe(false);
   });
 
   it("refuses to save an all-whitespace name", async () => {
     const ws = workspace();
-    const setWorkspaces = vi.fn();
-    const { result } = renderSettings(ws, [ws], setWorkspaces);
+    const { storeApi, setWorkspaces } = makeStoreApi([ws]);
+    const { result } = renderSettings(ws, storeApi);
 
     act(() => result.current.setName("   "));
 
@@ -120,5 +135,35 @@ describe("useSettingsState appearance save", () => {
 
     expect(mockUpdateWorkspaceAction).not.toHaveBeenCalled();
     expect(setWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber a workspace added to the store while the save was in flight", async () => {
+    const ws = workspace();
+    const concurrent = workspace({ id: "ws-2", name: "Concurrent Workspace" });
+    const { storeApi, setWorkspaces, setItems } = makeStoreApi([ws]);
+
+    // Simulate a `workspace.created` WS event landing mid-PATCH: the store
+    // gains a second workspace between render (when the old code captured
+    // its snapshot) and the moment the save handler actually reads state.
+    mockUpdateWorkspaceAction.mockImplementation(async () => {
+      setItems([ws, concurrent]);
+      return { ...ws, name: "Renamed", description: NEW_DESCRIPTION } as never;
+    });
+
+    const { result } = renderSettings(ws, storeApi);
+
+    act(() => {
+      result.current.setName("Renamed");
+      result.current.setDescription(NEW_DESCRIPTION);
+    });
+
+    await act(async () => {
+      await result.current.handleSaveAppearance();
+    });
+
+    expect(setWorkspaces).toHaveBeenCalledWith([
+      { ...ws, name: "Renamed", description: NEW_DESCRIPTION },
+      concurrent,
+    ]);
   });
 });

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -21,6 +21,8 @@ type Workspace = WorkspaceState["items"][number];
 
 const WORKSPACE_ID = "ws-1";
 const NEW_DESCRIPTION = "New description";
+const REMOTE_NAME = "Remote Name";
+const REMOTE_DESCRIPTION = "Remote description";
 
 function workspace(overrides: Partial<Workspace> = {}): Workspace {
   return {
@@ -77,12 +79,12 @@ async function saveAppearance(result: ReturnType<typeof renderSettings>["result"
   });
 }
 
-describe("useSettingsState appearance save", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    mockGetWorkspaceSettings.mockResolvedValue({ settings: {} } as never);
-  });
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockGetWorkspaceSettings.mockResolvedValue({ settings: {} } as never);
+});
 
+describe("useSettingsState appearance save", () => {
   it("saves the trimmed name and description through updateWorkspaceAction and syncs the store", async () => {
     const ws = workspace();
     const { setWorkspaces, result, rerender } = renderWithStore([ws]);
@@ -215,5 +217,30 @@ describe("useSettingsState appearance save", () => {
       { ...ws, name: "Renamed", description: NEW_DESCRIPTION },
       concurrent,
     ]);
+  });
+});
+
+describe("same-workspace appearance updates", () => {
+  it("syncs an untouched draft when the same workspace receives a remote update", () => {
+    const ws = workspace();
+    const { result, rerender } = renderWithStore([ws]);
+
+    rerender({ ws: { ...ws, name: REMOTE_NAME, description: REMOTE_DESCRIPTION } });
+
+    expect(result.current.name).toBe(REMOTE_NAME);
+    expect(result.current.description).toBe(REMOTE_DESCRIPTION);
+    expect(result.current.appearanceDirty).toBe(false);
+  });
+
+  it("preserves edited fields while syncing untouched fields from a remote update", () => {
+    const ws = workspace();
+    const { result, rerender } = renderWithStore([ws]);
+    act(() => result.current.setName("Local Draft"));
+
+    rerender({ ws: { ...ws, name: REMOTE_NAME, description: REMOTE_DESCRIPTION } });
+
+    expect(result.current.name).toBe("Local Draft");
+    expect(result.current.description).toBe(REMOTE_DESCRIPTION);
+    expect(result.current.appearanceDirty).toBe(true);
   });
 });

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -9,10 +9,10 @@ vi.mock("@/app/actions/workspaces", () => ({
   updateWorkspaceAction: vi.fn(),
 }));
 
-vi.mock("@/lib/api/domains/office-api", () => ({
-  updateWorkspaceSettings: vi.fn(),
-  getWorkspaceSettings: vi.fn(),
-}));
+vi.mock("@/lib/api/domains/office-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/domains/office-api")>();
+  return { ...actual, updateWorkspaceSettings: vi.fn(), getWorkspaceSettings: vi.fn() };
+});
 
 const mockUpdateWorkspaceAction = vi.mocked(updateWorkspaceAction);
 const mockGetWorkspaceSettings = vi.mocked(getWorkspaceSettings);
@@ -64,32 +64,40 @@ function renderSettings(
   });
 }
 
+// Combines the two setup calls every test needs: a store double plus the
+// hook rendered against it.
+function renderWithStore(items: Workspace[], onSetWorkspaces?: (items: Workspace[]) => void) {
+  const store = makeStoreApi(items, onSetWorkspaces);
+  return { ...store, ...renderSettings(items[0], store.storeApi) };
+}
+
+async function saveAppearance(result: ReturnType<typeof renderSettings>["result"]) {
+  await act(async () => {
+    await result.current.handleSaveAppearance();
+  });
+}
+
 describe("useSettingsState appearance save", () => {
   beforeEach(() => {
-    mockUpdateWorkspaceAction.mockReset();
-    mockGetWorkspaceSettings.mockReset();
+    vi.resetAllMocks();
     mockGetWorkspaceSettings.mockResolvedValue({ settings: {} } as never);
   });
 
   it("saves the trimmed name and description through updateWorkspaceAction and syncs the store", async () => {
     const ws = workspace();
-    const { storeApi, setWorkspaces } = makeStoreApi([ws]);
+    const { setWorkspaces, result, rerender } = renderWithStore([ws]);
     mockUpdateWorkspaceAction.mockResolvedValue({
       ...ws,
       name: "Renamed",
       description: NEW_DESCRIPTION,
     } as never);
 
-    const { result, rerender } = renderSettings(ws, storeApi);
-
     act(() => {
       result.current.setName("  Renamed  ");
       result.current.setDescription(NEW_DESCRIPTION);
     });
 
-    await act(async () => {
-      await result.current.handleSaveAppearance();
-    });
+    await saveAppearance(result);
 
     expect(mockUpdateWorkspaceAction).toHaveBeenCalledWith(WORKSPACE_ID, {
       name: "Renamed",
@@ -108,18 +116,13 @@ describe("useSettingsState appearance save", () => {
   });
 
   it("clears the dirty flag once the store reflects the saved workspace", async () => {
-    const ws = workspace();
-    const { storeApi, getItems } = makeStoreApi([ws]);
-    mockUpdateWorkspaceAction.mockResolvedValue({ ...ws, name: "Renamed" } as never);
-
-    const { result, rerender } = renderSettings(ws, storeApi);
+    const { getItems, result, rerender } = renderWithStore([workspace()]);
+    mockUpdateWorkspaceAction.mockResolvedValue({ ...workspace(), name: "Renamed" } as never);
 
     act(() => result.current.setName("Renamed"));
     expect(result.current.appearanceDirty).toBe(true);
 
-    await act(async () => {
-      await result.current.handleSaveAppearance();
-    });
+    await saveAppearance(result);
 
     // Simulate the Zustand store propagating the update back into
     // `activeWorkspace`, the way SettingsContent's subscription would on the
@@ -130,31 +133,37 @@ describe("useSettingsState appearance save", () => {
   });
 
   it("refuses to save an all-whitespace name", async () => {
-    const ws = workspace();
-    const { storeApi, setWorkspaces } = makeStoreApi([ws]);
-    const { result } = renderSettings(ws, storeApi);
+    const { setWorkspaces, result } = renderWithStore([workspace()]);
 
     act(() => result.current.setName("   "));
 
-    await act(async () => {
-      await result.current.handleSaveAppearance();
-    });
+    await saveAppearance(result);
 
     expect(mockUpdateWorkspaceAction).not.toHaveBeenCalled();
     expect(setWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("clears saving state and does not update the store when the action throws", async () => {
+    mockUpdateWorkspaceAction.mockRejectedValue(new Error("network error"));
+    const { setWorkspaces, result } = renderWithStore([workspace()]);
+
+    act(() => result.current.setName("Changed"));
+    await saveAppearance(result);
+
+    expect(setWorkspaces).not.toHaveBeenCalled();
+    expect(result.current.savingAppearance).toBe(false);
   });
 
   // A newer keystroke landing before the PATCH from an older one resolves
   // must survive that response, not get overwritten by the stale echo.
   it("keeps a draft typed during an in-flight save instead of reverting it", async () => {
     const ws = workspace();
-    const { storeApi } = makeStoreApi([ws]);
     let resolveUpdate!: (value: Workspace) => void;
     mockUpdateWorkspaceAction.mockImplementation(
       () => new Promise<Workspace>((resolve) => (resolveUpdate = resolve)) as never,
     );
 
-    const { result } = renderSettings(ws, storeApi);
+    const { result } = renderWithStore([ws]);
     act(() => result.current.setName("Alpha"));
     let savePromise!: Promise<void>;
     act(() => {
@@ -170,10 +179,22 @@ describe("useSettingsState appearance save", () => {
     expect(result.current.name).toBe("Alpha2");
   });
 
+  // A workspace.deleted WS event elsewhere can reassign the active workspace
+  // without this page remounting; the draft must reset to the new one's values.
+  it("resets the draft when the active workspace's identity changes", async () => {
+    const { result, rerender } = renderWithStore([workspace()]);
+    act(() => result.current.setName("Unsaved Draft"));
+    expect(result.current.appearanceDirty).toBe(true);
+    rerender({ ws: workspace({ id: "ws-2", name: "Other Workspace", description: "Other desc" }) });
+    expect(result.current.name).toBe("Other Workspace");
+    expect(result.current.description).toBe("Other desc");
+    expect(result.current.appearanceDirty).toBe(false);
+  });
+
   it("does not clobber a workspace added to the store while the save was in flight", async () => {
     const ws = workspace();
     const concurrent = workspace({ id: "ws-2", name: "Concurrent Workspace" });
-    const { storeApi, setWorkspaces, setItems } = makeStoreApi([ws]);
+    const { setWorkspaces, setItems, result } = renderWithStore([ws]);
 
     // Simulate a `workspace.created` WS event landing mid-PATCH: the store
     // gains a second workspace between render (when the old code captured
@@ -183,16 +204,12 @@ describe("useSettingsState appearance save", () => {
       return { ...ws, name: "Renamed", description: NEW_DESCRIPTION } as never;
     });
 
-    const { result } = renderSettings(ws, storeApi);
-
     act(() => {
       result.current.setName("Renamed");
       result.current.setDescription(NEW_DESCRIPTION);
     });
 
-    await act(async () => {
-      await result.current.handleSaveAppearance();
-    });
+    await saveAppearance(result);
 
     expect(setWorkspaces).toHaveBeenCalledWith([
       { ...ws, name: "Renamed", description: NEW_DESCRIPTION },

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -1,0 +1,124 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsState } from "./settings-content";
+import { updateWorkspaceAction } from "@/app/actions/workspaces";
+import { getWorkspaceSettings } from "@/lib/api/domains/office-api";
+import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
+
+vi.mock("@/app/actions/workspaces", () => ({
+  updateWorkspaceAction: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/office-api", () => ({
+  updateWorkspaceSettings: vi.fn(),
+  getWorkspaceSettings: vi.fn(),
+}));
+
+const mockUpdateWorkspaceAction = vi.mocked(updateWorkspaceAction);
+const mockGetWorkspaceSettings = vi.mocked(getWorkspaceSettings);
+
+type Workspace = WorkspaceState["items"][number];
+
+const WORKSPACE_ID = "ws-1";
+const NEW_DESCRIPTION = "New description";
+
+function workspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: WORKSPACE_ID,
+    name: "Original Name",
+    description: "Original description",
+    owner_id: "user-1",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderSettings(
+  activeWorkspace: Workspace,
+  workspaces: Workspace[],
+  setWorkspaces: (items: Workspace[]) => void,
+) {
+  return renderHook(
+    ({ ws, list }: { ws: Workspace; list: Workspace[] }) =>
+      useSettingsState(ws, list, setWorkspaces),
+    { initialProps: { ws: activeWorkspace, list: workspaces } },
+  );
+}
+
+describe("useSettingsState appearance save", () => {
+  beforeEach(() => {
+    mockUpdateWorkspaceAction.mockReset();
+    mockGetWorkspaceSettings.mockReset();
+    mockGetWorkspaceSettings.mockResolvedValue({ settings: {} } as never);
+  });
+
+  it("saves the trimmed name and description through updateWorkspaceAction and syncs the store", async () => {
+    const ws = workspace();
+    const setWorkspaces = vi.fn();
+    mockUpdateWorkspaceAction.mockResolvedValue({
+      ...ws,
+      name: "Renamed",
+      description: NEW_DESCRIPTION,
+    } as never);
+
+    const { result } = renderSettings(ws, [ws], setWorkspaces);
+
+    act(() => {
+      result.current.setName("  Renamed  ");
+      result.current.setDescription(NEW_DESCRIPTION);
+    });
+
+    await act(async () => {
+      await result.current.handleSaveAppearance();
+    });
+
+    expect(mockUpdateWorkspaceAction).toHaveBeenCalledWith(WORKSPACE_ID, {
+      name: "Renamed",
+      description: NEW_DESCRIPTION,
+    });
+    expect(setWorkspaces).toHaveBeenCalledWith([
+      { ...ws, name: "Renamed", description: NEW_DESCRIPTION },
+    ]);
+  });
+
+  it("clears the dirty flag once the store reflects the saved workspace", async () => {
+    const ws = workspace();
+    let stored: Workspace[] = [ws];
+    const setWorkspaces = vi.fn((items: Workspace[]) => {
+      stored = items;
+    });
+    mockUpdateWorkspaceAction.mockResolvedValue({ ...ws, name: "Renamed" } as never);
+
+    const { result, rerender } = renderSettings(ws, [ws], setWorkspaces);
+
+    act(() => result.current.setName("Renamed"));
+    expect(result.current.appearanceDirty).toBe(true);
+
+    await act(async () => {
+      await result.current.handleSaveAppearance();
+    });
+
+    // Simulate the Zustand store propagating the update back into
+    // `activeWorkspace`, the way SettingsContent's subscription would on the
+    // next render.
+    rerender({ ws: stored[0], list: stored });
+
+    expect(result.current.appearanceDirty).toBe(false);
+  });
+
+  it("refuses to save an all-whitespace name", async () => {
+    const ws = workspace();
+    const setWorkspaces = vi.fn();
+    const { result } = renderSettings(ws, [ws], setWorkspaces);
+
+    act(() => result.current.setName("   "));
+
+    await act(async () => {
+      await result.current.handleSaveAppearance();
+    });
+
+    expect(mockUpdateWorkspaceAction).not.toHaveBeenCalled();
+    expect(setWorkspaces).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -1,9 +1,13 @@
-import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, renderHook, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSettingsState } from "./settings-content";
 import { updateWorkspaceAction } from "@/app/actions/workspaces";
 import { getWorkspaceSettings } from "@/lib/api/domains/office-api";
 import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
+import {
+  SettingsSaveProvider,
+  useSettingsSaveCoordinator,
+} from "@/components/settings/settings-save-provider";
 
 vi.mock("@/app/actions/workspaces", () => ({
   updateWorkspaceAction: vi.fn(),
@@ -63,7 +67,22 @@ function renderSettings(
 ) {
   return renderHook(({ ws }: { ws: Workspace }) => useSettingsState(ws, storeApi), {
     initialProps: { ws: activeWorkspace },
+    wrapper: SettingsSaveProvider,
   });
+}
+
+function renderCoordinatedSettings(
+  activeWorkspace: Workspace,
+  storeApi: ReturnType<typeof makeStoreApi>["storeApi"],
+) {
+  return renderHook(
+    ({ ws }: { ws: Workspace }) => {
+      const settings = useSettingsState(ws, storeApi);
+      const coordinator = useSettingsSaveCoordinator();
+      return { settings, coordinator };
+    },
+    { initialProps: { ws: activeWorkspace }, wrapper: SettingsSaveProvider },
+  );
 }
 
 // Combines the two setup calls every test needs: a store double plus the
@@ -83,6 +102,8 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockGetWorkspaceSettings.mockResolvedValue({ settings: {} } as never);
 });
+
+afterEach(cleanup);
 
 describe("useSettingsState appearance save", () => {
   it("saves the trimmed name and description through updateWorkspaceAction and syncs the store", async () => {
@@ -143,17 +164,6 @@ describe("useSettingsState appearance save", () => {
 
     expect(mockUpdateWorkspaceAction).not.toHaveBeenCalled();
     expect(setWorkspaces).not.toHaveBeenCalled();
-  });
-
-  it("clears saving state and does not update the store when the action throws", async () => {
-    mockUpdateWorkspaceAction.mockRejectedValue(new Error("network error"));
-    const { setWorkspaces, result } = renderWithStore([workspace()]);
-
-    act(() => result.current.setName("Changed"));
-    await saveAppearance(result);
-
-    expect(setWorkspaces).not.toHaveBeenCalled();
-    expect(result.current.savingAppearance).toBe(false);
   });
 
   // A newer keystroke landing before the PATCH from an older one resolves
@@ -217,6 +227,64 @@ describe("useSettingsState appearance save", () => {
       { ...ws, name: "Renamed", description: NEW_DESCRIPTION },
       concurrent,
     ]);
+  });
+});
+
+describe("coordinated appearance save", () => {
+  it("registers appearance drafts with the shared save coordinator", async () => {
+    const ws = workspace();
+    const store = makeStoreApi([ws]);
+    const { result } = renderCoordinatedSettings(ws, store.storeApi);
+    mockUpdateWorkspaceAction.mockResolvedValue({ ...ws, name: "Renamed" } as never);
+
+    act(() => result.current.settings.setName("Renamed"));
+
+    expect(result.current.coordinator.hasDirty).toBe(true);
+    await act(async () => {
+      await expect(result.current.coordinator.saveAll()).resolves.toMatchObject({
+        canLeave: true,
+      });
+    });
+
+    expect(mockUpdateWorkspaceAction).toHaveBeenCalledWith(WORKSPACE_ID, {
+      name: "Renamed",
+      description: ws.description,
+    });
+    expect(store.setWorkspaces).toHaveBeenCalled();
+  });
+
+  it("propagates save failures after clearing saving state", async () => {
+    mockUpdateWorkspaceAction.mockRejectedValue(new Error("network error"));
+    const { setWorkspaces, result } = renderWithStore([workspace()]);
+
+    act(() => result.current.setName("Changed"));
+    await expect(
+      act(async () => {
+        await result.current.handleSaveAppearance();
+      }),
+    ).rejects.toThrow("network error");
+
+    expect(setWorkspaces).not.toHaveBeenCalled();
+    expect(result.current.savingAppearance).toBe(false);
+  });
+
+  it("resets the appearance draft to the authoritative workspace baseline", async () => {
+    const ws = workspace();
+    const { result } = renderCoordinatedSettings(ws, makeStoreApi([ws]).storeApi);
+
+    act(() => {
+      result.current.settings.setName("Unsaved name");
+      result.current.settings.setDescription("Unsaved description");
+    });
+
+    expect(screen.getByTestId("settings-floating-save")).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+    });
+
+    expect(result.current.settings.name).toBe(ws.name);
+    expect(result.current.settings.description).toBe(ws.description);
+    expect(result.current.settings.appearanceDirty).toBe(false);
   });
 });
 

--- a/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.test.tsx
@@ -80,7 +80,7 @@ describe("useSettingsState appearance save", () => {
       description: NEW_DESCRIPTION,
     } as never);
 
-    const { result } = renderSettings(ws, storeApi);
+    const { result, rerender } = renderSettings(ws, storeApi);
 
     act(() => {
       result.current.setName("  Renamed  ");
@@ -98,6 +98,13 @@ describe("useSettingsState appearance save", () => {
     expect(setWorkspaces).toHaveBeenCalledWith([
       { ...ws, name: "Renamed", description: NEW_DESCRIPTION },
     ]);
+
+    // The submitted draft had leading/trailing whitespace; the echo guard
+    // must compare against that raw draft, not its trimmed form, or the
+    // input keeps the whitespace forever and the dirty flag never clears.
+    rerender({ ws: { ...ws, name: "Renamed", description: NEW_DESCRIPTION } });
+    expect(result.current.name).toBe("Renamed");
+    expect(result.current.appearanceDirty).toBe(false);
   });
 
   it("clears the dirty flag once the store reflects the saved workspace", async () => {

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -300,7 +300,7 @@ function buildSaveAppearanceHandler({
       // does, and unconditionally overwriting the draft here would silently
       // discard it (refs, not the closed-over name/description, hold the
       // latest value across that round trip).
-      if (nameRef.current === trimmedName) setName(updated.name);
+      if (nameRef.current === name) setName(updated.name);
       if (descriptionRef.current === description) setDescription(updated.description ?? "");
       // Read the store's current list at save time, not the array captured at
       // render/handler-build time: an in-flight workspace.created/updated/deleted

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import type { TFunction } from "i18next";
 import Image from "@/components/routing/app-image";
 import { IconUpload, IconDeviceFloppy } from "@tabler/icons-react";
@@ -443,19 +450,51 @@ function useRecoveryState(activeWorkspace: Workspace | undefined) {
   };
 }
 
+type AppearanceBaseline = {
+  id: string | undefined;
+  name: string;
+  description: string;
+};
+
+function getAppearanceBaseline(workspace: Workspace | undefined): AppearanceBaseline {
+  return {
+    id: workspace?.id,
+    name: workspace?.name ?? "",
+    description: workspace?.description ?? "",
+  };
+}
+
+function reconcileAppearanceDraft(
+  previous: AppearanceBaseline,
+  next: AppearanceBaseline,
+  setName: Dispatch<SetStateAction<string>>,
+  setDescription: Dispatch<SetStateAction<string>>,
+) {
+  if (next.id !== previous.id) {
+    setName(next.name);
+    setDescription(next.description);
+    return;
+  }
+
+  setName((current) => (current === previous.name ? next.name : current));
+  setDescription((current) => (current === previous.description ? next.description : current));
+}
+
 export function useSettingsState(
   activeWorkspace: Workspace | undefined,
   storeApi: WorkspaceStoreApi,
 ) {
   const { t } = useTranslation();
-  const [name, setName] = useState(activeWorkspace?.name ?? "");
-  const [description, setDescription] = useState(activeWorkspace?.description ?? "");
+  const appearance = getAppearanceBaseline(activeWorkspace);
+  const [name, setName] = useState(appearance.name);
+  const [description, setDescription] = useState(appearance.description);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [savingAppearance, setSavingAppearance] = useState(false);
   const recovery = useRecoveryState(activeWorkspace);
   const permissions = usePermissionsState(activeWorkspace);
-  const activeWorkspaceId = activeWorkspace?.id;
+  const { id: appearanceId, name: appearanceName, description: appearanceDescription } = appearance;
+  const appearanceBaselineRef = useRef(appearance);
 
   // If the active workspace's identity changes without this page
   // remounting - e.g. a workspace.deleted WS event elsewhere reassigns
@@ -463,11 +502,20 @@ export function useSettingsState(
   // reset to the new workspace's values. Otherwise the stale draft from
   // the old workspace looks "dirty" against the new one's name, and Save
   // would persist the old workspace's data onto the new, unrelated one.
+  // For same-workspace updates, only fields that still match the previous
+  // baseline are refreshed. This keeps remote changes visible without
+  // overwriting a local draft.
   useEffect(() => {
-    setName(activeWorkspace?.name ?? "");
-    setDescription(activeWorkspace?.description ?? "");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeWorkspaceId]);
+    const next = {
+      id: appearanceId,
+      name: appearanceName,
+      description: appearanceDescription,
+    };
+    const previous = appearanceBaselineRef.current;
+
+    reconcileAppearanceDraft(previous, next, setName, setDescription);
+    appearanceBaselineRef.current = next;
+  }, [appearanceDescription, appearanceId, appearanceName]);
 
   // Latest-value refs so the in-flight save handler (a closure fixed at the
   // moment Save was clicked) can tell whether the draft has moved on since,
@@ -505,9 +553,6 @@ export function useSettingsState(
     [activeWorkspace, name, description, storeApi, nameRef, descriptionRef, t],
   );
 
-  const origName = activeWorkspace?.name ?? "";
-  const origDescription = activeWorkspace?.description ?? "";
-
   return {
     name,
     setName,
@@ -517,7 +562,7 @@ export function useSettingsState(
     fileInputRef,
     ...permissions,
     ...recovery,
-    appearanceDirty: name !== origName || description !== origDescription,
+    appearanceDirty: name !== appearanceName || description !== appearanceDescription,
     savingAppearance,
     handleLogoChange,
     handleSaveAppearance,

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -138,7 +138,13 @@ function AppearanceSection({
       </div>
       {dirty && (
         <div className="flex justify-end pt-2">
-          <Button size="sm" onClick={onSave} disabled={saving} className="cursor-pointer">
+          <Button
+            size="sm"
+            onClick={onSave}
+            disabled={saving}
+            className="cursor-pointer"
+            data-testid="appearance-save-button"
+          >
             <IconDeviceFloppy className="h-4 w-4 mr-1.5" />
             {saving ? t("office:saving") : t("common:save")}
           </Button>
@@ -449,6 +455,19 @@ export function useSettingsState(
   const [savingAppearance, setSavingAppearance] = useState(false);
   const recovery = useRecoveryState(activeWorkspace);
   const permissions = usePermissionsState(activeWorkspace);
+  const activeWorkspaceId = activeWorkspace?.id;
+
+  // If the active workspace's identity changes without this page
+  // remounting - e.g. a workspace.deleted WS event elsewhere reassigns
+  // workspaces.activeId while this page stays mounted - the draft must
+  // reset to the new workspace's values. Otherwise the stale draft from
+  // the old workspace looks "dirty" against the new one's name, and Save
+  // would persist the old workspace's data onto the new, unrelated one.
+  useEffect(() => {
+    setName(activeWorkspace?.name ?? "");
+    setDescription(activeWorkspace?.description ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorkspaceId]);
 
   // Latest-value refs so the in-flight save handler (a closure fixed at the
   // moment Save was clicked) can tell whether the draft has moved on since,
@@ -468,18 +487,23 @@ export function useSettingsState(
     if (file) setLogoPreview(URL.createObjectURL(file));
   };
 
-  const handleSaveAppearance = buildSaveAppearanceHandler({
-    activeWorkspace,
-    name,
-    description,
-    storeApi,
-    nameRef,
-    descriptionRef,
-    setName,
-    setDescription,
-    setSaving: setSavingAppearance,
-    t,
-  });
+  // useCallback (matching handleSavePermissions/handleSaveRecovery) so the
+  // handler only gets a new identity when an input it actually reads changes.
+  const handleSaveAppearance = useCallback(
+    buildSaveAppearanceHandler({
+      activeWorkspace,
+      name,
+      description,
+      storeApi,
+      nameRef,
+      descriptionRef,
+      setName,
+      setDescription,
+      setSaving: setSavingAppearance,
+      t,
+    }),
+    [activeWorkspace, name, description, storeApi, nameRef, descriptionRef, t],
+  );
 
   const origName = activeWorkspace?.name ?? "";
   const origDescription = activeWorkspace?.description ?? "";

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -8,9 +8,10 @@ import { toast } from "@/lib/toast/sonner";
 import { Input } from "@kandev/ui/input";
 import { Switch } from "@kandev/ui/switch";
 import { Button } from "@kandev/ui/button";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateWorkspaceSettings, getWorkspaceSettings } from "@/lib/api/domains/office-api";
 import { updateWorkspaceAction } from "@/app/actions/workspaces";
+import type { AppState } from "@/lib/state/store";
 import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
 import { ConfigSection } from "./config-section";
 import { DangerZoneSection } from "./danger-zone-section";
@@ -251,12 +252,15 @@ function RecoverySection({
 
 type Workspace = WorkspaceState["items"][number];
 
+type WorkspaceStoreApi = {
+  getState: () => Pick<AppState, "workspaces" | "setWorkspaces">;
+};
+
 type SaveAppearanceOptions = {
   activeWorkspace: Workspace | undefined;
   name: string;
   description: string;
-  workspaces: Workspace[];
-  setWorkspaces: (items: Workspace[]) => void;
+  storeApi: WorkspaceStoreApi;
   setName: (v: string) => void;
   setDescription: (v: string) => void;
   setSaving: (v: boolean) => void;
@@ -267,8 +271,7 @@ function buildSaveAppearanceHandler({
   activeWorkspace,
   name,
   description,
-  workspaces,
-  setWorkspaces,
+  storeApi,
   setName,
   setDescription,
   setSaving,
@@ -289,8 +292,14 @@ function buildSaveAppearanceHandler({
       });
       setName(updated.name);
       setDescription(updated.description ?? "");
+      // Read the store's current list at save time, not the array captured at
+      // render/handler-build time: an in-flight workspace.created/updated/deleted
+      // WS event can land during the PATCH round trip, and a stale snapshot here
+      // would clobber it with a whole-array replace (setWorkspaces has no merge
+      // semantics). Same idiom as config-chat-agent-section.tsx.
+      const { workspaces: current, setWorkspaces } = storeApi.getState();
       setWorkspaces(
-        workspaces.map((ws) =>
+        current.items.map((ws) =>
           ws.id === updated.id
             ? { ...ws, name: updated.name, description: updated.description }
             : ws,
@@ -420,8 +429,7 @@ function useRecoveryState(activeWorkspace: Workspace | undefined) {
 
 export function useSettingsState(
   activeWorkspace: Workspace | undefined,
-  workspaces: Workspace[],
-  setWorkspaces: (items: Workspace[]) => void,
+  storeApi: WorkspaceStoreApi,
 ) {
   const { t } = useTranslation();
   const [name, setName] = useState(activeWorkspace?.name ?? "");
@@ -441,8 +449,7 @@ export function useSettingsState(
     activeWorkspace,
     name,
     description,
-    workspaces,
-    setWorkspaces,
+    storeApi,
     setName,
     setDescription,
     setSaving: setSavingAppearance,
@@ -470,11 +477,12 @@ export function useSettingsState(
 
 export function SettingsContent() {
   const { t } = useTranslation();
+  const storeApi = useAppStoreApi();
   const workspaces = useAppStore((s) => s.workspaces);
   const setWorkspaces = useAppStore((s) => s.setWorkspaces);
   const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
   const activeWorkspace = workspaces.items.find((w) => w.id === workspaces.activeId);
-  const s = useSettingsState(activeWorkspace, workspaces.items, setWorkspaces);
+  const s = useSettingsState(activeWorkspace, storeApi);
   const initial = (s.name || "W").charAt(0).toUpperCase();
 
   return (

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -16,6 +16,7 @@ import { Input } from "@kandev/ui/input";
 import { Switch } from "@kandev/ui/switch";
 import { Button } from "@kandev/ui/button";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { useSettingsSaveContributor } from "@/components/settings/settings-save-provider";
 import { updateWorkspaceSettings, getWorkspaceSettings } from "@/lib/api/domains/office-api";
 import { updateWorkspaceAction } from "@/app/actions/workspaces";
 import type { AppState } from "@/lib/state/store";
@@ -68,24 +69,18 @@ function AppearanceSection({
   logoPreview,
   initial,
   fileInputRef,
-  dirty,
-  saving,
   onNameChange,
   onDescriptionChange,
   onLogoChange,
-  onSave,
 }: {
   name: string;
   description: string;
   logoPreview: string | null;
   initial: string;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
-  dirty: boolean;
-  saving: boolean;
   onNameChange: (v: string) => void;
   onDescriptionChange: (v: string) => void;
   onLogoChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onSave: () => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -143,20 +138,6 @@ function AppearanceSection({
           className="mt-1"
         />
       </div>
-      {dirty && (
-        <div className="flex justify-end pt-2">
-          <Button
-            size="sm"
-            onClick={onSave}
-            disabled={saving}
-            className="cursor-pointer"
-            data-testid="appearance-save-button"
-          >
-            <IconDeviceFloppy className="h-4 w-4 mr-1.5" />
-            {saving ? t("office:saving") : t("common:save")}
-          </Button>
-        </div>
-      )}
     </SettingCard>
   );
 }
@@ -331,6 +312,7 @@ function buildSaveAppearanceHandler({
       toast.success(t("office:appearanceSettingsSaved"));
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t("office:failedToSaveSettings"));
+      throw err;
     } finally {
       setSaving(false);
     }
@@ -553,6 +535,29 @@ export function useSettingsState(
     [activeWorkspace, name, description, storeApi, nameRef, descriptionRef, t],
   );
 
+  const appearanceDirty =
+    Boolean(appearanceId) && (name !== appearanceName || description !== appearanceDescription);
+  const appearanceRevision = JSON.stringify({
+    id: appearanceId,
+    name,
+    description,
+  });
+
+  useSettingsSaveContributor({
+    id: "office-workspace-appearance",
+    order: 10,
+    revision: appearanceRevision,
+    isDirty: appearanceDirty,
+    canSave: Boolean(name.trim()),
+    invalidReason: name.trim() ? undefined : t("workspaces:workspaceNameIsRequired"),
+    save: handleSaveAppearance,
+    discard: (revision) => {
+      if (!Object.is(revision, appearanceRevision)) return;
+      setName(appearanceName);
+      setDescription(appearanceDescription);
+    },
+  });
+
   return {
     name,
     setName,
@@ -562,7 +567,7 @@ export function useSettingsState(
     fileInputRef,
     ...permissions,
     ...recovery,
-    appearanceDirty: name !== appearanceName || description !== appearanceDescription,
+    appearanceDirty,
     savingAppearance,
     handleLogoChange,
     handleSaveAppearance,
@@ -589,12 +594,9 @@ export function SettingsContent() {
           logoPreview={s.logoPreview}
           initial={initial}
           fileInputRef={s.fileInputRef}
-          dirty={s.appearanceDirty}
-          saving={s.savingAppearance}
           onNameChange={s.setName}
           onDescriptionChange={s.setDescription}
           onLogoChange={s.handleLogoChange}
-          onSave={s.handleSaveAppearance}
         />
       </div>
 

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -261,6 +261,8 @@ type SaveAppearanceOptions = {
   name: string;
   description: string;
   storeApi: WorkspaceStoreApi;
+  nameRef: React.RefObject<string>;
+  descriptionRef: React.RefObject<string>;
   setName: (v: string) => void;
   setDescription: (v: string) => void;
   setSaving: (v: boolean) => void;
@@ -272,6 +274,8 @@ function buildSaveAppearanceHandler({
   name,
   description,
   storeApi,
+  nameRef,
+  descriptionRef,
   setName,
   setDescription,
   setSaving,
@@ -290,8 +294,14 @@ function buildSaveAppearanceHandler({
         name: trimmedName,
         description,
       });
-      setName(updated.name);
-      setDescription(updated.description ?? "");
+      // Only echo the server response back into the draft fields if the user
+      // hasn't kept typing since this save started: the PATCH round trip can
+      // take long enough for a newer keystroke to land before the response
+      // does, and unconditionally overwriting the draft here would silently
+      // discard it (refs, not the closed-over name/description, hold the
+      // latest value across that round trip).
+      if (nameRef.current === trimmedName) setName(updated.name);
+      if (descriptionRef.current === description) setDescription(updated.description ?? "");
       // Read the store's current list at save time, not the array captured at
       // render/handler-build time: an in-flight workspace.created/updated/deleted
       // WS event can land during the PATCH round trip, and a stale snapshot here
@@ -440,6 +450,19 @@ export function useSettingsState(
   const recovery = useRecoveryState(activeWorkspace);
   const permissions = usePermissionsState(activeWorkspace);
 
+  // Latest-value refs so the in-flight save handler (a closure fixed at the
+  // moment Save was clicked) can tell whether the draft has moved on since,
+  // instead of blindly trusting the name/description it captured at submit
+  // time.
+  const nameRef = useRef(name);
+  const descriptionRef = useRef(description);
+  useEffect(() => {
+    nameRef.current = name;
+  }, [name]);
+  useEffect(() => {
+    descriptionRef.current = description;
+  }, [description]);
+
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) setLogoPreview(URL.createObjectURL(file));
@@ -450,6 +473,8 @@ export function useSettingsState(
     name,
     description,
     storeApi,
+    nameRef,
+    descriptionRef,
     setName,
     setDescription,
     setSaving: setSavingAppearance,

--- a/apps/web/app/office/workspace/settings/components/settings-content.tsx
+++ b/apps/web/app/office/workspace/settings/components/settings-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { TFunction } from "i18next";
 import Image from "@/components/routing/app-image";
 import { IconUpload, IconDeviceFloppy } from "@tabler/icons-react";
 import { toast } from "@/lib/toast/sonner";
@@ -9,6 +10,7 @@ import { Switch } from "@kandev/ui/switch";
 import { Button } from "@kandev/ui/button";
 import { useAppStore } from "@/components/state-provider";
 import { updateWorkspaceSettings, getWorkspaceSettings } from "@/lib/api/domains/office-api";
+import { updateWorkspaceAction } from "@/app/actions/workspaces";
 import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
 import { ConfigSection } from "./config-section";
 import { DangerZoneSection } from "./danger-zone-section";
@@ -249,6 +251,128 @@ function RecoverySection({
 
 type Workspace = WorkspaceState["items"][number];
 
+type SaveAppearanceOptions = {
+  activeWorkspace: Workspace | undefined;
+  name: string;
+  description: string;
+  workspaces: Workspace[];
+  setWorkspaces: (items: Workspace[]) => void;
+  setName: (v: string) => void;
+  setDescription: (v: string) => void;
+  setSaving: (v: boolean) => void;
+  t: TFunction;
+};
+
+function buildSaveAppearanceHandler({
+  activeWorkspace,
+  name,
+  description,
+  workspaces,
+  setWorkspaces,
+  setName,
+  setDescription,
+  setSaving,
+  t,
+}: SaveAppearanceOptions) {
+  return async () => {
+    if (!activeWorkspace) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      toast.error(t("workspaces:workspaceNameIsRequired"));
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await updateWorkspaceAction(activeWorkspace.id, {
+        name: trimmedName,
+        description,
+      });
+      setName(updated.name);
+      setDescription(updated.description ?? "");
+      setWorkspaces(
+        workspaces.map((ws) =>
+          ws.id === updated.id
+            ? { ...ws, name: updated.name, description: updated.description }
+            : ws,
+        ),
+      );
+      toast.success(t("office:appearanceSettingsSaved"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("office:failedToSaveSettings"));
+    } finally {
+      setSaving(false);
+    }
+  };
+}
+
+function usePermissionsState(activeWorkspace: Workspace | undefined) {
+  const { t } = useTranslation();
+  const [approvalNewAgents, setApprovalNewAgents] = useState(true);
+  const [approvalTaskCompletion, setApprovalTaskCompletion] = useState(false);
+  const [approvalSkillChanges, setApprovalSkillChanges] = useState(true);
+  const [origApprovalNewAgents, setOrigApprovalNewAgents] = useState(true);
+  const [origApprovalTaskCompletion, setOrigApprovalTaskCompletion] = useState(false);
+  const [origApprovalSkillChanges, setOrigApprovalSkillChanges] = useState(true);
+  const [savingPermissions, setSavingPermissions] = useState(false);
+  const activeWorkspaceId = activeWorkspace?.id;
+
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    void getWorkspaceSettings(activeWorkspaceId)
+      .then((res) => {
+        const s = res.settings;
+        if (s.require_approval_for_new_agents !== undefined) {
+          setApprovalNewAgents(s.require_approval_for_new_agents);
+          setOrigApprovalNewAgents(s.require_approval_for_new_agents);
+        }
+        if (s.require_approval_for_task_completion !== undefined) {
+          setApprovalTaskCompletion(s.require_approval_for_task_completion);
+          setOrigApprovalTaskCompletion(s.require_approval_for_task_completion);
+        }
+        if (s.require_approval_for_skill_changes !== undefined) {
+          setApprovalSkillChanges(s.require_approval_for_skill_changes);
+          setOrigApprovalSkillChanges(s.require_approval_for_skill_changes);
+        }
+      })
+      .catch(() => {});
+  }, [activeWorkspaceId]);
+
+  const handleSavePermissions = useCallback(async () => {
+    if (!activeWorkspace) return;
+    setSavingPermissions(true);
+    try {
+      await updateWorkspaceSettings(activeWorkspace.id, {
+        require_approval_for_new_agents: approvalNewAgents,
+        require_approval_for_task_completion: approvalTaskCompletion,
+        require_approval_for_skill_changes: approvalSkillChanges,
+      });
+      setOrigApprovalNewAgents(approvalNewAgents);
+      setOrigApprovalTaskCompletion(approvalTaskCompletion);
+      setOrigApprovalSkillChanges(approvalSkillChanges);
+      toast.success(t("office:permissionSettingsSaved"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("office:failedToSaveSettings"));
+    } finally {
+      setSavingPermissions(false);
+    }
+  }, [activeWorkspace, approvalNewAgents, approvalTaskCompletion, approvalSkillChanges]);
+
+  return {
+    approvalNewAgents,
+    setApprovalNewAgents,
+    approvalTaskCompletion,
+    setApprovalTaskCompletion,
+    approvalSkillChanges,
+    setApprovalSkillChanges,
+    savingPermissions,
+    permissionsDirty:
+      approvalNewAgents !== origApprovalNewAgents ||
+      approvalTaskCompletion !== origApprovalTaskCompletion ||
+      approvalSkillChanges !== origApprovalSkillChanges,
+    handleSavePermissions,
+  };
+}
+
 function useRecoveryState(activeWorkspace: Workspace | undefined) {
   const { t } = useTranslation();
   const [lookbackHours, setLookbackHours] = useState(24);
@@ -294,82 +418,36 @@ function useRecoveryState(activeWorkspace: Workspace | undefined) {
   };
 }
 
-function useSettingsState(activeWorkspace: Workspace | undefined) {
+export function useSettingsState(
+  activeWorkspace: Workspace | undefined,
+  workspaces: Workspace[],
+  setWorkspaces: (items: Workspace[]) => void,
+) {
   const { t } = useTranslation();
   const [name, setName] = useState(activeWorkspace?.name ?? "");
   const [description, setDescription] = useState(activeWorkspace?.description ?? "");
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [approvalNewAgents, setApprovalNewAgents] = useState(true);
-  const [approvalTaskCompletion, setApprovalTaskCompletion] = useState(false);
-  const [approvalSkillChanges, setApprovalSkillChanges] = useState(true);
-  const [origApprovalNewAgents, setOrigApprovalNewAgents] = useState(true);
-  const [origApprovalTaskCompletion, setOrigApprovalTaskCompletion] = useState(false);
-  const [origApprovalSkillChanges, setOrigApprovalSkillChanges] = useState(true);
   const [savingAppearance, setSavingAppearance] = useState(false);
-  const [savingPermissions, setSavingPermissions] = useState(false);
   const recovery = useRecoveryState(activeWorkspace);
-
-  const activeWorkspaceId = activeWorkspace?.id;
-
-  useEffect(() => {
-    if (!activeWorkspaceId) return;
-    void getWorkspaceSettings(activeWorkspaceId)
-      .then((res) => {
-        const s = res.settings;
-        if (s.require_approval_for_new_agents !== undefined) {
-          setApprovalNewAgents(s.require_approval_for_new_agents);
-          setOrigApprovalNewAgents(s.require_approval_for_new_agents);
-        }
-        if (s.require_approval_for_task_completion !== undefined) {
-          setApprovalTaskCompletion(s.require_approval_for_task_completion);
-          setOrigApprovalTaskCompletion(s.require_approval_for_task_completion);
-        }
-        if (s.require_approval_for_skill_changes !== undefined) {
-          setApprovalSkillChanges(s.require_approval_for_skill_changes);
-          setOrigApprovalSkillChanges(s.require_approval_for_skill_changes);
-        }
-      })
-      .catch(() => {});
-  }, [activeWorkspaceId]);
+  const permissions = usePermissionsState(activeWorkspace);
 
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) setLogoPreview(URL.createObjectURL(file));
   };
 
-  const handleSaveAppearance = useCallback(async () => {
-    if (!activeWorkspace) return;
-    setSavingAppearance(true);
-    try {
-      await updateWorkspaceSettings(activeWorkspace.id, { name, description });
-      toast.success(t("office:appearanceSettingsSaved"));
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : t("office:failedToSaveSettings"));
-    } finally {
-      setSavingAppearance(false);
-    }
-  }, [activeWorkspace, name, description]);
-
-  const handleSavePermissions = useCallback(async () => {
-    if (!activeWorkspace) return;
-    setSavingPermissions(true);
-    try {
-      await updateWorkspaceSettings(activeWorkspace.id, {
-        require_approval_for_new_agents: approvalNewAgents,
-        require_approval_for_task_completion: approvalTaskCompletion,
-        require_approval_for_skill_changes: approvalSkillChanges,
-      });
-      setOrigApprovalNewAgents(approvalNewAgents);
-      setOrigApprovalTaskCompletion(approvalTaskCompletion);
-      setOrigApprovalSkillChanges(approvalSkillChanges);
-      toast.success(t("office:permissionSettingsSaved"));
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : t("office:failedToSaveSettings"));
-    } finally {
-      setSavingPermissions(false);
-    }
-  }, [activeWorkspace, approvalNewAgents, approvalTaskCompletion, approvalSkillChanges]);
+  const handleSaveAppearance = buildSaveAppearanceHandler({
+    activeWorkspace,
+    name,
+    description,
+    workspaces,
+    setWorkspaces,
+    setName,
+    setDescription,
+    setSaving: setSavingAppearance,
+    t,
+  });
 
   const origName = activeWorkspace?.name ?? "";
   const origDescription = activeWorkspace?.description ?? "";
@@ -381,23 +459,12 @@ function useSettingsState(activeWorkspace: Workspace | undefined) {
     setDescription,
     logoPreview,
     fileInputRef,
-    approvalNewAgents,
-    setApprovalNewAgents,
-    approvalTaskCompletion,
-    setApprovalTaskCompletion,
-    approvalSkillChanges,
-    setApprovalSkillChanges,
+    ...permissions,
     ...recovery,
     appearanceDirty: name !== origName || description !== origDescription,
-    permissionsDirty:
-      approvalNewAgents !== origApprovalNewAgents ||
-      approvalTaskCompletion !== origApprovalTaskCompletion ||
-      approvalSkillChanges !== origApprovalSkillChanges,
     savingAppearance,
-    savingPermissions,
     handleLogoChange,
     handleSaveAppearance,
-    handleSavePermissions,
   };
 }
 
@@ -407,7 +474,7 @@ export function SettingsContent() {
   const setWorkspaces = useAppStore((s) => s.setWorkspaces);
   const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
   const activeWorkspace = workspaces.items.find((w) => w.id === workspaces.activeId);
-  const s = useSettingsState(activeWorkspace);
+  const s = useSettingsState(activeWorkspace, workspaces.items, setWorkspaces);
   const initial = (s.name || "W").charAt(0).toUpperCase();
 
   return (

--- a/apps/web/e2e/tests/office/dashboard.spec.ts
+++ b/apps/web/e2e/tests/office/dashboard.spec.ts
@@ -65,12 +65,24 @@ test.describe("Dashboard", () => {
   });
 
   test("update workspace settings", async ({ officeApi, officeSeed }) => {
-    const updated = await officeApi.updateWorkspaceSettings(officeSeed.workspaceId, {
-      recovery_lookback_hours: 42,
-    });
-    expect(updated).toEqual({ ok: true });
+    const { settings: originalSettings } = await officeApi.getWorkspaceSettings(
+      officeSeed.workspaceId,
+    );
+    const originalLookbackHours = (originalSettings as { recovery_lookback_hours: number })
+      .recovery_lookback_hours;
 
-    const { settings } = await officeApi.getWorkspaceSettings(officeSeed.workspaceId);
-    expect((settings as { recovery_lookback_hours: number }).recovery_lookback_hours).toBe(42);
+    try {
+      const updated = await officeApi.updateWorkspaceSettings(officeSeed.workspaceId, {
+        recovery_lookback_hours: 42,
+      });
+      expect(updated).toEqual({ ok: true });
+
+      const { settings } = await officeApi.getWorkspaceSettings(officeSeed.workspaceId);
+      expect((settings as { recovery_lookback_hours: number }).recovery_lookback_hours).toBe(42);
+    } finally {
+      await officeApi.updateWorkspaceSettings(officeSeed.workspaceId, {
+        recovery_lookback_hours: originalLookbackHours,
+      });
+    }
   });
 });

--- a/apps/web/e2e/tests/office/dashboard.spec.ts
+++ b/apps/web/e2e/tests/office/dashboard.spec.ts
@@ -66,11 +66,11 @@ test.describe("Dashboard", () => {
 
   test("update workspace settings", async ({ officeApi, officeSeed }) => {
     const updated = await officeApi.updateWorkspaceSettings(officeSeed.workspaceId, {
-      name: "E2E Workspace Updated",
+      recovery_lookback_hours: 42,
     });
-    expect(updated).toBeDefined();
+    expect(updated).toEqual({ ok: true });
 
-    const settings = await officeApi.getWorkspaceSettings(officeSeed.workspaceId);
-    expect(settings).toBeDefined();
+    const { settings } = await officeApi.getWorkspaceSettings(officeSeed.workspaceId);
+    expect((settings as { recovery_lookback_hours: number }).recovery_lookback_hours).toBe(42);
   });
 });

--- a/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
@@ -1,8 +1,43 @@
 import { test, expect } from "../../fixtures/office-fixture";
+import { waitForHttp } from "../../helpers/causal-waits";
 
 test.describe("Workspace settings UI", () => {
   test("settings page shows danger zone", async ({ testPage, officeSeed: _ }) => {
     await testPage.goto("/office/workspace/settings");
     await expect(testPage.getByText(/danger zone/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("renaming the workspace persists and updates the sidebar", async ({
+    testPage,
+    apiClient,
+    officeSeed,
+  }) => {
+    const renamed = "E2E Workspace Renamed";
+    try {
+      await testPage.goto("/office/workspace/settings");
+      const nameInput = testPage.getByPlaceholder("Workspace name");
+      await expect(nameInput).toBeVisible({ timeout: 10_000 });
+      await nameInput.fill(renamed);
+      const saveButton = testPage.getByRole("button", { name: "Save" });
+
+      const workspaceSaved = waitForHttp(
+        testPage,
+        "PATCH",
+        new RegExp(`/api/v1/workspaces/${officeSeed.workspaceId}$`),
+      );
+      await saveButton.click();
+      await workspaceSaved;
+
+      // Save button clears once the store reflects the persisted name.
+      await expect(saveButton).toBeHidden();
+      await expect(testPage.getByTestId("sidebar-workspace-trigger")).toHaveText(
+        new RegExp(renamed),
+      );
+
+      await testPage.reload();
+      await expect(nameInput).toHaveValue(renamed);
+    } finally {
+      await apiClient.updateWorkspace(officeSeed.workspaceId, { name: "E2E Workspace" });
+    }
   });
 });

--- a/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
@@ -13,12 +13,14 @@ test.describe("Workspace settings UI", () => {
     officeSeed,
   }) => {
     const renamed = "E2E Workspace Renamed";
+    let originalName: string | undefined;
     try {
       await testPage.goto("/office/workspace/settings");
       const nameInput = testPage.getByPlaceholder("Workspace name");
       await expect(nameInput).toBeVisible({ timeout: 10_000 });
+      originalName = await nameInput.inputValue();
       await nameInput.fill(renamed);
-      const saveButton = testPage.getByRole("button", { name: "Save" });
+      const saveButton = testPage.getByTestId("appearance-save-button");
 
       const workspaceSaved = waitForHttp(
         testPage,
@@ -30,14 +32,14 @@ test.describe("Workspace settings UI", () => {
 
       // Save button clears once the store reflects the persisted name.
       await expect(saveButton).toBeHidden();
-      await expect(testPage.getByTestId("sidebar-workspace-trigger")).toHaveText(
-        new RegExp(renamed),
-      );
+      await expect(testPage.getByTestId("sidebar-workspace-trigger")).toContainText(renamed);
 
       await testPage.reload();
       await expect(nameInput).toHaveValue(renamed);
     } finally {
-      await apiClient.updateWorkspace(officeSeed.workspaceId, { name: "E2E Workspace" });
+      await apiClient.updateWorkspace(officeSeed.workspaceId, {
+        name: originalName ?? "E2E Workspace",
+      });
     }
   });
 });

--- a/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-settings-ui.spec.ts
@@ -20,7 +20,9 @@ test.describe("Workspace settings UI", () => {
       await expect(nameInput).toBeVisible({ timeout: 10_000 });
       originalName = await nameInput.inputValue();
       await nameInput.fill(renamed);
-      const saveButton = testPage.getByTestId("appearance-save-button");
+      const saveBar = testPage.getByTestId("settings-floating-save");
+      const saveButton = saveBar.getByRole("button", { name: "Save changes" });
+      await expect(saveBar).toBeVisible();
 
       const workspaceSaved = waitForHttp(
         testPage,
@@ -30,8 +32,7 @@ test.describe("Workspace settings UI", () => {
       await saveButton.click();
       await workspaceSaved;
 
-      // Save button clears once the store reflects the persisted name.
-      await expect(saveButton).toBeHidden();
+      await expect(saveBar).toHaveAttribute("data-status", "saved");
       await expect(testPage.getByTestId("sidebar-workspace-trigger")).toContainText(renamed);
 
       await testPage.reload();

--- a/apps/web/lib/api/domains/office-extended-api.ts
+++ b/apps/web/lib/api/domains/office-extended-api.ts
@@ -625,8 +625,6 @@ export function getWorkspaceSettings(workspaceId: string, options?: ApiRequestOp
 export function updateWorkspaceSettings(
   workspaceId: string,
   data: {
-    name?: string;
-    description?: string;
     require_approval_for_new_agents?: boolean;
     require_approval_for_task_completion?: boolean;
     require_approval_for_skill_changes?: boolean;

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -48,6 +48,7 @@ import {
 import { RoutineDetailRoute } from "./office-routine-client-routes";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { Trans, useTranslation } from "react-i18next";
+import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
 
 type RouteRenderer = () => React.ReactNode;
 
@@ -62,7 +63,11 @@ const OFFICE_ROUTES: Record<string, RouteRenderer> = {
   "/office/workspace/costs": () => <CostsPageClient initialCostSummary={null} />,
   "/office/workspace/skills": () => <SkillsPageClient initialSkills={[]} />,
   "/office/workspace/routing": () => <ProviderRoutingPage />,
-  "/office/workspace/settings": () => <SettingsPage />,
+  "/office/workspace/settings": () => (
+    <SettingsSaveProvider placement="content">
+      <SettingsPage />
+    </SettingsSaveProvider>
+  ),
   "/office/workspace/settings/sync": () => <SyncPage />,
   "/office/workspace/org": () => <OrgPage />,
 };
@@ -103,7 +108,7 @@ export function OfficeRoutes({ pathname }: { pathname: string }) {
 
   return (
     <TooltipProvider>
-      <div className="flex h-full min-h-0 flex-col">
+      <div className="relative flex h-full min-h-0 flex-col">
         <OfficeShell routePath={normalizedPathname}>
           {renderOfficeRoute(normalizedPathname)}
         </OfficeShell>


### PR DESCRIPTION
**Reviewer brief:** Office workspace Settings → Appearance reported "saved" but silently discarded the edit. Root cause: the save handler called a Go endpoint whose request struct declared `name`/`description` fields the handler never read, so the PATCH always no-opped while still returning success. Fixed by switching to the generic workspace-update endpoint the Kanban settings page already uses and syncing the result into the Zustand store. Two follow-on races in that sync (a mid-flight keystroke, and a trim-vs-submitted-value mismatch) surfaced during review and were closed in the same branch. Verified via 5 unit tests plus a dedicated E2E regression test ("renaming the workspace persists and updates the sidebar"), both green at HEAD.

Editing the Office workspace's name or description in Settings → Appearance showed a "saved" confirmation but the change silently reverted, because the save handler targeted a backend endpoint that declared `name`/`description` fields but never applied them. The fix routes the save through the generic workspace-update endpoint the Kanban settings page already uses, and closes two additional races found during review of the initial fix.

## Important Changes

- `settings-content.tsx`: appearance save now calls `updateWorkspaceAction` (the generic `PATCH /api/v1/workspaces/:id`) instead of the office-only endpoint that silently ignored `name`/`description`, and syncs the confirmed result into the Zustand store so the sidebar and Save-button dirty state reflect the change.
- The local draft only echoes the server response when the live draft still matches what was actually submitted, tracked via a ref kept current on every keystroke. This closes two review-round regressions: a keystroke typed while the save was in flight no longer gets silently reverted, and the comparison uses the raw submitted value rather than its trimmed form, so a name with leading/trailing whitespace no longer gets stuck showing "unsaved" after a successful save.
- `dto.go` / `office-extended-api.ts`: removed the two `name`/`description` fields from the office-settings request/payload types — dead code, never read by the handler.

## Validation

- `make fmt` — clean
- `make typecheck` — clean
- `make test-backend` — clean except three pre-existing, environment-caused failures unrelated to this diff (confirmed via a scratch worktree at `origin/main`, identical failures reproduce there): `internal/system/storage/workspaces` (macOS temp-dir symlink resolution) and `internal/agentctl/server/config` (`TestCollectAgentEnvGitHubCLIShimSurvivesLoginShell`, interference from this host's own login-shell PATH setup)
- `make test-web` — clean except the already-documented `lib/http-git-server.test.ts` failures (local Docker daemon unreachable on this host, confirmed via `docker info`)
- `make test-cli` — clean
- `make test-scripts` — clean except the already-documented pre-existing `scripts/pr-state` unbound-variable failure (`scripts/` is untouched by this branch)
- `make lint` — clean
- `cd apps/web && pnpm run typecheck` — clean
- `make lint-format` — clean
- `cd apps/web && pnpm run i18n:ratchet` — clean
- `cd apps/web && pnpm exec vitest run app/office/workspace/settings/components/settings-content.test.tsx` — 5/5 passed, including regression tests for both the mid-flight-keystroke race and the trim-vs-submitted whitespace race
- `pnpm exec playwright test --project=chromium e2e/tests/office/dashboard.spec.ts e2e/tests/office/workspace-settings-ui.spec.ts` — 10/10 passed, including "renaming the workspace persists and updates the sidebar" (the E2E regression test for this card's reported symptom)
- `make test-e2e` (full 5-project suite, managed runner, host under heavy concurrent-agent load): the `routing` project passed clean (7/7), and every office-related test observed in the `chromium` project passed (the `office/*` spec files, the i18n pseudo-coverage "on office — workspace settings" check, etc.). The run surfaced ~30 failures scattered across entirely unrelated areas (chat, git, gitlab, integrations, jira, layout, lsp, plugins, pr, review, session, auth) with multi-minute individual durations, consistent with this host's documented CPU/temp-dir contention (25+ concurrent agent worktrees) rather than a regression from this diff — no failure touched an office/workspace-settings file or test. The scoped E2E regression for this fix (`office/dashboard.spec.ts` + `office/workspace-settings-ui.spec.ts`, `--project chromium`) was independently re-run standalone against this exact HEAD and passed 10/10, including "renaming the workspace persists and updates the sidebar"

## Possible Improvements

Low risk: a follow-up card (tracked separately, not in this PR) covers guarding the workspace-cache HTTP write against a newer concurrent WebSocket update — the unguarded read-modify-write here follows an existing pattern shared with two other call sites in the codebase, so fixing it properly is a shared-layer change out of scope for this fix.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->