### PR TITLE
fix(web): retire the session recovery card once the agent boots again

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -347,6 +347,7 @@ func (s *Service) handleAgentBootReady(ctx context.Context, data watcher.AgentEv
 			zap.String("session_state", string(session.State)))
 		return
 	}
+	recoveryResolvedAt := s.markRecoveryResolved(ctx, data.SessionID, session)
 
 	// Idempotent: if the session is already WAITING_FOR_INPUT (e.g. revived
 	// from a previously launched session and the boot signal arrived faster
@@ -354,6 +355,18 @@ func (s *Service) handleAgentBootReady(ctx context.Context, data watcher.AgentEv
 	// fall through to the drain below: an orphaned queued message would
 	// otherwise sit forever.
 	if session.State == models.TaskSessionStateWaitingForInput {
+		if recoveryResolvedAt != nil {
+			s.publishTaskSessionStateChanged(
+				ctx,
+				data.TaskID,
+				data.SessionID,
+				session.State,
+				session.State,
+				session.ErrorMessage,
+				recoveryResolvedAt,
+				session,
+			)
+		}
 		s.logger.Debug("agent.boot_ready: session already WAITING_FOR_INPUT, skipping flip",
 			zap.String("session_id", data.SessionID))
 	} else {
@@ -1792,6 +1805,31 @@ func (s *Service) clearRecoveredAgentError(ctx context.Context, taskID string, s
 			zap.String("session_id", session.ID),
 			zap.Error(err))
 	}
+}
+
+// markRecoveryResolved persists the successful boot timestamp on the session.
+// The boot transcript is useful observability, but its writes are best effort.
+// Session metadata is the authoritative recovery result used by the frontend
+// after a reload when the transcript row is missing or incomplete.
+func (s *Service) markRecoveryResolved(ctx context.Context, sessionID string, session *models.TaskSession) *time.Time {
+	resolvedAt := time.Now().UTC()
+	resolvedAtValue := resolvedAt.Format(time.RFC3339Nano)
+	if err := s.repo.SetSessionMetadataKey(
+		ctx,
+		sessionID,
+		models.SessionMetaKeyRecoveryResolvedAt,
+		resolvedAtValue,
+	); err != nil {
+		s.logger.Warn("failed to persist recovery resolution",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return nil
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]interface{})
+	}
+	session.Metadata[models.SessionMetaKeyRecoveryResolvedAt] = resolvedAtValue
+	return &resolvedAt
 }
 
 // providerRemediationURL returns the adapter-validated remediation URL from the

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -841,6 +841,13 @@ func TestHandleAgentBootReady_DoesNotTriggerOnTurnComplete(t *testing.T) {
 			if finalSess.State != tc.expectSt {
 				t.Errorf("session.State = %q, want %q", finalSess.State, tc.expectSt)
 			}
+			resolvedAt, ok := finalSess.Metadata[models.SessionMetaKeyRecoveryResolvedAt].(string)
+			if !ok || resolvedAt == "" {
+				t.Fatalf("recovery resolution timestamp = %#v, want RFC3339 string", finalSess.Metadata[models.SessionMetaKeyRecoveryResolvedAt])
+			}
+			if _, err := time.Parse(time.RFC3339Nano, resolvedAt); err != nil {
+				t.Fatalf("recovery resolution timestamp %q is invalid: %v", resolvedAt, err)
+			}
 		})
 	}
 }

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -219,6 +219,10 @@ const (
 	SessionOriginTaskInitial             = "task_initial"
 	SessionMetaKeyContextWindow          = "context_window"
 	SessionMetaKeyContextCompactionCount = "context_compaction_count"
+	// SessionMetaKeyRecoveryResolvedAt stores the server timestamp of the
+	// latest successful agent boot. Recovery cards compare this timestamp with
+	// their own creation time, so the result survives transcript write failures.
+	SessionMetaKeyRecoveryResolvedAt = "recovery_resolved_at"
 )
 
 // SessionMetaKeySessionMode records the agent's last-known session permission

--- a/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import { StateProvider } from "@/components/state-provider";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StateProvider, useAppStoreApi } from "@/components/state-provider";
+import type { StoreApi } from "zustand";
 import { ActionMessage } from "./action-message";
 import {
   sessionId as toSessionId,
@@ -11,11 +12,16 @@ import {
 } from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
 
-// These specs never activate a button, so the recovery request never leaves the
-// client; a null client keeps the real WS module out of the test entirely.
-vi.mock("@/lib/ws/connection", () => ({ getWebSocketClient: () => null }));
+const requestMock = vi.fn().mockResolvedValue({});
 
-afterEach(cleanup);
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ request: requestMock }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 const RECOVERY_MESSAGE = "Agent encountered an error";
 const RESUME_TEST_ID = "recovery-resume-button";
@@ -31,7 +37,7 @@ function recoveryMessage(): Message {
     id: "msg-1",
     session_id: toSessionId(TEST_SESSION_ID),
     task_id: toTaskId(TEST_TASK_ID),
-    author_type: "system",
+    author_type: "agent",
     content: RECOVERY_MESSAGE,
     type: "status",
     created_at: FAILED_AT,
@@ -39,8 +45,24 @@ function recoveryMessage(): Message {
       variant: "error",
       recovery_actions: true,
       actions: [
-        { type: "ws_request", label: "Resume session", test_id: RESUME_TEST_ID },
-        { type: "ws_request", label: "Start fresh session", test_id: FRESH_TEST_ID },
+        {
+          type: "ws_request",
+          label: "Resume session",
+          test_id: RESUME_TEST_ID,
+          params: {
+            method: "session.recover",
+            payload: { task_id: TEST_TASK_ID, session_id: TEST_SESSION_ID, action: "resume" },
+          },
+        },
+        {
+          type: "ws_request",
+          label: "Start fresh session",
+          test_id: FRESH_TEST_ID,
+          params: {
+            method: "session.recover",
+            payload: { task_id: TEST_TASK_ID, session_id: TEST_SESSION_ID, action: "fresh_start" },
+          },
+        },
       ],
     },
   } as Message;
