### PR TITLE
feat: localize secret deletion confirmation

### DIFF
--- a/apps/web/components/settings/secrets-delete-dialog.test.tsx
+++ b/apps/web/components/settings/secrets-delete-dialog.test.tsx
@@ -1,14 +1,10 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { useRef, useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { activateLocale } from "@/lib/i18n";
 import type { SecretListItem } from "@/lib/types/http-secrets";
-import { DeleteSecretDialog } from "./secrets-delete-dialog";
+import { SecretDeleteConfirmation } from "./secrets-delete-dialog";
 
-/**
- * A secret's name is user data. It reaches the dialog as an interpolated value
- * and must never become a catalog key — the pseudo locale is the oracle here:
- * the sentence around the name changes, the name itself must not.
- */
 const secret: SecretListItem = {
   id: "secret-1",
   name: "OpenAI Production Key",
@@ -17,16 +13,32 @@ const secret: SecretListItem = {
   updated_at: "",
 };
 
-/**
- * The name renders inside a `<span>`, so testing-library's text matcher — which
- * joins only an element's direct text-node children — never sees the sentence
- * whole. Read the description element's own `textContent` instead.
- */
+const CONFIRM_POPOVER_TEST_ID = "secret-delete-confirm-popover";
+const CONFIRM_TEST_ID = "secret-delete-confirm";
+
+function ConfirmationHarness({ onConfirm = vi.fn() }: { onConfirm?: () => void | Promise<void> }) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button ref={anchorRef} type="button">
+        Delete secret
+      </button>
+      <SecretDeleteConfirmation
+        secret={secret}
+        open={open}
+        anchorRef={anchorRef}
+        onOpenChange={setOpen}
+        onCancel={() => setOpen(false)}
+        onConfirm={onConfirm}
+      />
+    </>
+  );
+}
+
 function descriptionText(): string {
-  const description = screen.getByText(secret.name).closest("p");
-  // Fail on the broken query rather than on an empty string comparison, which
-  // would point every assertion below at the wrong cause.
-  if (!description) throw new Error("secret name is not inside the <p> DialogDescription");
+  const description = screen.getByText(secret.name).closest('[data-slot="popover-description"]');
+  if (!description) throw new Error("secret name is not inside the popover description");
   return description.textContent ?? "";
 }
 
@@ -35,27 +47,60 @@ afterEach(async () => {
   await activateLocale("en");
 });
 
-describe("DeleteSecretDialog", () => {
-  it("renders the confirmation copy around the secret name", () => {
-    render(
-      <DeleteSecretDialog target={secret} onClose={vi.fn()} onConfirm={vi.fn()} isBusy={false} />,
+describe("SecretDeleteConfirmation", () => {
+  it("uses a local non-blocking confirmation surface", async () => {
+    render(<ConfirmationHarness />);
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).not.toBeNull();
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "Cancel" })),
     );
+  });
+
+  it("renders localized copy around the name without exposing secret material", () => {
+    render(<ConfirmationHarness />);
 
     expect(descriptionText()).toBe(
       `This will permanently remove ${secret.name}. This action cannot be undone.`,
     );
+    expect(descriptionText()).not.toContain("secret-value");
   });
 
   it("keeps the secret name verbatim when the locale changes", async () => {
     await activateLocale("pseudo");
-    render(
-      <DeleteSecretDialog target={secret} onClose={vi.fn()} onConfirm={vi.fn()} isBusy={false} />,
-    );
+    render(<ConfirmationHarness />);
 
-    // The surrounding sentence is catalog copy, so pseudo accents it.
     expect(descriptionText()).toMatch(/[À-ɏ]/);
     expect(descriptionText()).not.toContain("This will permanently remove");
-    // The name is user data — byte-identical under any locale.
     expect(descriptionText()).toContain(secret.name);
+  });
+
+  it("closes before invoking confirmation and returns focus on cancel", async () => {
+    const onConfirm = vi.fn(() => new Promise<void>(() => {}));
+    render(<ConfirmationHarness onConfirm={onConfirm} />);
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const anchor = screen.getByRole("button", { name: "Delete secret" });
+    fireEvent.click(cancel);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(anchor));
+  });
+
+  it("invokes confirmation once after the shell closes", async () => {
+    let shellClosed = false;
+    const onConfirm = vi.fn(() => {
+      shellClosed = screen.queryByTestId(CONFIRM_POPOVER_TEST_ID) === null;
+    });
+    render(<ConfirmationHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId(CONFIRM_TEST_ID),
+    );
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(shellClosed).toBe(true);
   });
 });

--- a/apps/web/components/settings/secrets-delete-dialog.tsx
+++ b/apps/web/components/settings/secrets-delete-dialog.tsx
@@ -1,68 +1,51 @@
 "use client";
 
+import type { RefObject } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Button } from "@kandev/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@kandev/ui/dialog";
+
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
 import type { SecretListItem } from "@/lib/types/http-secrets";
 
