### PR TITLE
fix(desktop): preserve validated Tailnet bind hosts

### DIFF
--- a/apps/backend/internal/launcher/supervisor.go
+++ b/apps/backend/internal/launcher/supervisor.go
@@ -188,6 +188,7 @@ func allowedSupervisorEnv(env []string) map[string]string {
 		"KANDEV_HOME_DIR":              true,
 		"KANDEV_DATABASE_PATH":         true,
 		"KANDEV_SERVER_PORT":           true,
+		"KANDEV_SERVER_HOST":           true,
 		"KANDEV_DESKTOP_HEALTH_TOKEN":  true,
 		"KANDEV_WEB_INTERNAL_URL":      true,
 		"KANDEV_AGENT_STANDALONE_PORT": true,

--- a/apps/backend/internal/launcher/supervisor_test.go
+++ b/apps/backend/internal/launcher/supervisor_test.go
@@ -11,6 +11,7 @@ import (
 func TestBuildManifestUsesSameBinaryBackendMode(t *testing.T) {
 	env := []string{
 		"KANDEV_SERVER_PORT=1234",
+		"KANDEV_SERVER_HOST=127.0.0.1,100.78.213.38",
 		"KANDEV_DESKTOP_HEALTH_TOKEN=health-token",
 		"KANDEV_CONSOLE_LOG_LEVEL=warn",
 		"KANDEV_WEB_TITLE_PREFIX=Debug",
@@ -29,6 +30,9 @@ func TestBuildManifestUsesSameBinaryBackendMode(t *testing.T) {
 	}
 	if manifest.Env["KANDEV_SERVER_PORT"] != "1234" {
 		t.Fatalf("KANDEV_SERVER_PORT = %q", manifest.Env["KANDEV_SERVER_PORT"])
+	}
+	if manifest.Env["KANDEV_SERVER_HOST"] != "127.0.0.1,100.78.213.38" {
+		t.Fatalf("KANDEV_SERVER_HOST = %q", manifest.Env["KANDEV_SERVER_HOST"])
 	}
 	if manifest.Env["KANDEV_CONSOLE_LOG_LEVEL"] != "warn" {
 		t.Fatalf("KANDEV_CONSOLE_LOG_LEVEL = %q", manifest.Env["KANDEV_CONSOLE_LOG_LEVEL"])

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -34,7 +34,7 @@ Use `scripts/release/prepare-desktop-runtime.sh` and `scripts/release/verify-des
 - Native menus emit versioned `kandev-desktop-v1-*` events for SPA-owned context and navigation.
   Updater, notification, and external-link operations use narrow generated Tauri commands scoped
   to the owned loopback WebView; do not grant the SPA direct plugin permissions.
-- Desktop launches force `KANDEV_SERVER_HOST=127.0.0.1`, prefer a stable desktop port with random fallback, and pass `KANDEV_BUNDLE_DIR` to the native launcher.
+- Desktop launches default `KANDEV_SERVER_HOST` to `127.0.0.1`; they retain an inherited host only when it contains both loopback and a validated Tailscale address. They prefer a stable desktop port with random fallback and pass `KANDEV_BUNDLE_DIR` to the native launcher.
 - Desktop launches set `KANDEV_DESKTOP_NATIVE_NOTIFICATIONS=true` so the owned backend suppresses
   only its duplicate System notification provider.
 - `KANDEV_DESKTOP_RUNTIME_DIR` is a test/development override for runtime resources.

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     ffi::{OsStr, OsString},
     io::{ErrorKind, Read, Write},
-    net::{TcpListener, TcpStream, ToSocketAddrs},
+    net::{IpAddr, TcpListener, TcpStream, ToSocketAddrs},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
@@ -371,10 +371,17 @@ pub fn desktop_environment(
         !key.to_string_lossy()
             .eq_ignore_ascii_case(DESKTOP_NATIVE_NOTIFICATIONS_ENV)
     });
-    env.insert(
-        OsString::from("KANDEV_SERVER_HOST"),
-        OsString::from(LOOPBACK_HOST),
-    );
+    // Desktop remains loopback-only by default. A remote bind is an explicit
+    // Tailnet-only opt-in: it must retain local loopback and include a
+    // Tailscale address. Wildcards and LAN/public addresses fall back safely.
+    if let Some(hosts) = tailnet_server_host_override(env.get(OsStr::new("KANDEV_SERVER_HOST"))) {
+        env.insert(OsString::from("KANDEV_SERVER_HOST"), hosts);
+    } else {
+        env.insert(
+            OsString::from("KANDEV_SERVER_HOST"),
+            OsString::from(LOOPBACK_HOST),
+        );
+    }
     env.insert(
         OsString::from("KANDEV_BUNDLE_DIR"),
         runtime_dir.as_os_str().to_os_string(),
@@ -385,6 +392,34 @@ pub fn desktop_environment(
     );
     env.insert(OsString::from("PATH"), path);
     env
+}
+
+fn tailnet_server_host_override(value: Option<&OsString>) -> Option<OsString> {
+    let raw = value?.to_string_lossy();
+    let mut has_loopback = false;
+    let mut has_tailnet = false;
+    let mut count = 0;
+
+    for host in raw.split(',').map(str::trim).filter(|host| !host.is_empty()) {
+        let ip: IpAddr = host.parse().ok()?;
+        count += 1;
+        if ip.is_loopback() {
+            has_loopback = true;
+        } else if is_tailscale_ip(ip) {
+            has_tailnet = true;
+        } else {
+            return None;
+        }
+    }
+
+    (count > 0 && has_loopback && has_tailnet).then(|| OsString::from(raw.as_ref()))
+}
+
+fn is_tailscale_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => matches!(ip.octets(), [100, 64..=127, _, _]),
+        IpAddr::V6(ip) => matches!(ip.segments(), [0xfd7a, 0x115c, 0xa1e0, _, _, _, _, _]),
+    }
 }
 
 pub fn pick_loopback_port() -> Result<u16, String> {
@@ -850,8 +885,39 @@ mod tests {
     }
 
     #[test]
-    fn desktop_environment_overrides_inherited_server_host_with_loopback() {
-        // Desktop launches must keep the embedded backend on the loopback host.
+    fn desktop_environment_preserves_validated_tailnet_server_hosts() {
+        let mut inherited = BTreeMap::new();
+        inherited.insert(
+            OsString::from("KANDEV_SERVER_HOST"),
+            OsString::from("127.0.0.1,100.78.213.38"),
+        );
+
+        let env = desktop_environment(Path::new("/opt/kandev"), inherited, None);
+
+        assert_eq!(
+            env.get(OsStr::new("KANDEV_SERVER_HOST")),
+            Some(&OsString::from("127.0.0.1,100.78.213.38"))
+        );
+    }
+
+    #[test]
+    fn desktop_environment_rejects_wildcard_or_non_tailnet_server_hosts() {
+        for invalid in ["0.0.0.0", "127.0.0.1,192.168.1.2", "100.78.213.38"] {
+            let mut inherited = BTreeMap::new();
+            inherited.insert(OsString::from("KANDEV_SERVER_HOST"), OsString::from(invalid));
+
+            let env = desktop_environment(Path::new("/opt/kandev"), inherited, None);
+
+            assert_eq!(
+                env.get(OsStr::new("KANDEV_SERVER_HOST")),
+                Some(&OsString::from(LOOPBACK_HOST)),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn desktop_environment_rejects_unrelated_inherited_server_host() {
         let mut inherited = BTreeMap::new();
         inherited.insert(
             OsString::from("KANDEV_SERVER_HOST"),


### PR DESCRIPTION
- Preserves an inherited backend host only when it combines loopback with a validated Tailscale address.
- Keeps loopback as the default for ordinary desktop launches.
- Rejects wildcard, LAN/public, Tailnet-only, and malformed values.
- Carries the validated host through the native launcher supervisor.
- Desktop-runtime and launcher checks passed locally.
- Ready for CI validation after owner-approved publication.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2862-bwo7.sprites.app |
| **Commit** | `e487bb0` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->