### PR TITLE
feat(ui): localize session delete confirmations

### DIFF
--- a/apps/web/components/task/mobile/mobile-sessions-section.test.tsx
+++ b/apps/web/components/task/mobile/mobile-sessions-section.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/hooks/domains/session/use-session-actions", () => ({
 
 const PILL_TESTID = "mobile-sessions-pill";
 const ICON_CIRCLE_CHECK = "tabler-icon-circle-check";
+const SESSION_ACTIONS_LABEL = "Session actions";
 const SESSION_A = "session-a";
 const SESSION_BG = "session-bg";
 const TASK_ID = "task-1";
@@ -357,7 +358,7 @@ describe("MobileSessionsPicker session delete confirmation", () => {
 
     // Open the picker sheet, then the session's actions menu.
     fireEvent.click(screen.getByTestId(PILL_TESTID));
-    const dotsButton = screen.getByRole("button", { name: "Session actions" });
+    const dotsButton = screen.getByRole("button", { name: SESSION_ACTIONS_LABEL });
     fireEvent.pointerDown(dotsButton);
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
 
@@ -376,7 +377,7 @@ describe("MobileSessionsPicker session delete confirmation", () => {
     render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
 
     fireEvent.click(screen.getByTestId(PILL_TESTID));
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: SESSION_ACTIONS_LABEL }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -385,12 +386,38 @@ describe("MobileSessionsPicker session delete confirmation", () => {
     expect(screen.queryByRole("group", { name: /delete session/i })).toBeNull();
   });
 
+  it("resets pending confirmation when the picker closes externally", async () => {
+    mocks.sessions = [session(SESSION_A, "profile-a", START_TIME, { state: "COMPLETED" })];
+    render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
+
+    fireEvent.click(screen.getByTestId(PILL_TESTID));
+    fireEvent.pointerDown(screen.getByRole("button", { name: SESSION_ACTIONS_LABEL }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(screen.getByRole("group", { name: /delete session/i })).toBeTruthy();
+    const picker = screen.getByRole("dialog", { name: "Sessions" });
+    expect(picker.getAttribute("data-state")).toBe("open");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await vi.waitFor(() => {
+      expect(picker.getAttribute("data-state")).toBe("closed");
+    });
+    expect(mocks.removeSession).not.toHaveBeenCalled();
+    expect(screen.queryByRole("group", { name: /delete session/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId(PILL_TESTID));
+    expect(screen.getByRole("dialog", { name: "Sessions" }).getAttribute("data-state")).toBe(
+      "open",
+    );
+    expect(screen.queryByRole("group", { name: /delete session/i })).toBeNull();
+  });
+
   it("dispatches deletion once after local confirmation", async () => {
     mocks.sessions = [session(SESSION_A, "profile-a", START_TIME, { state: "COMPLETED" })];
     render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
 
     fireEvent.click(screen.getByTestId(PILL_TESTID));
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: SESSION_ACTIONS_LABEL }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     fireEvent.click(screen.getByTestId("mobile-session-delete-confirm"));
 

--- a/apps/web/components/task/mobile/mobile-sessions-section.test.tsx
+++ b/apps/web/components/task/mobile/mobile-sessions-section.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   messagesBySession: {} as Record<string, unknown[]>,
   turnsBySession: {} as Record<string, unknown[]>,
   setActiveSession: vi.fn(),
+  removeSession: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-task-sessions", () => ({
@@ -44,7 +45,7 @@ vi.mock("@/hooks/domains/session/use-session-actions", () => ({
     setPrimary: vi.fn(),
     stop: vi.fn(),
     resume: vi.fn(),
-    remove: vi.fn(),
+    remove: mocks.removeSession,
   }),
   isSessionStoppable: () => false,
   isSessionDeletable: () => true,
@@ -125,6 +126,7 @@ beforeEach(() => {
   mocks.messagesBySession = {};
   mocks.turnsBySession = {};
   mocks.setActiveSession.mockReset();
+  mocks.removeSession.mockReset();
 });
 
 describe("MobileSessionsPicker selection", () => {
@@ -349,7 +351,7 @@ describe("MobileSessionsPicker pending lifecycle", () => {
 });
 
 describe("MobileSessionsPicker session delete confirmation", () => {
-  it("states conversation deletion and workspace retention from the actions sheet", () => {
+  it("morphs the target row into local touch-sized confirmation actions", () => {
     mocks.sessions = [session(SESSION_A, "profile-a", START_TIME, { state: "COMPLETED" })];
     render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
 
@@ -359,14 +361,39 @@ describe("MobileSessionsPicker session delete confirmation", () => {
     fireEvent.pointerDown(dotsButton);
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
 
-    const dialog = screen.getByRole("alertdialog");
-    expect(within(dialog).getByText(/permanently delete the conversation history/i)).toBeTruthy();
-    expect(
-      within(dialog).getAllByText(/task workspace and its files are kept/i).length,
-    ).toBeGreaterThan(0);
-    expect(within(dialog).getByText(/only session for this task/i)).toBeTruthy();
-    // No uncommitted/unpushed warning belongs on session deletion.
-    expect(within(dialog).queryByText(/uncommitted/i)).toBeNull();
-    expect(within(dialog).queryByText(/unpushed/i)).toBeNull();
+    const confirmation = screen.getByRole("group", { name: /delete session/i });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(confirmation.textContent).toContain("permanently delete the conversation history");
+    expect(confirmation.textContent).toContain("task workspace and its files are kept");
+    expect(confirmation.textContent).toContain("only session for this task");
+    const confirm = within(confirmation).getByTestId("mobile-session-delete-confirm");
+    expect(confirm.className).toContain("h-11");
+    expect(confirm.className).toContain("min-w-11");
+  });
+
+  it("cancels locally without deleting the session", () => {
+    mocks.sessions = [session(SESSION_A, "profile-a", START_TIME, { state: "COMPLETED" })];
+    render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
+
+    fireEvent.click(screen.getByTestId(PILL_TESTID));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.removeSession).not.toHaveBeenCalled();
+    expect(screen.getByTestId(`mobile-session-row-${SESSION_A}`)).toBeTruthy();
+    expect(screen.queryByRole("group", { name: /delete session/i })).toBeNull();
+  });
+
+  it("dispatches deletion once after local confirmation", async () => {
+    mocks.sessions = [session(SESSION_A, "profile-a", START_TIME, { state: "COMPLETED" })];
+    render(<MobileSessionsPicker taskId={TASK_ID} sessionId={SESSION_A} fullWidth />);
+
+    fireEvent.click(screen.getByTestId(PILL_TESTID));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    fireEvent.click(screen.getByTestId("mobile-session-delete-confirm"));
+
+    await vi.waitFor(() => expect(mocks.removeSession).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/web/components/task/mobile/mobile-sessions-section.tsx
+++ b/apps/web/components/task/mobile/mobile-sessions-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { IconDotsVertical, IconPlus, IconStar } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import {
@@ -10,17 +10,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@kandev/ui/dropdown-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@kandev/ui/alert-dialog";
 import { AgentLogo } from "@/components/agent-logo";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
 import { useAppStore } from "@/components/state-provider";
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import {
@@ -41,6 +32,7 @@ import type { ForegroundActivity, TaskSession, TaskSessionState } from "@/lib/ty
 import type { AgentProfileOption } from "@/lib/state/slices";
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
+import { SessionDeleteDescription } from "../session-tab-menu";
 
 type SessionRow = {
   id: string;
@@ -212,51 +204,36 @@ function SessionActionsMenu({
   );
 }
 
-function DeleteSessionConfirmDialog({
-  open,
-  onOpenChange,
+function SessionDeleteInlineConfirmation({
   isPrimary,
   isOnlySession,
+  targetName,
+  onCancel,
+  onClose,
   onConfirm,
 }: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
   isPrimary: boolean;
   isOnlySession: boolean;
-  onConfirm: () => void;
+  targetName: string;
+  onCancel: () => void;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t("task:deleteSession")}</AlertDialogTitle>
-          <AlertDialogDescription asChild>
-            <div>
-              <p>{t("task:thisWillPermanentlyDeleteTheConversation")}</p>
-              {isPrimary && !isOnlySession && (
-                <p className="mt-2 font-medium">{t("task:thisIsThePrimarySessionAnother")}</p>
-              )}
-              {isOnlySession && (
-                <p className="mt-2 font-medium">{t("task:thisIsTheOnlySessionFor")}</p>
-              )}
-            </div>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel className="cursor-pointer">{t("common:cancel")}</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={() => {
-              onOpenChange(false);
-              onConfirm();
-            }}
-            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            {t("task:delete")}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <InlineConfirmActions
+      density="touch"
+      testId="mobile-session-delete-confirmation"
+      ariaLabel={t("task:deleteSession")}
+      description={<SessionDeleteDescription isPrimary={isPrimary} isOnlySession={isOnlySession} />}
+      cancelLabel={t("common:cancel")}
+      confirmLabel={t("task:delete")}
+      confirmAriaLabel={t("task:delete2", { name: targetName })}
+      confirmTestId="mobile-session-delete-confirm"
+      onCancel={onCancel}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
   );
 }
 
@@ -281,19 +258,23 @@ function SessionRowItem({
   taskId,
   isActive,
   totalSessions,
+  isConfirming,
+  onAskDelete,
+  onCancelDelete,
   onSelect,
 }: {
   row: SessionRow;
   taskId: string;
   isActive: boolean;
   totalSessions: number;
+  isConfirming: boolean;
+  onAskDelete: () => void;
+  onCancelDelete: () => void;
   onSelect: (sessionId: string) => void;
 }) {
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [handoffOpen, setHandoffOpen] = useState(false);
   const [handoffPreset, setHandoffPreset] = useState<HandoffPreset | null>(null);
   const actions = useSessionActions({ sessionId: row.id, taskId });
-  const isOnly = totalSessions === 1;
   const showBadges = totalSessions > 1;
   const handleHandoffProfile = useCallback(
     (profileId: string) => {
@@ -337,16 +318,27 @@ function SessionRowItem({
           foregroundActivity={row.foregroundActivity}
           testId={`mobile-session-state-${row.id}`}
         />
-        <SessionActionsMenu
-          taskId={taskId}
-          state={row.state}
-          isPrimary={row.isPrimary}
-          onSetPrimary={() => void actions.setPrimary()}
-          onStop={() => void actions.stop()}
-          onResume={() => void actions.resume()}
-          onAskDelete={() => setConfirmDelete(true)}
-          onHandoffProfile={handleHandoffProfile}
-        />
+        {isConfirming ? (
+          <SessionDeleteInlineConfirmation
+            isPrimary={row.isPrimary}
+            isOnlySession={totalSessions === 1}
+            targetName={row.agentLabel}
+            onCancel={onCancelDelete}
+            onClose={onCancelDelete}
+            onConfirm={() => void actions.remove()}
+          />
+        ) : (
+          <SessionActionsMenu
+            taskId={taskId}
+            state={row.state}
+            isPrimary={row.isPrimary}
+            onSetPrimary={() => void actions.setPrimary()}
+            onStop={() => void actions.stop()}
+            onResume={() => void actions.resume()}
+            onAskDelete={onAskDelete}
+            onHandoffProfile={handleHandoffProfile}
+          />
+        )}
       </div>
       {handoffPreset && (
         <NewSessionDialog
@@ -359,13 +351,6 @@ function SessionRowItem({
           handoff={handoffPreset}
         />
       )}
-      <DeleteSessionConfirmDialog
-        open={confirmDelete}
-        onOpenChange={setConfirmDelete}
-        isPrimary={row.isPrimary}
-        isOnlySession={isOnly}
-        onConfirm={() => void actions.remove()}
-      />
     </>
   );
 }
@@ -407,20 +392,28 @@ function useSessionRows(taskId: string | null) {
 const MobileSessionsList = memo(function MobileSessionsList({
   taskId,
   activeSessionId,
+  open,
   onClose,
 }: {
   taskId: string | null;
   activeSessionId: string | null;
+  open: boolean;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
   const setActiveSession = useAppStore((s) => s.setActiveSession);
   const { rows, isLoading } = useSessionRows(taskId);
   const [launchOpen, setLaunchOpen] = useState(false);
+  const [confirmDeleteSessionId, setConfirmDeleteSessionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) setConfirmDeleteSessionId(null);
+  }, [open]);
 
   const handleSelect = useCallback(
     (sessionId: string) => {
       if (!taskId) return;
+      setConfirmDeleteSessionId(null);
       setActiveSession(taskId, sessionId);
       onClose();
     },
@@ -470,6 +463,9 @@ const MobileSessionsList = memo(function MobileSessionsList({
             taskId={taskId}
             isActive={row.id === activeSessionId}
             totalSessions={rows.length}
+            isConfirming={row.id === confirmDeleteSessionId}
+            onAskDelete={() => setConfirmDeleteSessionId(row.id)}
+            onCancelDelete={() => setConfirmDeleteSessionId(null)}
             onSelect={handleSelect}
           />
         ))}
@@ -559,6 +555,7 @@ export const MobileSessionsPicker = memo(function MobileSessionsPicker({
         <MobileSessionsList
           taskId={taskId}
           activeSessionId={effectiveSessionId}
+          open={open}
           onClose={() => setOpen(false)}
         />
       </MobilePickerSheet>

--- a/apps/web/components/task/mobile/mobile-sessions-section.tsx
+++ b/apps/web/components/task/mobile/mobile-sessions-section.tsx
@@ -32,7 +32,7 @@ import type { ForegroundActivity, TaskSession, TaskSessionState } from "@/lib/ty
 import type { AgentProfileOption } from "@/lib/state/slices";
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
-import { SessionDeleteDescription } from "../session-tab-menu";
+import { SessionDeleteDescription } from "../session-delete-description";
 
 type SessionRow = {
   id: string;

--- a/apps/web/components/task/session-delete-description.tsx
+++ b/apps/web/components/task/session-delete-description.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export function SessionDeleteDescription({
+  isPrimary,
+  isOnlySession,
+}: {
+  isPrimary: boolean;
+  isOnlySession: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <span>{t("task:thisWillPermanentlyDeleteTheConversation")}</span>
+      {isPrimary && !isOnlySession && (
+        <span className="mt-2 block font-medium">{t("task:thisIsThePrimarySessionAnother")}</span>
+      )}
+      {isOnlySession && (
+        <span className="mt-2 block font-medium">{t("task:thisIsTheOnlySessionFor")}</span>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/task/session-tab-menu.test.tsx
+++ b/apps/web/components/task/session-tab-menu.test.tsx
@@ -1,7 +1,14 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRef, useState } from "react";
 
-import { DeleteSessionDialog } from "./session-tab-menu";
+import { ContextMenu, ContextMenuTrigger } from "@kandev/ui/context-menu";
+
+import {
+  DeleteSessionDialog,
+  DeleteSessionPopover,
+  SessionContextMenuItems,
+} from "./session-tab-menu";
 
 describe("DeleteSessionDialog", () => {
   it("states conversation deletion and workspace retention", () => {
@@ -40,5 +47,97 @@ describe("DeleteSessionDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SessionContextMenuItems", () => {
+  it("keeps the delete menu action open for its local confirmation", () => {
+    const onDelete = vi.fn<(event: Event) => void>();
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <button type="button">Session</button>
+        </ContextMenuTrigger>
+        <SessionContextMenuItems
+          sessionState="COMPLETED"
+          isPrimary={false}
+          canShare={false}
+          taskId={null}
+          sessionId={undefined}
+          actions={{
+            handleSetPrimary: vi.fn(),
+            handleStop: vi.fn(),
+            handleResume: vi.fn(),
+            handleCloseOthers: vi.fn(),
+          }}
+          onDelete={onDelete}
+          onShare={vi.fn()}
+          onHandoffProfile={vi.fn()}
+          onStartRename={vi.fn()}
+        />
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Session" }), {
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete.mock.calls[0]?.[0].defaultPrevented).toBe(true);
+  });
+});
+
+function SessionDeletePopoverHarness({ onConfirm }: { onConfirm: () => void }) {
+  const [open, setOpen] = useState(true);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={anchorRef} type="button">
+        Delete session
+      </button>
+      <DeleteSessionPopover
+        open={open}
+        anchorRef={anchorRef}
+        onOpenChange={setOpen}
+        isPrimary
+        sessionCount={2}
+        targetName="Mock Fast"
+        onConfirm={onConfirm}
+      />
+    </>
+  );
+}
+
+describe("DeleteSessionPopover", () => {
+  it("cancels locally without dispatching an alert dialog", async () => {
+    const onConfirm = vi.fn();
+    render(<SessionDeletePopoverHarness onConfirm={onConfirm} />);
+
+    const popover = await screen.findByTestId("session-delete-confirm-popover");
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    fireEvent.click(within(popover).getByRole("button", { name: "Cancel" }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByTestId("session-delete-confirm-popover")).toBeNull());
+  });
+
+  it("confirms once after closing the local shell", async () => {
+    let shellClosed = false;
+    const onConfirm = vi.fn(() => {
+      shellClosed = screen.queryByTestId("session-delete-confirm-popover") === null;
+    });
+    render(<SessionDeletePopoverHarness onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByTestId("session-delete-confirm"));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(shellClosed).toBe(true);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 });

--- a/apps/web/components/task/session-tab-menu.tsx
+++ b/apps/web/components/task/session-tab-menu.tsx
@@ -23,6 +23,7 @@ import { HandoffContextMenuSub } from "@/components/task/handoff-profile-menu-it
 import { NewSessionDialog, type HandoffPreset } from "@/components/task/new-session-dialog";
 import type { TaskSessionState } from "@/lib/types/http";
 import { useTranslation } from "react-i18next";
+import { SessionDeleteDescription } from "./session-delete-description";
 
 /** Lifecycle callbacks the context menu needs from the owning tab. */
 export type SessionTabMenuActions = {
@@ -31,27 +32,6 @@ export type SessionTabMenuActions = {
   handleResume: () => void;
   handleCloseOthers: () => void;
 };
-
-export function SessionDeleteDescription({
-  isPrimary,
-  isOnlySession,
-}: {
-  isPrimary: boolean;
-  isOnlySession: boolean;
-}) {
-  const { t } = useTranslation();
-  return (
-    <>
-      <span>{t("task:thisWillPermanentlyDeleteTheConversation")}</span>
-      {isPrimary && !isOnlySession && (
-        <span className="mt-2 block font-medium">{t("task:thisIsThePrimarySessionAnother")}</span>
-      )}
-      {isOnlySession && (
-        <span className="mt-2 block font-medium">{t("task:thisIsTheOnlySessionFor")}</span>
-      )}
-    </>
-  );
-}
 
 export function DeleteSessionDialog({
   open,
@@ -154,6 +134,7 @@ export function SessionContextMenuItems({
   taskId: string | null;
   sessionId: string | undefined;
   actions: SessionTabMenuActions;
+  /** Passes the Radix selection event so the owner can capture its currentTarget as an anchor. */
   onDelete: (event: Event) => void;
   onShare: () => void;
   onHandoffProfile: (profileId: string) => void;
@@ -187,6 +168,7 @@ export function SessionContextMenuItems({
         <ContextMenuItem
           className="cursor-pointer text-destructive"
           onSelect={(event) => {
+            // Keep the context menu mounted so the confirmation popover can stay anchored here.
             event.preventDefault();
             onDelete(event);
           }}

--- a/apps/web/components/task/session-tab-menu.tsx
+++ b/apps/web/components/task/session-tab-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { RefObject } from "react";
 import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from "@kandev/ui/context-menu";
 import {
   AlertDialog,
@@ -11,6 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
 import {
   isSessionStoppable as isStoppable,
   isSessionDeletable as isDeletable,
@@ -29,6 +31,27 @@ export type SessionTabMenuActions = {
   handleResume: () => void;
   handleCloseOthers: () => void;
 };
+
+export function SessionDeleteDescription({
+  isPrimary,
+  isOnlySession,
+}: {
+  isPrimary: boolean;
+  isOnlySession: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <span>{t("task:thisWillPermanentlyDeleteTheConversation")}</span>
+      {isPrimary && !isOnlySession && (
+        <span className="mt-2 block font-medium">{t("task:thisIsThePrimarySessionAnother")}</span>
+      )}
+      {isOnlySession && (
+        <span className="mt-2 block font-medium">{t("task:thisIsTheOnlySessionFor")}</span>
+      )}
+    </>
+  );
+}
 
 export function DeleteSessionDialog({
   open,
@@ -51,13 +74,7 @@ export function DeleteSessionDialog({
           <AlertDialogTitle>{t("task:deleteSession")}</AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div>
-              <p>{t("task:thisWillPermanentlyDeleteTheConversation")}</p>
-              {isPrimary && sessionCount > 1 && (
-                <p className="mt-2 font-medium">{t("task:thisIsThePrimarySessionAnother")}</p>
-              )}
-              {sessionCount === 1 && (
-                <p className="mt-2 font-medium">{t("task:thisIsTheOnlySessionFor")}</p>
-              )}
+              <SessionDeleteDescription isPrimary={isPrimary} isOnlySession={sessionCount === 1} />
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
@@ -75,6 +92,47 @@ export function DeleteSessionDialog({
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+export function DeleteSessionPopover({
+  open,
+  anchorRef,
+  focusBoundaryRef,
+  onOpenChange,
+  isPrimary,
+  sessionCount,
+  targetName,
+  onConfirm,
+}: {
+  open: boolean;
+  anchorRef: RefObject<HTMLElement | null>;
+  focusBoundaryRef?: RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
+  isPrimary: boolean;
+  sessionCount: number;
+  targetName?: string | null;
+  onConfirm: () => void | Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const name = targetName || t("task:session");
+  return (
+    <ActionConfirmPopover
+      open={open}
+      anchorRef={anchorRef}
+      focusBoundaryRef={focusBoundaryRef}
+      title={t("task:deleteSession")}
+      description={
+        <SessionDeleteDescription isPrimary={isPrimary} isOnlySession={sessionCount === 1} />
+      }
+      cancelLabel={t("common:cancel")}
+      confirmLabel={t("task:delete")}
+      confirmAriaLabel={t("task:delete2", { name })}
+      confirmTestId="session-delete-confirm"
+      testId="session-delete-confirm-popover"
+      onOpenChange={onOpenChange}
+      onConfirm={onConfirm}
+    />
   );
 }
 
@@ -96,7 +154,7 @@ export function SessionContextMenuItems({
   taskId: string | null;
   sessionId: string | undefined;
   actions: SessionTabMenuActions;
-  onDelete: () => void;
+  onDelete: (event: Event) => void;
   onShare: () => void;
   onHandoffProfile: (profileId: string) => void;
   onStartRename: () => void;
@@ -126,7 +184,13 @@ export function SessionContextMenuItems({
         </ContextMenuItem>
       )}
       {sessionState && isDeletable(sessionState) && (
-        <ContextMenuItem className="cursor-pointer text-destructive" onSelect={onDelete}>
+        <ContextMenuItem
+          className="cursor-pointer text-destructive"
+          onSelect={(event) => {
+            event.preventDefault();
+            onDelete(event);
+          }}
+        >
           {t("task:delete")}
         </ContextMenuItem>
       )}
@@ -155,10 +219,14 @@ export function SessionContextMenuItems({
 /** Delete / share / handoff dialogs rendered alongside the tab. */
 export function SessionTabDialogs({
   confirmDelete,
+  menuDeleteOpen,
+  menuDeleteAnchorRef,
+  menuDeleteFocusBoundaryRef,
   setConfirmDelete,
   isPrimary,
   sessionCount,
   onConfirmDelete,
+  targetName,
   taskId,
   sessionId,
   shareOpen,
@@ -170,10 +238,14 @@ export function SessionTabDialogs({
   groupId,
 }: {
   confirmDelete: boolean;
+  menuDeleteOpen: boolean;
+  menuDeleteAnchorRef: RefObject<HTMLElement | null>;
+  menuDeleteFocusBoundaryRef?: RefObject<HTMLElement | null>;
   setConfirmDelete: (open: boolean) => void;
   isPrimary: boolean;
   sessionCount: number;
   onConfirmDelete: () => void;
+  targetName?: string | null;
   taskId: string | null;
   sessionId: string | undefined;
   shareOpen: boolean;
@@ -187,10 +259,20 @@ export function SessionTabDialogs({
   return (
     <>
       <DeleteSessionDialog
-        open={confirmDelete}
+        open={confirmDelete && !menuDeleteOpen}
         onOpenChange={setConfirmDelete}
         isPrimary={isPrimary}
         sessionCount={sessionCount}
+        onConfirm={onConfirmDelete}
+      />
+      <DeleteSessionPopover
+        open={menuDeleteOpen}
+        anchorRef={menuDeleteAnchorRef}
+        focusBoundaryRef={menuDeleteFocusBoundaryRef}
+        onOpenChange={setConfirmDelete}
+        isPrimary={isPrimary}
+        sessionCount={sessionCount}
+        targetName={targetName}
         onConfirm={onConfirmDelete}
       />
       {taskId && sessionId && (

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -3,9 +3,11 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { IconStar } from "@tabler/icons-react";
@@ -315,6 +317,22 @@ function useSessionTabDialogState(sessionId: string | undefined) {
   };
 }
 
+function useSessionMenuDelete(openMenuDelete: () => void) {
+  const menuDeleteAnchorRef = useRef<HTMLElement>(null);
+  const menuDeleteFocusBoundaryRef = useRef<HTMLElement>(null);
+  const handleMenuDelete = useCallback(
+    (event: Event) => {
+      const anchor = event.currentTarget;
+      if (!(anchor instanceof HTMLElement)) return;
+      menuDeleteAnchorRef.current = anchor;
+      menuDeleteFocusBoundaryRef.current = anchor.closest('[data-slot="context-menu-content"]');
+      openMenuDelete();
+    },
+    [openMenuDelete],
+  );
+  return { menuDeleteAnchorRef, menuDeleteFocusBoundaryRef, handleMenuDelete };
+}
+
 /** Tab body: inline rename input while renaming, normal trigger content otherwise. */
 function SessionTabBody({
   props,
@@ -369,6 +387,55 @@ function useSessionTabTitleSync(api: IDockviewPanelHeaderProps["api"], tabTitle:
   }, [tabTitle, api]);
 }
 
+type SessionTabDialogHostProps = {
+  dialogs: ReturnType<typeof useSessionTabDialogState>;
+  deleteState: ReturnType<typeof useSessionTabDelete>;
+  menuDeleteAnchorRef: RefObject<HTMLElement | null>;
+  menuDeleteFocusBoundaryRef: RefObject<HTMLElement | null>;
+  isPrimary: boolean;
+  sessionCount: number;
+  targetName: string | null;
+  taskId: string | null;
+  sessionId: string | undefined;
+  groupId: string | undefined;
+};
+
+function SessionTabDialogHost({
+  dialogs,
+  deleteState,
+  menuDeleteAnchorRef,
+  menuDeleteFocusBoundaryRef,
+  isPrimary,
+  sessionCount,
+  targetName,
+  taskId,
+  sessionId,
+  groupId,
+}: SessionTabDialogHostProps) {
+  return (
+    <SessionTabDialogs
+      confirmDelete={dialogs.confirmDelete && deleteState.deleteOrigin === "tab"}
+      menuDeleteOpen={dialogs.confirmDelete && deleteState.deleteOrigin === "menu"}
+      menuDeleteAnchorRef={menuDeleteAnchorRef}
+      menuDeleteFocusBoundaryRef={menuDeleteFocusBoundaryRef}
+      setConfirmDelete={deleteState.handleDeleteDialogOpenChange}
+      isPrimary={isPrimary}
+      sessionCount={sessionCount}
+      onConfirmDelete={deleteState.handleConfirmDelete}
+      targetName={targetName}
+      taskId={taskId}
+      sessionId={sessionId}
+      shareOpen={dialogs.shareOpen}
+      setShareOpen={dialogs.setShareOpen}
+      handoffOpen={dialogs.handoffOpen}
+      setHandoffOpen={dialogs.setHandoffOpen}
+      handoffPreset={dialogs.handoffPreset}
+      setHandoffPreset={dialogs.setHandoffPreset}
+      groupId={groupId}
+    />
+  );
+}
+
 /**
  * Custom dockview tab for session panels.
  * Shows agent logo, index badge, and star for primary; right-click for lifecycle actions.
@@ -402,14 +469,10 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   // Multi-session tab close means delete, not hide-only. Running/starting sessions are
   // not deletable, so we omit the X rather than reviving hide-only close behavior.
   const showDeleteOnClose = showMultiSessionBadges && !!sessionState && isDeletable(sessionState);
-  const { setConfirmDelete, setIsRenaming, setShareOpen } = dialogs;
-  const {
-    handleCloseTab,
-    handleDeleteDialogOpenChange,
-    handleConfirmDelete,
-    handleMenuDelete,
-    isDeletingFromTab,
-  } = useSessionTabDelete(setConfirmDelete, actions.handleDelete);
+  const deleteState = useSessionTabDelete(dialogs.setConfirmDelete, actions.handleDelete);
+  const { handleCloseTab, handleMenuDelete: openMenuDelete, isDeletingFromTab } = deleteState;
+  const { menuDeleteAnchorRef, menuDeleteFocusBoundaryRef, handleMenuDelete } =
+    useSessionMenuDelete(openMenuDelete);
   const { handlePointerDownCapture, handleKeyDownCapture } = useSessionTabUserActivationIntent(
     sessionId,
     activeSessionId,
@@ -432,7 +495,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
             renameInitial={sessionName || tabTitle || ""}
             renameSeqBadge={showMultiSessionBadges ? sessionNumber : null}
             onCommitRename={handleCommitRename}
-            onCancelRename={() => setIsRenaming(false)}
+            onCancelRename={() => dialogs.setIsRenaming(false)}
             sessionId={sessionId}
             isPrimary={isPrimary}
             showMultiSessionBadges={showMultiSessionBadges}
@@ -453,25 +516,21 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
           sessionId={sessionId}
           actions={actions}
           onDelete={handleMenuDelete}
-          onShare={() => setShareOpen(true)}
+          onShare={() => dialogs.setShareOpen(true)}
           onHandoffProfile={dialogs.handleHandoffProfile}
-          onStartRename={() => setIsRenaming(true)}
+          onStartRename={() => dialogs.setIsRenaming(true)}
         />
       </ContextMenu>
-      <SessionTabDialogs
-        confirmDelete={dialogs.confirmDelete}
-        setConfirmDelete={handleDeleteDialogOpenChange}
+      <SessionTabDialogHost
+        dialogs={dialogs}
+        deleteState={deleteState}
+        menuDeleteAnchorRef={menuDeleteAnchorRef}
+        menuDeleteFocusBoundaryRef={menuDeleteFocusBoundaryRef}
         isPrimary={isPrimary}
         sessionCount={sessionCount}
-        onConfirmDelete={handleConfirmDelete}
+        targetName={tabTitle}
         taskId={taskId}
         sessionId={sessionId}
-        shareOpen={dialogs.shareOpen}
-        setShareOpen={setShareOpen}
-        handoffOpen={dialogs.handoffOpen}
-        setHandoffOpen={dialogs.setHandoffOpen}
-        handoffPreset={dialogs.handoffPreset}
-        setHandoffPreset={dialogs.setHandoffPreset}
         groupId={api.group?.id}
       />
     </>

--- a/apps/web/components/task/use-session-tab-delete.ts
+++ b/apps/web/components/task/use-session-tab-delete.ts
@@ -45,6 +45,7 @@ export function useSessionTabDelete(
   }, [setConfirmDelete]);
 
   return {
+    deleteOrigin,
     handleCloseTab,
     handleDeleteDialogOpenChange,
     handleConfirmDelete,

--- a/apps/web/e2e/tests/session/mobile-session-deletion.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-session-deletion.spec.ts
@@ -67,13 +67,23 @@ test.describe("mobile: session deletion", () => {
     await expect(actionsMenu).toBeVisible({ timeout: 5_000 });
     await actionsMenu.getByRole("menuitem", { name: "Delete" }).tap();
 
-    const dialog = testPage.getByRole("alertdialog");
-    await expect(dialog).toBeVisible();
-    // The native mobile dialog states the conversation-deletion contract and
+    const confirmation = secondaryRow.getByTestId("mobile-session-delete-confirmation");
+    await expect(confirmation).toBeVisible();
+    await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
+    // The row-local confirmation states the conversation-deletion contract and
     // explicitly says the task workspace and files are retained.
-    await expect(dialog).toContainText("permanently delete the conversation history");
-    await expect(dialog).toContainText("task workspace and its files are kept");
-    await dialog.getByRole("button", { name: "Delete" }).tap();
+    await expect(confirmation).toContainText("permanently delete the conversation history");
+    await expect(confirmation).toContainText("task workspace and its files are kept");
+
+    await confirmation.getByRole("button", { name: "Cancel" }).tap();
+    await expect(confirmation).not.toBeVisible();
+    await expect(secondaryRow).toBeVisible();
+
+    await secondaryRow.getByRole("button", { name: "Session actions" }).click();
+    const reopenedActionsMenu = testPage.getByRole("menu");
+    await expect(reopenedActionsMenu).toBeVisible({ timeout: 5_000 });
+    await reopenedActionsMenu.getByRole("menuitem", { name: "Delete" }).tap();
+    await secondaryRow.getByTestId("mobile-session-delete-confirm").tap();
 
     await expect(secondaryRow).not.toBeVisible({ timeout: 15_000 });
     await expect(sheet.getByTestId(`mobile-session-row-${primarySessionId}`)).toBeVisible();

--- a/apps/web/e2e/tests/session/multi-session-ux.spec.ts
+++ b/apps/web/e2e/tests/session/multi-session-ux.spec.ts
@@ -275,15 +275,16 @@ test.describe("Multi-session UX", () => {
     await expect(deleteItem).toBeVisible({ timeout: 5_000 });
     await deleteItem.click();
 
-    // Confirmation dialog should appear
-    const dialog = session.alertDialog();
-    await expect(dialog).toBeVisible({ timeout: 5_000 });
-    await expect(dialog).toContainText("Delete session?");
+    // The context-menu action uses an anchored, non-modal confirmation.
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(confirmation).toContainText("Delete session?");
+    await expect(session.alertDialog()).toHaveCount(0);
 
     // Cancel the deletion
-    const cancelBtn = dialog.getByRole("button", { name: "Cancel" });
+    const cancelBtn = confirmation.getByRole("button", { name: "Cancel" });
     await cancelBtn.click();
-    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(confirmation).not.toBeVisible({ timeout: 5_000 });
 
     // Verify session still exists
     const { sessions } = await apiClient.listTaskSessions(task.id);
@@ -331,12 +332,13 @@ test.describe("Multi-session UX", () => {
     await tab1.click({ button: "right" });
 
     await session.contextMenuItem("Delete").click();
-    const dialog = session.alertDialog();
-    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(session.alertDialog()).toHaveCount(0);
 
-    const confirmBtn = dialog.getByRole("button", { name: "Delete" });
+    const confirmBtn = confirmation.getByTestId("session-delete-confirm");
     await confirmBtn.click();
-    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(confirmation).not.toBeVisible({ timeout: 5_000 });
 
     // Wait for the deleted session's tab to disappear (identified by session ID,
     // not display number, because the remaining session gets renumbered to #1).
@@ -533,10 +535,11 @@ test.describe("Session deletion preserves the task workspace", () => {
     await expect(tab).toBeVisible({ timeout: 10_000 });
     await tab.click({ button: "right" });
     await session.contextMenuItem("Delete").click();
-    const dialog = session.alertDialog();
-    await expect(dialog).toBeVisible({ timeout: 5_000 });
-    await expect(dialog).toContainText("task workspace and its files are kept");
-    await dialog.getByRole("button", { name: "Delete" }).click();
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(confirmation).toContainText("task workspace and its files are kept");
+    await expect(session.alertDialog()).toHaveCount(0);
+    await confirmation.getByTestId("session-delete-confirm").click();
 
     // The task workspace and its uncommitted marker survive session deletion.
     await expect

--- a/apps/web/e2e/tests/session/session-tab-management.spec.ts
+++ b/apps/web/e2e/tests/session/session-tab-management.spec.ts
@@ -184,9 +184,10 @@ test.describe("Session tab management — close behavior", () => {
 
     await session.sessionTabBySessionId(session1Id).click({ button: "right" });
     await session.contextMenuItem("Delete").click();
-    const dialog = session.alertDialog();
-    await expect(dialog).toBeVisible({ timeout: 5_000 });
-    await dialog.getByRole("button", { name: "Delete" }).click();
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(session.alertDialog()).toHaveCount(0);
+    await confirmation.getByTestId("session-delete-confirm").click();
 
     // Tab disappears…
     await expect(session.sessionTabBySessionId(session1Id)).not.toBeVisible({ timeout: 15_000 });
@@ -224,8 +225,10 @@ test.describe("Session tab management — close behavior", () => {
 
     await session.sessionTabBySessionId(session1Id).click({ button: "right" });
     await session.contextMenuItem("Delete").click();
-    await expect(session.alertDialog()).toBeVisible({ timeout: 5_000 });
-    await session.alertDialog().getByRole("button", { name: "Delete" }).click();
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(session.alertDialog()).toHaveCount(0);
+    await confirmation.getByTestId("session-delete-confirm").click();
 
     await expect(session.sessionTabBySessionId(session1Id)).not.toBeVisible({ timeout: 15_000 });
     await expect(session.sessionTabBySessionId(session2Id)).toBeVisible({ timeout: 5_000 });
@@ -276,8 +279,10 @@ test.describe("Session tab management — close behavior", () => {
 
     await session.sessionTabBySessionId(session1Id).click({ button: "right" });
     await session.contextMenuItem("Delete").click();
-    await expect(session.alertDialog()).toBeVisible({ timeout: 5_000 });
-    await session.alertDialog().getByRole("button", { name: "Delete" }).click();
+    const confirmation = testPage.getByTestId("session-delete-confirm-popover");
+    await expect(confirmation).toBeVisible({ timeout: 5_000 });
+    await expect(session.alertDialog()).toHaveCount(0);
+    await confirmation.getByTestId("session-delete-confirm").click();
 
     // Wait for backend to confirm deletion (don't wait for tab to disappear).
     await expect

--- a/docs/plans/session-tab-delete-feedback/plan.md
+++ b/docs/plans/session-tab-delete-feedback/plan.md
@@ -1,6 +1,7 @@
 ---
 spec: docs/specs/ui/session-tab-delete-feedback.md
 created: 2026-08-05
+amended: 2026-08-22
 status: shipped
 ---
 
@@ -12,7 +13,9 @@ Give the desktop Dockview session-tab close flow local pending feedback while pr
 session lifecycle behavior used by context menus and mobile. First make the shared delete action
 selectively suppress progress/success toasts, then replace Dockview's opaque close icon with a
 small repository-owned action that can render an X or spinner. Finish with focused desktop and
-mobile Playwright coverage.
+mobile Playwright coverage. A later localized-confirmation refinement keeps the tab-X dialog,
+anchors context-menu confirmation to its Delete item, and morphs the phone picker row into inline
+touch actions.
 
 ## Frontend
 
@@ -44,18 +47,23 @@ Add the close action's accessible label to `apps/web/src/locales/en/common.json`
 
 ### Mobile design contract
 
-- **Desktop outcome:** the session-tab X is the progress surface and remains in the existing tab
-  strip; no overlay or layout change is introduced.
+- **Desktop outcome:** the session-tab X remains the progress surface and retains its alert dialog.
+  Context-menu Delete keeps the menu mounted and opens a compact confirmation popover anchored to
+  that item.
 - **Mobile entry point:** the existing `MobileSessionsPicker` pill opens `MobilePickerSheet`, and a
-  session row's visible actions menu owns deletion. There is no Dockview X on phone.
+  session row's visible actions menu owns deletion. The target row then morphs into touch-sized
+  inline Cancel and Delete actions; there is no Dockview X or nested confirmation dialog on phone.
 - **Nearest shipped exemplar:** `apps/web/components/task/mobile/mobile-sessions-section.tsx`
   remains authoritative for the phone hierarchy, bottom-sheet surface, internal scroll owner,
   safe-area handling, and touch targets.
-- **Shared versus specialized behavior:** the delete transport/store mutation remains shared in
-  `useSessionActions`; only the desktop tab-X presentation and feedback mode specialize. Mobile
-  markup and its default feedback mode do not change.
-- **Parity proof:** a mobile Playwright scenario deletes one of two sessions through the Sessions
-  picker and verifies the selected session disappears while the remaining session stays reachable.
+- **Shared versus specialized behavior:** the delete transport/store mutation and localized warning
+  copy remain shared. Desktop context-menu and phone picker components specialize only the local
+  confirmation presentation; their default request feedback remains unchanged.
+- **Dismissal:** Cancel, session selection, and externally closing the picker clear pending inline
+  confirmation without dispatching deletion.
+- **Parity proof:** desktop Playwright scenarios cover the anchored context-menu confirmation. A
+  mobile scenario cancels and then confirms the inline row action, proving the selected session
+  disappears while the remaining session stays reachable.
 
 ## Tests
 
@@ -67,6 +75,9 @@ Add the close action's accessible label to `apps/web/src/locales/en/common.json`
   `apps/web/components/task/session-tab-close-action.test.tsx` to prove the idle X is operable, the
   pending state renders a status spinner with `aria-busy`, and pending activation cannot dispatch a
   second callback.
+- **Localized confirmation surfaces:** `session-tab-menu.test.tsx` proves the context menu remains
+  mounted for its anchored popover. `mobile-sessions-section.test.tsx` proves inline confirm,
+  cancellation, dispatch, touch-target sizing, and cleanup when the picker closes externally.
 
 ## E2E Tests
 
@@ -74,9 +85,14 @@ Add the close action's accessible label to `apps/web/src/locales/en/common.json`
   THEN the tab/session is removed and no `Deleting session...` or successful-deletion toast appears.
   **File:** `apps/web/e2e/tests/session/session-tab-management.spec.ts`.
 - **Scenario:** GIVEN two deletable sessions on a phone viewport, WHEN the user opens the Sessions
-  picker and deletes one through its row action, THEN that row disappears and the remaining session
-  stays reachable. **File:** `apps/web/e2e/tests/session/mobile-session-deletion.spec.ts`, run by
-  the `mobile-chrome` project.
+  picker and chooses Delete, THEN the row shows inline confirmation with no alert dialog; cancelling
+  preserves the row, and confirming removes it while the remaining session stays reachable.
+  **File:** `apps/web/e2e/tests/session/mobile-session-deletion.spec.ts`, run by the `mobile-chrome`
+  project.
+- **Scenario:** GIVEN a desktop session context menu, WHEN the user chooses Delete, THEN a compact
+  anchored popover appears without an alert dialog and the existing cancel/confirm deletion outcomes
+  remain intact. **Files:** `apps/web/e2e/tests/session/multi-session-ux.spec.ts` and
+  `apps/web/e2e/tests/session/session-tab-management.spec.ts`.
 
 The transient spinner is covered deterministically by the component test because the real delete
 response can settle too quickly for a race-free Playwright observation. Playwright covers the
@@ -101,6 +117,18 @@ The pseudo-locale artifact updated is `apps/web/src/locales/pseudo/common.json`.
 used isolated temporary backends and cleaned their generated results; no external systems were
 changed.
 
+### Review remediation (2026-08-22)
+
+- `pnpm --filter @kandev/web test -- components/task/mobile/mobile-sessions-section.test.tsx components/task/session-tab-menu.test.tsx` - 2 files, 17 tests passed.
+- `pnpm run typecheck` - passed.
+- Targeted ESLint for the shared description, desktop menu, mobile picker, and regression test -
+  passed with no warnings.
+- `pnpm run i18n:check` and `pnpm run i18n:ratchet` - passed; catalogs remain complete and four
+  modified frontend files passed the new-code ratchet.
+- Local Playwright was not repeated because remediation changes only test coverage, comments,
+  component ownership, and internal documentation; exact-head CI reruns the integrated desktop and
+  mobile scenarios.
+
 ## Implementation Waves And Parallel Candidates
 
 Wave 1:
@@ -113,6 +141,11 @@ Wave 2:
 
 Execution is sequential in the primary conversation. The E2E task depends on the production and
 unit-test changes from task 01; these tasks are not parallel-safe.
+
+## Public documentation
+
+No public documentation change. This refines transient confirmation presentation without changing
+commands, configuration, navigation terminology, or a public API.
 
 ## Risks
 

--- a/docs/plans/session-tab-delete-feedback/task-01-inline-delete-feedback.md
+++ b/docs/plans/session-tab-delete-feedback/task-01-inline-delete-feedback.md
@@ -95,3 +95,11 @@ feedback.
 
 Generated artifact: `apps/web/src/locales/pseudo/common.json`. No external side effects beyond local
 WebSocket test mocks.
+
+## Localized-confirmation follow-up
+
+The later shipped refinement preserves this task's tab-X dialog and feedback-mode contract while
+moving desktop context-menu confirmation into an anchored popover and phone confirmation into its
+Sessions picker row. Shared warning copy now lives in the purpose-neutral
+`components/task/session-delete-description.tsx`; the context-menu event and `preventDefault()`
+contracts are documented beside their public callback and Radix handler.

--- a/docs/plans/session-tab-delete-feedback/task-02-session-deletion-e2e.md
+++ b/docs/plans/session-tab-delete-feedback/task-02-session-deletion-e2e.md
@@ -19,8 +19,10 @@ the existing Sessions picker.
 
 - The existing desktop X-confirm-delete scenario verifies the selected tab and backend session are
   removed without a deletion progress or success toast.
-- A `mobile-chrome` scenario deletes one of two sessions through the Sessions picker row action and
-  verifies the other session remains reachable.
+- Desktop context-menu scenarios use the anchored confirmation popover, not an alert dialog, while
+  preserving cancel and confirm outcomes.
+- A `mobile-chrome` scenario cancels and then confirms the inline Sessions picker row action,
+  verifies no alert dialog opens, and proves the other session remains reachable.
 - Both scenarios use stable test IDs or scoped accessible controls and assert user-visible outcomes,
   not API-only behavior.
 
@@ -73,8 +75,9 @@ task/plan status.
 
 - Extended the desktop close-confirmation scenario to assert that neither the deletion progress nor
   success toast appears.
-- Added `mobile-session-deletion.spec.ts`, using the native Sessions picker and scoped row actions
-  to delete one of two sessions while keeping the remaining row reachable.
+- Added `mobile-session-deletion.spec.ts`, using the native Sessions picker and scoped inline row
+  actions to cancel once, delete one of two sessions, and keep the remaining row reachable without
+  an alert dialog.
 - `rtk pnpm e2e:run tests/session/session-tab-management.spec.ts -- --grep "tab close button shows delete confirmation"` — 1 desktop test passed with a production build.
 - `rtk pnpm e2e:run --no-build --project mobile-chrome tests/session/mobile-session-deletion.spec.ts` — 1 mobile test passed.
 - `rtk pnpm e2e:run --no-build tests/session/session-tab-management.spec.ts tests/session/session-tab-close-guard.spec.ts` — 9 desktop tests passed.

--- a/docs/specs/ui/session-tab-delete-feedback.md
+++ b/docs/specs/ui/session-tab-delete-feedback.md
@@ -1,7 +1,7 @@
 ---
 status: shipped
 created: 2026-08-05
-amended: 2026-08-08
+amended: 2026-08-22
 owner: kandev
 ---
 
@@ -15,10 +15,22 @@ its progress directly, and the pending tab control must use the same circular vi
 the neighboring terminal-tab close action. Promoting a session to primary is also a routine tab
 state change whose successful result does not need a global toast.
 
+Session deletion is available from several surfaces. Confirmation should stay beside the
+initiating action where the layout permits, instead of opening a second blocking surface that
+hides the session context the user is acting on.
+
 ## What
 
 - Clicking the X on a deletable agent-session tab continues to open the existing delete
   confirmation dialog.
+- Choosing Delete from a desktop session context menu keeps that menu mounted and opens a compact,
+  non-modal confirmation popover anchored to the Delete item. Cancelling or dismissing the popover
+  leaves the session unchanged.
+- On phone, choosing Delete from a row in the Sessions picker morphs that row into touch-sized
+  Cancel and Delete actions. It does not open another dialog or drawer. Cancelling, selecting
+  another session, or closing the picker clears the pending confirmation without deleting.
+- Desktop and phone confirmation surfaces share the same conversation-deletion,
+  workspace-retention, primary-session, and only-session warnings.
 - After the user confirms, the X is replaced in place by a compact circular indeterminate spinner
   matching the terminal-tab close action, not the grid-shaped activity spinner, until the delete
   request settles. The close action is non-interactive and exposed as busy while the request is
@@ -30,8 +42,8 @@ state change whose successful result does not need a global toast.
   explains the failure so the user can retry.
 - Promoting a non-primary agent session to primary updates the primary marker without a progress or
   success toast. If the promotion fails, one error toast explains the failure.
-- Deletion started from the session context menu or a mobile session action keeps its existing
-  feedback behavior.
+- After local confirmation, context-menu and mobile deletion retain the default request progress,
+  success, and error feedback.
 
 ## Failure modes
 
@@ -60,14 +72,21 @@ state change whose successful result does not need a global toast.
   current primary session remains unchanged and one error toast is shown.
 - **GIVEN** the user cancels the delete confirmation, **WHEN** the dialog closes, **THEN** the tab
   remains unchanged and no spinner or deletion toast appears.
-- **GIVEN** a phone viewport, **WHEN** the user deletes a session from the Sessions picker, **THEN**
-  the mobile flow remains reachable and removes the selected session without relying on a desktop
-  tab X.
+- **GIVEN** a desktop session context menu, **WHEN** the user chooses Delete, **THEN** a compact
+  confirmation popover stays anchored to that menu item without opening an alert dialog or starting
+  deletion.
+- **GIVEN** a phone viewport, **WHEN** the user chooses Delete from a Sessions picker row, **THEN**
+  that row shows touch-sized inline Cancel and Delete actions without opening an alert dialog.
+- **GIVEN** a phone row has pending delete confirmation, **WHEN** the user closes the Sessions
+  picker externally, **THEN** the pending confirmation is cleared and reopening the picker shows
+  the normal row actions without dispatching deletion.
+- **GIVEN** a phone viewport, **WHEN** the user confirms deletion from the inline row actions,
+  **THEN** the selected session is removed and the remaining session stays reachable without
+  relying on a desktop tab X.
 
 ## Out of scope
 
-- Removing or redesigning the delete confirmation dialog.
+- Removing or redesigning the tab-X delete confirmation dialog.
 - Changing backend session-deletion semantics, active-session selection, or Dockview reconciliation.
-- Changing the mobile session picker layout or controls; its shared primary-session action follows
-  the same no-success-toast feedback rule.
+- Changing the Sessions picker hierarchy, drawer, or non-delete row actions.
 - Replacing feedback for context-menu, mobile, stop, or resume actions.


### PR DESCRIPTION
Session deletion confirmations currently interrupt the desktop context-menu flow with a global dialog and stack a dialog over the mobile sessions drawer, making the action feel disconnected from its target. This localizes desktop confirmation at the menu anchor and morphs the mobile row into touch-sized inline actions while preserving deletion behavior and existing copy.

## Validation

- Focused Vitest suites: 3 files, 19 tests passed.
- `pnpm run typecheck` passed.
- `pnpm run i18n:check` and `pnpm run i18n:ratchet` passed.
- Commit hooks passed, including changed-file web lint and i18n guards.
- `pnpm e2e:run --no-build tests/session/session-tab-management.spec.ts`: 8 passed.
- `pnpm e2e:run --no-build --project mobile-chrome tests/session/mobile-session-deletion.spec.ts`: 1 passed.
- Targeted `multi-session-ux.spec.ts` deletion run reached one backend-delete pass; two cases were blocked before deletion by the existing new-session dialog setup remaining open.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop session delete confirmation](https://raw.githubusercontent.com/kdlbs/kandev/b983a42b0b71c103f49dfc28e927fc82738398b5/session-delete-confirmation-capture--desktop-session-delete-confirmation.png)

![Mobile session delete confirmation](https://raw.githubusercontent.com/kdlbs/kandev/b983a42b0b71c103f49dfc28e927fc82738398b5/mobile-session-delete-confirmation-capture--mobile-session-delete-confirmation.png)
<!-- kandev-screenshots-end -->