### PR TITLE
feat(ui): inline workflow sync removal confirmation

### DIFF
--- a/apps/web/components/confirmation/inline-confirm-actions.tsx
+++ b/apps/web/components/confirmation/inline-confirm-actions.tsx
@@ -14,6 +14,7 @@ export type InlineConfirmActionsProps = {
   confirmTestId?: string;
   onCancel: () => void;
   onClose?: () => void;
+  /** Reject the returned promise to restore the confirmation UI for retry. */
   onConfirm: () => void | Promise<void>;
 };
 

--- a/apps/web/components/settings/workflow-sync-dialog.test.tsx
+++ b/apps/web/components/settings/workflow-sync-dialog.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  WorkflowSyncController,
+  WorkflowSyncFormState,
+} from "@/hooks/domains/settings/use-workflow-sync";
+import type { WorkflowSyncConfig } from "@/lib/types/workflow-sync";
+import { WorkflowSyncDialog } from "./workflow-sync-dialog";
+
+afterEach(cleanup);
+
+const WORKFLOWS_DIR = ".kandev/workflows";
+const REMOVE_TEST_ID = "workflow-sync-remove";
+const REMOVE_CONFIRMATION_TEST_ID = "workflow-sync-remove-confirmation";
+const REMOVE_CONFIRM_TEST_ID = "workflow-sync-remove-confirm";
+
+const EMPTY_FORM: WorkflowSyncFormState = {
+  provider: "github",
+  repo_owner: "",
+  repo_name: "",
+  project_path: "",
+  branch: "main",
+  path: WORKFLOWS_DIR,
+  interval_seconds: 300,
+  poll_enabled: true,
+};
+
+function config(overrides: Partial<WorkflowSyncConfig> = {}): WorkflowSyncConfig {
+  return {
+    workspace_id: "workspace-1",
+    provider: "github",
+    repo_owner: "acme",
+    repo_name: "flows",
+    project_path: "",
+    branch: "main",
+    path: WORKFLOWS_DIR,
+    interval_seconds: 300,
+    poll_enabled: true,
+    last_ok: true,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function formForConfig(currentConfig: WorkflowSyncConfig | null): WorkflowSyncFormState {
+  if (!currentConfig) return { ...EMPTY_FORM };
+  return {
+    provider: currentConfig.provider,
+    repo_owner: currentConfig.repo_owner,
+    repo_name: currentConfig.repo_name,
+    project_path: currentConfig.project_path,
+    branch: currentConfig.branch,
+    path: currentConfig.path,
+    interval_seconds: currentConfig.interval_seconds,
+    poll_enabled: currentConfig.poll_enabled,
+  };
+}
+
+function controller(overrides: Partial<WorkflowSyncController> = {}): WorkflowSyncController {
+  const currentConfig = overrides.config === undefined ? config() : overrides.config;
+  return {
+    config: currentConfig,
+    form: formForConfig(currentConfig),
+    url: currentConfig ? "https://github.com/acme/flows" : "",
+    urlInvalid: false,
+    loading: false,
+    saving: false,
+    syncing: false,
+    update: vi.fn(),
+    setUrlInput: vi.fn(),
+    setProvider: vi.fn(),
+    handleSave: vi.fn().mockResolvedValue(true),
+    handleDelete: vi.fn().mockResolvedValue(true),
+    handleSyncNow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("WorkflowSyncDialog removal confirmation", () => {
+  it("keeps removal inline in the existing dialog without a second overlay", () => {
+    const sync = controller();
+    render(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+
+    expect(screen.getByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(screen.getByTestId(REMOVE_CONFIRM_TEST_ID)).toBeTruthy();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(sync.handleDelete).not.toHaveBeenCalled();
+  });
+
+  it("cancels without mutating sync state", () => {
+    const sync = controller();
+    const onOpenChange = vi.fn();
+    render(<WorkflowSyncDialog open onOpenChange={onOpenChange} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(sync.handleDelete).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeNull();
+    expect(screen.getByTestId(REMOVE_TEST_ID)).toBeTruthy();
+  });
+
+  it("confirms removal once and closes after successful mutation", async () => {
+    const sync = controller();
+    const onOpenChange = vi.fn();
+    render(<WorkflowSyncDialog open onOpenChange={onOpenChange} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    fireEvent.click(screen.getByTestId(REMOVE_CONFIRM_TEST_ID));
+
+    await waitFor(() => expect(sync.handleDelete).toHaveBeenCalledTimes(1));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps inline actions available when removal fails", async () => {
+    const sync = controller({ handleDelete: vi.fn().mockResolvedValue(false) });
+    const onOpenChange = vi.fn();
+    render(<WorkflowSyncDialog open onOpenChange={onOpenChange} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    fireEvent.click(screen.getByTestId(REMOVE_CONFIRM_TEST_ID));
+
+    await waitFor(() => expect(sync.handleDelete).toHaveBeenCalledTimes(1));
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeTruthy();
+  });
+
+  it("clears inline state when the dialog closes or target changes", async () => {
+    const sync = controller();
+    const { rerender } = render(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    expect(screen.getByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeTruthy();
+
+    rerender(<WorkflowSyncDialog open={false} onOpenChange={vi.fn()} sync={sync} />);
+    rerender(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={sync} />);
+    expect(screen.queryByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeNull();
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    const nextSync = controller({ config: config({ repo_name: "new-flows" }) });
+    rerender(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={nextSync} />);
+    await waitFor(() => expect(screen.queryByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeNull());
+  });
+});

--- a/apps/web/components/settings/workflow-sync-dialog.test.tsx
+++ b/apps/web/components/settings/workflow-sync-dialog.test.tsx
@@ -105,6 +105,18 @@ describe("WorkflowSyncDialog removal confirmation", () => {
     expect(screen.getByTestId(REMOVE_TEST_ID)).toBeTruthy();
   });
 
+  it("prevents saves while removal confirmation is active", () => {
+    const sync = controller();
+    render(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+
+    const save = screen.getByTestId<HTMLButtonElement>("workflow-sync-save");
+    expect(save.disabled).toBe(true);
+    fireEvent.click(save);
+    expect(sync.handleSave).not.toHaveBeenCalled();
+  });
+
   it("confirms removal once and closes after successful mutation", async () => {
     const sync = controller();
     const onOpenChange = vi.fn();
@@ -145,5 +157,25 @@ describe("WorkflowSyncDialog removal confirmation", () => {
     const nextSync = controller({ config: config({ repo_name: "new-flows" }) });
     rerender(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={nextSync} />);
     await waitFor(() => expect(screen.queryByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeNull());
+  });
+
+  it("clears inline state when the user edits the repository URL", async () => {
+    const sync = controller();
+    const { rerender } = render(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={sync} />);
+
+    fireEvent.click(screen.getByTestId(REMOVE_TEST_ID));
+    fireEvent.change(screen.getByTestId("workflow-sync-url-input"), {
+      target: { value: "https://github.com/acme/other-flows" },
+    });
+    expect(sync.setUrlInput).toHaveBeenCalledWith("https://github.com/acme/other-flows");
+
+    const editedSync = controller({
+      form: { ...sync.form, repo_name: "other-flows" },
+      url: "https://github.com/acme/other-flows",
+    });
+    rerender(<WorkflowSyncDialog open onOpenChange={vi.fn()} sync={editedSync} />);
+
+    await waitFor(() => expect(screen.queryByTestId(REMOVE_CONFIRMATION_TEST_ID)).toBeNull());
+    expect(screen.getByTestId(REMOVE_TEST_ID)).toBeTruthy();
   });
 });

--- a/apps/web/components/settings/workflow-sync-dialog.tsx
+++ b/apps/web/components/settings/workflow-sync-dialog.tsx
@@ -403,7 +403,7 @@ export function WorkflowSyncDialog({ open, onOpenChange, sync }: WorkflowSyncDia
           <Button
             type="button"
             onClick={handleSave}
-            disabled={disableSave}
+            disabled={disableSave || removeConfirming}
             className="cursor-pointer"
             data-testid="workflow-sync-save"
             data-dialog-default-action

--- a/apps/web/components/settings/workflow-sync-dialog.tsx
+++ b/apps/web/components/settings/workflow-sync-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -20,11 +21,15 @@ import type {
 } from "@/hooks/domains/settings/use-workflow-sync";
 import type { WorkflowSyncProvider } from "@/lib/types/workflow-sync";
 import { RemoteRepoProviderTabs } from "@/components/task-create-dialog-remote-repo-provider-tabs";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import type { RemoteRepositoryProvider } from "@/hooks/domains/integrations/use-remote-repositories";
 
 const WORKFLOW_EXPORT_FORMAT = "kandev_workflow";
 const WORKFLOW_EXPORT_EXTENSIONS = ".yml/.yaml/.json";
 const SYNC_PROVIDERS: RemoteRepositoryProvider[] = ["github", "gitlab"];
+const REMOVE_TEST_ID = "workflow-sync-remove";
+const REMOVE_CONFIRMATION_TEST_ID = "workflow-sync-remove-confirmation";
+const REMOVE_CONFIRM_TEST_ID = "workflow-sync-remove-confirm";
 
 type ProviderFieldProps = {
   provider: WorkflowSyncProvider;
@@ -224,6 +229,87 @@ function isSaveDisabled(sync: WorkflowSyncController, intervalInvalid: boolean):
   return sync.saving || sync.loading || sync.urlInvalid || intervalInvalid || targetMissing;
 }
 
+type WorkflowSyncRemovalActionsProps = {
+  hasConfig: boolean;
+  confirming: boolean;
+  saving: boolean;
+  onRequest: () => void;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+function WorkflowSyncRemovalActions({
+  hasConfig,
+  confirming,
+  saving,
+  onRequest,
+  onCancel,
+  onConfirm,
+}: WorkflowSyncRemovalActionsProps) {
+  const { t } = useTranslation();
+  if (!hasConfig) return null;
+
+  const removeLabel = t("workflows:remove");
+  if (confirming) {
+    return (
+      <InlineConfirmActions
+        density="touch"
+        testId={REMOVE_CONFIRMATION_TEST_ID}
+        ariaLabel={removeLabel}
+        description={t("workflows:removeSyncConfirm")}
+        cancelLabel={t("common:cancel")}
+        confirmLabel={removeLabel}
+        confirmAriaLabel={removeLabel}
+        confirmTestId={REMOVE_CONFIRM_TEST_ID}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="destructive"
+      onClick={onRequest}
+      disabled={saving}
+      className="sm:mr-auto cursor-pointer"
+      data-testid={REMOVE_TEST_ID}
+    >
+      {removeLabel}
+    </Button>
+  );
+}
+
+function useClearWorkflowSyncRemovalConfirmation(
+  open: boolean,
+  sync: WorkflowSyncController,
+  setRemoveConfirming: Dispatch<SetStateAction<boolean>>,
+) {
+  // Clear a pending confirmation when the dialog closes or when its configured
+  // target changes. Status-only refreshes leave target fields unchanged, so
+  // they do not interrupt an action the user is already confirming.
+  useEffect(() => {
+    setRemoveConfirming(false);
+  }, [
+    open,
+    sync.config?.workspace_id,
+    sync.config?.provider,
+    sync.config?.repo_owner,
+    sync.config?.repo_name,
+    sync.config?.project_path,
+    sync.config?.branch,
+    sync.config?.path,
+    sync.form.provider,
+    sync.form.repo_owner,
+    sync.form.repo_name,
+    sync.form.project_path,
+    sync.form.branch,
+    sync.form.path,
+    setRemoveConfirming,
+  ]);
+}
+
 type WorkflowSyncDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -235,6 +321,7 @@ type WorkflowSyncDialogProps = {
 // error surfaced via toast.
 export function WorkflowSyncDialog({ open, onOpenChange, sync }: WorkflowSyncDialogProps) {
   const { t } = useTranslation();
+  const [removeConfirming, setRemoveConfirming] = useState(false);
   const hasConfig = !!sync.config;
   const switchingProvider = hasConfig && sync.config?.provider !== sync.form.provider;
   const intervalInvalid =
@@ -243,16 +330,37 @@ export function WorkflowSyncDialog({ open, onOpenChange, sync }: WorkflowSyncDia
   const disableSave = isSaveDisabled(sync, intervalInvalid);
   const resolved = resolvedTarget(t, sync.form);
 
+  useClearWorkflowSyncRemovalConfirmation(open, sync, setRemoveConfirming);
+
   const handleSave = async () => {
     if (await sync.handleSave()) onOpenChange(false);
   };
   const handleRemove = async () => {
-    if (await sync.handleDelete()) onOpenChange(false);
+    if (await sync.handleDelete()) {
+      onOpenChange(false);
+      return;
+    }
+    // InlineConfirmActions restores its own shell when this callback rejects.
+    // Keep parent confirmation state mounted so the existing failure toast and
+    // retry path remain inside this dialog.
+    return Promise.reject();
+  };
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setRemoveConfirming(false);
+    onOpenChange(nextOpen);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg" data-testid="workflow-sync-dialog">
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogContent
+        className="sm:max-w-lg"
+        data-testid="workflow-sync-dialog"
+        onEscapeKeyDown={(event) => {
+          if (!removeConfirming) return;
+          event.preventDefault();
+          setRemoveConfirming(false);
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{t("workflows:syncTitle")}</DialogTitle>
           <DialogDescription>{t("workflows:syncDescription")}</DialogDescription>
@@ -284,18 +392,14 @@ export function WorkflowSyncDialog({ open, onOpenChange, sync }: WorkflowSyncDia
           </p>
         </div>
         <DialogFooter>
-          {hasConfig && (
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={handleRemove}
-              disabled={sync.saving}
-              className="sm:mr-auto cursor-pointer"
-              data-testid="workflow-sync-remove"
-            >
-              {t("workflows:remove")}
-            </Button>
-          )}
+          <WorkflowSyncRemovalActions
+            hasConfig={hasConfig}
+            confirming={removeConfirming}
+            saving={sync.saving}
+            onRequest={() => setRemoveConfirming(true)}
+            onCancel={() => setRemoveConfirming(false)}
+            onConfirm={handleRemove}
+          />
           <Button
             type="button"
             onClick={handleSave}

--- a/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
@@ -2,6 +2,69 @@ import { test, expect } from "../../fixtures/test-base";
 import { WorkflowSettingsPage } from "../../pages/workflow-settings-page";
 
 test.describe("Workflow settings on mobile", () => {
+  test("remove sync confirmation keeps 44px inline actions", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await apiClient.configureGitLab(seedData.workspaceId);
+    const configResponse = await apiClient.rawRequest(
+      "POST",
+      `/api/v1/workflow-sync/config?workspace_id=${encodeURIComponent(seedData.workspaceId)}`,
+      {
+        provider: "gitlab",
+        project_path: "platform/kandev",
+        branch: "main",
+        path: ".kandev/workflows",
+        interval_seconds: 300,
+        poll_enabled: true,
+      },
+    );
+    expect(configResponse.ok).toBe(true);
+
+    const page = new WorkflowSettingsPage(testPage);
+    await page.goto(seedData.workspaceId);
+
+    const dialog = testPage.getByTestId("workflow-sync-dialog");
+    await testPage.getByTestId("workflow-sync-open").tap();
+    await expect(dialog).toBeVisible();
+    await dialog.getByTestId("workflow-sync-remove").tap();
+    const confirmation = dialog.getByTestId("workflow-sync-remove-confirmation");
+    await expect(confirmation).toBeVisible();
+
+    for (const control of [
+      confirmation.getByRole("button", { name: "Cancel" }),
+      confirmation.getByTestId("workflow-sync-remove-confirm"),
+    ]) {
+      const box = await control.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(
+        await testPage.evaluate(() => window.innerWidth),
+      );
+    }
+    expect(
+      await testPage.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
+    ).toBe(false);
+
+    await testPage.keyboard.press("Escape");
+    await expect(confirmation).not.toBeVisible();
+    await expect(dialog.getByTestId("workflow-sync-remove")).toBeVisible();
+
+    await dialog.getByTestId("workflow-sync-remove").tap();
+    await dialog.getByTestId("workflow-sync-remove-confirm").tap();
+    await expect(dialog).not.toBeVisible();
+    expect(
+      (
+        await apiClient.rawRequest(
+          "GET",
+          `/api/v1/workflow-sync/config?workspace_id=${encodeURIComponent(seedData.workspaceId)}`,
+        )
+      ).status,
+    ).toBe(204);
+  });
+
   test("configures original-session rules with touch-sized controls", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/workflow/workflow-sync-gitlab.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-sync-gitlab.spec.ts
@@ -137,6 +137,70 @@ test.describe("GitLab workflow sync", () => {
     await expect(dialog.getByTestId("workflow-sync-save")).toBeEnabled();
   });
 
+  test("removes sync through inline actions without a native dialog", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await apiClient.configureGitLab(seedData.workspaceId);
+    const configResponse = await apiClient.rawRequest(
+      "POST",
+      `/api/v1/workflow-sync/config?workspace_id=${encodeURIComponent(seedData.workspaceId)}`,
+      {
+        provider: "gitlab",
+        project_path: GITLAB_PROJECT,
+        branch: "main",
+        path: ".kandev/workflows",
+        interval_seconds: 300,
+        poll_enabled: true,
+      },
+    );
+    expect(configResponse.ok).toBe(true);
+
+    const page = new WorkflowSettingsPage(testPage);
+    await page.goto(seedData.workspaceId);
+
+    let nativeDialogSeen = false;
+    testPage.on("dialog", async (nativeDialog) => {
+      nativeDialogSeen = true;
+      await nativeDialog.dismiss();
+    });
+
+    const dialog = testPage.getByTestId("workflow-sync-dialog");
+    await testPage.getByTestId("workflow-sync-open").click();
+    await expect(dialog).toBeVisible();
+    await dialog.getByTestId("workflow-sync-remove").click();
+    await expect(dialog.getByTestId("workflow-sync-remove-confirmation")).toBeVisible();
+    await expect(testPage.getByRole("dialog")).toHaveCount(1);
+
+    await dialog
+      .getByTestId("workflow-sync-remove-confirmation")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(dialog.getByTestId("workflow-sync-remove")).toBeVisible();
+    expect(
+      (
+        await apiClient.rawRequest(
+          "GET",
+          `/api/v1/workflow-sync/config?workspace_id=${encodeURIComponent(seedData.workspaceId)}`,
+        )
+      ).status,
+    ).toBe(200);
+
+    await dialog.getByTestId("workflow-sync-remove").click();
+    await dialog.getByTestId("workflow-sync-remove-confirm").click();
+    await expect(dialog).not.toBeVisible();
+    expect(nativeDialogSeen).toBe(false);
+    expect(
+      (
+        await apiClient.rawRequest(
+          "GET",
+          `/api/v1/workflow-sync/config?workspace_id=${encodeURIComponent(seedData.workspaceId)}`,
+        )
+      ).status,
+    ).toBe(204);
+  });
+
   // A branch name containing a slash (a common convention, e.g.
   // "features/TICKET-123") can't always be told apart from the directory
   // that follows it when parsing a pasted link — this is exactly what

--- a/apps/web/hooks/domains/settings/use-workflow-sync.test.ts
+++ b/apps/web/hooks/domains/settings/use-workflow-sync.test.ts
@@ -111,13 +111,11 @@ describe("useWorkflowSync", () => {
     expect(result.current.syncing).toBe(false);
   });
 
-  it("handleDelete clears config and resets the form when confirmed", async () => {
+  it("handleDelete clears config and resets the form without a browser confirmation", async () => {
     getWorkflowSyncConfigMock.mockResolvedValue(makeConfig());
     deleteWorkflowSyncConfigMock.mockResolvedValue({ deleted: true });
-    vi.stubGlobal(
-      "confirm",
-      vi.fn(() => true),
-    );
+    const confirmMock = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmMock);
     const { result } = renderHook(() => useWorkflowSync("ws-1"));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -126,6 +124,7 @@ describe("useWorkflowSync", () => {
     });
 
     expect(deleteWorkflowSyncConfigMock).toHaveBeenCalledWith({ workspaceId: "ws-1" });
+    expect(confirmMock).not.toHaveBeenCalled();
     expect(result.current.config).toBeNull();
     expect(result.current.form.repo_owner).toBe("");
   });

--- a/apps/web/hooks/domains/settings/use-workflow-sync.ts
+++ b/apps/web/hooks/domains/settings/use-workflow-sync.ts
@@ -275,9 +275,6 @@ export function useWorkflowSync(workspaceId: string) {
   }, [workspaceId, form, toast, reset]);
 
   const handleDelete = useCallback(async () => {
-    if (!confirm(t("workflows:removeSyncConfirm"))) {
-      return false;
-    }
     try {
       await deleteWorkflowSyncConfig({ workspaceId });
       setConfig(null);


### PR DESCRIPTION
Workflow sync removal previously opened a browser confirmation that could not follow the app's
localized modal and mobile interaction patterns. The existing workflow-sync dialog now keeps the
confirmation inline with touch-sized Cancel and Remove actions while preserving mutation and error
behavior.

## Validation

- `cd apps && pnpm install --frozen-lockfile`
- Focused Vitest: 22 passed across the workflow-sync hook, dialog, and API suites, using a bounded
  single-worker VM pool.
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm run i18n:check`
- `cd apps/web && pnpm run i18n:ratchet`
- Managed desktop workflow-sync E2E: 4 passed in the final behavior run; final focused inline-remove
  rerun: 1 passed.
- Managed mobile E2E with `--grep "remove sync confirmation"`: 1 passed, including Escape, 44px
  actions, no horizontal overflow, and successful removal.
- Two later full desktop reruns encountered the existing 5-second workflow-page hydration timeout
  before dialog interaction under shared-host contention; focused final interaction coverage passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop workflow sync removal confirmation](https://raw.githubusercontent.com/kdlbs/kandev/80824c21ad26660ef1e3ff5498581566123d6944/workflow-sync-remove-confirmation-desktop.png)

![Mobile workflow sync removal confirmation](https://raw.githubusercontent.com/kdlbs/kandev/80824c21ad26660ef1e3ff5498581566123d6944/workflow-sync-remove-confirmation-mobile.png)
<!-- kandev-screenshots-end -->