### PR TITLE
feat(orchestrator): resume opted-in parents on child review

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -19,7 +19,13 @@ import (
 )
 
 func (s *Service) handleTaskStateChanged(ctx context.Context, data watcher.TaskEventData) {
-	if data.NewState == nil || !models.IsTerminalTaskState(*data.NewState) {
+	if data.NewState == nil {
+		return
+	}
+
+	s.maybeResumeParentController(ctx, data)
+
+	if !models.IsTerminalTaskState(*data.NewState) {
 		return
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_controller_resume.go
+++ b/apps/backend/internal/orchestrator/event_handlers_controller_resume.go
@@ -1,0 +1,97 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+const controllerResumeCoalesceKey = "controller_resume"
+
+func controllerResumeReviewableState(state v1.TaskState) bool {
+	return state == v1.TaskStateReview || models.IsTerminalTaskState(state)
+}
+
+func (s *Service) maybeResumeParentController(ctx context.Context, data watcher.TaskEventData) {
+	if data.NewState == nil || !controllerResumeReviewableState(*data.NewState) {
+		return
+	}
+	if data.OldState != nil && *data.OldState == *data.NewState {
+		return
+	}
+	child, err := s.repo.GetTask(ctx, data.TaskID)
+	if err != nil {
+		s.logger.Warn("controller resume: failed to load changed child task", zap.String("task_id", data.TaskID), zap.Error(err))
+		return
+	}
+	if child.ParentID == "" {
+		return
+	}
+	s.resumeParentControllerForChild(ctx, child, *data.NewState)
+}
+
+func (s *Service) resumeParentControllerForChild(ctx context.Context, child *models.Task, newState v1.TaskState) {
+	parent, err := s.repo.GetTask(ctx, child.ParentID)
+	if err != nil {
+		s.logger.Warn("controller resume: failed to load parent task", zap.String("parent_task_id", child.ParentID), zap.Error(err))
+		return
+	}
+	if parent.ID == child.ID || parent.IsEphemeral || parent.ArchivedAt != nil || !models.IsControllerResumeEnabled(parent.Metadata) {
+		return
+	}
+	operationID := controllerResumeOperationID(parent.ID, child.ID, newState, child.UpdatedAt)
+	if _, loaded := s.controllerResumeApplied.LoadOrStore(operationID, struct{}{}); loaded {
+		return
+	}
+	if err := s.dispatchControllerResumeWake(ctx, parent.ID, child, newState); err != nil {
+		s.controllerResumeApplied.Delete(operationID)
+		s.logger.Warn("controller resume: wake dispatch failed", zap.String("parent_task_id", parent.ID), zap.String("child_task_id", child.ID), zap.Error(err))
+	}
+}
+
+func (s *Service) dispatchControllerResumeWake(ctx context.Context, parentID string, child *models.Task, newState v1.TaskState) error {
+	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, parentID)
+	if err != nil || session == nil {
+		return fmt.Errorf("parent task %s has no active session", parentID)
+	}
+	prompt := fmt.Sprintf("[controller-resume] Direct child task %q (%s) entered %s. Review its result and continue orchestration.", child.Title, child.ID, newState)
+	metadata := map[string]interface{}{
+		"source":        "controller_resume",
+		"child_task_id": child.ID,
+		"child_state":   string(newState),
+	}
+	return s.deliverControllerResumePrompt(ctx, session, prompt, metadata)
+}
+
+func (s *Service) deliverControllerResumePrompt(ctx context.Context, session *models.TaskSession, prompt string, metadata map[string]interface{}) error {
+	switch session.State {
+	case models.TaskSessionStateCreated, models.TaskSessionStateRunning, models.TaskSessionStateStarting, models.TaskSessionStateWaitingForInput, models.TaskSessionStateIdle:
+	default:
+		return fmt.Errorf("session %s is not promptable: %s", session.ID, session.State)
+	}
+	if s.messageQueue == nil {
+		return fmt.Errorf("message queue is not configured")
+	}
+	if _, _, err := s.messageQueue.QueueMessageWithCoalesceKey(ctx, session.ID, session.TaskID, prompt, "", messagequeue.QueuedByWorkflow, false, nil, metadata, controllerResumeCoalesceKey, true); err != nil {
+		return err
+	}
+	s.publishQueueStatusEvent(ctx, session.ID)
+	if session.State == models.TaskSessionStateWaitingForInput || session.State == models.TaskSessionStateIdle {
+		s.drainQueuedMessageForPromptableSession(ctx, session.ID)
+	}
+	return nil
+}
+
+func controllerResumeOperationID(parentID, childID string, state v1.TaskState, childUpdatedAt time.Time) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%s", parentID, childID, state, childUpdatedAt.UTC().Format(time.RFC3339Nano))))
+	return fmt.Sprintf("controller_resume:%s:%s", parentID, hex.EncodeToString(sum[:]))
+}

--- a/apps/backend/internal/orchestrator/event_handlers_controller_resume_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_controller_resume_test.go
@@ -1,0 +1,119 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func TestHandleTaskStateChanged_QueuesResumeForOptedInParentOnReview(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "")
+
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	parent.Metadata = map[string]interface{}{"controller_resume_enabled": true}
+	if err := repo.UpdateTask(ctx, parent); err != nil {
+		t.Fatalf("enable controller resume: %v", err)
+	}
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID:          "child",
+		WorkspaceID: "ws1",
+		Title:       "Reviewable child",
+		State:       v1.TaskStateInProgress,
+		ParentID:    "parent",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	oldState := v1.TaskStateInProgress
+	newState := v1.TaskStateReview
+	svc.handleTaskStateChanged(ctx, watcher.TaskEventData{
+		TaskID:   "child",
+		OldState: &oldState,
+		NewState: &newState,
+	})
+
+	if got := svc.messageQueue.GetStatus(ctx, "parent-session").Count; got != 1 {
+		t.Fatalf("queued controller resume wakes = %d, want 1", got)
+	}
+}
+
+func TestHandleTaskStateChanged_DoesNotResumeParentWithoutOptIn(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "")
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID:          "child",
+		WorkspaceID: "ws1",
+		Title:       "Reviewable child",
+		State:       v1.TaskStateInProgress,
+		ParentID:    "parent",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	oldState := v1.TaskStateInProgress
+	newState := v1.TaskStateReview
+	svc.handleTaskStateChanged(ctx, watcher.TaskEventData{TaskID: "child", OldState: &oldState, NewState: &newState})
+
+	if got := svc.messageQueue.GetStatus(ctx, "parent-session").Count; got != 0 {
+		t.Fatalf("queued controller resume wakes = %d, want 0 without opt-in", got)
+	}
+}
+
+func TestHandleTaskStateChanged_CoalescesControllerResumeAcrossChildren(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "")
+
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	parent.Metadata = map[string]interface{}{"controller_resume_enabled": true}
+	if err := repo.UpdateTask(ctx, parent); err != nil {
+		t.Fatalf("enable controller resume: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for _, childID := range []string{"child-1", "child-2"} {
+		requireCreateTask(t, repo, &models.Task{
+			ID:          childID,
+			WorkspaceID: "ws1",
+			Title:       childID,
+			State:       v1.TaskStateInProgress,
+			ParentID:    "parent",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+	}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	oldState := v1.TaskStateInProgress
+	newState := v1.TaskStateReview
+	for _, childID := range []string{"child-1", "child-2"} {
+		svc.handleTaskStateChanged(ctx, watcher.TaskEventData{TaskID: childID, OldState: &oldState, NewState: &newState})
+	}
+
+	status := svc.messageQueue.GetStatus(ctx, "parent-session")
+	if status.Count != 1 {
+		t.Fatalf("queued controller resume wakes = %d, want one coalesced wake", status.Count)
+	}
+	if got := status.Entries[0].Metadata["child_task_id"]; got != "child-2" {
+		t.Fatalf("coalesced wake child_task_id = %v, want child-2", got)
+	}
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -547,6 +547,8 @@ type Service struct {
 	// childCompletionLocks serializes duplicate on_children_completed deliveries.
 	childCompletionLocksMu sync.Mutex
 	childCompletionLocks   map[string]*childCompletionOperationLock
+	// controllerResumeApplied de-duplicates re-delivered child state changes.
+	controllerResumeApplied sync.Map
 	// onProcessOnEnterComplete is a package-test hook for synchronizing with
 	// applyEngineTransition's asynchronous processOnEnter goroutine.
 	onProcessOnEnterComplete func()

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -184,6 +184,9 @@ const (
 	// that produced the launch-only runtime seed. A seed is valid only for this
 	// profile, even if task profile selection changes before the first launch.
 	MetaKeyInitialSessionRuntimeConfigProfileID = "initial_session_runtime_config_profile_id"
+	// MetaKeyControllerResumeEnabled opts a parent task into event-driven
+	// controller resume when a direct child becomes reviewable.
+	MetaKeyControllerResumeEnabled = "controller_resume_enabled"
 )
 
 // IsAgentTitlePending reports whether task metadata contains the durable
@@ -193,6 +196,13 @@ const (
 func IsAgentTitlePending(metadata map[string]interface{}) bool {
 	pending, ok := metadata[MetaKeyAgentTitlePending].(bool)
 	return ok && pending
+}
+
+// IsControllerResumeEnabled reports whether task metadata explicitly opts the
+// task into event-driven controller resume.
+func IsControllerResumeEnabled(metadata map[string]interface{}) bool {
+	enabled, ok := metadata[MetaKeyControllerResumeEnabled].(bool)
+	return ok && enabled
 }
 
 // AgentTitleOwnerSessionID returns the session that owns the pending title


### PR DESCRIPTION
- Reconsiders opted-in parent controllers when a child reaches REVIEW or a terminal state.
- Coalesces duplicate wakeups for the same child-state change.
- Leaves archived, ephemeral, self-referential, and non-opted-in parents untouched.
- Does not add persistence or change the default controller behavior.
- Targeted tests, race coverage, and vet passed locally.
- Ready for CI validation after owner-approved publication.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2860-bwo7.sprites.app |
| **Commit** | `905e989` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->