@@ -74,7 +96,13 @@ function bootMessage(createdAt: string, metadata: Record<string, unknown> = {}):
 function renderWithTranscript(sessionState: TaskSessionState, messages: Message[]) {
   const initialState: Partial<AppState> = {
     taskSessions: { items: { [TEST_SESSION_ID]: { state: sessionState } as TaskSession } },
-    turns: { bySession: {}, activeBySession: {} },
+    turns: {
+      bySession: {},
+      activeBySession: {},
+      loadedBySession: {},
+      reconcileEpochBySession: {},
+      settledBoundaryBySession: {},
+    },
     messages: { bySession: { [TEST_SESSION_ID]: messages }, metaBySession: {} },
   };
   return render(<ActionMessage comment={recoveryMessage()} />, {
@@ -130,5 +158,94 @@ describe("ActionMessage — recovery card retires once the agent is back", () =>
     renderWithTranscript("WAITING_FOR_INPUT", []);
 
     expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+});
+
+/** Renders the card with a live store handle so a spec can land transcript rows and
+ *  session transitions after the user has already pressed Resume. */
+function renderWithLiveStore(messages: Message[]) {
+  let store: StoreApi<AppState> | null = null;
+  function CaptureStore() {
+    store = useAppStoreApi();
+    return null;
+  }
+  const initialState: Partial<AppState> = {
+    taskSessions: {
+      items: { [TEST_SESSION_ID]: { state: "WAITING_FOR_INPUT" } as TaskSession },
+    },
+    turns: {
+      bySession: {},
+      activeBySession: {},
+      loadedBySession: {},
+      reconcileEpochBySession: {},
+      settledBoundaryBySession: {},
+    },
+    messages: { bySession: { [TEST_SESSION_ID]: messages }, metaBySession: {} },
+  };
+  render(
+    <StateProvider initialState={initialState}>
+      <CaptureStore />
+      <ActionMessage comment={recoveryMessage()} />
+    </StateProvider>,
+  );
+  return {
+    setSessionState: (state: TaskSessionState) =>
+      act(() => {
+        store?.getState().setTaskSession({
+          id: toSessionId(TEST_SESSION_ID),
+          task_id: toTaskId(TEST_TASK_ID),
+          state,
+          started_at: "",
+          updated_at: "",
+        } as TaskSession);
+      }),
+    setMessages: (next: Message[]) =>
+      act(() => {
+        store?.getState().setMessages(toSessionId(TEST_SESSION_ID), next);
+      }),
+  };
+}
+
+describe("ActionMessage — a recovery that failed keeps its controls", () => {
+  it("brings the card back when the boot after an accepted resume reports failure", async () => {
+    const live = renderWithLiveStore([]);
+
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+
+    // The launch was accepted, so the card hid; the agent then failed to come up.
+    live.setSessionState("STARTING");
+    live.setMessages([bootMessage(BOOTED_AFTER_FAILURE, { status: "failed" })]);
+    live.setSessionState("WAITING_FOR_INPUT");
+
+    expect(screen.getByText(RECOVERY_MESSAGE)).toBeTruthy();
+    expect(screen.getByTestId(FRESH_TEST_ID)).toBeTruthy();
+  });
+
+  it("brings the card back when an accepted resume drives the session to FAILED", async () => {
+    const live = renderWithLiveStore([]);
+
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+    await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+
+    live.setSessionState("FAILED");
+
+    expect(screen.getByText(RECOVERY_MESSAGE)).toBeTruthy();
+    expect(screen.getByTestId(FRESH_TEST_ID)).toBeTruthy();
+  });
+
+  it("keeps the card retired when the accepted resume actually boots", async () => {
+    const live = renderWithLiveStore([]);
+
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+    await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+
+    live.setSessionState("STARTING");
+    live.setMessages([bootMessage(BOOTED_AFTER_FAILURE)]);
+    live.setSessionState("WAITING_FOR_INPUT");
+
+    expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull();
+    expect(screen.queryByTestId(RESUME_TEST_ID)).toBeNull();
   });
 });

--- a/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { ActionMessage } from "./action-message";
+import {
+  sessionId as toSessionId,
+  taskId as toTaskId,
+  type Message,
+  type TaskSession,
+  type TaskSessionState,
+} from "@/lib/types/http";
+import type { AppState } from "@/lib/state/store";
+
+// These specs never activate a button, so the recovery request never leaves the
+// client; a null client keeps the real WS module out of the test entirely.
+vi.mock("@/lib/ws/connection", () => ({ getWebSocketClient: () => null }));
+
+afterEach(cleanup);
+
+const RECOVERY_MESSAGE = "Agent encountered an error";
+const RESUME_TEST_ID = "recovery-resume-button";
+const FRESH_TEST_ID = "recovery-fresh-button";
+const TEST_SESSION_ID = "sess-1";
+const TEST_TASK_ID = "task-1";
+const FAILED_AT = "2026-05-30T00:00:00Z";
+const BOOTED_AFTER_FAILURE = "2026-05-30T00:01:00Z";
+const BOOTED_BEFORE_FAILURE = "2026-05-29T23:59:00Z";
+
+function recoveryMessage(): Message {
+  return {
+    id: "msg-1",
+    session_id: toSessionId(TEST_SESSION_ID),
+    task_id: toTaskId(TEST_TASK_ID),
+    author_type: "system",
+    content: RECOVERY_MESSAGE,
+    type: "status",
+    created_at: FAILED_AT,
+    metadata: {
+      variant: "error",
+      recovery_actions: true,
+      actions: [
+        { type: "ws_request", label: "Resume session", test_id: RESUME_TEST_ID },
+        { type: "ws_request", label: "Start fresh session", test_id: FRESH_TEST_ID },
+      ],
+    },
+  } as Message;
+}
+
+function bootMessage(createdAt: string, metadata: Record<string, unknown> = {}): Message {
+  return {
+    id: `boot-${createdAt}`,
+    session_id: toSessionId(TEST_SESSION_ID),
+    task_id: toTaskId(TEST_TASK_ID),
+    author_type: "agent",
+    content: "",
+    type: "script_execution",
+    created_at: createdAt,
+    metadata: {
+      script_type: "agent_boot",
+      agent_name: "OpenCode",
+      is_resuming: true,
+      status: "exited",
+      ...metadata,
+    },
+  } as Message;
+}
+
+/**
+ * Renders the card against a seeded transcript and WITHOUT activating Resume.
+ * That is the reported situation: the click acknowledgment is in-memory, so a
+ * reload, a task switch, or an auto-resume-on-open all present the persisted
+ * card with no acknowledgment at all.
+ */
+function renderWithTranscript(sessionState: TaskSessionState, messages: Message[]) {
+  const initialState: Partial<AppState> = {
+    taskSessions: { items: { [TEST_SESSION_ID]: { state: sessionState } as TaskSession } },
+    turns: { bySession: {}, activeBySession: {} },
+    messages: { bySession: { [TEST_SESSION_ID]: messages }, metaBySession: {} },
+  };
+  return render(<ActionMessage comment={recoveryMessage()} />, {
+    wrapper: ({ children }) => (
+      <StateProvider initialState={initialState}>{children}</StateProvider>
+    ),
+  });
+}
+
+describe("ActionMessage — recovery card retires once the agent is back", () => {
+  it("hides the card when a resume re-established the agent after the failure", () => {
+    // A resumed agent settles at WAITING_FOR_INPUT, not RUNNING, so the session
+    // state alone never retires the card.
+    renderWithTranscript("WAITING_FOR_INPUT", [bootMessage(BOOTED_AFTER_FAILURE)]);
+
+    expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull();
+    expect(screen.queryByTestId(RESUME_TEST_ID)).toBeNull();
+    expect(screen.queryByTestId(FRESH_TEST_ID)).toBeNull();
+  });
+
+  it("hides the card when a fresh start re-established the agent after the failure", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", [
+      bootMessage(BOOTED_AFTER_FAILURE, { is_resuming: false }),
+    ]);
+
+    expect(screen.queryByTestId(RESUME_TEST_ID)).toBeNull();
+  });
+
+  it("keeps the card visible when the resume attempt failed", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", [
+      bootMessage(BOOTED_AFTER_FAILURE, { status: "failed" }),
+    ]);
+
+    expect(screen.getByText(RECOVERY_MESSAGE)).toBeTruthy();
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+
+  it("keeps the card visible while the resume is still running", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", [
+      bootMessage(BOOTED_AFTER_FAILURE, { status: "running" }),
+    ]);
+
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+
+  it("keeps the card visible when the only successful boot predates the failure", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", [bootMessage(BOOTED_BEFORE_FAILURE)]);
+
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+
+  it("keeps the card visible when the transcript holds no boot record at all", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", []);
+
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+});

