### PR TITLE
fix(scripts): make pr-state work on macOS's stock bash and jq 1.6

### DIFF
--- a/scripts/pr-state
+++ b/scripts/pr-state
@@ -393,7 +393,7 @@ review_evidence_json() {
         markdown_prose_lines
         | any(
             .
-            | gsub("^[[:space:]]*(?:(?:[-*+]\\s+)|(?:[0-9]+\\.\\s+))?(?:\\*\\*|__|_|\\*)?"; "")
+            | sub("^[[:space:]]*(?:(?:[-*+]\\s+)|(?:[0-9]+\\.\\s+))?(?:\\*\\*|__|_|\\*)?"; "")
             | test("^(?:blocked|changes[ _-]?requested|action required|must fix|required fix|please fix)\\b"; "i")
           );
       def review_eligibility:
@@ -752,7 +752,7 @@ fetch_review_threads_nodes_json() {
             }
           }
         }' \
-      -f owner="$owner" -f repo="$repo" -F pr="$pr_number" "${cursor_args[@]}")"; then
+      -f owner="$owner" -f repo="$repo" -F pr="$pr_number" ${cursor_args[@]+"${cursor_args[@]}"})"; then
       rm -f "$nodes_file"
       return 1
     fi

--- a/scripts/pr-state.test.sh
+++ b/scripts/pr-state.test.sh
@@ -1515,8 +1515,8 @@ test_anchored_prefix_strip_cannot_loop() {
   # so sub() is both the terminating and the semantically correct operator.
   # The hazard is a pattern that can match the empty string. A trailing optional
   # group is the realistic shape of that: gsub("...(?:x)?"; ...) matches nothing
-  # at every position. A pattern ending in a required atom, such as
-  # gsub("^[[:space:]]+|[[:space:]]+$"; ...), is fine and must not be flagged.
+  # at every position. This source guard is conservative. It flags any gsub
+  # pattern that contains `?`, including safe patterns that contain required atoms.
   local offenders
   offenders="$(grep -n 'gsub("[^"]*?";' "$SCRIPT" || true)"
   if [ -n "$offenders" ]; then
@@ -1524,10 +1524,35 @@ test_anchored_prefix_strip_cannot_loop() {
     fail "a gsub pattern ending in an optional group can match empty and loops on jq 1.6; use sub()"
   fi
 
-  # The filter must terminate quickly whatever jq is installed.
-  local start elapsed
+  # The filter must terminate quickly whatever jq is installed. Use a background
+  # watchdog because macOS does not provide the GNU `timeout` command by default.
+  local start elapsed tmp timeout_file jq_pid watchdog_pid jq_status
+  make_tmp_dir tmp
+  timeout_file="$tmp/jq-timeout"
   start=$(date +%s)
-  if ! jq -n '"- **blocked** on review" | sub("^[[:space:]]*(?:(?:[-*+]\\s+)|(?:[0-9]+\\.\\s+))?(?:\\*\\*|__|_|\\*)?"; "")' >/dev/null 2>&1; then
+  jq -n '"- **blocked** on review" | sub("^[[:space:]]*(?:(?:[-*+]\\s+)|(?:[0-9]+\\.\\s+))?(?:\\*\\*|__|_|\\*)?"; "")' >/dev/null 2>&1 &
+  jq_pid=$!
+  (
+    sleep 5
+    if kill -0 "$jq_pid" 2>/dev/null; then
+      : >"$timeout_file"
+      kill "$jq_pid" 2>/dev/null || true
+    fi
+  ) &
+  watchdog_pid=$!
+
+  if wait "$jq_pid"; then
+    jq_status=0
+  else
+    jq_status=$?
+  fi
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  if [ -e "$timeout_file" ]; then
+    fail "the prefix strip terminates promptly (timed out after 5s)"
+  fi
+  if [ "$jq_status" -ne 0 ]; then
     fail "the prefix strip evaluates successfully"
   fi
   elapsed=$(( $(date +%s) - start ))

--- a/scripts/pr-state.test.sh
+++ b/scripts/pr-state.test.sh
@@ -1484,6 +1484,60 @@ test_jq_file_args_avoid_process_substitution() {
 }
 
 test_jq_file_args_avoid_process_substitution
+# Both of these guard against host-toolchain failures that CI cannot reproduce:
+# the runners ship bash 5 and jq 1.7, while macOS ships bash 3.2 as /bin/bash and
+# jq 1.6 is still widely installed. Each bug made pr-state report a dirty PR as
+# clean, so the invariant is asserted structurally rather than left untested.
+test_array_expansions_are_safe_under_set_u() {
+  local offenders
+  # The guarded form contains "${arr[@]}" inside it, so lines carrying the
+  # [@]+ guard are not offenders.
+  offenders="$(grep -n '"\${[A-Za-z_][A-Za-z0-9_]*\[@\]}"' "$SCRIPT" | grep -v '\[@\]+' || true)"
+  if [ -n "$offenders" ]; then
+    printf '%s\n' "$offenders" >&2
+    fail "array expansions use \${arr[@]+\"\${arr[@]}\"} (bash 3.2 errors on an empty array under set -u)"
+  fi
+
+  # And the guarded form itself must be safe both empty and populated.
+  if ! bash -c 'set -u; a=(); : ${a[@]+"${a[@]}"}' 2>/dev/null; then
+    fail "the guarded expansion is safe for an empty array"
+  fi
+  if [ "$(bash -c 'set -u; a=(one two); printf "%s," ${a[@]+"${a[@]}"}')" != "one,two," ]; then
+    fail "the guarded expansion preserves array elements"
+  fi
+
+  pass "array expansions survive bash 3.2 under set -u"
+}
+
+test_anchored_prefix_strip_cannot_loop() {
+  # A gsub whose pattern is entirely optional matches the empty string at every
+  # position, which never terminates on jq 1.6. The strips here are ^-anchored,
+  # so sub() is both the terminating and the semantically correct operator.
+  # The hazard is a pattern that can match the empty string. A trailing optional
+  # group is the realistic shape of that: gsub("...(?:x)?"; ...) matches nothing
+  # at every position. A pattern ending in a required atom, such as
+  # gsub("^[[:space:]]+|[[:space:]]+$"; ...), is fine and must not be flagged.
+  local offenders
+  offenders="$(grep -n 'gsub("[^"]*?";' "$SCRIPT" || true)"
+  if [ -n "$offenders" ]; then
+    printf '%s\n' "$offenders" >&2
+    fail "a gsub pattern ending in an optional group can match empty and loops on jq 1.6; use sub()"
+  fi
+
+  # The filter must terminate quickly whatever jq is installed.
+  local start elapsed
+  start=$(date +%s)
+  if ! jq -n '"- **blocked** on review" | sub("^[[:space:]]*(?:(?:[-*+]\\s+)|(?:[0-9]+\\.\\s+))?(?:\\*\\*|__|_|\\*)?"; "")' >/dev/null 2>&1; then
+    fail "the prefix strip evaluates successfully"
+  fi
+  elapsed=$(( $(date +%s) - start ))
+  if [ "$elapsed" -gt 5 ]; then
+    fail "the prefix strip terminates promptly (took ${elapsed}s)"
+  fi
+
+  pass "anchored prefix strips terminate on jq 1.6"
+}
+
 test_snapshot_happy_path
 test_old_head_review_does_not_qualify
 test_exact_head_selected_review_qualifies
@@ -1524,3 +1578,5 @@ test_job_log_mode_unpacks_zip_responses
 test_comment_mode_returns_full_review_comment
 test_comment_mode_reports_fetch_failure
 test_comment_mode_rejects_incompatible_flags
+test_array_expansions_are_safe_under_set_u
+test_anchored_prefix_strip_cannot_loop


### PR DESCRIPTION
On a stock macOS toolchain, `scripts/pr-state` silently misreported PR state: unresolved review threads came back as `null` or the script hung and died with no output at all, both of which read as a clean PR to `pr-fixup`'s clean predicate.

## Important Changes

- `"${cursor_args[@]}"` on an empty array aborts review-thread pagination under `set -u` on bash 3.2 (macOS's stock `/bin/bash`, since Apple has frozen it at 3.2.57 over the GPLv3 license and ships no newer version) — switched to `${cursor_args[@]+"${cursor_args[@]}"}`, which is safe on an empty array.
- `has_explicit_blocker_statement`'s prefix strip used `gsub` on an entirely-optional pattern, which matches the empty string at every position and never terminates — switched to `sub`, which is also the semantically correct operator since the pattern is `^`-anchored and only one replacement was ever intended.

## Validation

Verified on this host's actual toolchain (`bash 3.2.57(1)-release`, confirmed via `bash --version`; this is the unmodified stock `/bin/bash` that `#!/usr/bin/env bash` resolves to on macOS):

- `bash scripts/pr-state.test.sh` — 43/43 tests pass, exit 0.
- Reverted the `cursor_args` fix alone: the suite fails immediately with `scripts/pr-state: line 755: cursor_args[@]: unbound variable`, failing the `threads count` test — reproducing the reported RED state.
- Reverted the `sub`/`gsub` fix alone: the suite hangs and times out (exit 124) partway through, producing no further output — reproducing the reported silent-hang behavior (observed on this host's jq 1.7.1, not only jq 1.6).
- `make test-scripts` has two pre-existing failures, unrelated to this change and present identically on `origin/main`:
  - `scripts/dev-prod-db-path.test.sh` fails a Windows-path expectation.
  - `scripts/opencode-code-review.test.sh` fails at "Harness requires trusted producer only for the dedicated OpenCode App"; this file is byte-identical to `origin/main` (`git diff origin/main -- scripts/opencode-code-review.test.sh` is empty).

The repo declares no bash or jq version requirement anywhere (`scripts/doctor` only checks for `pre-commit`), and CI runs ubuntu-latest with bash 5 and a newer jq, so neither bug reproduces there. Four other scripts carry the same latent bash 3.2 empty-array hazard — `dev-isolated`, `kandev-instances`, `kandev-kill`, `kandev-logs` — and are deliberately out of scope here.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->