### PR TITLE
fix(gitcredentials): reject unsafe clone authorities

### DIFF
--- a/apps/backend/internal/gitcredentials/identity.go
+++ b/apps/backend/internal/gitcredentials/identity.go
@@ -97,6 +97,9 @@ type parsedRemote struct {
 
 func parseRemote(raw string) (parsedRemote, error) {
 	value := strings.TrimSpace(raw)
+	if !hasSafeRemoteAuthority(value) {
+		return parsedRemote{}, fmt.Errorf("invalid clone URL authority")
+	}
 	canonical := repoclone.CanonicalHTTPSCloneURL(value)
 	if canonical != "" {
 		if err := validateSSHRemote(value); err != nil {
@@ -138,6 +141,9 @@ func validateSSHRemote(value string) error {
 
 func trustedOrigin(input RepositoryIdentityInput, remoteHost string) (string, error) {
 	if host := strings.TrimSpace(input.ProviderHost); host != "" {
+		if !hasSafeProviderHostAuthority(host) {
+			return "", repositoryIdentityError(input.RepositoryID, "has an invalid provider host")
+		}
 		origin, err := repoclone.HTTPSProviderOrigin(host)
 		if err != nil {
 			return "", repositoryIdentityError(input.RepositoryID, "has an invalid provider host")
@@ -167,4 +173,67 @@ func repositoryIdentityError(repositoryID, detail string) error {
 		return fmt.Errorf("repository identity %s", detail)
 	}
 	return fmt.Errorf("repository %q %s; repair its clone URL or provider host", repositoryID, detail)
+}
+
+func hasSafeRemoteAuthority(value string) bool {
+	authority, found := rawRemoteAuthority(value)
+	return found && isSafeRawAuthority(authority)
+}
+
+func rawRemoteAuthority(value string) (string, bool) {
+	if schemeEnd := strings.Index(value, "://"); schemeEnd >= 0 && isURLScheme(value[:schemeEnd]) {
+		return authorityBeforePath(value[schemeEnd+len("://"):])
+	}
+	user, hostAndPath, found := strings.Cut(value, "@")
+	if !found || user == "" {
+		return "", false
+	}
+	host, _, found := strings.Cut(hostAndPath, ":")
+	if !found || host == "" {
+		return "", false
+	}
+	return user + "@" + host, true
+}
+
+func hasSafeProviderHostAuthority(value string) bool {
+	if schemeEnd := strings.Index(value, "://"); schemeEnd >= 0 {
+		if !isURLScheme(value[:schemeEnd]) {
+			return false
+		}
+		value = value[schemeEnd+len("://"):]
+	}
+	authority, found := authorityBeforePath(value)
+	return found && isSafeRawAuthority(authority)
+}
+
+func authorityBeforePath(value string) (string, bool) {
+	if authorityEnd := strings.IndexAny(value, "/?#"); authorityEnd >= 0 {
+		value = value[:authorityEnd]
+	}
+	return value, value != ""
+}
+
+func isURLScheme(value string) bool {
+	if value == "" || !isASCIILetter(value[0]) {
+		return false
+	}
+	for i := 1; i < len(value); i++ {
+		if !isASCIILetter(value[i]) && (value[i] < '0' || value[i] > '9') && value[i] != '+' && value[i] != '-' && value[i] != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}
+
+func isSafeRawAuthority(authority string) bool {
+	for i := 0; i < len(authority); i++ {
+		if authority[i] > 0x7f || authority[i] == '%' {
+			return false
+		}
+	}
+	return true
 }

--- a/apps/backend/internal/gitcredentials/identity.go
+++ b/apps/backend/internal/gitcredentials/identity.go
@@ -177,7 +177,7 @@ func repositoryIdentityError(repositoryID, detail string) error {
 
 func hasSafeRemoteAuthority(value string) bool {
 	authority, found := rawRemoteAuthority(value)
-	return found && isSafeRawAuthority(authority)
+	return found && repoclone.IsSafeRawAuthority(authority)
 }
 
 func rawRemoteAuthority(value string) (string, bool) {
@@ -203,7 +203,7 @@ func hasSafeProviderHostAuthority(value string) bool {
 		value = value[schemeEnd+len("://"):]
 	}
 	authority, found := authorityBeforePath(value)
-	return found && isSafeRawAuthority(authority)
+	return found && repoclone.IsSafeRawAuthority(authority)
 }
 
 func authorityBeforePath(value string) (string, bool) {
@@ -227,13 +227,4 @@ func isURLScheme(value string) bool {
 
 func isASCIILetter(value byte) bool {
 	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
-}
-
-func isSafeRawAuthority(authority string) bool {
-	for i := 0; i < len(authority); i++ {
-		if authority[i] > 0x7f || authority[i] == '%' {
-			return false
-		}
-	}
-	return true
 }

--- a/apps/backend/internal/gitcredentials/identity_hostile_test.go
+++ b/apps/backend/internal/gitcredentials/identity_hostile_test.go
@@ -1,0 +1,99 @@
+package gitcredentials
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveRepositoryIdentityRejectsUnsafeRemoteAuthorities(t *testing.T) {
+	t.Parallel()
+	remotes := []string{
+		"git@gİthub.com:acme/widgets.git",
+		"ssh://git@gİthub.com/acme/widgets.git",
+		"https://gİthub.com/acme/widgets.git",
+		"git@g%C4%B0thub.com:acme/widgets.git",
+		"ssh://git@g%C4%B0thub.com/acme/widgets.git",
+		"https://g%C4%B0thub.com/acme/widgets.git",
+		"git@g%25C4%25B0thub.com:acme/widgets.git",
+		"ssh://git@g%25C4%25B0thub.com/acme/widgets.git",
+		"https://g%25C4%25B0thub.com/acme/widgets.git",
+	}
+	for _, providerHost := range []string{"", "https://github.com"} {
+		for _, remoteURL := range remotes {
+			t.Run(providerHost+"/"+remoteURL, func(t *testing.T) {
+				t.Parallel()
+				_, err := ResolveRepositoryIdentity(RepositoryIdentityInput{
+					RepositoryID: "repo-1", ProviderHost: providerHost, RemoteURL: remoteURL,
+				})
+				if err == nil {
+					t.Fatal("ResolveRepositoryIdentity() error = nil, want rejection")
+				}
+				if strings.Contains(err.Error(), remoteURL) || !strings.Contains(err.Error(), "repair its clone URL or provider host") {
+					t.Fatalf("error = %q, want generic remediation without hostile remote", err)
+				}
+			})
+		}
+	}
+}
+
+func TestParseRemoteRejectsUnsafeHTTPSAuthorities(t *testing.T) {
+	t.Parallel()
+	for _, remoteURL := range []string{
+		"https://gİthub.com/acme/widgets.git",
+		"https://g%C4%B0thub.com/acme/widgets.git",
+		"https://g%25C4%25B0thub.com/acme/widgets.git",
+	} {
+		t.Run(remoteURL, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseRemote(remoteURL); err == nil {
+				t.Fatalf("parseRemote(%q) error = nil, want rejection", remoteURL)
+			}
+		})
+	}
+}
+
+func TestResolveRepositoryIdentityRejectsUnsafeProviderHost(t *testing.T) {
+	t.Parallel()
+	for _, providerHost := range []string{
+		"gİthub.com",
+		"g%C4%B0thub.com",
+		"g%25C4%25B0thub.com",
+	} {
+		t.Run(providerHost, func(t *testing.T) {
+			t.Parallel()
+			_, err := ResolveRepositoryIdentity(RepositoryIdentityInput{
+				RepositoryID: "repo-1", ProviderHost: providerHost,
+				RemoteURL: "https://github.com/acme/widgets.git",
+			})
+			if err == nil {
+				t.Fatal("ResolveRepositoryIdentity() error = nil, want rejection")
+			}
+			if strings.Contains(err.Error(), providerHost) || !strings.Contains(err.Error(), "repair its clone URL or provider host") {
+				t.Fatalf("error = %q, want generic remediation without hostile provider host", err)
+			}
+		})
+	}
+}
+
+func TestResolveRepositoryIdentityPreservesUnicodeAndEncodedPaths(t *testing.T) {
+	t.Parallel()
+	for _, remoteURL := range []string{
+		"git@github.com:acme/wídgets.git",
+		"ssh://git@github.com/acme/wídgets.git",
+		"https://github.com/acme/wídgets.git",
+		"git@github.com:acme/w%C3%ADdgets.git",
+		"ssh://git@github.com/acme/w%C3%ADdgets.git",
+		"https://github.com/acme/w%C3%ADdgets.git",
+	} {
+		t.Run(remoteURL, func(t *testing.T) {
+			t.Parallel()
+			identity, err := ResolveRepositoryIdentity(RepositoryIdentityInput{RepositoryID: "repo-1", RemoteURL: remoteURL})
+			if err != nil {
+				t.Fatalf("ResolveRepositoryIdentity() error = %v", err)
+			}
+			if identity.Path != "/acme/wídgets.git" {
+				t.Fatalf("identity.Path = %q, want %q", identity.Path, "/acme/wídgets.git")
+			}
+		})
+	}
+}

--- a/apps/backend/internal/repoclone/origin.go
+++ b/apps/backend/internal/repoclone/origin.go
@@ -17,6 +17,9 @@ func HTTPSProviderOrigin(providerHost string) (string, error) {
 	if !strings.Contains(value, "://") {
 		value = ProtocolHTTPS + "://" + value
 	}
+	if !hasSafeRawAuthority(value) {
+		return "", fmt.Errorf("provider host must be a credential-free HTTPS URL")
+	}
 	parsed, err := url.Parse(value)
 	if err != nil || !strings.EqualFold(parsed.Scheme, ProtocolHTTPS) || parsed.Host == "" ||
 		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
@@ -41,6 +44,9 @@ func CanonicalHTTPSCloneURL(raw string) string {
 	if !strings.Contains(value, "://") {
 		return scpStyleHTTPSCloneURL(value)
 	}
+	if !hasSafeRawAuthority(value) {
+		return ""
+	}
 	parsed, err := url.Parse(value)
 	if err != nil || !strings.EqualFold(parsed.Scheme, ProtocolSSH) ||
 		parsed.Hostname() == "" || parsed.Path == "" || parsed.Path == "/" {
@@ -60,6 +66,9 @@ func scpStyleHTTPSCloneURL(value string) string {
 	if !found || host == "" || strings.Contains(host, "/") {
 		return ""
 	}
+	if !isSafeRawAuthority(user + "@" + host) {
+		return ""
+	}
 	path = strings.TrimPrefix(path, "/")
 	if path == "" {
 		return ""
@@ -71,7 +80,11 @@ func scpStyleHTTPSCloneURL(value string) string {
 // and requires their origin to match the provider identity that authorized
 // credential use.
 func ValidateHTTPSCloneOrigin(cloneURL, providerHost string) error {
-	parsed, err := url.Parse(strings.TrimSpace(cloneURL))
+	value := strings.TrimSpace(cloneURL)
+	if !hasSafeRawAuthority(value) {
+		return fmt.Errorf("clone URL must be a credential-free HTTPS URL")
+	}
+	parsed, err := url.Parse(value)
 	if err != nil || !strings.EqualFold(parsed.Scheme, ProtocolHTTPS) || parsed.Host == "" ||
 		parsed.User != nil || parsed.Path == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return fmt.Errorf("clone URL must be a credential-free HTTPS URL")
@@ -85,4 +98,28 @@ func ValidateHTTPSCloneOrigin(cloneURL, providerHost string) error {
 		return fmt.Errorf("clone URL origin %q does not match provider origin %q", gotOrigin, wantOrigin)
 	}
 	return nil
+}
+
+func hasSafeRawAuthority(value string) bool {
+	authority, found := rawAuthority(value)
+	return found && isSafeRawAuthority(authority)
+}
+
+func rawAuthority(value string) (string, bool) {
+	if schemeEnd := strings.Index(value, "://"); schemeEnd >= 0 {
+		value = value[schemeEnd+len("://"):]
+	}
+	if authorityEnd := strings.IndexAny(value, "/?#"); authorityEnd >= 0 {
+		value = value[:authorityEnd]
+	}
+	return value, value != ""
+}
+
+func isSafeRawAuthority(authority string) bool {
+	for i := 0; i < len(authority); i++ {
+		if authority[i] > 0x7f || authority[i] == '%' {
+			return false
+		}
+	}
+	return true
 }

--- a/apps/backend/internal/repoclone/origin.go
+++ b/apps/backend/internal/repoclone/origin.go
@@ -66,7 +66,7 @@ func scpStyleHTTPSCloneURL(value string) string {
 	if !found || host == "" || strings.Contains(host, "/") {
 		return ""
 	}
-	if !isSafeRawAuthority(user + "@" + host) {
+	if !IsSafeRawAuthority(user + "@" + host) {
 		return ""
 	}
 	path = strings.TrimPrefix(path, "/")
@@ -102,11 +102,11 @@ func ValidateHTTPSCloneOrigin(cloneURL, providerHost string) error {
 
 func hasSafeRawAuthority(value string) bool {
 	authority, found := rawAuthority(value)
-	return found && isSafeRawAuthority(authority)
+	return found && IsSafeRawAuthority(authority)
 }
 
 func rawAuthority(value string) (string, bool) {
-	if schemeEnd := strings.Index(value, "://"); schemeEnd >= 0 {
+	if schemeEnd := strings.Index(value, "://"); schemeEnd >= 0 && isURLScheme(value[:schemeEnd]) {
 		value = value[schemeEnd+len("://"):]
 	}
 	if authorityEnd := strings.IndexAny(value, "/?#"); authorityEnd >= 0 {
@@ -115,11 +115,29 @@ func rawAuthority(value string) (string, bool) {
 	return value, value != ""
 }
 
-func isSafeRawAuthority(authority string) bool {
+// IsSafeRawAuthority reports whether a raw authority stays ASCII-only and
+// percent-free before any URL parsing or case folding can reinterpret it.
+func IsSafeRawAuthority(authority string) bool {
 	for i := 0; i < len(authority); i++ {
 		if authority[i] > 0x7f || authority[i] == '%' {
 			return false
 		}
 	}
 	return true
+}
+
+func isURLScheme(value string) bool {
+	if value == "" || !isASCIILetter(value[0]) {
+		return false
+	}
+	for i := 1; i < len(value); i++ {
+		if !isASCIILetter(value[i]) && (value[i] < '0' || value[i] > '9') && value[i] != '+' && value[i] != '-' && value[i] != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }

--- a/apps/backend/internal/repoclone/origin_test.go
+++ b/apps/backend/internal/repoclone/origin_test.go
@@ -16,6 +16,14 @@ func TestCanonicalHTTPSCloneURL(t *testing.T) {
 		{name: "ssh scheme", raw: "ssh://git@github.com/acme/widgets.git", want: "https://github.com/acme/widgets.git"},
 		{name: "ssh scheme with port", raw: "ssh://git@gitlab.example:2222/group/widgets.git", want: "https://gitlab.example/group/widgets.git"},
 		{name: "ssh scheme drops password", raw: "ssh://git:secret@github.com/acme/widgets.git", want: "https://github.com/acme/widgets.git"},
+		{name: "scp style rejects Unicode authority", raw: "git@gİthub.com:acme/widgets.git"},
+		{name: "ssh scheme rejects Unicode authority", raw: "ssh://git@gİthub.com/acme/widgets.git"},
+		{name: "scp style rejects encoded authority", raw: "git@g%C4%B0thub.com:acme/widgets.git"},
+		{name: "ssh scheme rejects encoded authority", raw: "ssh://git@g%C4%B0thub.com/acme/widgets.git"},
+		{name: "scp style rejects double encoded authority", raw: "git@g%25C4%25B0thub.com:acme/widgets.git"},
+		{name: "ssh scheme rejects double encoded authority", raw: "ssh://git@g%25C4%25B0thub.com/acme/widgets.git"},
+		{name: "scp style preserves Unicode path", raw: "git@github.com:acme/wídgets.git", want: "https://github.com/acme/wídgets.git"},
+		{name: "ssh scheme preserves Unicode path", raw: "ssh://git@github.com/acme/wídgets.git", want: "https://github.com/acme/wídgets.git"},
 		{name: "https passes through untouched", raw: "https://github.com/acme/widgets.git"},
 		{name: "file remote", raw: "file:///tmp/widgets.git"},
 		{name: "local path", raw: "/home/user/widgets"},
@@ -30,6 +38,22 @@ func TestCanonicalHTTPSCloneURL(t *testing.T) {
 			t.Parallel()
 			if got := CanonicalHTTPSCloneURL(test.raw); got != test.want {
 				t.Fatalf("CanonicalHTTPSCloneURL(%q) = %q, want %q", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+func TestHTTPSProviderOriginRejectsUnsafeAuthority(t *testing.T) {
+	t.Parallel()
+	for _, providerHost := range []string{
+		"https://gİthub.com",
+		"https://g%C4%B0thub.com",
+		"https://g%25C4%25B0thub.com",
+	} {
+		t.Run(providerHost, func(t *testing.T) {
+			t.Parallel()
+			if _, err := HTTPSProviderOrigin(providerHost); err == nil {
+				t.Fatalf("HTTPSProviderOrigin(%q) error = nil, want rejection", providerHost)
 			}
 		})
 	}
@@ -75,6 +99,24 @@ func TestValidateHTTPSCloneOrigin(t *testing.T) {
 			name:         "non HTTPS",
 			cloneURL:     "http://bitbucket.example.test/repo.git",
 			providerHost: "https://bitbucket.example.test",
+			wantErr:      true,
+		},
+		{
+			name:         "Unicode clone authority",
+			cloneURL:     "https://gİthub.com/acme/widgets.git",
+			providerHost: "https://github.com",
+			wantErr:      true,
+		},
+		{
+			name:         "encoded clone authority",
+			cloneURL:     "https://g%C4%B0thub.com/acme/widgets.git",
+			providerHost: "https://github.com",
+			wantErr:      true,
+		},
+		{
+			name:         "unsafe provider authority",
+			cloneURL:     "https://github.com/acme/widgets.git",
+			providerHost: "https://gİthub.com",
 			wantErr:      true,
 		},
 	}

--- a/apps/backend/internal/repoclone/origin_test.go
+++ b/apps/backend/internal/repoclone/origin_test.go
@@ -46,6 +46,9 @@ func TestCanonicalHTTPSCloneURL(t *testing.T) {
 func TestHTTPSProviderOriginRejectsUnsafeAuthority(t *testing.T) {
 	t.Parallel()
 	for _, providerHost := range []string{
+		"gİthub.com",
+		"g%C4%B0thub.com",
+		"g%25C4%25B0thub.com",
 		"https://gİthub.com",
 		"https://g%C4%B0thub.com",
 		"https://g%25C4%25B0thub.com",
@@ -117,6 +120,12 @@ func TestValidateHTTPSCloneOrigin(t *testing.T) {
 			name:         "unsafe provider authority",
 			cloneURL:     "https://github.com/acme/widgets.git",
 			providerHost: "https://gİthub.com",
+			wantErr:      true,
+		},
+		{
+			name:         "bare Unicode provider authority",
+			cloneURL:     "https://github.com/acme/widgets.git",
+			providerHost: "gİthub.com",
 			wantErr:      true,
 		},
 	}

--- a/docs/specs/integrations/github-authentication.md
+++ b/docs/specs/integrations/github-authentication.md
@@ -435,8 +435,9 @@ post-signature processing failures produce `failing`; a later valid successful d
 - Public base URL validation requires a canonical HTTPS origin with no credentials, query, or
   fragment and rejects loopback, private, link-local, or non-globally-routable DNS results. Kandev
   does not fetch the supplied URL as validation.
-- Repository identity accepts credential-free HTTPS and SSH remote forms. It rejects an SSH
-  password, query, or fragment before canonicalization, and an error never contains the rejected
+- Repository identity accepts credential-free HTTPS and SSH remote forms. Authorities must remain
+  ASCII-only and percent-free before URL parsing or case folding. It rejects an SSH password,
+  query, or fragment before canonicalization, and an error never contains the rejected
   secret-bearing remote.
 - App private keys, client secrets, webhook secrets, personal tokens, and live installation tokens
   never enter executor environments. Only brokered PAT/CLI tokens or repository-restricted


### PR DESCRIPTION
Reject hostile Unicode and percent-encoded clone authorities before any canonicalization can reinterpret them, so managed Git credential trust checks fail closed instead of accepting a look-alike origin.

## Important Changes

- Added raw-authority guards in `repoclone` and `gitcredentials` so SSH, SCP-style, HTTPS remote, and provider-host inputs must stay ASCII and percent-free before trust comparison.

## Validation

- `go test ./internal/repoclone/... ./internal/gitcredentials/... -count=1`
- `go test -race ./...`
- `golangci-lint run ./... --new-from-rev="957e6bbf7" --timeout=5m` fails in this environment before analysis with `context loading failed: no go files to analyze`.

## Possible Improvements

- Low risk: investigate whether `golangci-lint` v2.9.0 in this workspace needs different invocation semantics before treating the loader failure as a repository issue.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->