### PR TITLE
feat(ui): localize integration removal confirmations

### DIFF
--- a/apps/web/components/azure-devops/azure-devops-settings.test.tsx
+++ b/apps/web/components/azure-devops/azure-devops-settings.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StateProvider } from "@/components/state-provider";
 import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
@@ -68,6 +68,8 @@ import { AzureDevOpsConnectionSection, AzureDevOpsIntegrationPage } from "./azur
 
 const OLD_ORGANIZATION_URL = "https://dev.azure.com/old-org";
 const WORKSPACE_ID = "workspace-a";
+const DELETE_BUTTON_TEST_ID = "azure-devops-delete-button";
+const CONFIRM_POPOVER_TEST_ID = "azure-devops-remove-confirm-popover";
 
 const config: AzureDevOpsConfig = {
   workspaceId: WORKSPACE_ID,
@@ -95,6 +97,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -211,18 +214,18 @@ describe("AzureDevOpsConnectionSection removal", () => {
       </SettingsSaveProvider>,
     );
 
-    const removeButton = await screen.findByTestId("azure-devops-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
 
     expect(nativeConfirm).not.toHaveBeenCalled();
-    const popover = screen.getByTestId("azure-devops-remove-confirm-popover");
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
     fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
 
     fireEvent.click(removeButton);
     fireEvent.click(
-      within(screen.getByTestId("azure-devops-remove-confirm-popover")).getByTestId(
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId(
         "azure-devops-remove-confirm",
       ),
     );
@@ -238,21 +241,52 @@ describe("AzureDevOpsConnectionSection removal", () => {
       </SettingsSaveProvider>,
     );
 
-    const removeButton = await screen.findByTestId("azure-devops-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
     const inline = screen.getByTestId("azure-devops-remove-inline-confirmation");
-    expect(screen.queryByTestId("azure-devops-remove-confirm-popover")).toBeNull();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
     expect(within(inline).getByTestId("azure-devops-remove-confirm").className).toContain("h-11");
 
     fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByTestId("azure-devops-delete-button"));
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
     fireEvent.click(
       within(screen.getByTestId("azure-devops-remove-inline-confirmation")).getByTestId(
         "azure-devops-remove-confirm",
       ),
     );
     await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+
+  it("clears confirmation when polling removes and later restores the configuration", async () => {
+    vi.useFakeTimers();
+    mocks.getConfig
+      .mockResolvedValueOnce(config)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(config);
+    render(
+      <SettingsSaveProvider>
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
+      </SettingsSaveProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.queryByTestId(DELETE_BUTTON_TEST_ID)).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.getByTestId(DELETE_BUTTON_TEST_ID)).toBeTruthy();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/components/azure-devops/azure-devops-settings.test.tsx
+++ b/apps/web/components/azure-devops/azure-devops-settings.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
 }));
 
+let finePointer = true;
+
 vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }));