--- a/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message-recovery.test.tsx
@@ -93,9 +93,17 @@ function bootMessage(createdAt: string, metadata: Record<string, unknown> = {}):
  * reload, a task switch, or an auto-resume-on-open all present the persisted
  * card with no acknowledgment at all.
  */
-function renderWithTranscript(sessionState: TaskSessionState, messages: Message[]) {
+function renderWithTranscript(
+  sessionState: TaskSessionState,
+  messages: Message[],
+  sessionMetadata?: Record<string, unknown>,
+) {
   const initialState: Partial<AppState> = {
-    taskSessions: { items: { [TEST_SESSION_ID]: { state: sessionState } as TaskSession } },
+    taskSessions: {
+      items: {
+        [TEST_SESSION_ID]: { state: sessionState, metadata: sessionMetadata } as TaskSession,
+      },
+    },
     turns: {
       bySession: {},
       activeBySession: {},
@@ -158,6 +166,13 @@ describe("ActionMessage — recovery card retires once the agent is back", () =>
     renderWithTranscript("WAITING_FOR_INPUT", []);
 
     expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+
+  it("uses the durable session resolution when the boot record is missing", () => {
+    renderWithTranscript("WAITING_FOR_INPUT", [], { recovery_resolved_at: BOOTED_AFTER_FAILURE });
+
+    expect(screen.queryByTestId(RESUME_TEST_ID)).toBeNull();
+    expect(screen.queryByTestId(FRESH_TEST_ID)).toBeNull();
   });
 });
 

--- a/apps/web/components/task/chat/messages/action-message-state.ts
+++ b/apps/web/components/task/chat/messages/action-message-state.ts
@@ -1,0 +1,50 @@
+import { useAppStore } from "@/components/state-provider";
+import type { Message } from "@/lib/types/http";
+import {
+  hasFailedAgentBootAfter,
+  hasSuccessfulAgentBootAfter,
+} from "@/hooks/processed-message-filtering";
+
+/** Reads how the agent boots after this message turned out. Each selector returns a
+ * derived boolean, not the array, so the memoized message row does not re-render on
+ * every streamed token. */
+export function useAgentBootOutcomeAfterMessage(
+  comment: Message,
+  enabled: boolean,
+): {
+  agentRebooted: boolean;
+  agentBootFailed: boolean;
+} {
+  const agentRebooted = useAppStore((state) =>
+    enabled && comment.session_id
+      ? hasSuccessfulAgentBootAfter(
+          state.messages.bySession[comment.session_id],
+          comment.created_at,
+        )
+      : false,
+  );
+  const agentBootFailed = useAppStore((state) =>
+    enabled && comment.session_id
+      ? hasFailedAgentBootAfter(state.messages.bySession[comment.session_id], comment.created_at)
+      : false,
+  );
+  return { agentRebooted, agentBootFailed };
+}
+
+export function useActionMessageSession(sessionId: Message["session_id"]) {
+  const sessionState = useAppStore((state) =>
+    sessionId ? (state.taskSessions.items[sessionId]?.state ?? undefined) : undefined,
+  );
+  const sessionError = useAppStore((state) =>
+    sessionId
+      ? (state.taskSessions.items[sessionId]?.error_message as string | undefined)
+      : undefined,
+  );
+  const sessionMetadata = useAppStore((state) =>
+    sessionId ? state.taskSessions.items[sessionId]?.metadata : undefined,
+  );
+  const activeTurnId = useAppStore((state) =>
+    sessionId ? (state.turns.activeBySession[sessionId] ?? undefined) : undefined,
+  );
+  return { sessionState, sessionError, sessionMetadata, activeTurnId };
+}

--- a/apps/web/components/task/chat/messages/action-message.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { StateProvider } from "@/components/state-provider";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StateProvider, useAppStoreApi } from "@/components/state-provider";
+import type { StoreApi } from "zustand";
 import { ActionMessage } from "./action-message";
 import {
   sessionId as toSessionId,
@@ -161,6 +162,46 @@ function renderAction(
   });
 }
 
+/** Like renderAction, but captures the store so the test can drive live session
+ *  state transitions (STARTING/RUNNING → WAITING_FOR_INPUT) the way a real
+ *  resume does over the WebSocket. */
+function renderActionWithStore(
+  comment: Message,
+  sessionState: TaskSessionState,
+  sessionError = "",
+) {
+  let store: StoreApi<AppState> | null = null;
+  function CaptureStore() {
+    store = useAppStoreApi();
+    return null;
+  }
+  const initialState: Partial<AppState> = {
+    taskSessions: {
+      items: {
+        [TEST_SESSION_ID]: { state: sessionState, error_message: sessionError } as TaskSession,
+      },
+    },
+    turns: { bySession: {}, activeBySession: {} },
+  };
+  const utils = render(
+    <StateProvider initialState={initialState}>
+      <CaptureStore />
+      <ActionMessage comment={comment} />
+    </StateProvider>,
+  );
+  const setSessionState = (next: TaskSessionState) =>
+    act(() => {
+      store?.getState().setTaskSession({
+        id: toSessionId(TEST_SESSION_ID),
+        task_id: toTaskId(TEST_TASK_ID),
+        state: next,
+        started_at: "",
+        updated_at: "",
+      } as TaskSession);
+    });
+  return { ...utils, setSessionState };
+}
+
 describe("ActionMessage — transient retry (warning variant)", () => {
   it("renders the retrying copy in amber, not red", () => {
     renderAction(retryMessage(), "WAITING_FOR_INPUT");
@@ -244,6 +285,25 @@ describe("ActionMessage — transient retry (warning variant)", () => {
     renderAction(errorMsg, "WAITING_FOR_INPUT", "");
     fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
     await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+  });
+
+  it("keeps the recovery card hidden after a successful resume settles back to waiting", async () => {
+    const errorMsg = recoveryMessage(true);
+
+    const { setSessionState } = renderActionWithStore(errorMsg, "WAITING_FOR_INPUT", "");
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+    await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+
+    // A successful resume drives the session through an active state (which
+    // hides the card via isSessionActive) and then back to WAITING_FOR_INPUT
+    // once the agent is idle again. The recovery acknowledgment must survive
+    // that intermediate unmount so the card does not reappear until the user
+    // actually sends the next message.
+    setSessionState("STARTING");
+    setSessionState("WAITING_FOR_INPUT");
+
+    expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull();
+    expect(screen.queryByTestId(RESUME_TEST_ID)).toBeNull();
   });
 
   it("keeps a recovery card visible when the WebSocket client is unavailable", () => {

--- a/apps/web/components/task/chat/messages/action-message.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message.test.tsx
@@ -181,7 +181,13 @@ function renderActionWithStore(
         [TEST_SESSION_ID]: { state: sessionState, error_message: sessionError } as TaskSession,
       },
     },
-    turns: { bySession: {}, activeBySession: {} },
+    turns: {
+      bySession: {},
+      activeBySession: {},
+      loadedBySession: {},
+      reconcileEpochBySession: {},
+      settledBoundaryBySession: {},
+    },
   };
   const utils = render(
     <StateProvider initialState={initialState}>

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -25,7 +25,10 @@ import type { MessageAction } from "@/components/task/chat/types";
 import { ActionMessageDetails, type ActionMeta } from "./action-message-details";
 import { formatDateTime } from "@/lib/i18n/formats";
 import { parseRetryAt, retryCountdownLabel } from "./transient-retry";
-import { hasSuccessfulAgentBootAfter } from "@/hooks/processed-message-filtering";
+import {
+  hasFailedAgentBootAfter,
+  hasSuccessfulAgentBootAfter,
+} from "@/hooks/processed-message-filtering";
 
 const ICON_MAP: Record<string, React.ElementType> = {
   archive: IconArchive,
@@ -61,7 +64,11 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   // records that the agent booted again after this failure. It survives a
   // reload or task switch and also covers auto-resume-on-open, where the card
   // would otherwise linger until the next prompt flipped the session to RUNNING.
-  const agentRebooted = useAgentRebootedAfterMessage(comment);
+  const { agentRebooted, agentBootFailed } = useAgentBootOutcomeAfterMessage(comment);
+  // The click acknowledgment only covers the wait for that outcome. A recovery
+  // that came back failed — a failed boot row, or a session driven to FAILED —
+  // must surface its card again, buttons included, or the retry is unreachable.
+  const recoveryFailedAgain = agentBootFailed || sessionState === "FAILED";
 
   if (metadata?.action_visibility === "running") {
     if (sessionState === "RUNNING" && comment.turn_id && activeTurnId === comment.turn_id) {
@@ -87,7 +94,7 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={comment.task_id}
-      recoveryResolved={recoveryRequested || agentRebooted}
+      recoveryResolved={agentRebooted || (recoveryRequested && !recoveryFailedAgain)}
       onRecoveryRequested={() => setRecoveryRequested(true)}
     />
   );
@@ -418,11 +425,14 @@ function ProviderQuotaRecovery({
   );
 }
 
-/** Reads the session transcript for a successful agent boot newer than this
- *  message. Selecting the derived boolean (not the array) keeps the memoized
- *  message row from re-rendering on every streamed token. */
-function useAgentRebootedAfterMessage(comment: Message): boolean {
-  return useAppStore((state) =>
+/** Reads how the agent boots after this message turned out. Each selector returns a
+ *  derived boolean, not the array, so the memoized message row does not re-render on
+ *  every streamed token. */
+function useAgentBootOutcomeAfterMessage(comment: Message): {
+  agentRebooted: boolean;
+  agentBootFailed: boolean;
+} {
+  const agentRebooted = useAppStore((state) =>
     comment.session_id
       ? hasSuccessfulAgentBootAfter(
           state.messages.bySession[comment.session_id],
@@ -430,6 +440,12 @@ function useAgentRebootedAfterMessage(comment: Message): boolean {
         )
       : false,
   );
+  const agentBootFailed = useAppStore((state) =>
+    comment.session_id
+      ? hasFailedAgentBootAfter(state.messages.bySession[comment.session_id], comment.created_at)
+      : false,
+  );
+  return { agentRebooted, agentBootFailed };
 }
 
 function useActionMessageSession(sessionId: Message["session_id"]) {

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -49,6 +49,13 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   const { sessionState, sessionError, activeTurnId } = useActionMessageSession(comment.session_id);
   const metadata = comment.metadata as ActionMeta | undefined;
   const message = comment.content || t("task:anErrorOccurred");
+  // The recovery acknowledgment lives here, on the message row that stays
+  // mounted, not on SettledFailureMessage: a successful resume drives the
+  // session through STARTING/RUNNING (which unmounts the card via
+  // isSessionActive) and back to WAITING_FOR_INPUT once the agent is idle.
+  // Local state on the card would reset on that remount and the recovery banner
+  // would reappear until the next user message.
+  const [recoveryRequested, setRecoveryRequested] = useState(false);
 
   if (metadata?.action_visibility === "running") {
     if (sessionState === "RUNNING" && comment.turn_id && activeTurnId === comment.turn_id) {
@@ -74,6 +81,8 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={comment.task_id}
+      recoveryRequested={recoveryRequested}
+      onRecoveryRequested={() => setRecoveryRequested(true)}
     />
   );
 });
@@ -84,12 +93,16 @@ function SettledActionMessage({
   sessionError,
   sessionState,
   taskId,
+  recoveryRequested,
+  onRecoveryRequested,
 }: {
   metadata: ActionMeta | undefined;
   message: string;
   sessionError?: string;
   sessionState?: TaskSessionState;
   taskId?: string;
+  recoveryRequested: boolean;
+  onRecoveryRequested: () => void;
 }) {
   // A retry card is persisted against the failed turn, so hide it while the
   // replacement turn is starting or running to avoid showing stale progress.
@@ -106,6 +119,8 @@ function SettledActionMessage({
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={taskId}
+      recoveryRequested={recoveryRequested}
+      onRecoveryRequested={onRecoveryRequested}
     />
   );
 }
@@ -116,17 +131,21 @@ function SettledFailureMessage({
   sessionError,
   sessionState,
   taskId,
+  recoveryRequested,
+  onRecoveryRequested,
 }: {
   metadata: ActionMeta | undefined;
   message: string;
   sessionError?: string;
   sessionState?: TaskSessionState;
   taskId?: string;
+  recoveryRequested: boolean;
+  onRecoveryRequested: () => void;
 }) {
-  const [recoveryRequested, setRecoveryRequested] = useState(false);
-
   // A waiting session can still need recovery, so only hide this persisted
   // card after its own Resume request is acknowledged (or the session starts).
+  // `recoveryRequested` is owned by ActionMessage so the acknowledgment
+  // survives the isSessionActive unmount above during a resume.
   if (isSessionActive(sessionState) || (metadata?.recovery_actions && recoveryRequested))
     return null;
 
@@ -135,7 +154,7 @@ function SettledFailureMessage({
     message,
     sessionError,
     taskId,
-    onRecoveryRequested: () => setRecoveryRequested(true),
+    onRecoveryRequested,
   });
   if (specialRecovery) return specialRecovery;
 
@@ -158,9 +177,7 @@ function SettledFailureMessage({
             <ActionButtons
               actions={metadata.actions}
               taskId={taskId}
-              onRecoveryRequested={
-                metadata.recovery_actions ? () => setRecoveryRequested(true) : undefined
-              }
+              onRecoveryRequested={metadata.recovery_actions ? onRecoveryRequested : undefined}
             />
           )}
         </div>

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -25,6 +25,7 @@ import type { MessageAction } from "@/components/task/chat/types";
 import { ActionMessageDetails, type ActionMeta } from "./action-message-details";
 import { formatDateTime } from "@/lib/i18n/formats";
 import { parseRetryAt, retryCountdownLabel } from "./transient-retry";
+import { hasSuccessfulAgentBootAfter } from "@/hooks/processed-message-filtering";
 
 const ICON_MAP: Record<string, React.ElementType> = {
   archive: IconArchive,
@@ -56,6 +57,11 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   // Local state on the card would reset on that remount and the recovery banner
   // would reappear until the next user message.
   const [recoveryRequested, setRecoveryRequested] = useState(false);
+  // Durable counterpart to the click acknowledgment: the transcript itself
+  // records that the agent booted again after this failure. It survives a
+  // reload or task switch and also covers auto-resume-on-open, where the card
+  // would otherwise linger until the next prompt flipped the session to RUNNING.
+  const agentRebooted = useAgentRebootedAfterMessage(comment);
 
   if (metadata?.action_visibility === "running") {
     if (sessionState === "RUNNING" && comment.turn_id && activeTurnId === comment.turn_id) {
@@ -81,7 +87,7 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={comment.task_id}
-      recoveryRequested={recoveryRequested}
+      recoveryResolved={recoveryRequested || agentRebooted}
       onRecoveryRequested={() => setRecoveryRequested(true)}
     />
   );
@@ -93,7 +99,7 @@ function SettledActionMessage({
   sessionError,
   sessionState,
   taskId,
-  recoveryRequested,
+  recoveryResolved,
   onRecoveryRequested,
 }: {
   metadata: ActionMeta | undefined;
@@ -101,7 +107,7 @@ function SettledActionMessage({
   sessionError?: string;
   sessionState?: TaskSessionState;
   taskId?: string;
-  recoveryRequested: boolean;
+  recoveryResolved: boolean;
   onRecoveryRequested: () => void;
 }) {
   // A retry card is persisted against the failed turn, so hide it while the
@@ -119,7 +125,7 @@ function SettledActionMessage({
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={taskId}
-      recoveryRequested={recoveryRequested}
+      recoveryResolved={recoveryResolved}
       onRecoveryRequested={onRecoveryRequested}
     />
   );
@@ -131,7 +137,7 @@ function SettledFailureMessage({
   sessionError,
   sessionState,
   taskId,
-  recoveryRequested,
+  recoveryResolved,
   onRecoveryRequested,
 }: {
   metadata: ActionMeta | undefined;
@@ -139,14 +145,16 @@ function SettledFailureMessage({
   sessionError?: string;
   sessionState?: TaskSessionState;
   taskId?: string;
-  recoveryRequested: boolean;
+  recoveryResolved: boolean;
   onRecoveryRequested: () => void;
 }) {
-  // A waiting session can still need recovery, so only hide this persisted
-  // card after its own Resume request is acknowledged (or the session starts).
-  // `recoveryRequested` is owned by ActionMessage so the acknowledgment
-  // survives the isSessionActive unmount above during a resume.
-  if (isSessionActive(sessionState) || (metadata?.recovery_actions && recoveryRequested))
+  // A waiting session can still need recovery, so only hide this persisted card
+  // once its own recovery resolved: either the Resume click was acknowledged or
+  // the transcript shows the agent booted again after this failure. A resumed
+  // agent settles at WAITING_FOR_INPUT, which isSessionActive deliberately
+  // excludes, so without that second signal the card outlives the failure it
+  // describes.
+  if (isSessionActive(sessionState) || (metadata?.recovery_actions && recoveryResolved))
     return null;
 
   const specialRecovery = renderSpecialRecovery({
@@ -407,6 +415,20 @@ function ProviderQuotaRecovery({
         </div>
       </div>
     </section>
+  );
+}
+
+/** Reads the session transcript for a successful agent boot newer than this
+ *  message. Selecting the derived boolean (not the array) keeps the memoized
+ *  message row from re-rendering on every streamed token. */
+function useAgentRebootedAfterMessage(comment: Message): boolean {
+  return useAppStore((state) =>
+    comment.session_id
+      ? hasSuccessfulAgentBootAfter(
+          state.messages.bySession[comment.session_id],
+          comment.created_at,
+        )
+      : false,
   );
 }
 

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -17,6 +17,7 @@ import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { useActionMessageSession, useAgentBootOutcomeAfterMessage } from "./action-message-state";
 import { useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
 import { deleteTask } from "@/lib/api/domains/kanban-api";
@@ -25,10 +26,7 @@ import type { MessageAction } from "@/components/task/chat/types";
 import { ActionMessageDetails, type ActionMeta } from "./action-message-details";
 import { formatDateTime } from "@/lib/i18n/formats";
 import { parseRetryAt, retryCountdownLabel } from "./transient-retry";
-import {
-  hasFailedAgentBootAfter,
-  hasSuccessfulAgentBootAfter,
-} from "@/hooks/processed-message-filtering";
+import { hasSessionRecoveryResolutionAfter } from "@/hooks/processed-message-filtering";
 
 const ICON_MAP: Record<string, React.ElementType> = {
   archive: IconArchive,
@@ -50,9 +48,12 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   // state transition doesn't re-render every message in the list (only the
   // rare action messages that actually depend on it).
   const { t } = useTranslation();
-  const { sessionState, sessionError, activeTurnId } = useActionMessageSession(comment.session_id);
+  const { sessionState, sessionError, sessionMetadata, activeTurnId } = useActionMessageSession(
+    comment.session_id,
+  );
   const metadata = comment.metadata as ActionMeta | undefined;
   const message = comment.content || t("task:anErrorOccurred");
+  const isRecoveryMessage = metadata?.recovery_actions === true;
   // The recovery acknowledgment lives here, on the message row that stays
   // mounted, not on SettledFailureMessage: a successful resume drives the
   // session through STARTING/RUNNING (which unmounts the card via
@@ -64,7 +65,13 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   // records that the agent booted again after this failure. It survives a
   // reload or task switch and also covers auto-resume-on-open, where the card
   // would otherwise linger until the next prompt flipped the session to RUNNING.
-  const { agentRebooted, agentBootFailed } = useAgentBootOutcomeAfterMessage(comment);
+  const { agentRebooted, agentBootFailed } = useAgentBootOutcomeAfterMessage(
+    comment,
+    isRecoveryMessage,
+  );
+  const recoveryResolvedDurably = isRecoveryMessage
+    ? hasSessionRecoveryResolutionAfter(sessionMetadata, comment.created_at)
+    : false;
   // The click acknowledgment only covers the wait for that outcome. A recovery
   // that came back failed — a failed boot row, or a session driven to FAILED —
   // must surface its card again, buttons included, or the retry is unreachable.
@@ -94,7 +101,9 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
       sessionError={sessionError}
       sessionState={sessionState}
       taskId={comment.task_id}
-      recoveryResolved={agentRebooted || (recoveryRequested && !recoveryFailedAgain)}
+      recoveryResolved={
+        recoveryResolvedDurably || agentRebooted || (recoveryRequested && !recoveryFailedAgain)
+      }
       onRecoveryRequested={() => setRecoveryRequested(true)}
     />
   );
@@ -423,44 +432,6 @@ function ProviderQuotaRecovery({
       </div>
     </section>
   );
-}
-
-/** Reads how the agent boots after this message turned out. Each selector returns a
- *  derived boolean, not the array, so the memoized message row does not re-render on
- *  every streamed token. */
-function useAgentBootOutcomeAfterMessage(comment: Message): {
-  agentRebooted: boolean;
-  agentBootFailed: boolean;
-} {
-  const agentRebooted = useAppStore((state) =>
-    comment.session_id
-      ? hasSuccessfulAgentBootAfter(
-          state.messages.bySession[comment.session_id],
-          comment.created_at,
-        )
-      : false,
-  );
-  const agentBootFailed = useAppStore((state) =>
-    comment.session_id
-      ? hasFailedAgentBootAfter(state.messages.bySession[comment.session_id], comment.created_at)
-      : false,
-  );
-  return { agentRebooted, agentBootFailed };
-}
-
-function useActionMessageSession(sessionId: Message["session_id"]) {
-  const sessionState = useAppStore((state) =>
-    sessionId ? (state.taskSessions.items[sessionId]?.state ?? undefined) : undefined,
-  );
-  const sessionError = useAppStore((state) =>
-    sessionId
-      ? (state.taskSessions.items[sessionId]?.error_message as string | undefined)
-      : undefined,
-  );
-  const activeTurnId = useAppStore((state) =>
-    sessionId ? (state.turns.activeBySession[sessionId] ?? undefined) : undefined,
-  );
-  return { sessionState, sessionError, activeTurnId };
 }
 
 function RunningActionNotice({

--- a/apps/web/components/task/chat/messages/script-execution-message.tsx
+++ b/apps/web/components/task/chat/messages/script-execution-message.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@kandev/ui/badge";
 import { ExpandableRow } from "./expandable-row";
 import { useExpandState } from "./use-expand-state";
 import { useTranslation } from "react-i18next";
+import { isSuccessfulScriptExecutionMetadata } from "@/hooks/processed-message-filtering";
 
 interface ScriptExecutionMetadata {
   script_type: "setup" | "cleanup" | "agent_boot";
@@ -208,8 +209,7 @@ function parseScriptMetadata(comment: Message) {
   const status = metadata?.status;
   const scriptType = metadata?.script_type;
   const isRunning = status === "starting" || status === "running";
-  const isSuccess =
-    status === "exited" && (metadata?.exit_code === 0 || metadata?.exit_code === undefined);
+  const isSuccess = isSuccessfulScriptExecutionMetadata(metadata);
   return { metadata, status, scriptType, isRunning, isSuccess };
 }
 

--- a/apps/web/e2e/tests/session/session-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/session-recovery.spec.ts
@@ -223,6 +223,13 @@ test.describe("Session recovery", () => {
       },
     );
 
+    // The resume settles the session back to WAITING_FOR_INPUT (agent idle).
+    // The recovery card must not reappear now that the acknowledgment is
+    // remembered — before the fix it came back until the next message flipped
+    // the session to RUNNING, without the user ever typing anything.
+    await expect(session.recoveryResumeButton()).toHaveCount(0);
+    await expect(session.recoveryFreshButton()).toHaveCount(0);
+
     // Verify agent works after recovery
     await session.sendMessage("/e2e:simple-message");
     await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });

--- a/apps/web/e2e/tests/session/session-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/session-recovery.spec.ts
@@ -236,11 +236,14 @@ test.describe("Session recovery", () => {
     // transcript's own agent-boot record is what keeps it hidden.
     await testPage.reload();
     await session.waitForLoad();
-    await expect(testPage.getByTestId("chat-input-editor")).toHaveAttribute(
-      "contenteditable",
-      "true",
-      { timeout: 30_000 },
-    );
+    // Gate on the transcript's own boot record rather than the composer becoming
+    // editable: the boot row is the signal the card is derived from, so waiting
+    // for it removes the race where a fast hydration outruns the WS history.
+    // (session.waitForChatIdle is unusable here — it clicks a visible Resume
+    // button, which would hide the very regression this asserts.)
+    await expect(testPage.getByText(/Resumed agent|Started agent/i).first()).toBeVisible({
+      timeout: 30_000,
+    });
     await expect(session.recoveryResumeButton()).toHaveCount(0);
     await expect(session.recoveryFreshButton()).toHaveCount(0);
 

--- a/apps/web/e2e/tests/session/session-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/session-recovery.spec.ts
@@ -224,9 +224,23 @@ test.describe("Session recovery", () => {
     );
 
     // The resume settles the session back to WAITING_FOR_INPUT (agent idle).
-    // The recovery card must not reappear now that the acknowledgment is
-    // remembered — before the fix it came back until the next message flipped
-    // the session to RUNNING, without the user ever typing anything.
+    // The recovery card must not reappear now that the resume is resolved —
+    // before the fix it came back until the next message flipped the session to
+    // RUNNING, without the user ever typing anything.
+    await expect(session.recoveryResumeButton()).toHaveCount(0);
+    await expect(session.recoveryFreshButton()).toHaveCount(0);
+
+    // Reload: the card is persisted, so a fix that only remembered the click in
+    // component state would resurrect it here (this is also what the user hits
+    // when a task is reopened and the session auto-resumes on open). The
+    // transcript's own agent-boot record is what keeps it hidden.
+    await testPage.reload();
+    await session.waitForLoad();
+    await expect(testPage.getByTestId("chat-input-editor")).toHaveAttribute(
+      "contenteditable",
+      "true",
+      { timeout: 30_000 },
+    );
     await expect(session.recoveryResumeButton()).toHaveCount(0);
     await expect(session.recoveryFreshButton()).toHaveCount(0);
 

--- a/apps/web/hooks/processed-message-filtering.test.ts
+++ b/apps/web/hooks/processed-message-filtering.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
+import { hasSuccessfulAgentBootAfter } from "./processed-message-filtering";
+
+const ERROR_AT = "2026-05-30T00:00:00Z";
+const AFTER = "2026-05-30T00:01:00Z";
+const BEFORE = "2026-05-29T23:59:00Z";
+
+function bootMessage(createdAt: string, metadata: Record<string, unknown> = {}): Message {
+  return {
+    id: `boot-${createdAt}-${JSON.stringify(metadata)}`,
+    session_id: toSessionId("s1"),
+    task_id: toTaskId("t1"),
+    author_type: "agent",
+    content: "",
+    type: "script_execution",
+    created_at: createdAt,
+    metadata: {
+      script_type: "agent_boot",
+      agent_name: "Mock",
+      is_resuming: true,
+      status: "exited",
+      ...metadata,
+    },
+  } as Message;
+}
+
+describe("hasSuccessfulAgentBootAfter", () => {
+  it("returns true when the agent was resumed after the failure", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER)], ERROR_AT)).toBe(true);
+  });
+
+  it("returns true when a fresh start re-established the agent after the failure", () => {
+    expect(
+      hasSuccessfulAgentBootAfter([bootMessage(AFTER, { is_resuming: false })], ERROR_AT),
+    ).toBe(true);
+  });
+
+  it("returns true when an explicit zero exit code reports success", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER, { exit_code: 0 })], ERROR_AT)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the only successful boot predates the failure", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(BEFORE)], ERROR_AT)).toBe(false);
+  });
+
+  it("returns false when the resume attempt failed", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER, { status: "failed" })], ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the boot exited non-zero", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER, { exit_code: 1 })], ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("returns false while the resume is still running", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER, { status: "running" })], ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("ignores non-boot scripts that finished after the failure", () => {
+    const setup = bootMessage(AFTER, { script_type: "setup" });
+    expect(hasSuccessfulAgentBootAfter([setup], ERROR_AT)).toBe(false);
+  });
+
+  it("ignores messages that are not script executions", () => {
+    const chat = { ...bootMessage(AFTER), type: "message" } as Message;
+    expect(hasSuccessfulAgentBootAfter([chat], ERROR_AT)).toBe(false);
+  });
+
+  it("returns false for unparseable or missing timestamps", () => {
+    expect(hasSuccessfulAgentBootAfter([bootMessage("")], ERROR_AT)).toBe(false);
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER)], "")).toBe(false);
+    expect(hasSuccessfulAgentBootAfter(undefined, ERROR_AT)).toBe(false);
+    expect(hasSuccessfulAgentBootAfter([], ERROR_AT)).toBe(false);
+  });
+
+  it("finds the boot even when it is not the newest message", () => {
+    const later = { ...bootMessage("2026-05-30T00:02:00Z"), type: "message" } as Message;
+    expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER), later], ERROR_AT)).toBe(true);
+  });
+});

--- a/apps/web/hooks/processed-message-filtering.test.ts
+++ b/apps/web/hooks/processed-message-filtering.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
-import { hasSuccessfulAgentBootAfter } from "./processed-message-filtering";
+import {
+  hasFailedAgentBootAfter,
+  hasSuccessfulAgentBootAfter,
+} from "./processed-message-filtering";
 
 const ERROR_AT = "2026-05-30T00:00:00Z";
 const AFTER = "2026-05-30T00:01:00Z";
@@ -84,5 +87,38 @@ describe("hasSuccessfulAgentBootAfter", () => {
   it("finds the boot even when it is not the newest message", () => {
     const later = { ...bootMessage("2026-05-30T00:02:00Z"), type: "message" } as Message;
     expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER), later], ERROR_AT)).toBe(true);
+  });
+});
+
+describe("hasFailedAgentBootAfter", () => {
+  it("returns true when a boot after the failure reports status failed", () => {
+    expect(hasFailedAgentBootAfter([bootMessage(AFTER, { status: "failed" })], ERROR_AT)).toBe(
+      true,
+    );
+  });
+
+  it("returns true when a boot after the failure exits non-zero", () => {
+    expect(hasFailedAgentBootAfter([bootMessage(AFTER, { exit_code: 1 })], ERROR_AT)).toBe(true);
+  });
+
+  it("returns false for a successful boot", () => {
+    expect(hasFailedAgentBootAfter([bootMessage(AFTER)], ERROR_AT)).toBe(false);
+  });
+
+  it("returns false while the boot is still running", () => {
+    expect(hasFailedAgentBootAfter([bootMessage(AFTER, { status: "running" })], ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the failed boot predates the failure", () => {
+    expect(hasFailedAgentBootAfter([bootMessage(BEFORE, { status: "failed" })], ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("ignores non-boot scripts that failed after the failure", () => {
+    const setup = bootMessage(AFTER, { script_type: "setup", status: "failed" });
+    expect(hasFailedAgentBootAfter([setup], ERROR_AT)).toBe(false);
   });
 });

--- a/apps/web/hooks/processed-message-filtering.test.ts
+++ b/apps/web/hooks/processed-message-filtering.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
 import {
   hasFailedAgentBootAfter,
+  hasSessionRecoveryResolutionAfter,
   hasSuccessfulAgentBootAfter,
+  isSuccessfulScriptExecutionMetadata,
 } from "./processed-message-filtering";
 
 const ERROR_AT = "2026-05-30T00:00:00Z";
@@ -87,6 +89,34 @@ describe("hasSuccessfulAgentBootAfter", () => {
   it("finds the boot even when it is not the newest message", () => {
     const later = { ...bootMessage("2026-05-30T00:02:00Z"), type: "message" } as Message;
     expect(hasSuccessfulAgentBootAfter([bootMessage(AFTER), later], ERROR_AT)).toBe(true);
+  });
+});
+
+describe("recovery resolution metadata", () => {
+  it("resolves a card only when the session timestamp is newer", () => {
+    expect(hasSessionRecoveryResolutionAfter({ recovery_resolved_at: AFTER }, ERROR_AT)).toBe(true);
+    expect(hasSessionRecoveryResolutionAfter({ recovery_resolved_at: BEFORE }, ERROR_AT)).toBe(
+      false,
+    );
+  });
+
+  it("rejects missing or invalid recovery timestamps", () => {
+    expect(hasSessionRecoveryResolutionAfter(undefined, ERROR_AT)).toBe(false);
+    expect(hasSessionRecoveryResolutionAfter({ recovery_resolved_at: "invalid" }, ERROR_AT)).toBe(
+      false,
+    );
+    expect(hasSessionRecoveryResolutionAfter({ recovery_resolved_at: AFTER }, "invalid")).toBe(
+      false,
+    );
+  });
+});
+
+describe("isSuccessfulScriptExecutionMetadata", () => {
+  it("uses the shared exited-zero success rule", () => {
+    expect(isSuccessfulScriptExecutionMetadata({ status: "exited" })).toBe(true);
+    expect(isSuccessfulScriptExecutionMetadata({ status: "exited", exit_code: 0 })).toBe(true);
+    expect(isSuccessfulScriptExecutionMetadata({ status: "exited", exit_code: 1 })).toBe(false);
+    expect(isSuccessfulScriptExecutionMetadata({ status: "running" })).toBe(false);
   });
 });
 

--- a/apps/web/hooks/processed-message-filtering.ts
+++ b/apps/web/hooks/processed-message-filtering.ts
@@ -128,12 +128,35 @@ type AgentBootMetadata = {
  *  the boot header renders with (script-execution-message.tsx): an "exited"
  *  status carrying a zero or absent exit code. */
 export function isSuccessfulAgentBootMessage(message: Message): boolean {
+  if (!isAgentBootMessage(message)) return false;
+  const metadata = message.metadata as AgentBootMetadata | undefined;
+  return (
+    metadata?.status === "exited" && (metadata.exit_code === 0 || metadata.exit_code === undefined)
+  );
+}
+
+/** True when a message is an agent boot row, whatever its outcome. */
+function isAgentBootMessage(message: Message): boolean {
   if (message.type !== "script_execution") return false;
   const metadata = message.metadata as AgentBootMetadata | undefined;
-  if (metadata?.script_type !== "agent_boot") return false;
-  return (
-    metadata.status === "exited" && (metadata.exit_code === 0 || metadata.exit_code === undefined)
-  );
+  return metadata?.script_type === "agent_boot";
+}
+
+/** True when an agent boot after `afterCreatedAt` reported a failure — the signal that a
+ *  requested recovery did not take, so its card must come back. */
+export function hasFailedAgentBootAfter(
+  messages: Message[] | undefined,
+  afterCreatedAt: string | undefined,
+): boolean {
+  const failedAt = Date.parse(afterCreatedAt ?? "");
+  if (Number.isNaN(failedAt) || !messages?.length) return false;
+  return messages.some((message) => {
+    if (!isAgentBootMessage(message) || isSuccessfulAgentBootMessage(message)) return false;
+    const metadata = message.metadata as AgentBootMetadata | undefined;
+    if (metadata?.status !== "failed" && metadata?.status !== "exited") return false;
+    const bootedAt = Date.parse(message.created_at ?? "");
+    return !Number.isNaN(bootedAt) && bootedAt > failedAt;
+  });
 }
 
 /** True when the agent was successfully (re)established after `afterCreatedAt`.

--- a/apps/web/hooks/processed-message-filtering.ts
+++ b/apps/web/hooks/processed-message-filtering.ts
@@ -116,6 +116,44 @@ export function isAgentBootResumeMessage(message: Message): boolean {
   return metadata?.script_type === "agent_boot" && metadata?.is_resuming === true;
 }
 
+type AgentBootMetadata = {
+  script_type?: string;
+  is_resuming?: boolean;
+  status?: string;
+  exit_code?: number;
+};
+
+/** True when a script_execution row reports an agent that finished booting
+ *  successfully, whether resumed or freshly started. Mirrors the success rule
+ *  the boot header renders with (script-execution-message.tsx): an "exited"
+ *  status carrying a zero or absent exit code. */
+export function isSuccessfulAgentBootMessage(message: Message): boolean {
+  if (message.type !== "script_execution") return false;
+  const metadata = message.metadata as AgentBootMetadata | undefined;
+  if (metadata?.script_type !== "agent_boot") return false;
+  return (
+    metadata.status === "exited" && (metadata.exit_code === 0 || metadata.exit_code === undefined)
+  );
+}
+
+/** True when the agent was successfully (re)established after `afterCreatedAt`.
+ *  A recovery card is persisted against the failure that produced it, so this is
+ *  the durable signal that the card is stale. Unlike an in-memory acknowledgment
+ *  of the Resume click it survives a reload or task switch, and it also covers
+ *  the auto-resume-on-open path where no button was ever pressed. */
+export function hasSuccessfulAgentBootAfter(
+  messages: Message[] | undefined,
+  afterCreatedAt: string | undefined,
+): boolean {
+  const failedAt = Date.parse(afterCreatedAt ?? "");
+  if (Number.isNaN(failedAt) || !messages?.length) return false;
+  return messages.some((message) => {
+    if (!isSuccessfulAgentBootMessage(message)) return false;
+    const bootedAt = Date.parse(message.created_at ?? "");
+    return !Number.isNaN(bootedAt) && bootedAt > failedAt;
+  });
+}
+
 export function isSetupScriptMessage(message: Message): boolean {
   if (message.type !== "script_execution") return false;
   const metadata = message.metadata as { script_type?: string } | undefined;

--- a/apps/web/hooks/processed-message-filtering.ts
+++ b/apps/web/hooks/processed-message-filtering.ts
@@ -123,6 +123,17 @@ type AgentBootMetadata = {
   exit_code?: number;
 };
 
+export type ScriptExecutionOutcomeMetadata = Pick<AgentBootMetadata, "status" | "exit_code">;
+
+/** True when a script execution row reports a zero or absent exit code. */
+export function isSuccessfulScriptExecutionMetadata(
+  metadata: ScriptExecutionOutcomeMetadata | undefined,
+): boolean {
+  return (
+    metadata?.status === "exited" && (metadata.exit_code === 0 || metadata.exit_code === undefined)
+  );
+}
+
 /** True when a script_execution row reports an agent that finished booting
  *  successfully, whether resumed or freshly started. Mirrors the success rule
  *  the boot header renders with (script-execution-message.tsx): an "exited"
@@ -130,9 +141,7 @@ type AgentBootMetadata = {
 export function isSuccessfulAgentBootMessage(message: Message): boolean {
   if (!isAgentBootMessage(message)) return false;
   const metadata = message.metadata as AgentBootMetadata | undefined;
-  return (
-    metadata?.status === "exited" && (metadata.exit_code === 0 || metadata.exit_code === undefined)
-  );
+  return isSuccessfulScriptExecutionMetadata(metadata);
 }
 
 /** True when a message is an agent boot row, whatever its outcome. */
@@ -175,6 +184,18 @@ export function hasSuccessfulAgentBootAfter(
     const bootedAt = Date.parse(message.created_at ?? "");
     return !Number.isNaN(bootedAt) && bootedAt > failedAt;
   });
+}
+
+/** True when session metadata records a successful boot after a recovery card. */
+export function hasSessionRecoveryResolutionAfter(
+  metadata: Record<string, unknown> | null | undefined,
+  afterCreatedAt: string | undefined,
+): boolean {
+  const resolvedAt = Date.parse(
+    typeof metadata?.recovery_resolved_at === "string" ? metadata.recovery_resolved_at : "",
+  );
+  const failedAt = Date.parse(afterCreatedAt ?? "");
+  return !Number.isNaN(resolvedAt) && !Number.isNaN(failedAt) && resolvedAt > failedAt;
 }
 
 export function isSetupScriptMessage(message: Message): boolean {


### PR DESCRIPTION
The Resume session / Start fresh session card stayed on screen after a successful recovery, so the only way to clear it was to send a prompt: a resumed agent settles at `WAITING_FOR_INPUT`, which the card never counted as recovered. It now retires as soon as the transcript shows the agent booted again.

Task: Hide resume banner on session resume

## Important Changes

- `hasSuccessfulAgentBootAfter` derives the "recovered" signal from the persisted transcript — a successful `agent_boot` newer than the failure — so the card also stays hidden across a reload, a task switch, and the auto-resume-on-open path, where no button is ever pressed and an in-memory flag does not exist.
- A failed or still-running boot deliberately keeps the card and its buttons, so a recovery that did not work retains its affordance.

## Validation

- `pnpm exec vitest run components/task/chat/messages/action-message.test.tsx components/task/chat/messages/action-message-recovery.test.tsx hooks/processed-message-filtering.test.ts hooks/use-processed-messages.test.ts` — 92 passed. The two new "card retires" cases were confirmed failing against the old behaviour first, with the Resume button still in the DOM.
- `pnpm run typecheck` — clean.
- `pnpm exec eslint --max-warnings 0` over the changed files — clean. The new specs live in their own files so the existing suites stay under the 600-line `max-lines` limit.
- `pnpm exec prettier` — clean.
- `apps/web/e2e/tests/session/session-recovery.spec.ts` now reloads the page after recovering and asserts the buttons stay absent, which an in-memory acknowledgement cannot satisfy.
- Manually verified in a dev instance against a real failed session: reopening the task no longer shows the stale card, and it stays gone after a refresh without sending anything.

## Possible Improvements

Low risk: the card is hidden from client-derived state, so a session whose boot record sits outside the loaded message window still shows it until that history loads — unchanged from the previous behaviour.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->