-type DeleteSecretDialogProps = {
-  target: SecretListItem | null;
-  onClose: () => void;
-  onConfirm: () => void;
-  isBusy: boolean;
+type SecretDeleteConfirmationProps = {
+  secret: SecretListItem;
+  open: boolean;
+  anchorRef: RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
 };
 
-/** Renders the confirm-delete dialog for a secret, with cancel and destructive confirm actions. */
-export function DeleteSecretDialog({
-  target,
-  onClose,
+/** Anchors secret deletion confirmation to its row action on fine pointers. */
+export function SecretDeleteConfirmation({
+  secret,
+  open,
+  anchorRef,
+  onOpenChange,
+  onCancel,
   onConfirm,
-  isBusy,
-}: DeleteSecretDialogProps) {
+}: SecretDeleteConfirmationProps) {
   const { t } = useTranslation();
-  // The secret's own name is user data: it is interpolated as a value and never
-  // routed through a catalog key.
-  const name = target?.name ?? t("settings:thisSecret");
+
   return (
-    <Dialog
-      open={Boolean(target)}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("settings:deleteSecret")}</DialogTitle>
-          <DialogDescription>
-            <Trans i18nKey="settings:thisWillPermanentlyRemoveSecret" values={{ name }}>
-              This will permanently remove{" "}
-              <span className="font-medium text-foreground">{name}</span>. This action cannot be
-              undone.
-            </Trans>
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={onClose} className="cursor-pointer">
-            {t("settings:cancel")}
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={onConfirm}
-            disabled={isBusy}
-            className="cursor-pointer"
-          >
-            {t("settings:deleteSecret")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ActionConfirmPopover
+      open={open}
+      anchorRef={anchorRef}
+      title={t("settings:deleteSecret")}
+      description={
+        <Trans i18nKey="settings:thisWillPermanentlyRemoveSecret" values={{ name: secret.name }}>
+          This will permanently remove{" "}
+          <span className="font-medium text-foreground">{secret.name}</span>. This action cannot be
+          undone.
+        </Trans>
+      }
+      cancelLabel={t("settings:cancel")}
+      confirmLabel={t("settings:deleteSecret")}
+      confirmAriaLabel={t("settings:deleteSecretNamed", { name: secret.name })}
+      confirmTestId="secret-delete-confirm"
+      testId="secret-delete-confirm-popover"
+      onOpenChange={onOpenChange}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
   );
 }

--- a/apps/web/components/settings/secrets-list-item-row.test.tsx
+++ b/apps/web/components/settings/secrets-list-item-row.test.tsx
@@ -1,6 +1,14 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { fireEvent, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SecretListItem } from "@/lib/types/http-secrets";
+
+let finePointer = true;
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: finePointer }),
+}));
+
 import { SecretListItemRow } from "./secrets-list-item-row";
 
 const secret: SecretListItem = {
@@ -16,25 +24,36 @@ const secret: SecretListItem = {
 function renderRow(overrides: Partial<Parameters<typeof SecretListItemRow>[0]> = {}) {
   const onEdit = vi.fn();
   const onDelete = vi.fn();
+  const onDeleteCancel = vi.fn();
+  const onDeleteConfirm = vi.fn();
   const onCopyMove = vi.fn();
   render(
     <SecretListItemRow
       secret={secret}
       onEdit={onEdit}
       onDelete={onDelete}
+      onDeleteCancel={onDeleteCancel}
+      onDeleteConfirm={onDeleteConfirm}
       onCopyMove={onCopyMove}
       isBusy={false}
       showCreate={false}
       isEditing={false}
+      isDeleteConfirming={false}
       {...overrides}
     />,
   );
-  return { onEdit, onDelete, onCopyMove };
+  return { onEdit, onDelete, onDeleteCancel, onDeleteConfirm, onCopyMove };
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  finePointer = true;
+  cleanup();
+});
 
 const COPY_MOVE_BUTTON = "Copy or move API Key";
+const DELETE_BUTTON = "Delete secret API Key";
+const CONFIRM_POPOVER_TEST_ID = "secret-delete-confirm-popover";
+const CONFIRM_TEST_ID = "secret-delete-confirm";
 
 /** Returns whether the copy/move button is currently disabled. */
 function copyMoveDisabled(): boolean {
@@ -42,6 +61,47 @@ function copyMoveDisabled(): boolean {
 }
 
 describe("SecretListItemRow", () => {
+  it("keeps delete trigger target-aware and touch-sized", () => {
+    const { onDelete } = renderRow();
+    const deleteButton = screen.getByRole("button", { name: DELETE_BUTTON });
+
+    expect(deleteButton.className).toContain("min-h-11");
+    expect(deleteButton.className).toContain("min-w-11");
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledWith(secret);
+  });
+
+  it("anchors fine-pointer confirmation to this row", async () => {
+    const { onDeleteConfirm } = renderRow({ isDeleteConfirming: true });
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(within(popover).getByRole("button", { name: DELETE_BUTTON })).not.toBeNull();
+    fireEvent.click(within(popover).getByTestId(CONFIRM_TEST_ID));
+
+    await waitFor(() => expect(onDeleteConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("morphs into inline touch confirmation on coarse pointers", async () => {
+    finePointer = false;
+    const { onDeleteCancel, onDeleteConfirm } = renderRow({ isDeleteConfirming: true });
+    const inline = screen.getByTestId("secret-delete-inline-confirmation");
+
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(screen.queryByRole("button", { name: COPY_MOVE_BUTTON })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reveal secret API Key" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit secret API Key" })).toBeNull();
+    expect(inline.getAttribute("aria-label")).toBe(DELETE_BUTTON);
+    expect(within(inline).getByTestId(CONFIRM_TEST_ID).className).toContain("h-11");
+    expect(within(inline).getByTestId(CONFIRM_TEST_ID).className).toContain("min-w-11");
+
+    fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
+    expect(onDeleteCancel).toHaveBeenCalledTimes(1);
+    fireEvent.click(within(inline).getByTestId(CONFIRM_TEST_ID));
+    await waitFor(() => expect(onDeleteConfirm).toHaveBeenCalledTimes(1));
+  });
+
   it("runs the copy/move action", () => {
     const { onCopyMove } = renderRow();
     screen.getByRole("button", { name: COPY_MOVE_BUTTON }).click();

--- a/apps/web/components/settings/secrets-list-item-row.tsx
+++ b/apps/web/components/settings/secrets-list-item-row.tsx
@@ -1,39 +1,79 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { IconCopy, IconEdit, IconEye, IconEyeOff, IconKey, IconTrash } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { revealSecret } from "@/lib/api/domains/secrets-api";
 import type { SecretListItem } from "@/lib/types/http-secrets";
+import { SecretDeleteConfirmation } from "./secrets-delete-dialog";
 
 type SecretListItemRowProps = {
   secret: SecretListItem;
   workspaceId?: string;
   onEdit: (secret: SecretListItem) => void;
   onDelete: (secret: SecretListItem) => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: () => void | Promise<void>;
   onCopyMove: (secret: SecretListItem) => void;
   isBusy: boolean;
   showCreate: boolean;
   isEditing: boolean;
+  isDeleteConfirming: boolean;
 };
 
-/** Renders a single secret row: name, scope badge, and copy/move, reveal, edit, and delete actions. */
+type SecretListItemRowActionsProps = {
+  secret: SecretListItem;
+  onEdit: (secret: SecretListItem) => void;
+  onDelete: (secret: SecretListItem) => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: () => void | Promise<void>;
+  onCopyMove: (secret: SecretListItem) => void;
+  onReveal: () => void | Promise<void>;
+  isBusy: boolean;
+  showCreate: boolean;
+  isEditing: boolean;
+  isDeleteConfirming: boolean;
+  isFinePointer: boolean;
+  revealed: boolean;
+  revealing: boolean;
+  deleteAnchorRef: RefObject<HTMLButtonElement | null>;
+};
+
+type SecretListItemRowDeleteActionProps = {
+  secret: SecretListItem;
+  onDelete: (secret: SecretListItem) => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: () => void | Promise<void>;
+  isBusy: boolean;
+  isDeleteConfirming: boolean;
+  isFinePointer: boolean;
+  deleteAnchorRef: RefObject<HTMLButtonElement | null>;
+};
+
+/** Renders a single secret row with local delete confirmation on every pointer type. */
 export function SecretListItemRow({
   secret,
   workspaceId,
   onEdit,
   onDelete,
+  onDeleteCancel,
+  onDeleteConfirm,
   onCopyMove,
   isBusy,
   showCreate,
   isEditing,
+  isDeleteConfirming,
 }: SecretListItemRowProps) {
   const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
   const [revealed, setRevealed] = useState(false);
   const [revealedValue, setRevealedValue] = useState<string | null>(null);
   const [revealing, setRevealing] = useState(false);
+  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
 
   /** Fetches and shows the secret value, or hides it when already revealed. */
   const handleReveal = async () => {
@@ -58,7 +98,10 @@ export function SecretListItemRow({
   };
 
   return (
-    <div className="rounded-lg border border-border/70 bg-background p-4 space-y-2">
+    <div
+      className="rounded-lg border border-border/70 bg-background p-4 space-y-2"
+      data-testid={`secret-row-${secret.id}`}
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <IconKey className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -69,54 +112,23 @@ export function SecretListItemRow({
               : t("settings:globalScope")}
           </Badge>
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-1 shrink-0">
-          <Button
-            variant="ghost"
-            onClick={() => onCopyMove(secret)}
-            // A Move removes the source; it must never run while that secret's
-            // edit/create draft is open (the draft would outlive its row).
-            disabled={isBusy || showCreate || isEditing}
-            className="min-h-11 cursor-pointer"
-            aria-label={t("settings:copyMoveSecretNamed", { name: secret.name })}
-          >
-            <IconCopy className="h-4 w-4" />
-            {t("settings:copyMove")}
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleReveal}
-            disabled={revealing || isBusy}
-            className="min-h-11 min-w-11 cursor-pointer"
-            aria-label={
-              revealed
-                ? t("settings:hideSecretNamed", { name: secret.name })
-                : t("settings:revealSecretNamed", { name: secret.name })
-            }
-          >
-            {revealed ? <IconEyeOff className="h-4 w-4" /> : <IconEye className="h-4 w-4" />}
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => onEdit(secret)}
-            disabled={isBusy || showCreate || isEditing}
-            className="min-h-11 min-w-11 cursor-pointer"
-            aria-label={t("settings:editSecretNamed", { name: secret.name })}
-          >
-            <IconEdit className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => onDelete(secret)}
-            disabled={isBusy}
-            className="min-h-11 min-w-11 cursor-pointer"
-            aria-label={t("settings:deleteSecretNamed", { name: secret.name })}
-          >
-            <IconTrash className="h-4 w-4" />
-          </Button>
-        </div>
+        <SecretListItemRowActions
+          secret={secret}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onDeleteCancel={onDeleteCancel}
+          onDeleteConfirm={onDeleteConfirm}
+          onCopyMove={onCopyMove}
+          onReveal={handleReveal}
+          isBusy={isBusy}
+          showCreate={showCreate}
+          isEditing={isEditing}
+          isDeleteConfirming={isDeleteConfirming}
+          isFinePointer={isFinePointer}
+          revealed={revealed}
+          revealing={revealing}
+          deleteAnchorRef={deleteAnchorRef}
+        />
       </div>
       {revealed && revealedValue !== null && (
         <div className="text-xs font-mono bg-muted/50 rounded px-2 py-1 break-all">
@@ -124,5 +136,137 @@ export function SecretListItemRow({
         </div>
       )}
     </div>
+  );
+}
+
+function SecretListItemRowActions({
+  secret,
+  onEdit,
+  onDelete,
+  onDeleteCancel,
+  onDeleteConfirm,
+  onCopyMove,
+  onReveal,
+  isBusy,
+  showCreate,
+  isEditing,
+  isDeleteConfirming,
+  isFinePointer,
+  revealed,
+  revealing,
+  deleteAnchorRef,
+}: SecretListItemRowActionsProps) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-end gap-1 shrink-0">
+        {(!isDeleteConfirming || isFinePointer) && (
+          <>
+            <Button
+              variant="ghost"
+              onClick={() => onCopyMove(secret)}
+              // A Move removes the source; it must never run while that secret's
+              // edit/create draft is open (the draft would outlive its row).
+              disabled={isBusy || showCreate || isEditing}
+              className="min-h-11 cursor-pointer"
+              aria-label={t("settings:copyMoveSecretNamed", { name: secret.name })}
+            >
+              <IconCopy className="h-4 w-4" />
+              {t("settings:copyMove")}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onReveal}
+              disabled={revealing || isBusy}
+              className="min-h-11 min-w-11 cursor-pointer"
+              aria-label={
+                revealed
+                  ? t("settings:hideSecretNamed", { name: secret.name })
+                  : t("settings:revealSecretNamed", { name: secret.name })
+              }
+            >
+              {revealed ? <IconEyeOff className="h-4 w-4" /> : <IconEye className="h-4 w-4" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onEdit(secret)}
+              disabled={isBusy || showCreate || isEditing}
+              className="min-h-11 min-w-11 cursor-pointer"
+              aria-label={t("settings:editSecretNamed", { name: secret.name })}
+            >
+              <IconEdit className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+        <SecretListItemRowDeleteAction
+          secret={secret}
+          onDelete={onDelete}
+          onDeleteCancel={onDeleteCancel}
+          onDeleteConfirm={onDeleteConfirm}
+          isBusy={isBusy}
+          isDeleteConfirming={isDeleteConfirming}
+          isFinePointer={isFinePointer}
+          deleteAnchorRef={deleteAnchorRef}
+        />
+      </div>
+    </>
+  );
+}
+
+function SecretListItemRowDeleteAction({
+  secret,
+  onDelete,
+  onDeleteCancel,
+  onDeleteConfirm,
+  isBusy,
+  isDeleteConfirming,
+  isFinePointer,
+  deleteAnchorRef,
+}: SecretListItemRowDeleteActionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {!isFinePointer && isDeleteConfirming ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="secret-delete-inline-confirmation"
+          ariaLabel={t("settings:deleteSecretNamed", { name: secret.name })}
+          cancelLabel={t("settings:cancel")}
+          confirmLabel={t("settings:deleteSecret")}
+          confirmAriaLabel={t("settings:deleteSecretNamed", { name: secret.name })}
+          confirmTestId="secret-delete-confirm"
+          onCancel={onDeleteCancel}
+          onClose={onDeleteCancel}
+          onConfirm={onDeleteConfirm}
+        />
+      ) : (
+        <Button
+          ref={deleteAnchorRef}
+          variant="ghost"
+          size="icon"
+          onClick={() => onDelete(secret)}
+          disabled={isBusy}
+          className="min-h-11 min-w-11 cursor-pointer"
+          aria-label={t("settings:deleteSecretNamed", { name: secret.name })}
+        >
+          <IconTrash className="h-4 w-4" />
+        </Button>
+      )}
+      {isFinePointer ? (
+        <SecretDeleteConfirmation
+          secret={secret}
+          open={isDeleteConfirming}
+          anchorRef={deleteAnchorRef}
+          onOpenChange={(open) => {
+            if (!open) onDeleteCancel();
+          }}
+          onCancel={onDeleteCancel}
+          onConfirm={onDeleteConfirm}
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/web/components/settings/secrets-list-item-row.tsx
+++ b/apps/web/components/settings/secrets-list-item-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, type RefObject } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { IconCopy, IconEdit, IconEye, IconEyeOff, IconKey, IconTrash } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
@@ -159,7 +159,11 @@ function SecretListItemRowActions({
   const { t } = useTranslation();
   return (
     <>
-      <div className="flex flex-wrap items-center justify-end gap-1 shrink-0">
+      <div
+        className={`flex flex-wrap items-center justify-end gap-1 ${
+          !isFinePointer && isDeleteConfirming ? "w-full min-w-0" : "shrink-0"
+        }`}
+      >
         {(!isDeleteConfirming || isFinePointer) && (
           <>
             <Button
@@ -234,6 +238,16 @@ function SecretListItemRowDeleteAction({
           density="touch"
           testId="secret-delete-inline-confirmation"
           ariaLabel={t("settings:deleteSecretNamed", { name: secret.name })}
+          description={
+            <Trans
+              i18nKey="settings:thisWillPermanentlyRemoveSecret"
+              values={{ name: secret.name }}
+            >
+              This will permanently remove{" "}
+              <span className="font-medium text-foreground">{secret.name}</span>. This action cannot
+              be undone.
+            </Trans>
+          }
           cancelLabel={t("settings:cancel")}
           confirmLabel={t("settings:deleteSecret")}
           confirmAriaLabel={t("settings:deleteSecretNamed", { name: secret.name })}

--- a/apps/web/components/settings/secrets-settings.test.ts
+++ b/apps/web/components/settings/secrets-settings.test.ts
@@ -1,6 +1,50 @@
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createElement, type ReactNode } from "react";
 import type { SecretListItem } from "@/lib/types/http-secrets";
-import { getSecretDraftMeta } from "./secrets-settings";
+
+const mocks = vi.hoisted(() => ({
+  deleteSecret: vi.fn(),
+  addSecret: vi.fn(),
+  updateSecret: vi.fn(),
+  removeSecret: vi.fn(),
+  toast: vi.fn(),
+  items: [] as SecretListItem[],
+  responsive: { isFinePointer: true },
+}));
+
+vi.mock("@/lib/api/domains/secrets-api", () => ({
+  createSecret: vi.fn(),
+  updateSecret: mocks.updateSecret,
+  deleteSecret: mocks.deleteSecret,
+}));
+vi.mock("@/hooks/domains/settings/use-secrets", () => ({
+  useSecrets: () => ({
+    loaded: true,
+    items: mocks.items,
+    addSecret: mocks.addSecret,
+    updateSecret: mocks.updateSecret,
+    removeSecret: mocks.removeSecret,
+  }),
+}));
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({ addSecret: mocks.addSecret, workspaces: { items: [] } }),
+}));
+vi.mock("@/components/toast-provider", () => ({ useToast: () => ({ toast: mocks.toast }) }));
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => mocks.responsive,
+}));
+vi.mock("@/components/settings/settings-page-template", () => ({
+  SettingsPageTemplate: ({ children }: { children: ReactNode }) =>
+    createElement("div", null, children),
+}));
+vi.mock("@/components/settings/workspaces/workspace-section-header", () => ({
+  WorkspaceSectionHeader: () => null,
+}));
+vi.mock("./copy-move-secret-dialog", () => ({ CopyMoveSecretDialog: () => null }));
+
+import { getSecretDraftMeta, SecretsSettings } from "./secrets-settings";
 
 const secret: SecretListItem = {
   id: "secret-1",
@@ -9,6 +53,25 @@ const secret: SecretListItem = {
   created_at: "",
   updated_at: "",
 };
+
+const DELETE_BUTTON = "Delete secret Saved secret";
+const CONFIRM_POPOVER_TEST_ID = "secret-delete-confirm-popover";
+const CONFIRM_TEST_ID = "secret-delete-confirm";
+
+function renderSettings() {
+  render(createElement(SecretsSettings, { initialItems: mocks.items }));
+}
+
+beforeEach(() => {
+  mocks.items = [secret];
+  mocks.responsive.isFinePointer = true;
+  mocks.deleteSecret.mockReset();
+  mocks.deleteSecret.mockResolvedValue(undefined);
+  mocks.removeSecret.mockReset();
+  mocks.toast.mockReset();
+});
+
+afterEach(() => cleanup());
 
 describe("getSecretDraftMeta", () => {
   it("treats a newly opened secret form as dirty before persistence", () => {
@@ -25,5 +88,82 @@ describe("getSecretDraftMeta", () => {
     expect(
       getSecretDraftMeta([secret], secret.id, false, { name: "Renamed", value: "" }).isDirty,
     ).toBe(true);
+  });
+});
+
+describe("SecretsSettings deletion lifecycle", () => {
+  it("cancels locally without dispatching deletion", () => {
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: DELETE_BUTTON }));
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.deleteSecret).not.toHaveBeenCalled();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+  });
+
+  it("closes before dispatching exactly one delete and removes on success", async () => {
+    let confirmationClosed = false;
+    mocks.deleteSecret.mockImplementation(async () => {
+      confirmationClosed = screen.queryByTestId(CONFIRM_POPOVER_TEST_ID) === null;
+    });
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: DELETE_BUTTON }));
+    fireEvent.click(
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId(CONFIRM_TEST_ID),
+    );
+
+    await waitFor(() => expect(mocks.deleteSecret).toHaveBeenCalledTimes(1));
+    expect(confirmationClosed).toBe(true);
+    await waitFor(() => expect(mocks.removeSecret).toHaveBeenCalledWith(secret.id));
+  });
+
+  it("keeps row actions busy until deletion settles", async () => {
+    let resolveDelete!: () => void;
+    mocks.deleteSecret.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      }),
+    );
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: DELETE_BUTTON }));
+    fireEvent.click(
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId(CONFIRM_TEST_ID),
+    );
+
+    await waitFor(() => expect(mocks.deleteSecret).toHaveBeenCalledTimes(1));
+    expect(
+      (screen.getByRole("button", { name: DELETE_BUTTON }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    resolveDelete();
+    await waitFor(() => expect(mocks.removeSecret).toHaveBeenCalledWith(secret.id));
+  });
+
+  it("keeps the secret and reports a localized failure when deletion fails", async () => {
+    mocks.deleteSecret.mockRejectedValue(new Error("server details must stay out of copy"));
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: DELETE_BUTTON }));
+    fireEvent.click(
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId(CONFIRM_TEST_ID),
+    );
+
+    await waitFor(() =>
+      expect(mocks.toast).toHaveBeenCalledWith({
+        description: "Couldn't delete secret",
+        variant: "error",
+      }),
+    );
+    expect(screen.getByText(secret.name)).not.toBeNull();
+    expect(
+      (screen.getByRole("button", { name: DELETE_BUTTON }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+    expect(mocks.removeSecret).not.toHaveBeenCalled();
+    expect(JSON.stringify(mocks.toast.mock.calls)).not.toContain(
+      "server details must stay out of copy",
+    );
   });
 });

--- a/apps/web/components/settings/secrets-settings.tsx
+++ b/apps/web/components/settings/secrets-settings.tsx
@@ -7,6 +7,7 @@ import { Button } from "@kandev/ui/button";
 import { SettingsPageTemplate } from "@/components/settings/settings-page-template";
 import { WorkspaceSectionHeader } from "@/components/settings/workspaces/workspace-section-header";
 import { useAppStore } from "@/components/state-provider";
+import { useToast } from "@/components/toast-provider";
 import { useSecrets } from "@/hooks/domains/settings/use-secrets";
 import type { ApiRequestOptions } from "@/lib/api/client";
 import { createSecret, updateSecret, deleteSecret } from "@/lib/api/domains/secrets-api";
@@ -14,7 +15,6 @@ import { useRequest } from "@/lib/http/use-request";
 import type { SecretListItem, SecretScope, UpdateSecretRequest } from "@/lib/types/http-secrets";
 import { SecretForm, defaultFormState, type SecretFormState } from "./secret-form";
 import { SecretListItemRow } from "./secrets-list-item-row";
-import { DeleteSecretDialog } from "./secrets-delete-dialog";
 import { CopyMoveSecretDialog, type CopyMoveMode } from "./copy-move-secret-dialog";
 
 /* ------------------------------------------------------------------ */
@@ -136,6 +136,8 @@ function useSecretRequests(
 
 /** Composes request runners and UI actions (create, edit, delete, transfer) from the secrets state. */
 function useSecretsActions(state: ReturnType<typeof useSecretsState>) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
   const { rememberTransferTrigger, restoreTransferTrigger } = useTransferFocusRestore();
   const {
     addSecret: addToStore,
@@ -211,8 +213,11 @@ function useSecretsActions(state: ReturnType<typeof useSecretsState>) {
     closeDelete: () => setDeleteTarget(null),
     confirmDelete: () => {
       if (!deleteTarget) return;
-      deleteRequest.run(deleteTarget.id).catch(() => undefined);
+      const id = deleteTarget.id;
       setDeleteTarget(null);
+      return deleteRequest.run(id).catch(() => {
+        toast({ description: t("settings:secretDeleteFailed"), variant: "error" });
+      });
     },
     openTransfer: (secret: SecretListItem) => {
       // Remember the focused Copy/Move button; close restores it because
@@ -296,7 +301,7 @@ export type SecretsSettingsActions = {
   startCreate: () => void;
   openDelete: (secret: SecretListItem) => void;
   closeDelete: () => void;
-  confirmDelete: () => void;
+  confirmDelete: () => void | Promise<void>;
   openTransfer: (secret: SecretListItem) => void;
   closeTransfer: () => void;
   items: SecretListItem[];
@@ -419,21 +424,17 @@ function SecretsSettingsBody({
               workspaceId={workspaceId}
               onEdit={actions.startEditing}
               onDelete={actions.openDelete}
+              onDeleteCancel={actions.closeDelete}
+              onDeleteConfirm={actions.confirmDelete}
               onCopyMove={actions.openTransfer}
               isBusy={isBusy}
               showCreate={showCreate}
               isEditing={editingId === secret.id}
+              isDeleteConfirming={deleteTarget?.id === secret.id}
             />
           ))}
         </div>
       </div>
-
-      <DeleteSecretDialog
-        target={deleteTarget}
-        onClose={actions.closeDelete}
-        onConfirm={actions.confirmDelete}
-        isBusy={isBusy}
-      />
     </>
   );
 }

--- a/apps/web/e2e/tests/settings/mobile-secrets-delete.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-secrets-delete.spec.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "node:crypto";
+
+import { test, expect } from "../../fixtures/test-base";
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
+
+const SECRET_VALUE = "e2e-mobile-secret-delete-redaction-value";
+
+function runToken() {
+  return `${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+test.describe("mobile-secrets-delete", () => {
+  test("confirms inline at the target row without exposing the value", async ({
+    testPage,
+    apiClient,
+    prCapture,
+  }) => {
+    await testPage.setViewportSize({ width: 390, height: 844 });
+    const name = `E2E Mobile Delete Secret ${runToken()}`;
+    const secret = await apiClient.createSecret(name, SECRET_VALUE);
+
+    try {
+      await expect
+        .poll(async () => (await apiClient.listSecrets()).some((item) => item.id === secret.id), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+      await testPage.goto("/settings/general/secrets");
+      const row = testPage.getByTestId(`secret-row-${secret.id}`);
+      const trigger = row.getByRole("button", { name: `Delete secret ${name}` });
+      await trigger.tap();
+
+      const inline = row.getByTestId("secret-delete-inline-confirmation");
+      await expect(inline).toBeVisible();
+      await expect(testPage.getByTestId("secret-delete-confirm-popover")).toHaveCount(0);
+      await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
+      await expect(inline).not.toContainText(SECRET_VALUE);
+      await expect(testPage.locator("body")).not.toContainText(SECRET_VALUE);
+
+      for (const control of [
+        inline.getByRole("button", { name: "Cancel" }),
+        inline.getByTestId("secret-delete-confirm"),
+      ]) {
+        const box = await control.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeGreaterThanOrEqual(44);
+      }
+      await assertNoDocumentHorizontalOverflow(testPage, "mobile secret deletion confirmation");
+      await prCapture.screenshot("mobile-secrets-delete-confirmation", {
+        caption: "Mobile secret row inline confirmation",
+      });
+
+      await inline.getByRole("button", { name: "Cancel" }).tap();
+      await expect(inline).toHaveCount(0);
+      expect((await apiClient.listSecrets()).some((item) => item.id === secret.id)).toBe(true);
+
+      await row.getByRole("button", { name: `Delete secret ${name}` }).tap();
+      await row
+        .getByTestId("secret-delete-inline-confirmation")
+        .getByTestId("secret-delete-confirm")
+        .tap();
+      await expect(row).toHaveCount(0);
+      await expect
+        .poll(async () => (await apiClient.listSecrets()).some((item) => item.id === secret.id))
+        .toBe(false);
+      await expect(testPage.locator("body")).not.toContainText(SECRET_VALUE);
+    } finally {
+      await apiClient.deleteSecretIfPresent(secret.id).catch(() => undefined);
+    }
+  });
+});

--- a/apps/web/e2e/tests/settings/mobile-secrets-delete.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-secrets-delete.spec.ts
@@ -32,6 +32,13 @@ test.describe("mobile-secrets-delete", () => {
 
       const inline = row.getByTestId("secret-delete-inline-confirmation");
       await expect(inline).toBeVisible();
+      await expect(inline).toContainText(
+        `This will permanently remove ${name}. This action cannot be undone.`,
+      );
+      const warningBox = await inline.locator("p").boundingBox();
+      expect(warningBox).not.toBeNull();
+      expect(warningBox!.x).toBeGreaterThanOrEqual(0);
+      expect(warningBox!.x + warningBox!.width).toBeLessThanOrEqual(testPage.viewportSize()!.width);
       await expect(testPage.getByTestId("secret-delete-confirm-popover")).toHaveCount(0);
       await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
       await expect(inline).not.toContainText(SECRET_VALUE);

--- a/apps/web/e2e/tests/settings/secrets-delete.spec.ts
+++ b/apps/web/e2e/tests/settings/secrets-delete.spec.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+
+import { test, expect } from "../../fixtures/test-base";
+
+const SECRET_VALUE = "e2e-secret-delete-redaction-value";
+
+function runToken() {
+  return `${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+test.describe("Secret deletion", () => {
+  test("confirms at the target row, supports cancel, and removes the secret", async ({
+    testPage,
+    apiClient,
+    prCapture,
+  }) => {
+    const name = `E2E Delete Secret ${runToken()}`;
+    const secret = await apiClient.createSecret(name, SECRET_VALUE);
+
+    try {
+      await expect
+        .poll(async () => (await apiClient.listSecrets()).some((item) => item.id === secret.id), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+      await testPage.goto("/settings/general/secrets");
+      const row = testPage.getByTestId(`secret-row-${secret.id}`);
+      const trigger = row.getByRole("button", { name: `Delete secret ${name}` });
+      await expect(trigger).toBeVisible();
+      await expect(testPage.locator("body")).not.toContainText(SECRET_VALUE);
+
+      await trigger.click();
+      const confirmation = testPage.getByTestId("secret-delete-confirm-popover");
+      await expect(confirmation).toBeVisible();
+      await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
+      await expect(confirmation).not.toContainText(SECRET_VALUE);
+      await prCapture.screenshot("desktop-secrets-delete-confirmation", {
+        caption: "Desktop secret row confirmation",
+      });
+
+      await confirmation.getByRole("button", { name: "Cancel" }).click();
+      await expect(confirmation).toBeHidden();
+      await expect(trigger).toBeFocused();
+      expect((await apiClient.listSecrets()).some((item) => item.id === secret.id)).toBe(true);
+
+      await trigger.click();
+      await testPage.getByTestId("secret-delete-confirm").click();
+      await expect(row).toHaveCount(0);
+      await expect
+        .poll(async () => (await apiClient.listSecrets()).some((item) => item.id === secret.id))
+        .toBe(false);
+      await expect(testPage.locator("body")).not.toContainText(SECRET_VALUE);
+    } finally {
+      await apiClient.deleteSecretIfPresent(secret.id);
+    }
+  });
+
+  test("keeps the target row and reports localized failure", async ({ testPage, apiClient }) => {
+    const name = `E2E Failed Delete Secret ${runToken()}`;
+    const secret = await apiClient.createSecret(name, SECRET_VALUE);
+
+    try {
+      await expect
+        .poll(async () => (await apiClient.listSecrets()).some((item) => item.id === secret.id), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+      await testPage.goto("/settings/general/secrets");
+      const row = testPage.getByTestId(`secret-row-${secret.id}`);
+      await testPage.route(`**/api/v1/secrets/${secret.id}`, async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "synthetic delete failure" }),
+        });
+      });
+      await row.getByRole("button", { name: `Delete secret ${name}` }).click();
+      await testPage.getByTestId("secret-delete-confirm").click();
+
+      await expect(testPage.getByTestId("toast-message")).toContainText("Couldn't delete secret");
+      await expect(row).toBeVisible();
+      await expect(testPage.locator("body")).not.toContainText(SECRET_VALUE);
+      await expect(testPage.locator("body")).not.toContainText("synthetic delete failure");
+    } finally {
+      await testPage.unroute(`**/api/v1/secrets/${secret.id}`);
+      await apiClient.deleteSecretIfPresent(secret.id);
+    }
+  });
+});

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -127,6 +127,7 @@
   "deleteLayoutProfile": "Delete layout profile",
   "deleteLayoutProfileNamed": "Delete {{name}}?",
   "deleteSecret": "Delete secret",
+  "secretDeleteFailed": "Couldn't delete secret",
   "deleteThisCustomLayoutAfterConfirmation": "Delete this custom layout after confirmation.",
   "desktopNotifications": "Desktop Notifications",
   "desktopNotificationsDescription": "Notify this device when a selected agent turn, question, or Office event occurs.",

--- a/apps/web/src/locales/pseudo/settings.json
+++ b/apps/web/src/locales/pseudo/settings.json
@@ -127,6 +127,7 @@
   "deleteLayoutProfile": "Ďēĺēţē ĺàŷōũţ ƥŕōƒĩĺē",
   "deleteLayoutProfileNamed": "Ďēĺēţē {{name}}?",
   "deleteSecret": "Ďēĺēţē śēćŕēţ",
+  "secretDeleteFailed": "Ćōũĺďń'ţ ďēĺēţē śēćŕēţ",
   "deleteThisCustomLayoutAfterConfirmation": "Ďēĺēţē ţĥĩś ćũśţōḿ ĺàŷōũţ àƒţēŕ ćōńƒĩŕḿàţĩōń.",
   "desktopNotifications": "Ďēśķţōƥ Ńōţĩƒĩćàţĩōńś",
   "desktopNotificationsDescription": "Ńōţĩƒŷ ţĥĩś ďēvĩćē ŵĥēń à śēĺēćţēď àĝēńţ ţũŕń, qũēśţĩōń, ōŕ Ōƒƒĩćē ēvēńţ ōććũŕś.",

--- a/apps/web/src/locales/pt-pt/settings.json
+++ b/apps/web/src/locales/pt-pt/settings.json
@@ -124,6 +124,7 @@
   "deleteLayoutProfile": "Eliminar o perfil de esquema",
   "deleteLayoutProfileNamed": "Eliminar {{name}}?",
   "deleteSecret": "Eliminar segredo",
+  "secretDeleteFailed": "Não foi possível eliminar o segredo",
   "deleteThisCustomLayoutAfterConfirmation": "Eliminar este esquema personalizado após confirmação.",
   "desktopNotifications": "Notificações no computador",
   "desktopNotificationsDescription": "Notificar este dispositivo quando ocorrer um turno de agente, uma pergunta ou um evento do Office selecionados.",

--- a/apps/web/src/locales/zh-cn/settings.json
+++ b/apps/web/src/locales/zh-cn/settings.json
@@ -127,6 +127,7 @@
   "deleteLayoutProfile": "删除布局配置",
   "deleteLayoutProfileNamed": "删除 {{name}}？",
   "deleteSecret": "删除密钥",
+  "secretDeleteFailed": "无法删除密钥",
   "deleteThisCustomLayoutAfterConfirmation": "确认后删除此自定义布局。",
   "desktopNotifications": "桌面通知",
   "desktopNotificationsDescription": "当选定的智能体回合、问题或办公室事件发生时通知此设备。",

--- a/apps/web/src/locales/zh-hk/settings.json
+++ b/apps/web/src/locales/zh-hk/settings.json
@@ -127,6 +127,7 @@
   "deleteLayoutProfile": "刪除佈局設定",
   "deleteLayoutProfileNamed": "刪除 {{name}}？",
   "deleteSecret": "刪除密鑰",
+  "secretDeleteFailed": "無法刪除密鑰",
   "deleteThisCustomLayoutAfterConfirmation": "確認後刪除此自訂佈局。",
   "desktopNotifications": "桌面通知",
   "desktopNotificationsDescription": "當選定的代理程式回合、問題或辦公室事件發生時通知此設備。",

--- a/apps/web/src/locales/zh-tw/settings.json
+++ b/apps/web/src/locales/zh-tw/settings.json
@@ -127,6 +127,7 @@
   "deleteLayoutProfile": "刪除佈局設定",
   "deleteLayoutProfileNamed": "刪除 {{name}}？",
   "deleteSecret": "刪除金鑰",
+  "secretDeleteFailed": "無法刪除金鑰",
   "deleteThisCustomLayoutAfterConfirmation": "確認後刪除此自訂佈局。",
   "desktopNotifications": "桌面通知",
   "desktopNotificationsDescription": "當選定的代理程式回合、問題或辦公室事件發生時通知此裝置。",


### PR DESCRIPTION
Secret deletion currently blocks the settings page with a modal, making target context harder to retain on touch devices. The secret row now owns a localized, target-aware confirmation while keeping secret values redacted and preserving the existing mutation lifecycle.

## Validation

- Focused Vitest suite: 4 files, 20 tests passed.
- `pnpm run typecheck` passed.
- `pnpm run i18n:check` passed.
- `pnpm run i18n:ratchet` passed.
- `pnpm run i18n:zh-hant` passed with no unrelated retained catalog changes.
- Changed-file ESLint with `--max-warnings=0` passed.
- `pnpm run build:e2e` passed.
- Desktop secret-delete E2E: 2 tests passed, including cancel/focus, success removal, failure toast, and redaction.
- Mobile secret-delete E2E: 1 test passed, including inline actions, 44px hitboxes, no horizontal overflow, success removal, and redaction.
- Desktop and mobile confirmation screenshots captured and visually checked.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

Desktop confirmation:

![Desktop secret row confirmation](https://raw.githubusercontent.com/kdlbs/kandev/09a5dca1fc4c176926334f1eee1b7c99b11b1a77/desktop-secrets-delete-confirmation.png)

Mobile inline confirmation:

![Mobile secret row inline confirmation](https://raw.githubusercontent.com/kdlbs/kandev/09a5dca1fc4c176926334f1eee1b7c99b11b1a77/mobile-secrets-delete-confirmation.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->