@@ -25,6 +27,9 @@ vi.mock("@/hooks/domains/azure-devops/use-azure-devops-projects", () => ({
     error: null,
     refresh: vi.fn(),
   }),
+}));
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: finePointer }),
 }));
 vi.mock("@/lib/api/domains/azure-devops-api", () => ({
   deleteAzureDevOpsConfig: mocks.deleteConfig,
@@ -62,9 +67,10 @@ vi.mock("@/components/azure-devops/azure-devops-default-queries", () => ({
 import { AzureDevOpsConnectionSection, AzureDevOpsIntegrationPage } from "./azure-devops-settings";
 
 const OLD_ORGANIZATION_URL = "https://dev.azure.com/old-org";
+const WORKSPACE_ID = "workspace-a";
 
 const config: AzureDevOpsConfig = {
-  workspaceId: "workspace-a",
+  workspaceId: WORKSPACE_ID,
   organizationUrl: OLD_ORGANIZATION_URL,
   defaultProjectId: "project-old",
   defaultProjectName: "Old project",
@@ -77,6 +83,7 @@ const config: AzureDevOpsConfig = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  finePointer = true;
   mocks.getConfig.mockResolvedValue(config);
   mocks.setConfig.mockResolvedValue({
     ...config,
@@ -86,13 +93,16 @@ beforeEach(() => {
   });
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("AzureDevOpsConnectionSection", () => {
   it("links to the organization PAT page and explains the required read scopes", async () => {
     render(
       <SettingsSaveProvider>
-        <AzureDevOpsConnectionSection workspaceId="workspace-a" />
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
       </SettingsSaveProvider>,
     );
 
@@ -123,7 +133,7 @@ describe("AzureDevOpsConnectionSection", () => {
   it("does not create a token link from a non-Azure organization URL", async () => {
     render(
       <SettingsSaveProvider>
-        <AzureDevOpsConnectionSection workspaceId="workspace-a" />
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
       </SettingsSaveProvider>,
     );
 
@@ -144,7 +154,7 @@ describe("AzureDevOpsConnectionSection", () => {
   it("removes trailing slashes before saving an organization URL", async () => {
     render(
       <SettingsSaveProvider>
-        <AzureDevOpsConnectionSection workspaceId="workspace-a" />
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
       </SettingsSaveProvider>,
     );
     const organization = await screen.findByTestId("azure-devops-organization");
@@ -156,7 +166,7 @@ describe("AzureDevOpsConnectionSection", () => {
     fireEvent.click(screen.getByTestId("azure-devops-save-button"));
 
     await waitFor(() => expect(mocks.setConfig).toHaveBeenCalledTimes(1));
-    expect(mocks.setConfig).toHaveBeenCalledWith("workspace-a", {
+    expect(mocks.setConfig).toHaveBeenCalledWith(WORKSPACE_ID, {
       organizationUrl: OLD_ORGANIZATION_URL,
       defaultProjectId: "project-old",
       defaultProjectName: "Old project",
@@ -168,7 +178,7 @@ describe("AzureDevOpsConnectionSection", () => {
   it("omits a project selected for the previous organization", async () => {
     render(
       <SettingsSaveProvider>
-        <AzureDevOpsConnectionSection workspaceId="workspace-a" />
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
       </SettingsSaveProvider>,
     );
     const organization = await screen.findByTestId("azure-devops-organization");
@@ -181,7 +191,7 @@ describe("AzureDevOpsConnectionSection", () => {
     fireEvent.click(screen.getByTestId("azure-devops-save-button"));
 
     await waitFor(() => expect(mocks.setConfig).toHaveBeenCalledTimes(1));
-    expect(mocks.setConfig).toHaveBeenCalledWith("workspace-a", {
+    expect(mocks.setConfig).toHaveBeenCalledWith(WORKSPACE_ID, {
       organizationUrl: "https://dev.azure.com/new-org",
       defaultProjectId: undefined,
       defaultProjectName: undefined,
@@ -191,12 +201,67 @@ describe("AzureDevOpsConnectionSection", () => {
   });
 });
 
+describe("AzureDevOpsConnectionSection removal", () => {
+  it("uses local fine-pointer confirmation and calls removal once after confirmation", async () => {
+    const nativeConfirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", nativeConfirm);
+    render(
+      <SettingsSaveProvider>
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
+      </SettingsSaveProvider>,
+    );
+
+    const removeButton = await screen.findByTestId("azure-devops-delete-button");
+    fireEvent.click(removeButton);
+
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    const popover = screen.getByTestId("azure-devops-remove-confirm-popover");
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+
+    fireEvent.click(removeButton);
+    fireEvent.click(
+      within(screen.getByTestId("azure-devops-remove-confirm-popover")).getByTestId(
+        "azure-devops-remove-confirm",
+      ),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+    expect(mocks.deleteConfig).toHaveBeenCalledWith(WORKSPACE_ID);
+  });
+
+  it("morphs removal into touch-sized inline confirmation on coarse pointers", async () => {
+    finePointer = false;
+    render(
+      <SettingsSaveProvider>
+        <AzureDevOpsConnectionSection workspaceId={WORKSPACE_ID} />
+      </SettingsSaveProvider>,
+    );
+
+    const removeButton = await screen.findByTestId("azure-devops-delete-button");
+    fireEvent.click(removeButton);
+    const inline = screen.getByTestId("azure-devops-remove-inline-confirmation");
+    expect(screen.queryByTestId("azure-devops-remove-confirm-popover")).toBeNull();
+    expect(within(inline).getByTestId("azure-devops-remove-confirm").className).toContain("h-11");
+
+    fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("azure-devops-delete-button"));
+    fireEvent.click(
+      within(screen.getByTestId("azure-devops-remove-inline-confirmation")).getByTestId(
+        "azure-devops-remove-confirm",
+      ),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+});
+
 describe("AzureDevOpsIntegrationPage", () => {
   it("matches GitHub's analogous section order and includes default queries", async () => {
     render(
       <StateProvider>
         <SettingsSaveProvider>
-          <AzureDevOpsIntegrationPage workspaceId="workspace-a" />
+          <AzureDevOpsIntegrationPage workspaceId={WORKSPACE_ID} />
         </SettingsSaveProvider>
       </StateProvider>,
     );

--- a/apps/web/components/azure-devops/azure-devops-settings.tsx
+++ b/apps/web/components/azure-devops/azure-devops-settings.tsx
@@ -446,6 +446,10 @@ function ConnectionActions({ state, disabled }: { state: SettingsState; disabled
   const removeAnchorRef = useRef<HTMLButtonElement>(null);
   const removeConfirmation = t("azuredevops:removeConfigurationConfirm");
 
+  useEffect(() => {
+    if (!state.config && confirmingRemove) setConfirmingRemove(false);
+  }, [confirmingRemove, state.config]);
+
   return (
     <div className="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:items-center">
       <Button

--- a/apps/web/components/azure-devops/azure-devops-settings.tsx
+++ b/apps/web/components/azure-devops/azure-devops-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
   IconBrandAzure,
@@ -19,6 +19,8 @@ import { Label } from "@kandev/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
@@ -32,6 +34,7 @@ import { SettingsSection } from "@/components/settings/settings-section";
 import { useToast } from "@/components/toast-provider";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 import { useAzureDevOpsProjects } from "@/hooks/domains/azure-devops/use-azure-devops-projects";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import {
   deleteAzureDevOpsConfig,
   getAzureDevOpsConfig,
@@ -218,7 +221,6 @@ function useAzureDevOpsSettings(workspaceId: string) {
   }, [config, form, t, toast, workspaceId]);
 
   const remove = useCallback(async () => {
-    if (!confirm(t("azuredevops:removeConfigurationConfirm"))) return;
     try {
       await deleteAzureDevOpsConfig(workspaceId);
       setConfig(null);
@@ -439,6 +441,11 @@ function saveButtonLabel(t: (key: string) => string, state: SettingsState): stri
 
 function ConnectionActions({ state, disabled }: { state: SettingsState; disabled: boolean }) {
   const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const removeAnchorRef = useRef<HTMLButtonElement>(null);
+  const removeConfirmation = t("azuredevops:removeConfigurationConfirm");
+
   return (
     <div className="flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:items-center">
       <Button
@@ -462,18 +469,49 @@ function ConnectionActions({ state, disabled }: { state: SettingsState; disabled
         <IconDeviceFloppy className="h-4 w-4" />
         {saveButtonLabel(t, state)}
       </Button>
-      {state.config && (
+      {state.config && (isFinePointer || !confirmingRemove) && (
         <Button
+          ref={removeAnchorRef}
           type="button"
           variant="destructive"
-          onClick={() => void state.remove()}
-          className="w-full cursor-pointer sm:ml-auto sm:w-auto"
+          onClick={() => setConfirmingRemove(true)}
+          className="min-h-11 w-full cursor-pointer sm:ml-auto sm:w-auto"
           data-testid="azure-devops-delete-button"
         >
           <IconTrash className="h-4 w-4" />
           {t("azuredevops:remove")}
         </Button>
       )}
+      {state.config && !isFinePointer && confirmingRemove ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="azure-devops-remove-inline-confirmation"
+          ariaLabel={removeConfirmation}
+          description={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("azuredevops:remove")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="azure-devops-remove-confirm"
+          onCancel={() => setConfirmingRemove(false)}
+          onClose={() => setConfirmingRemove(false)}
+          onConfirm={() => void state.remove()}
+        />
+      ) : null}
+      {state.config && isFinePointer ? (
+        <ActionConfirmPopover
+          open={confirmingRemove}
+          anchorRef={removeAnchorRef}
+          title={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("azuredevops:remove")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="azure-devops-remove-confirm"
+          testId="azure-devops-remove-confirm-popover"
+          onOpenChange={setConfirmingRemove}
+          onCancel={() => setConfirmingRemove(false)}
+          onConfirm={() => void state.remove()}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/jira/jira-action-bar.tsx
+++ b/apps/web/components/jira/jira-action-bar.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { useTranslation } from "react-i18next";
+
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
+
+type JiraActionBarProps = {
+  testing: boolean;
+  loading: boolean;
+  hasConfig: boolean;
+  disableTest: boolean;
+  onTest: () => void;
+  onDelete: () => void;
+};
+
+export function JiraActionBar({
+  testing,
+  loading,
+  hasConfig,
+  disableTest,
+  onTest,
+  onDelete,
+}: JiraActionBarProps) {
+  const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
+  const removeConfirmation = t("jira:removeJiraConfiguration");
+
+  useEffect(() => {
+    if (!hasConfig && confirmingDelete) setConfirmingDelete(false);
+  }, [confirmingDelete, hasConfig]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onTest}
+        disabled={testing || loading || disableTest}
+        className="cursor-pointer"
+        title={disableTest ? t("jira:pasteATokenToTestTheConnection") : undefined}
+        data-testid="jira-test-button"
+      >
+        {testing ? t("jira:testingConnection") : t("jira:testConnection")}
+      </Button>
+      {hasConfig && (isFinePointer || !confirmingDelete) && (
+        <Button
+          ref={deleteAnchorRef}
+          type="button"
+          variant="destructive"
+          onClick={() => setConfirmingDelete(true)}
+          className="ml-auto min-h-11 cursor-pointer"
+          data-testid="jira-delete-button"
+        >
+          {t("jira:removeConfiguration")}
+        </Button>
+      )}
+      {hasConfig && !isFinePointer && confirmingDelete ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="jira-remove-inline-confirmation"
+          ariaLabel={removeConfirmation}
+          description={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("jira:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="jira-remove-confirm"
+          onCancel={() => setConfirmingDelete(false)}
+          onClose={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
+      {hasConfig && isFinePointer ? (
+        <ActionConfirmPopover
+          open={confirmingDelete}
+          anchorRef={deleteAnchorRef}
+          title={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("jira:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="jira-remove-confirm"
+          testId="jira-remove-confirm-popover"
+          onOpenChange={setConfirmingDelete}
+          onCancel={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/jira/jira-settings.test.tsx
+++ b/apps/web/components/jira/jira-settings.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { JiraConfig } from "@/lib/types/jira";
 import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 let finePointer = true;
+const DELETE_BUTTON_TEST_ID = "jira-delete-button";
+const CONFIRM_POPOVER_TEST_ID = "jira-remove-confirm-popover";
 
 vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
@@ -65,6 +67,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -74,18 +77,18 @@ describe("JiraConnectionSection removal", () => {
     vi.stubGlobal("confirm", nativeConfirm);
     renderSection();
 
-    const removeButton = await screen.findByTestId("jira-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
 
     expect(nativeConfirm).not.toHaveBeenCalled();
-    const popover = screen.getByTestId("jira-remove-confirm-popover");
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
     fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
 
     fireEvent.click(removeButton);
     fireEvent.click(
-      within(screen.getByTestId("jira-remove-confirm-popover")).getByTestId("jira-remove-confirm"),
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId("jira-remove-confirm"),
     );
     await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
     expect(mocks.deleteConfig).toHaveBeenCalledWith({ workspaceId: "workspace-a" });
@@ -95,20 +98,47 @@ describe("JiraConnectionSection removal", () => {
     finePointer = false;
     renderSection();
 
-    const removeButton = await screen.findByTestId("jira-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
     const inline = screen.getByTestId("jira-remove-inline-confirmation");
-    expect(screen.queryByTestId("jira-remove-confirm-popover")).toBeNull();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
     expect(within(inline).getByTestId("jira-remove-confirm").className).toContain("h-11");
 
     fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByTestId("jira-delete-button"));
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
     fireEvent.click(
       within(screen.getByTestId("jira-remove-inline-confirmation")).getByTestId(
         "jira-remove-confirm",
       ),
     );
     await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+
+  it("clears confirmation when polling removes and later restores the configuration", async () => {
+    vi.useFakeTimers();
+    mocks.getConfig
+      .mockResolvedValueOnce(config)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(config);
+    renderSection();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.queryByTestId(DELETE_BUTTON_TEST_ID)).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.getByTestId(DELETE_BUTTON_TEST_ID)).toBeTruthy();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/jira/jira-settings.test.tsx
+++ b/apps/web/components/jira/jira-settings.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JiraConfig } from "@/lib/types/jira";
+import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
+
+const mocks = vi.hoisted(() => ({
+  deleteConfig: vi.fn(),
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  testConnection: vi.fn(),
+  toast: vi.fn(),
+}));
+
+let finePointer = true;
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+vi.mock("@/hooks/domains/integrations/use-integration-availability", () => ({
+  INTEGRATION_STATUS_REFRESH_MS: 100_000,
+}));
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: finePointer }),
+}));
+vi.mock("@/components/jira/jira-enabled-control", () => ({
+  JiraEnabledControl: () => null,
+}));
+vi.mock("@/lib/api/domains/jira-api", () => ({
+  deleteJiraConfig: mocks.deleteConfig,
+  getJiraConfig: mocks.getConfig,
+  setJiraConfig: mocks.setConfig,
+  testJiraConnection: mocks.testConnection,
+}));
+
+import { JiraConnectionSection } from "./jira-settings";
+
+const config: JiraConfig = {
+  workspaceId: "workspace-a",
+  siteUrl: "https://acme.atlassian.net",
+  email: "alice@example.com",
+  authMethod: "api_token",
+  instanceType: "cloud",
+  defaultProjectKey: "PROJ",
+  hasSecret: true,
+  lastOk: true,
+  createdAt: "2026-07-18T00:00:00Z",
+  updatedAt: "2026-07-18T00:00:00Z",
+};
+
+function renderSection() {
+  return render(
+    <SettingsSaveProvider>
+      <JiraConnectionSection workspaceId="workspace-a" />
+    </SettingsSaveProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  finePointer = true;
+  mocks.getConfig.mockResolvedValue(config);
+  mocks.deleteConfig.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("JiraConnectionSection removal", () => {
+  it("uses local fine-pointer confirmation and invokes deletion once", async () => {
+    const nativeConfirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", nativeConfirm);
+    renderSection();
+
+    const removeButton = await screen.findByTestId("jira-delete-button");
+    fireEvent.click(removeButton);
+
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    const popover = screen.getByTestId("jira-remove-confirm-popover");
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+
+    fireEvent.click(removeButton);
+    fireEvent.click(
+      within(screen.getByTestId("jira-remove-confirm-popover")).getByTestId("jira-remove-confirm"),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+    expect(mocks.deleteConfig).toHaveBeenCalledWith({ workspaceId: "workspace-a" });
+  });
+
+  it("uses touch-sized inline confirmation on coarse pointers", async () => {
+    finePointer = false;
+    renderSection();
+
+    const removeButton = await screen.findByTestId("jira-delete-button");
+    fireEvent.click(removeButton);
+    const inline = screen.getByTestId("jira-remove-inline-confirmation");
+    expect(screen.queryByTestId("jira-remove-confirm-popover")).toBeNull();
+    expect(within(inline).getByTestId("jira-remove-confirm").className).toContain("h-11");
+
+    fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("jira-delete-button"));
+    fireEvent.click(
+      within(screen.getByTestId("jira-remove-inline-confirmation")).getByTestId(
+        "jira-remove-confirm",
+      ),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/components/jira/jira-settings.tsx
+++ b/apps/web/components/jira/jira-settings.tsx
@@ -339,6 +339,10 @@ function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete 
   const deleteAnchorRef = useRef<HTMLButtonElement>(null);
   const removeConfirmation = t("jira:removeJiraConfiguration");
 
+  useEffect(() => {
+    if (!hasConfig && confirmingDelete) setConfirmingDelete(false);
+  }, [confirmingDelete, hasConfig]);
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Button

--- a/apps/web/components/jira/jira-settings.tsx
+++ b/apps/web/components/jira/jira-settings.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { IconTicket } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { CardContent } from "@kandev/ui/card";
@@ -11,6 +18,8 @@ import { Separator } from "@kandev/ui/separator";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { useToast } from "@/components/toast-provider";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { useSettingsSaveContributor } from "@/components/settings/settings-save-provider";
 import { SettingsCard } from "@/components/settings/settings-card";
@@ -23,6 +32,7 @@ import {
 } from "@/components/integrations/auth-status-banner";
 import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import {
   getJiraConfig,
   setJiraConfig,
@@ -324,6 +334,11 @@ type ActionBarProps = {
 
 function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete }: ActionBarProps) {
   const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
+  const removeConfirmation = t("jira:removeJiraConfiguration");
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Button
@@ -337,17 +352,48 @@ function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete 
       >
         {testing ? t("jira:testingConnection") : t("jira:testConnection")}
       </Button>
-      {hasConfig && (
+      {hasConfig && (isFinePointer || !confirmingDelete) && (
         <Button
+          ref={deleteAnchorRef}
           type="button"
           variant="destructive"
-          onClick={onDelete}
-          className="ml-auto cursor-pointer"
+          onClick={() => setConfirmingDelete(true)}
+          className="ml-auto min-h-11 cursor-pointer"
           data-testid="jira-delete-button"
         >
           {t("jira:removeConfiguration")}
         </Button>
       )}
+      {hasConfig && !isFinePointer && confirmingDelete ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="jira-remove-inline-confirmation"
+          ariaLabel={removeConfirmation}
+          description={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("jira:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="jira-remove-confirm"
+          onCancel={() => setConfirmingDelete(false)}
+          onClose={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
+      {hasConfig && isFinePointer ? (
+        <ActionConfirmPopover
+          open={confirmingDelete}
+          anchorRef={deleteAnchorRef}
+          title={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("jira:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="jira-remove-confirm"
+          testId="jira-remove-confirm-popover"
+          onOpenChange={setConfirmingDelete}
+          onCancel={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
     </div>
   );
 }
@@ -422,7 +468,6 @@ function useJiraConfigMutations({
   }, [workspaceId, form, setConfig, setForm, setTestResult, setSaving, t, toast]);
 
   const handleDelete = useCallback(async () => {
-    if (!confirm(t("jira:removeJiraConfiguration"))) return;
     try {
       await deleteJiraConfig({ workspaceId });
       setConfig(null);

--- a/apps/web/components/jira/jira-settings.tsx
+++ b/apps/web/components/jira/jira-settings.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from "react";
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { IconTicket } from "@tabler/icons-react";
-import { Button } from "@kandev/ui/button";
 import { CardContent } from "@kandev/ui/card";
 import { Input } from "@kandev/ui/input";
 import { settingsCredentialClassName } from "@/components/settings/settings-control";
@@ -18,21 +10,19 @@ import { Separator } from "@kandev/ui/separator";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { useToast } from "@/components/toast-provider";
-import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
-import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { useSettingsSaveContributor } from "@/components/settings/settings-save-provider";
 import { SettingsCard } from "@/components/settings/settings-card";
 import { TaskPresetsSection } from "@/components/jira/task-presets-section";
 import { JiraIssueWatchersSection } from "@/components/jira/jira-issue-watchers-section";
 import { JiraEnabledControl } from "@/components/jira/jira-enabled-control";
+import { JiraActionBar } from "@/components/jira/jira-action-bar";
 import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
 import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
-import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import {
   getJiraConfig,
   setJiraConfig,
@@ -323,85 +313,6 @@ function configToHealth(config: JiraConfig | null): IntegrationAuthHealth | null
   };
 }
 
-type ActionBarProps = {
-  testing: boolean;
-  loading: boolean;
-  hasConfig: boolean;
-  disableTest: boolean;
-  onTest: () => void;
-  onDelete: () => void;
-};
-
-function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete }: ActionBarProps) {
-  const { t } = useTranslation();
-  const { isFinePointer } = useResponsiveBreakpoint();
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
-  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
-  const removeConfirmation = t("jira:removeJiraConfiguration");
-
-  useEffect(() => {
-    if (!hasConfig && confirmingDelete) setConfirmingDelete(false);
-  }, [confirmingDelete, hasConfig]);
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Button
-        type="button"
-        variant="outline"
-        onClick={onTest}
-        disabled={testing || loading || disableTest}
-        className="cursor-pointer"
-        title={disableTest ? t("jira:pasteATokenToTestTheConnection") : undefined}
-        data-testid="jira-test-button"
-      >
-        {testing ? t("jira:testingConnection") : t("jira:testConnection")}
-      </Button>
-      {hasConfig && (isFinePointer || !confirmingDelete) && (
-        <Button
-          ref={deleteAnchorRef}
-          type="button"
-          variant="destructive"
-          onClick={() => setConfirmingDelete(true)}
-          className="ml-auto min-h-11 cursor-pointer"
-          data-testid="jira-delete-button"
-        >
-          {t("jira:removeConfiguration")}
-        </Button>
-      )}
-      {hasConfig && !isFinePointer && confirmingDelete ? (
-        <InlineConfirmActions
-          density="touch"
-          testId="jira-remove-inline-confirmation"
-          ariaLabel={removeConfirmation}
-          description={removeConfirmation}
-          cancelLabel={t("common:cancel")}
-          confirmLabel={t("jira:removeConfiguration")}
-          confirmAriaLabel={removeConfirmation}
-          confirmTestId="jira-remove-confirm"
-          onCancel={() => setConfirmingDelete(false)}
-          onClose={() => setConfirmingDelete(false)}
-          onConfirm={onDelete}
-        />
-      ) : null}
-      {hasConfig && isFinePointer ? (
-        <ActionConfirmPopover
-          open={confirmingDelete}
-          anchorRef={deleteAnchorRef}
-          title={removeConfirmation}
-          cancelLabel={t("common:cancel")}
-          confirmLabel={t("jira:removeConfiguration")}
-          confirmAriaLabel={removeConfirmation}
-          confirmTestId="jira-remove-confirm"
-          testId="jira-remove-confirm-popover"
-          onOpenChange={setConfirmingDelete}
-          onCancel={() => setConfirmingDelete(false)}
-          onConfirm={onDelete}
-        />
-      ) : null}
-    </div>
-  );
-}
-
 function useJiraConfigRefresh(workspaceId: string, setConfig: (cfg: JiraConfig | null) => void) {
   // Background refresh so the auth-health banner picks up new probe results
   // from the backend poller without requiring a page reload. We re-fetch the
@@ -648,7 +559,7 @@ export function JiraConnectionSection({ workspaceId }: { workspaceId: string }) 
           />
           <TestResultAlert result={s.testResult} />
           <Separator />
-          <ActionBar
+          <JiraActionBar
             testing={s.testing}
             loading={s.loading}
             hasConfig={!!s.config}

--- a/apps/web/components/linear/linear-settings.test.tsx
+++ b/apps/web/components/linear/linear-settings.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LinearConfig } from "@/lib/types/linear";
+import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
+
+const mocks = vi.hoisted(() => ({
+  deleteConfig: vi.fn(),
+  getConfig: vi.fn(),
+  listTeams: vi.fn(),
+  setConfig: vi.fn(),
+  testConnection: vi.fn(),
+  toast: vi.fn(),
+}));
+
+let finePointer = true;
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+vi.mock("@/hooks/domains/integrations/use-integration-availability", () => ({
+  INTEGRATION_STATUS_REFRESH_MS: 100_000,
+}));
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: finePointer }),
+}));
+vi.mock("@/components/linear/linear-enabled-control", () => ({
+  LinearEnabledControl: () => null,
+}));
+vi.mock("@/lib/api/domains/linear-api", () => ({
+  deleteLinearConfig: mocks.deleteConfig,
+  getLinearConfig: mocks.getConfig,
+  listLinearTeams: mocks.listTeams,
+  setLinearConfig: mocks.setConfig,
+  testLinearConnection: mocks.testConnection,
+}));
+
+import { LinearConnectionSection } from "./linear-settings";
+
+const config: LinearConfig = {
+  workspaceId: "workspace-a",
+  authMethod: "api_key",
+  defaultTeamKey: "ENG",
+  hasSecret: true,
+  lastOk: true,
+  createdAt: "2026-07-18T00:00:00Z",
+  updatedAt: "2026-07-18T00:00:00Z",
+};
+
+function renderSection() {
+  return render(
+    <SettingsSaveProvider>
+      <LinearConnectionSection workspaceId="workspace-a" />
+    </SettingsSaveProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  finePointer = true;
+  mocks.getConfig.mockResolvedValue(config);
+  mocks.listTeams.mockResolvedValue({ teams: [] });
+  mocks.deleteConfig.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("LinearConnectionSection removal", () => {
+  it("uses local fine-pointer confirmation and invokes deletion once", async () => {
+    const nativeConfirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", nativeConfirm);
+    renderSection();
+
+    const removeButton = await screen.findByTestId("linear-delete-button");
+    fireEvent.click(removeButton);
+
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    const popover = screen.getByTestId("linear-remove-confirm-popover");
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+
+    fireEvent.click(removeButton);
+    fireEvent.click(
+      within(screen.getByTestId("linear-remove-confirm-popover")).getByTestId(
+        "linear-remove-confirm",
+      ),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+    expect(mocks.deleteConfig).toHaveBeenCalledWith({ workspaceId: "workspace-a" });
+  });
+
+  it("uses touch-sized inline confirmation on coarse pointers", async () => {
+    finePointer = false;
+    renderSection();
+
+    const removeButton = await screen.findByTestId("linear-delete-button");
+    fireEvent.click(removeButton);
+    const inline = screen.getByTestId("linear-remove-inline-confirmation");
+    expect(screen.queryByTestId("linear-remove-confirm-popover")).toBeNull();
+    expect(within(inline).getByTestId("linear-remove-confirm").className).toContain("h-11");
+
+    fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("linear-delete-button"));
+    fireEvent.click(
+      within(screen.getByTestId("linear-remove-inline-confirmation")).getByTestId(
+        "linear-remove-confirm",
+      ),
+    );
+    await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/components/linear/linear-settings.test.tsx
+++ b/apps/web/components/linear/linear-settings.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LinearConfig } from "@/lib/types/linear";
 import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 let finePointer = true;
+const DELETE_BUTTON_TEST_ID = "linear-delete-button";
+const CONFIRM_POPOVER_TEST_ID = "linear-remove-confirm-popover";
 
 vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
@@ -65,6 +67,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -74,20 +77,18 @@ describe("LinearConnectionSection removal", () => {
     vi.stubGlobal("confirm", nativeConfirm);
     renderSection();
 
-    const removeButton = await screen.findByTestId("linear-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
 
     expect(nativeConfirm).not.toHaveBeenCalled();
-    const popover = screen.getByTestId("linear-remove-confirm-popover");
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
     fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
 
     fireEvent.click(removeButton);
     fireEvent.click(
-      within(screen.getByTestId("linear-remove-confirm-popover")).getByTestId(
-        "linear-remove-confirm",
-      ),
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId("linear-remove-confirm"),
     );
     await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
     expect(mocks.deleteConfig).toHaveBeenCalledWith({ workspaceId: "workspace-a" });
@@ -97,20 +98,47 @@ describe("LinearConnectionSection removal", () => {
     finePointer = false;
     renderSection();
 
-    const removeButton = await screen.findByTestId("linear-delete-button");
+    const removeButton = await screen.findByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(removeButton);
     const inline = screen.getByTestId("linear-remove-inline-confirmation");
-    expect(screen.queryByTestId("linear-remove-confirm-popover")).toBeNull();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
     expect(within(inline).getByTestId("linear-remove-confirm").className).toContain("h-11");
 
     fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
     expect(mocks.deleteConfig).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByTestId("linear-delete-button"));
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
     fireEvent.click(
       within(screen.getByTestId("linear-remove-inline-confirmation")).getByTestId(
         "linear-remove-confirm",
       ),
     );
     await waitFor(() => expect(mocks.deleteConfig).toHaveBeenCalledTimes(1));
+  });
+
+  it("clears confirmation when polling removes and later restores the configuration", async () => {
+    vi.useFakeTimers();
+    mocks.getConfig
+      .mockResolvedValueOnce(config)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(config);
+    renderSection();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.queryByTestId(DELETE_BUTTON_TEST_ID)).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100_000);
+    });
+    expect(screen.getByTestId(DELETE_BUTTON_TEST_ID)).toBeTruthy();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(mocks.deleteConfig).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/linear/linear-settings.tsx
+++ b/apps/web/components/linear/linear-settings.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { IconHexagon } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { CardContent } from "@kandev/ui/card";
@@ -10,6 +17,8 @@ import { Separator } from "@kandev/ui/separator";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { useToast } from "@/components/toast-provider";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { useSettingsSaveContributor } from "@/components/settings/settings-save-provider";
 import { SettingsCard } from "@/components/settings/settings-card";
@@ -20,6 +29,7 @@ import {
 } from "@/components/integrations/auth-status-banner";
 import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import {
   getLinearConfig,
   setLinearConfig,
@@ -191,6 +201,11 @@ type ActionBarProps = {
 
 function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete }: ActionBarProps) {
   const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
+  const removeConfirmation = t("linear:removeLinearConfigurationConfirm");
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Button
@@ -204,17 +219,48 @@ function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete 
       >
         {testing ? t("linear:testing") : t("linear:testConnection")}
       </Button>
-      {hasConfig && (
+      {hasConfig && (isFinePointer || !confirmingDelete) && (
         <Button
+          ref={deleteAnchorRef}
           type="button"
           variant="destructive"
-          onClick={onDelete}
-          className="ml-auto cursor-pointer"
+          onClick={() => setConfirmingDelete(true)}
+          className="ml-auto min-h-11 cursor-pointer"
           data-testid="linear-delete-button"
         >
           {t("linear:removeConfiguration")}
         </Button>
       )}
+      {hasConfig && !isFinePointer && confirmingDelete ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="linear-remove-inline-confirmation"
+          ariaLabel={removeConfirmation}
+          description={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("linear:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="linear-remove-confirm"
+          onCancel={() => setConfirmingDelete(false)}
+          onClose={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
+      {hasConfig && isFinePointer ? (
+        <ActionConfirmPopover
+          open={confirmingDelete}
+          anchorRef={deleteAnchorRef}
+          title={removeConfirmation}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("linear:removeConfiguration")}
+          confirmAriaLabel={removeConfirmation}
+          confirmTestId="linear-remove-confirm"
+          testId="linear-remove-confirm-popover"
+          onOpenChange={setConfirmingDelete}
+          onCancel={() => setConfirmingDelete(false)}
+          onConfirm={onDelete}
+        />
+      ) : null}
     </div>
   );
 }
@@ -288,7 +334,6 @@ function useSettingsActions({
   }, [workspaceId, form, t, toast, setConfig, setBaselineConfig, setForm, setTestResult]);
 
   const handleDelete = useCallback(async () => {
-    if (!confirm(t("linear:removeLinearConfigurationConfirm"))) return;
     try {
       await deleteLinearConfig({ workspaceId });
       setConfig(null);

--- a/apps/web/components/linear/linear-settings.tsx
+++ b/apps/web/components/linear/linear-settings.tsx
@@ -206,6 +206,10 @@ function ActionBar({ testing, loading, hasConfig, disableTest, onTest, onDelete 
   const deleteAnchorRef = useRef<HTMLButtonElement>(null);
   const removeConfirmation = t("linear:removeLinearConfigurationConfirm");
 
+  useEffect(() => {
+    if (!hasConfig && confirmingDelete) setConfirmingDelete(false);
+  }, [confirmingDelete, hasConfig]);
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Button

--- a/apps/web/components/sentry/sentry-instance-card.test.tsx
+++ b/apps/web/components/sentry/sentry-instance-card.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { SentryConfig } from "@/lib/types/sentry";
 import { SentryInstanceCard } from "./sentry-instance-card";
 
@@ -30,7 +30,6 @@ describe("SentryInstanceCard", () => {
           isFinePointer
           confirmingDelete={false}
           onDeleteCancel={() => {}}
-          onDeleteOpenChange={() => {}}
           onDeleteConfirm={() => {}}
         />
         <SentryInstanceCard
@@ -40,7 +39,6 @@ describe("SentryInstanceCard", () => {
           isFinePointer
           confirmingDelete={false}
           onDeleteCancel={() => {}}
-          onDeleteOpenChange={() => {}}
           onDeleteConfirm={() => {}}
         />
       </>,
@@ -48,5 +46,25 @@ describe("SentryInstanceCard", () => {
 
     expect(screen.getByRole("button", { name: "Edit Production Sentry instance" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Delete Self-hosted Sentry instance" })).toBeTruthy();
+  });
+
+  it("reports which instance owns a closing confirmation", () => {
+    const onDeleteCancel = vi.fn();
+
+    render(
+      <SentryInstanceCard
+        instance={instance("instance-2", "Self-hosted")}
+        onEdit={() => {}}
+        onDelete={() => {}}
+        isFinePointer
+        confirmingDelete
+        onDeleteCancel={onDeleteCancel}
+        onDeleteConfirm={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onDeleteCancel).toHaveBeenCalledWith("instance-2");
   });
 });

--- a/apps/web/components/sentry/sentry-instance-card.test.tsx
+++ b/apps/web/components/sentry/sentry-instance-card.test.tsx
@@ -27,11 +27,21 @@ describe("SentryInstanceCard", () => {
           instance={instance("instance-1", "Production")}
           onEdit={() => {}}
           onDelete={() => {}}
+          isFinePointer
+          confirmingDelete={false}
+          onDeleteCancel={() => {}}
+          onDeleteOpenChange={() => {}}
+          onDeleteConfirm={() => {}}
         />
         <SentryInstanceCard
           instance={instance("instance-2", "Self-hosted")}
           onEdit={() => {}}
           onDelete={() => {}}
+          isFinePointer
+          confirmingDelete={false}
+          onDeleteCancel={() => {}}
+          onDeleteOpenChange={() => {}}
+          onDeleteConfirm={() => {}}
         />
       </>,
     );

--- a/apps/web/components/sentry/sentry-instance-card.tsx
+++ b/apps/web/components/sentry/sentry-instance-card.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useRef } from "react";
 import { IconPencil, IconTrash } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import type { SentryConfig } from "@/lib/types/sentry";
 import { useTranslation } from "react-i18next";
 
@@ -25,15 +28,31 @@ type SentryInstanceCardProps = {
   instance: SentryConfig;
   onEdit: () => void;
   onDelete: () => void;
+  isFinePointer: boolean;
+  confirmingDelete: boolean;
+  onDeleteCancel: () => void;
+  onDeleteOpenChange: (open: boolean) => void;
+  onDeleteConfirm: () => void;
 };
 
 // SentryInstanceCard renders one saved instance: its name, URL, per-instance
 // auth-health banner, and edit/delete actions.
-export function SentryInstanceCard({ instance, onEdit, onDelete }: SentryInstanceCardProps) {
+export function SentryInstanceCard({
+  instance,
+  onEdit,
+  onDelete,
+  isFinePointer,
+  confirmingDelete,
+  onDeleteCancel,
+  onDeleteOpenChange,
+  onDeleteConfirm,
+}: SentryInstanceCardProps) {
   const { t } = useTranslation();
+  const deleteAnchorRef = useRef<HTMLButtonElement>(null);
+  const confirmationTitle = t("sentry:removeInstanceConfirm", { name: instance.name });
   return (
     <div className="space-y-3 rounded-md border p-4" data-testid="sentry-instance-card">
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="font-medium truncate" data-testid="sentry-instance-name">
             {instance.name}
@@ -53,20 +72,53 @@ export function SentryInstanceCard({ instance, onEdit, onDelete }: SentryInstanc
             <IconPencil className="h-3.5 w-3.5" />
             {t("sentry:edit")}
           </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="destructive"
-            onClick={onDelete}
-            aria-label={t("sentry:deleteInstanceAria", { name: instance.name })}
-            className="cursor-pointer gap-1"
-            data-testid="sentry-instance-delete-button"
-          >
-            <IconTrash className="h-3.5 w-3.5" />
-            {t("sentry:delete")}
-          </Button>
+          {(isFinePointer || !confirmingDelete) && (
+            <Button
+              ref={deleteAnchorRef}
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={onDelete}
+              aria-label={t("sentry:deleteInstanceAria", { name: instance.name })}
+              className="min-h-11 cursor-pointer gap-1"
+              data-testid="sentry-instance-delete-button"
+            >
+              <IconTrash className="h-3.5 w-3.5" />
+              {t("sentry:delete")}
+            </Button>
+          )}
         </div>
       </div>
+      {!isFinePointer && confirmingDelete ? (
+        <InlineConfirmActions
+          density="touch"
+          testId="sentry-remove-inline-confirmation"
+          ariaLabel={confirmationTitle}
+          description={confirmationTitle}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("sentry:delete")}
+          confirmAriaLabel={confirmationTitle}
+          confirmTestId="sentry-remove-confirm"
+          onCancel={onDeleteCancel}
+          onClose={() => onDeleteOpenChange(false)}
+          onConfirm={onDeleteConfirm}
+        />
+      ) : null}
+      {isFinePointer ? (
+        <ActionConfirmPopover
+          open={confirmingDelete}
+          anchorRef={deleteAnchorRef}
+          title={confirmationTitle}
+          cancelLabel={t("common:cancel")}
+          confirmLabel={t("sentry:delete")}
+          confirmAriaLabel={confirmationTitle}
+          confirmTestId="sentry-remove-confirm"
+          testId="sentry-remove-confirm-popover"
+          onOpenChange={onDeleteOpenChange}
+          onCancel={onDeleteCancel}
+          onConfirm={onDeleteConfirm}
+        />
+      ) : null}
       <IntegrationAuthStatusBanner health={configToHealth(instance)} />
     </div>
   );

--- a/apps/web/components/sentry/sentry-instance-card.tsx
+++ b/apps/web/components/sentry/sentry-instance-card.tsx
@@ -30,8 +30,7 @@ type SentryInstanceCardProps = {
   onDelete: () => void;
   isFinePointer: boolean;
   confirmingDelete: boolean;
-  onDeleteCancel: () => void;
-  onDeleteOpenChange: (open: boolean) => void;
+  onDeleteCancel: (instanceId: string) => void;
   onDeleteConfirm: () => void;
 };
 
@@ -44,12 +43,12 @@ export function SentryInstanceCard({
   isFinePointer,
   confirmingDelete,
   onDeleteCancel,
-  onDeleteOpenChange,
   onDeleteConfirm,
 }: SentryInstanceCardProps) {
   const { t } = useTranslation();
   const deleteAnchorRef = useRef<HTMLButtonElement>(null);
   const confirmationTitle = t("sentry:removeInstanceConfirm", { name: instance.name });
+  const cancelDelete = () => onDeleteCancel(instance.id);
   return (
     <div className="space-y-3 rounded-md border p-4" data-testid="sentry-instance-card">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -99,8 +98,8 @@ export function SentryInstanceCard({
           confirmLabel={t("sentry:delete")}
           confirmAriaLabel={confirmationTitle}
           confirmTestId="sentry-remove-confirm"
-          onCancel={onDeleteCancel}
-          onClose={() => onDeleteOpenChange(false)}
+          onCancel={cancelDelete}
+          onClose={cancelDelete}
           onConfirm={onDeleteConfirm}
         />
       ) : null}
@@ -114,8 +113,10 @@ export function SentryInstanceCard({
           confirmAriaLabel={confirmationTitle}
           confirmTestId="sentry-remove-confirm"
           testId="sentry-remove-confirm-popover"
-          onOpenChange={onDeleteOpenChange}
-          onCancel={onDeleteCancel}
+          onOpenChange={(open) => {
+            if (!open) cancelDelete();
+          }}
+          onCancel={cancelDelete}
           onConfirm={onDeleteConfirm}
         />
       ) : null}

--- a/apps/web/components/sentry/sentry-settings.test.tsx
+++ b/apps/web/components/sentry/sentry-settings.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
-import { listSentryInstances } from "@/lib/api/domains/sentry-api";
+import { deleteSentryInstance, listSentryInstances } from "@/lib/api/domains/sentry-api";
 import type { SentryConfig } from "@/lib/types/sentry";
 import { SettingsSaveProvider } from "@/components/settings/settings-save-provider";
 
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   ],
 }));
 
+let finePointer = true;
+
 vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }));
@@ -26,6 +28,10 @@ vi.mock("@/hooks/domains/sentry/use-sentry-enabled", () => ({
 
 vi.mock("@/hooks/domains/integrations/use-integration-availability", () => ({
   INTEGRATION_STATUS_REFRESH_MS: 1,
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: finePointer }),
 }));
 
 vi.mock("@kandev/ui/switch", () => ({
@@ -91,12 +97,14 @@ const instance: SentryConfig = {
 beforeEach(() => {
   vi.useFakeTimers();
   mocks.activeWorkspaceId = "ws-active";
+  finePointer = true;
 });
 
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("SentryConnectionSection", () => {
@@ -142,6 +150,78 @@ describe("SentryConnectionSection", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses local fine-pointer confirmation and deletes one instance after confirmation", async () => {
+    const nativeConfirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", nativeConfirm);
+    vi.mocked(listSentryInstances).mockResolvedValueOnce([instance]).mockResolvedValueOnce([]);
+    vi.mocked(deleteSentryInstance).mockResolvedValue({ deleted: true });
+
+    render(
+      <SettingsHarness>
+        <SentryConnectionSection workspaceId="workspace-1" />
+      </SettingsHarness>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const deleteButton = screen.getByTestId("sentry-instance-delete-button");
+    fireEvent.click(deleteButton);
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    const popover = screen.getByTestId("sentry-remove-confirm-popover");
+    expect(deleteSentryInstance).not.toHaveBeenCalled();
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+    expect(deleteSentryInstance).not.toHaveBeenCalled();
+
+    fireEvent.click(deleteButton);
+    fireEvent.click(
+      within(screen.getByTestId("sentry-remove-confirm-popover")).getByTestId(
+        "sentry-remove-confirm",
+      ),
+    );
+    await act(async () => {
+      vi.runAllTicks();
+      await Promise.resolve();
+    });
+    expect(deleteSentryInstance).toHaveBeenCalledTimes(1);
+    expect(deleteSentryInstance).toHaveBeenCalledWith("workspace-1", "instance-1");
+  });
+
+  it("uses touch-sized inline confirmation on coarse pointers", async () => {
+    finePointer = false;
+    vi.mocked(listSentryInstances).mockResolvedValue([instance]);
+    vi.mocked(deleteSentryInstance).mockResolvedValue({ deleted: true });
+
+    render(
+      <SettingsHarness>
+        <SentryConnectionSection workspaceId="workspace-1" />
+      </SettingsHarness>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const deleteButton = screen.getByTestId("sentry-instance-delete-button");
+    fireEvent.click(deleteButton);
+    const inline = screen.getByTestId("sentry-remove-inline-confirmation");
+    expect(screen.queryByTestId("sentry-remove-confirm-popover")).toBeNull();
+    expect(within(inline).getByTestId("sentry-remove-confirm").className).toContain("h-11");
+    fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
+    expect(deleteSentryInstance).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("sentry-instance-delete-button"));
+    fireEvent.click(
+      within(screen.getByTestId("sentry-remove-inline-confirmation")).getByTestId(
+        "sentry-remove-confirm",
+      ),
+    );
+    await act(async () => {
+      vi.runAllTicks();
+      await Promise.resolve();
+    });
+    expect(deleteSentryInstance).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/components/sentry/sentry-settings.test.tsx
+++ b/apps/web/components/sentry/sentry-settings.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 let finePointer = true;
+const DELETE_BUTTON_TEST_ID = "sentry-instance-delete-button";
+const CONFIRM_POPOVER_TEST_ID = "sentry-remove-confirm-popover";
 
 vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
@@ -130,7 +132,66 @@ describe("SentryConnectionSection", () => {
 
     expect(screen.getByRole("button", { name: "Add instance" })).toBeTruthy();
   });
+});
 
+describe("SentryConnectionSection stale delete confirmation", () => {
+  it("clears delete confirmation when polling removes and later restores the instance", async () => {
+    vi.mocked(listSentryInstances)
+      .mockResolvedValueOnce([instance])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([instance]);
+
+    render(
+      <SettingsHarness>
+        <SentryConnectionSection workspaceId="workspace-1" />
+      </SettingsHarness>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.queryByTestId("sentry-instance-card")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.getByTestId("sentry-instance-card")).toBeTruthy();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(deleteSentryInstance).not.toHaveBeenCalled();
+  });
+
+  it("clears delete confirmation before editing the same instance", async () => {
+    vi.mocked(listSentryInstances).mockResolvedValue([instance]);
+
+    render(
+      <SettingsHarness>
+        <SentryConnectionSection workspaceId="workspace-1" />
+      </SettingsHarness>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
+    expect(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("sentry-instance-edit-button"));
+    const form = screen.getByTestId("sentry-edit-form");
+    fireEvent.click(within(form).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByTestId("sentry-instance-card")).toBeTruthy();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
+    expect(deleteSentryInstance).not.toHaveBeenCalled();
+  });
+});
+
+describe("SentryConnectionSection loading and removal", () => {
   it("keeps initial load failures visible but silences recurring poll failures", async () => {
     vi.mocked(listSentryInstances).mockRejectedValue(new Error("offline"));
 
@@ -167,19 +228,17 @@ describe("SentryConnectionSection", () => {
       await Promise.resolve();
     });
 
-    const deleteButton = screen.getByTestId("sentry-instance-delete-button");
+    const deleteButton = screen.getByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(deleteButton);
     expect(nativeConfirm).not.toHaveBeenCalled();
-    const popover = screen.getByTestId("sentry-remove-confirm-popover");
+    const popover = screen.getByTestId(CONFIRM_POPOVER_TEST_ID);
     expect(deleteSentryInstance).not.toHaveBeenCalled();
     fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
     expect(deleteSentryInstance).not.toHaveBeenCalled();
 
     fireEvent.click(deleteButton);
     fireEvent.click(
-      within(screen.getByTestId("sentry-remove-confirm-popover")).getByTestId(
-        "sentry-remove-confirm",
-      ),
+      within(screen.getByTestId(CONFIRM_POPOVER_TEST_ID)).getByTestId("sentry-remove-confirm"),
     );
     await act(async () => {
       vi.runAllTicks();
@@ -203,15 +262,15 @@ describe("SentryConnectionSection", () => {
       await Promise.resolve();
     });
 
-    const deleteButton = screen.getByTestId("sentry-instance-delete-button");
+    const deleteButton = screen.getByTestId(DELETE_BUTTON_TEST_ID);
     fireEvent.click(deleteButton);
     const inline = screen.getByTestId("sentry-remove-inline-confirmation");
-    expect(screen.queryByTestId("sentry-remove-confirm-popover")).toBeNull();
+    expect(screen.queryByTestId(CONFIRM_POPOVER_TEST_ID)).toBeNull();
     expect(within(inline).getByTestId("sentry-remove-confirm").className).toContain("h-11");
     fireEvent.click(within(inline).getByRole("button", { name: "Cancel" }));
     expect(deleteSentryInstance).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId("sentry-instance-delete-button"));
+    fireEvent.click(screen.getByTestId(DELETE_BUTTON_TEST_ID));
     fireEvent.click(
       within(screen.getByTestId("sentry-remove-inline-confirmation")).getByTestId(
         "sentry-remove-confirm",

--- a/apps/web/components/sentry/sentry-settings.tsx
+++ b/apps/web/components/sentry/sentry-settings.tsx
@@ -79,8 +79,7 @@ type InstanceListProps = {
   confirmingDeleteId: string | null;
   onEdit: (id: string) => void;
   onDelete: (instance: SentryConfig) => void;
-  onDeleteCancel: () => void;
-  onDeleteOpenChange: (open: boolean) => void;
+  onDeleteCancel: (instanceId: string) => void;
   onDeleteConfirm: () => void;
   onSaved: () => void;
   onCancel: () => void;
@@ -96,7 +95,6 @@ function InstanceList({
   onEdit,
   onDelete,
   onDeleteCancel,
-  onDeleteOpenChange,
   onDeleteConfirm,
   onSaved,
   onCancel,
@@ -132,7 +130,6 @@ function InstanceList({
             isFinePointer={isFinePointer}
             confirmingDelete={confirmingDeleteId === instance.id}
             onDeleteCancel={onDeleteCancel}
-            onDeleteOpenChange={onDeleteOpenChange}
             onDeleteConfirm={onDeleteConfirm}
           />
         ),
@@ -194,13 +191,18 @@ function useSentryDeleteConfirmation(
   const cancelDelete = useCallback(() => {
     setConfirmingDeleteId(null);
   }, []);
+  const cancelDeleteFor = useCallback((instanceId: string) => {
+    // Popover close events can arrive after another card opens its confirmation.
+    // A stale close must not disarm that newer, instance-scoped action.
+    setConfirmingDeleteId((currentId) => (currentId === instanceId ? null : currentId));
+  }, []);
   const confirmDelete = useCallback(() => {
     const instance = instances.find((item) => item.id === confirmingDeleteId);
     setConfirmingDeleteId(null);
     if (instance) void handleDelete(instance);
   }, [confirmingDeleteId, handleDelete, instances]);
 
-  return { confirmingDeleteId, startDelete, cancelDelete, confirmDelete };
+  return { confirmingDeleteId, startDelete, cancelDelete, cancelDeleteFor, confirmDelete };
 }
 
 /** Sentry connection card: title/enable toggle plus the list of configured Sentry instances. */
@@ -222,7 +224,7 @@ export function SentryConnectionSection({ workspaceId }: { workspaceId: string }
   }, [reload]);
 
   const handleDelete = useDeleteInstance(workspaceId, reload);
-  const { confirmingDeleteId, startDelete, cancelDelete, confirmDelete } =
+  const { confirmingDeleteId, startDelete, cancelDelete, cancelDeleteFor, confirmDelete } =
     useSentryDeleteConfirmation(instances, handleDelete);
 
   const canAddInstance =
@@ -262,10 +264,7 @@ export function SentryConnectionSection({ workspaceId }: { workspaceId: string }
                 setMode({ kind: "edit", id });
               }}
               onDelete={startDelete}
-              onDeleteCancel={cancelDelete}
-              onDeleteOpenChange={(open) => {
-                if (!open) cancelDelete();
-              }}
+              onDeleteCancel={cancelDeleteFor}
               onDeleteConfirm={confirmDelete}
               onSaved={handleSaved}
               onCancel={closeForm}

--- a/apps/web/components/sentry/sentry-settings.tsx
+++ b/apps/web/components/sentry/sentry-settings.tsx
@@ -10,6 +10,7 @@ import { SettingsCard } from "@/components/settings/settings-card";
 import { SentryEnabledControl } from "@/components/sentry/sentry-enabled-control";
 import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import {
   deleteSentryInstance,
   listSentryInstances,
@@ -74,8 +75,13 @@ type InstanceListProps = {
   instances: SentryConfig[];
   mode: EditMode;
   workspaceId: string;
+  isFinePointer: boolean;
+  confirmingDeleteId: string | null;
   onEdit: (id: string) => void;
   onDelete: (instance: SentryConfig) => void;
+  onDeleteCancel: () => void;
+  onDeleteOpenChange: (open: boolean) => void;
+  onDeleteConfirm: () => void;
   onSaved: () => void;
   onCancel: () => void;
   onDirtyChange: (isDirty: boolean) => void;
@@ -85,8 +91,13 @@ function InstanceList({
   instances,
   mode,
   workspaceId,
+  isFinePointer,
+  confirmingDeleteId,
   onEdit,
   onDelete,
+  onDeleteCancel,
+  onDeleteOpenChange,
+  onDeleteConfirm,
   onSaved,
   onCancel,
   onDirtyChange,
@@ -118,6 +129,11 @@ function InstanceList({
             instance={instance}
             onEdit={() => onEdit(instance.id)}
             onDelete={() => onDelete(instance)}
+            isFinePointer={isFinePointer}
+            confirmingDelete={confirmingDeleteId === instance.id}
+            onDeleteCancel={onDeleteCancel}
+            onDeleteOpenChange={onDeleteOpenChange}
+            onDeleteConfirm={onDeleteConfirm}
           />
         ),
       )}
@@ -133,7 +149,6 @@ function useDeleteInstance(workspaceId: string, reload: () => Promise<void>) {
   const { toast } = useToast();
   return useCallback(
     async (instance: SentryConfig) => {
-      if (!confirm(t("sentry:removeInstanceConfirm", { name: instance.name }))) return;
       try {
         await deleteSentryInstance(workspaceId, instance.id);
         toast({ description: t("sentry:instanceRemoved"), variant: "success" });
@@ -160,9 +175,38 @@ function useDeleteInstance(workspaceId: string, reload: () => Promise<void>) {
   );
 }
 
+function useSentryDeleteConfirmation(
+  instances: SentryConfig[],
+  handleDelete: (instance: SentryConfig) => Promise<void>,
+) {
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!confirmingDeleteId || instances.some((instance) => instance.id === confirmingDeleteId)) {
+      return;
+    }
+    setConfirmingDeleteId(null);
+  }, [confirmingDeleteId, instances]);
+
+  const startDelete = useCallback((instance: SentryConfig) => {
+    setConfirmingDeleteId(instance.id);
+  }, []);
+  const cancelDelete = useCallback(() => {
+    setConfirmingDeleteId(null);
+  }, []);
+  const confirmDelete = useCallback(() => {
+    const instance = instances.find((item) => item.id === confirmingDeleteId);
+    setConfirmingDeleteId(null);
+    if (instance) void handleDelete(instance);
+  }, [confirmingDeleteId, handleDelete, instances]);
+
+  return { confirmingDeleteId, startDelete, cancelDelete, confirmDelete };
+}
+
 /** Sentry connection card: title/enable toggle plus the list of configured Sentry instances. */
 export function SentryConnectionSection({ workspaceId }: { workspaceId: string }) {
   const { t } = useTranslation();
+  const { isFinePointer } = useResponsiveBreakpoint();
   const { instances, loading, reload } = useInstanceList(workspaceId);
   const [mode, setMode] = useState<EditMode>({ kind: "none" });
   const [formDirty, setFormDirty] = useState(false);
@@ -178,6 +222,8 @@ export function SentryConnectionSection({ workspaceId }: { workspaceId: string }
   }, [reload]);
 
   const handleDelete = useDeleteInstance(workspaceId, reload);
+  const { confirmingDeleteId, startDelete, cancelDelete, confirmDelete } =
+    useSentryDeleteConfirmation(instances, handleDelete);
 
   const canAddInstance =
     mode.kind === "none" ||
@@ -208,11 +254,16 @@ export function SentryConnectionSection({ workspaceId }: { workspaceId: string }
               instances={instances}
               mode={mode}
               workspaceId={workspaceId}
+              isFinePointer={isFinePointer}
+              confirmingDeleteId={confirmingDeleteId}
               onEdit={(id) => {
                 setFormDirty(false);
                 setMode({ kind: "edit", id });
               }}
-              onDelete={handleDelete}
+              onDelete={startDelete}
+              onDeleteCancel={cancelDelete}
+              onDeleteOpenChange={cancelDelete}
+              onDeleteConfirm={confirmDelete}
               onSaved={handleSaved}
               onCancel={closeForm}
               onDirtyChange={setFormDirty}

--- a/apps/web/components/sentry/sentry-settings.tsx
+++ b/apps/web/components/sentry/sentry-settings.tsx
@@ -257,12 +257,15 @@ export function SentryConnectionSection({ workspaceId }: { workspaceId: string }
               isFinePointer={isFinePointer}
               confirmingDeleteId={confirmingDeleteId}
               onEdit={(id) => {
+                cancelDelete();
                 setFormDirty(false);
                 setMode({ kind: "edit", id });
               }}
               onDelete={startDelete}
               onDeleteCancel={cancelDelete}
-              onDeleteOpenChange={cancelDelete}
+              onDeleteOpenChange={(open) => {
+                if (!open) cancelDelete();
+              }}
               onDeleteConfirm={confirmDelete}
               onSaved={handleSaved}
               onCancel={closeForm}

--- a/apps/web/e2e/tests/integrations/integration-remove-confirmations.spec.ts
+++ b/apps/web/e2e/tests/integrations/integration-remove-confirmations.spec.ts
@@ -1,0 +1,132 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test-base";
+import { SentrySettingsPage } from "../../pages/sentry-settings-page";
+
+function guardAgainstNativeDialogs(testPage: Page) {
+  let seen = false;
+  testPage.on("dialog", async (dialog) => {
+    seen = true;
+    await dialog.dismiss();
+  });
+  return () => seen;
+}
+
+test.describe("integration configuration removal confirmations", () => {
+  test("Azure DevOps removal stays local and confirms once", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setAzureDevOpsConfig(seedData.workspaceId, {
+      organizationUrl: "https://dev.azure.com/acme",
+      pat: "azure-test-pat",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/azure-devops`,
+    );
+
+    const removeButton = testPage.getByTestId("azure-devops-delete-button");
+    await expect(removeButton).toBeVisible();
+    await removeButton.click();
+    const popover = testPage.getByTestId("azure-devops-remove-confirm-popover");
+    await expect(popover).toContainText("Azure DevOps");
+    await popover.getByRole("button", { name: "Cancel" }).click();
+    await expect(popover).toHaveCount(0);
+    await expect(removeButton).toBeVisible();
+
+    await removeButton.click();
+    await testPage.getByTestId("azure-devops-remove-confirm").click();
+    await expect(removeButton).toHaveCount(0);
+    await expect(testPage.getByTestId("azure-devops-organization")).toHaveValue("");
+    expect(sawNativeDialog()).toBe(false);
+  });
+
+  test("Jira removal stays local and confirms once", async ({ testPage, apiClient, seedData }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setJiraConfig({
+      workspaceId: seedData.workspaceId,
+      siteUrl: "https://acme.atlassian.net",
+      email: "alice@example.com",
+      secret: "jira-test-token",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/jira`,
+    );
+
+    const removeButton = testPage.getByTestId("jira-delete-button");
+    await expect(removeButton).toBeVisible();
+    await removeButton.click();
+    const popover = testPage.getByTestId("jira-remove-confirm-popover");
+    await expect(popover).toContainText("Jira");
+    await popover.getByRole("button", { name: "Cancel" }).click();
+    await expect(popover).toHaveCount(0);
+    await expect(removeButton).toBeVisible();
+
+    await removeButton.click();
+    await testPage.getByTestId("jira-remove-confirm").click();
+    await expect(removeButton).toHaveCount(0);
+    await expect(testPage.getByTestId("jira-site-input")).toHaveValue("");
+    expect(sawNativeDialog()).toBe(false);
+  });
+
+  test("Linear removal stays local and confirms once", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setLinearConfig({
+      workspaceId: seedData.workspaceId,
+      secret: "lin_api_test",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/linear`,
+    );
+
+    const removeButton = testPage.getByTestId("linear-delete-button");
+    await expect(removeButton).toBeVisible();
+    await removeButton.click();
+    const popover = testPage.getByTestId("linear-remove-confirm-popover");
+    await expect(popover).toContainText("Linear");
+    await popover.getByRole("button", { name: "Cancel" }).click();
+    await expect(popover).toHaveCount(0);
+    await expect(removeButton).toBeVisible();
+
+    await removeButton.click();
+    await testPage.getByTestId("linear-remove-confirm").click();
+    await expect(removeButton).toHaveCount(0);
+    await expect(testPage.getByTestId("linear-secret-input")).toHaveValue("");
+    expect(sawNativeDialog()).toBe(false);
+  });
+
+  test("Sentry removal identifies the instance and confirms once", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.mockSentryReset();
+    await apiClient.createSentryInstance({
+      workspaceId: seedData.workspaceId,
+      name: "Production Sentry",
+      secret: "sntrys_test",
+    });
+    const settings = new SentrySettingsPage(testPage);
+    await settings.goto(seedData.workspaceId);
+
+    const card = settings.cardByName("Production Sentry");
+    const removeButton = card.getByTestId("sentry-instance-delete-button");
+    await removeButton.click();
+    const popover = testPage.getByTestId("sentry-remove-confirm-popover");
+    await expect(popover).toContainText("Production Sentry");
+    await popover.getByRole("button", { name: "Cancel" }).click();
+    await expect(popover).toHaveCount(0);
+    await expect(removeButton).toBeVisible();
+
+    await removeButton.click();
+    await testPage.getByTestId("sentry-remove-confirm").click();
+    await expect(settings.cardByName("Production Sentry")).toHaveCount(0);
+    expect(sawNativeDialog()).toBe(false);
+  });
+});

--- a/apps/web/e2e/tests/integrations/jira-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/jira-settings.spec.ts
@@ -125,9 +125,8 @@ test.describe("Jira settings", () => {
     await settings.saveButton.click();
     await expect(settings.deleteButton).toBeVisible();
 
-    // confirm() is a native dialog — auto-accept so the click proceeds.
-    testPage.once("dialog", (d) => void d.accept());
     await settings.deleteButton.click();
+    await testPage.getByTestId("jira-remove-confirm").click();
     await expect(settings.deleteButton).toHaveCount(0);
     await expect(settings.siteInput).toHaveValue("");
     await expect(settings.secretInput).toHaveValue("");

--- a/apps/web/e2e/tests/integrations/linear-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/linear-settings.spec.ts
@@ -199,8 +199,8 @@ test.describe("Linear settings", () => {
     await settings.saveButton.click();
     await expect(settings.deleteButton).toBeVisible();
 
-    testPage.once("dialog", (d) => void d.accept());
     await settings.deleteButton.click();
+    await testPage.getByTestId("linear-remove-confirm").click();
     await expect(settings.deleteButton).toHaveCount(0);
     await expect(settings.secretInput).toHaveValue("");
     await expect(settings.statusBanner).toHaveCount(0);

--- a/apps/web/e2e/tests/integrations/mobile-integration-remove-confirmations.spec.ts
+++ b/apps/web/e2e/tests/integrations/mobile-integration-remove-confirmations.spec.ts
@@ -1,0 +1,131 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test-base";
+import { SentrySettingsPage } from "../../pages/sentry-settings-page";
+
+function guardAgainstNativeDialogs(testPage: Page) {
+  let seen = false;
+  testPage.on("dialog", async (dialog) => {
+    seen = true;
+    await dialog.dismiss();
+  });
+  return () => seen;
+}
+
+async function expectTouchSized(locator: Locator) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThanOrEqual(44);
+}
+
+async function expectNoHorizontalOverflow(testPage: Page) {
+  await expect
+    .poll(() => testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+    .toBe(true);
+}
+
+test.describe("integration configuration removal confirmations on mobile", () => {
+  test("Azure DevOps uses inline touch confirmation", async ({ testPage, apiClient, seedData }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setAzureDevOpsConfig(seedData.workspaceId, {
+      organizationUrl: "https://dev.azure.com/acme",
+      pat: "azure-mobile-pat",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/azure-devops`,
+    );
+
+    const removeButton = testPage.getByTestId("azure-devops-delete-button");
+    await removeButton.tap();
+    const inline = testPage.getByTestId("azure-devops-remove-inline-confirmation");
+    await expect(inline).toBeVisible();
+    await expectTouchSized(inline.getByTestId("azure-devops-remove-confirm"));
+    await inline.getByRole("button", { name: "Cancel" }).tap();
+    await expect(removeButton).toBeVisible();
+    await removeButton.tap();
+    await inline.getByTestId("azure-devops-remove-confirm").tap();
+    await expect(removeButton).toHaveCount(0);
+    expect(sawNativeDialog()).toBe(false);
+    await expectNoHorizontalOverflow(testPage);
+  });
+
+  test("Jira uses inline touch confirmation", async ({ testPage, apiClient, seedData }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setJiraConfig({
+      workspaceId: seedData.workspaceId,
+      siteUrl: "https://acme.atlassian.net",
+      email: "alice@example.com",
+      secret: "jira-mobile-token",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/jira`,
+    );
+
+    const removeButton = testPage.getByTestId("jira-delete-button");
+    await removeButton.tap();
+    const inline = testPage.getByTestId("jira-remove-inline-confirmation");
+    await expect(inline).toBeVisible();
+    await expectTouchSized(inline.getByTestId("jira-remove-confirm"));
+    await inline.getByRole("button", { name: "Cancel" }).tap();
+    await expect(removeButton).toBeVisible();
+    await removeButton.tap();
+    await inline.getByTestId("jira-remove-confirm").tap();
+    await expect(removeButton).toHaveCount(0);
+    expect(sawNativeDialog()).toBe(false);
+    await expectNoHorizontalOverflow(testPage);
+  });
+
+  test("Linear uses inline touch confirmation", async ({ testPage, apiClient, seedData }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.setLinearConfig({
+      workspaceId: seedData.workspaceId,
+      secret: "lin_api_mobile",
+    });
+    await testPage.goto(
+      `/settings/workspaces/${encodeURIComponent(seedData.workspaceId)}/integrations/linear`,
+    );
+
+    const removeButton = testPage.getByTestId("linear-delete-button");
+    await removeButton.tap();
+    const inline = testPage.getByTestId("linear-remove-inline-confirmation");
+    await expect(inline).toBeVisible();
+    await expectTouchSized(inline.getByTestId("linear-remove-confirm"));
+    await inline.getByRole("button", { name: "Cancel" }).tap();
+    await expect(removeButton).toBeVisible();
+    await removeButton.tap();
+    await inline.getByTestId("linear-remove-confirm").tap();
+    await expect(removeButton).toHaveCount(0);
+    expect(sawNativeDialog()).toBe(false);
+    await expectNoHorizontalOverflow(testPage);
+  });
+
+  test("Sentry uses an inline confirmation identified by instance", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sawNativeDialog = guardAgainstNativeDialogs(testPage);
+    await apiClient.mockSentryReset();
+    await apiClient.createSentryInstance({
+      workspaceId: seedData.workspaceId,
+      name: "Mobile Sentry",
+      secret: "sntrys_mobile",
+    });
+    const settings = new SentrySettingsPage(testPage);
+    await settings.goto(seedData.workspaceId);
+
+    const card = settings.cardByName("Mobile Sentry");
+    const removeButton = card.getByTestId("sentry-instance-delete-button");
+    await removeButton.tap();
+    const inline = testPage.getByTestId("sentry-remove-inline-confirmation");
+    await expect(inline).toBeVisible();
+    await expect(inline).toContainText("Mobile Sentry");
+    await expectTouchSized(inline.getByTestId("sentry-remove-confirm"));
+    await inline.getByRole("button", { name: "Cancel" }).tap();
+    await expect(removeButton).toBeVisible();
+    await removeButton.tap();
+    await inline.getByTestId("sentry-remove-confirm").tap();
+    await expect(settings.cardByName("Mobile Sentry")).toHaveCount(0);
+    expect(sawNativeDialog()).toBe(false);
+    await expectNoHorizontalOverflow(testPage);
+  });
+});

--- a/apps/web/e2e/tests/integrations/mobile-integration-remove-confirmations.spec.ts
+++ b/apps/web/e2e/tests/integrations/mobile-integration-remove-confirmations.spec.ts
@@ -116,7 +116,7 @@ test.describe("integration configuration removal confirmations on mobile", () =>
     const card = settings.cardByName("Mobile Sentry");
     const removeButton = card.getByTestId("sentry-instance-delete-button");
     await removeButton.tap();
-    const inline = testPage.getByTestId("sentry-remove-inline-confirmation");
+    const inline = card.getByTestId("sentry-remove-inline-confirmation");
     await expect(inline).toBeVisible();
     await expect(inline).toContainText("Mobile Sentry");
     await expectTouchSized(inline.getByTestId("sentry-remove-confirm"));

--- a/apps/web/e2e/tests/integrations/sentry-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/sentry-settings.spec.ts
@@ -114,12 +114,12 @@ test.describe("Sentry settings — instances", () => {
     await expect(settings.cards).toHaveCount(2);
 
     await settings.cardByName("Primary").getByTestId("sentry-instance-delete-button").click();
-    await testPage.getByTestId("sentry-remove-confirm").click();
+    await testPage.getByRole("button", { name: 'Remove Sentry instance "Primary"?' }).click();
     await expect(testPage.getByText(/still bound to it/i)).toBeVisible();
     await expect(settings.cardByName("Primary")).toBeVisible();
 
     await settings.cardByName("Secondary").getByTestId("sentry-instance-delete-button").click();
-    await testPage.getByTestId("sentry-remove-confirm").click();
+    await testPage.getByRole("button", { name: 'Remove Sentry instance "Secondary"?' }).click();
     await expect(settings.cardByName("Secondary")).toHaveCount(0);
     await expect(settings.cardByName("Primary")).toBeVisible();
   });

--- a/apps/web/e2e/tests/integrations/sentry-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/sentry-settings.spec.ts
@@ -112,13 +112,14 @@ test.describe("Sentry settings — instances", () => {
     const settings = new SentrySettingsPage(testPage);
     await settings.goto(seedData.workspaceId);
     await expect(settings.cards).toHaveCount(2);
-    testPage.on("dialog", (d) => d.accept());
 
     await settings.cardByName("Primary").getByTestId("sentry-instance-delete-button").click();
+    await testPage.getByTestId("sentry-remove-confirm").click();
     await expect(testPage.getByText(/still bound to it/i)).toBeVisible();
     await expect(settings.cardByName("Primary")).toBeVisible();
 
     await settings.cardByName("Secondary").getByTestId("sentry-instance-delete-button").click();
+    await testPage.getByTestId("sentry-remove-confirm").click();
     await expect(settings.cardByName("Secondary")).toHaveCount(0);
     await expect(settings.cardByName("Primary")).toBeVisible();
   });


### PR DESCRIPTION
## Summary

- Replace browser confirmations for Azure DevOps, Jira, Linear, and Sentry configuration removal with shared localized confirmation surfaces.
- Keep fine-pointer anchored confirmations and coarse-pointer inline touch actions, including Sentry instance identification.
- Add focused unit, desktop, and mobile coverage for cancellation, confirmation, native-dialog absence, and touch usability.

## Validation

- Targeted provider unit suite: 4 files, 17 tests passed.
- Sentry instance-card test: 1 test passed.
- `pnpm run typecheck`
- `pnpm run i18n:check`
- `pnpm run i18n:ratchet`
- Desktop integration-removal E2E: 4 passed.
- Mobile integration-removal E2E: 4 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->