### PR TITLE
feat(ui): localize task detach confirmations

### DIFF
--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState } from "react";
+import { memo, useState, type Ref } from "react";
 import { IconCheck, IconChevronDown, IconLoader2 } from "@tabler/icons-react";
 
 import { cn } from "@/lib/utils";
@@ -61,6 +61,8 @@ interface ComboboxProps {
   headerAction?: React.ReactNode;
   /** When true, swap the trigger chevron for a spinner to indicate loading. */
   loading?: boolean;
+  /** Ref for consumers that anchor a local confirmation to this trigger. */
+  triggerRef?: Ref<HTMLButtonElement>;
 }
 
 function TriggerLabel({
@@ -161,14 +163,12 @@ export const Combobox = memo(function Combobox({
   filter,
   headerAction,
   loading = false,
+  triggerRef,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const portalContainer = useTaskCreateDialogPopoverContainer();
-  // Track the highlighted item. Defaults to the selected value so the current
-  // selection is highlighted when the popover opens (not the first item).
+  // Keep the selected value highlighted when the popover opens, not the first item.
   const [highlighted, setHighlighted] = useState("");
-
-  const selectedOption = options.find((option) => option.value === value);
 
   return (
     <Popover
@@ -180,6 +180,7 @@ export const Combobox = memo(function Combobox({
     >
       <PopoverTrigger asChild>
         <Button
+          ref={triggerRef}
           variant="ghost"
           role="combobox"
           aria-label={ariaLabel}
@@ -190,7 +191,7 @@ export const Combobox = memo(function Combobox({
         >
           <div className="flex min-w-0 flex-1 items-center">
             <TriggerLabel
-              selectedOption={selectedOption}
+              selectedOption={options.find((option) => option.value === value)}
               plainTrigger={plainTrigger}
               placeholder={placeholder}
             />

--- a/apps/web/components/confirmation/action-confirm-popover.test.tsx
+++ b/apps/web/components/confirmation/action-confirm-popover.test.tsx
@@ -135,6 +135,40 @@ describe("ActionConfirmPopover anchor lifecycle", () => {
 
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   });
+
+  it("returns focus to a separate focus target on cancel", async () => {
+    function SeparateFocusHarness() {
+      const [open, setOpen] = useState(true);
+      const anchorRef = useRef<HTMLDivElement>(null);
+      const focusReturnRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <div ref={anchorRef}>Positioning anchor</div>
+          <button ref={focusReturnRef} type="button">
+            More options
+          </button>
+          <ActionConfirmPopover
+            open={open}
+            anchorRef={anchorRef}
+            focusReturnRef={focusReturnRef}
+            title={deleteTitle}
+            description="This cannot be undone."
+            cancelLabel="Cancel"
+            confirmLabel="Delete"
+            onOpenChange={setOpen}
+            onConfirm={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    render(<SeparateFocusHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "More options" })),
+    );
+  });
 });
 
 describe("ActionConfirmPopover focus boundaries", () => {

--- a/apps/web/components/confirmation/action-confirm-popover.tsx
+++ b/apps/web/components/confirmation/action-confirm-popover.tsx
@@ -14,6 +14,7 @@ import {
 export type ActionConfirmPopoverProps = {
   open: boolean;
   anchorRef: RefObject<HTMLElement | null>;
+  focusReturnRef?: RefObject<HTMLElement | null>;
   focusBoundaryRef?: RefObject<HTMLElement | null>;
   title: ReactNode;
   description?: ReactNode;
@@ -37,6 +38,7 @@ export type ActionConfirmPopoverProps = {
 export function ActionConfirmPopover({
   open,
   anchorRef,
+  focusReturnRef,
   focusBoundaryRef,
   title,
   description,
@@ -105,6 +107,7 @@ export function ActionConfirmPopover({
         confirmTestId={confirmTestId}
         testId={testId}
         cancelRef={cancelRef}
+        focusReturnRef={focusReturnRef}
         focusBoundaryRef={focusBoundaryRef}
         confirmedRef={confirmedRef}
         anchorRef={anchorRef}
@@ -126,6 +129,7 @@ type ActionConfirmPopoverContentProps = {
   confirmTestId?: string;
   testId: string;
   cancelRef: RefObject<HTMLButtonElement | null>;
+  focusReturnRef?: RefObject<HTMLElement | null>;
   focusBoundaryRef?: RefObject<HTMLElement | null>;
   confirmedRef: { current: boolean };
   anchorRef: RefObject<HTMLElement | null>;
@@ -144,6 +148,7 @@ function ActionConfirmPopoverContent({
   confirmTestId,
   testId,
   cancelRef,
+  focusReturnRef,
   focusBoundaryRef,
   confirmedRef,
   anchorRef,
@@ -169,7 +174,11 @@ function ActionConfirmPopoverContent({
       }}
       onCloseAutoFocus={(event) => {
         event.preventDefault();
-        if (!confirmedRef.current && isConnected(anchorRef.current)) anchorRef.current.focus();
+        if (!confirmedRef.current) {
+          const focusReturnTarget = focusReturnRef?.current ?? null;
+          if (isConnected(focusReturnTarget)) focusReturnTarget.focus();
+          else if (isConnected(anchorRef.current)) anchorRef.current.focus();
+        }
         confirmedRef.current = false;
       }}
     >

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { CSS, type Transform } from "@dnd-kit/utilities";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
@@ -49,6 +49,7 @@ type KanbanCardActionProps = {
   menuEntries: KanbanCardMenuEntry[];
   isDeleting?: boolean;
   isArchiving?: boolean;
+  menuTriggerRef?: RefObject<HTMLButtonElement | null>;
 };
 
 type DraggableCardState = {
@@ -389,6 +390,7 @@ function KanbanCardActions({
   menuEntries,
   isDeleting,
   isArchiving,
+  menuTriggerRef,
 }: KanbanCardActionProps) {
   const { t } = useTranslation("common");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -476,6 +478,7 @@ function KanbanCardActions({
         isDeleting={isDeleting}
         isArchiving={isArchiving}
         menuEntries={menuEntries}
+        menuTriggerRef={menuTriggerRef}
       />
     </div>
   );
@@ -488,7 +491,7 @@ type KanbanCardMenuProps = KanbanCardActionProps & {
 
 function KanbanCardMenu(props: KanbanCardMenuProps) {
   const { t } = useTranslation();
-  const { effectiveMenuOpen, setMenuOpen, isDeleting, isArchiving } = props;
+  const { effectiveMenuOpen, setMenuOpen, isDeleting, isArchiving, menuTriggerRef } = props;
   const { menuEntries } = props;
   const isProcessing = isDeleting || isArchiving;
 
@@ -502,6 +505,7 @@ function KanbanCardMenu(props: KanbanCardMenuProps) {
     >
       <DropdownMenuTrigger asChild>
         <button
+          ref={menuTriggerRef}
           type="button"
           className="text-muted-foreground hover:text-foreground hover:bg-muted rounded-sm p-1 -m-1 transition-colors cursor-pointer"
           onClick={(e) => e.stopPropagation()}
@@ -554,6 +558,7 @@ function KanbanCardActionSlot({
   menuEntries,
   isDeleting,
   isArchiving,
+  menuTriggerRef,
 }: KanbanCardActionProps & { isMultiSelectMode?: boolean }) {
   if (isMultiSelectMode) return null;
   return (
@@ -564,6 +569,7 @@ function KanbanCardActionSlot({
       menuEntries={menuEntries}
       isDeleting={isDeleting}
       isArchiving={isArchiving}
+      menuTriggerRef={menuTriggerRef}
     />
   );
 }
@@ -586,6 +592,7 @@ export function KanbanCardShell({
   onCheckboxClick,
   onOpenFullPage,
   menuEntries,
+  menuTriggerRef,
 }: KanbanCardShellProps) {
   const showCheckbox = isMultiSelectMode || !!isSelected;
   const style = {
@@ -634,6 +641,7 @@ export function KanbanCardShell({
                   menuEntries={menuEntries}
                   isDeleting={isDeleting}
                   isArchiving={isArchiving}
+                  menuTriggerRef={menuTriggerRef}
                 />
               }
             />

--- a/apps/web/components/kanban-card-repositories.ts
+++ b/apps/web/components/kanban-card-repositories.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useAppStore } from "@/components/state-provider";
+import type { Repository } from "@/lib/types/http";
+
+const EMPTY_REPOSITORIES: Repository[] = [];
+
+export function useActiveWorkspaceRepositories() {
+  const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
+  return useAppStore((state) =>
+    activeWorkspaceId
+      ? (state.repositories.itemsByWorkspaceId[activeWorkspaceId] ?? EMPTY_REPOSITORIES)
+      : EMPTY_REPOSITORIES,
+  );
+}

--- a/apps/web/components/kanban-card-repositories.ts
+++ b/apps/web/components/kanban-card-repositories.ts
@@ -1,6 +1,10 @@
 "use client";
 
 import { useAppStore } from "@/components/state-provider";
+import type { RepositoryChip, Task } from "@/components/kanban-card";
+import { repositorySlug } from "@/lib/repository-slug";
+import { formatUserHomePath } from "@/lib/utils";
+import { repositoryId as toRepositoryId } from "@/lib/types/http";
 import type { Repository } from "@/lib/types/http";
 
 const EMPTY_REPOSITORIES: Repository[] = [];
@@ -12,4 +16,30 @@ export function useActiveWorkspaceRepositories() {
       ? (state.repositories.itemsByWorkspaceId[activeWorkspaceId] ?? EMPTY_REPOSITORIES)
       : EMPTY_REPOSITORIES,
   );
+}
+
+/** Resolves linked repositories to card chips, primary first. */
+export function resolveTaskRepositoryChips(
+  task: Task,
+  repositories: Repository[],
+): RepositoryChip[] {
+  const byId = new Map(repositories.map((repo) => [repo.id, repo]));
+  const seen = new Set<string>();
+  const chips: RepositoryChip[] = [];
+  const push = (id: string | undefined) => {
+    if (!id || seen.has(id)) return;
+    const repo = byId.get(toRepositoryId(id));
+    if (!repo) return;
+    seen.add(id);
+    const label = repositorySlug(repo);
+    if (!label) return;
+    chips.push({
+      label,
+      ...(repo.local_path ? { path: formatUserHomePath(repo.local_path) } : {}),
+    });
+  };
+  push(task.repositoryId);
+  const ordered = [...(task.repositories ?? [])].sort((a, b) => a.position - b.position);
+  for (const link of ordered) push(link.repository_id);
+  return chips;
 }

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import { KanbanCardContextMenu } from "@/components/kanban-card-context-menu";
 import { KanbanCardShell } from "@/components/kanban-card-content";
+import { useActiveWorkspaceRepositories } from "@/components/kanban-card-repositories";
 import {
   buildKanbanCardMenuEntries,
   useKanbanCardMoveTargets,
@@ -12,7 +13,7 @@ import { useTaskPluginLinkActions } from "@/components/task/task-session-sidebar
 import { useAppStore } from "@/components/state-provider";
 import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
-import { TaskDetachConfirmDialog } from "@/components/task/task-detach-confirm-dialog";
+import { TaskDetachConfirmationSurface } from "@/components/task/task-detach-confirm-dialog";
 import {
   TaskExternalLinkDialog,
   type ExternalLinkProvider,
@@ -37,8 +38,6 @@ import {
 } from "@/lib/types/http";
 import type { PluginTaskMenuContext } from "@/lib/plugins/types";
 import { usePluginRegistry } from "@/lib/plugins/registry";
-
-const EMPTY_REPOSITORIES: Repository[] = [];
 
 export interface Task {
   id: string;
@@ -303,6 +302,7 @@ function useKanbanCardMenus({
   const moveMenu = useKanbanCardMoveMenuActions({ task, steps, isSelected, selectedIds, onMove });
   const dialogs = useKanbanCardDialogState();
   const { detachTask, detachingTaskId } = useDetachTask();
+  const detachAnchorRef = useRef<HTMLDivElement>(null);
   const isDetaching = detachingTaskId === task.id;
   const disabled = Boolean(isDeleting || isArchiving || isDetaching);
   const actingOnMultiSelection = Boolean(isSelected && selectedIds && selectedIds.size > 1);
@@ -314,6 +314,12 @@ function useKanbanCardMenus({
     } catch (error) {
       console.error("Failed to detach task:", error);
     }
+  };
+
+  const requestDetachConfirmation = () => {
+    // Let Radix finish the menu's pointer sequence before the non-modal
+    // popover opens; otherwise the initiating menu event is an outside click.
+    window.setTimeout(() => dialogs.setShowDetachConfirm(true), 300);
   };
 
   const menuBase = {
@@ -329,10 +335,7 @@ function useKanbanCardMenus({
     onEdit: onEdit ? () => onEdit(task) : undefined,
     onArchive: onArchive ? () => dialogs.setShowArchiveConfirm(true) : undefined,
     onDelete: onDelete ? () => dialogs.setShowDeleteConfirm(true) : undefined,
-    onDetach:
-      task.parentTaskId && !actingOnMultiSelection
-        ? () => dialogs.setShowDetachConfirm(true)
-        : undefined,
+    onDetach: task.parentTaskId && !actingOnMultiSelection ? requestDetachConfirmation : undefined,
     ...buildLinkDialogHandlers(externalLinkAvailability, dialogs),
     pluginLinkActions,
   };
@@ -354,6 +357,7 @@ function useKanbanCardMenus({
       pluginMenuContext,
     }),
     isDetaching,
+    detachAnchorRef,
     handleDetachConfirm,
   };
 }
@@ -398,14 +402,6 @@ function KanbanCardDialogs({
         executorType={task.primaryExecutorType}
         isArchiving={isArchiving}
         onConfirm={({ cascade }) => onArchive?.(task, { cascade })}
-      />
-      <TaskDetachConfirmDialog
-        open={menu.showDetachConfirm}
-        onOpenChange={menu.setShowDetachConfirm}
-        taskTitle={task.title}
-        sharesParentWorkspace={task.workspaceMode === "inherit_parent"}
-        isDetaching={menu.isDetaching}
-        onConfirm={menu.handleDetachConfirm}
       />
       <TaskGitHubPRDialog
         workspaceId={workspaceId}
@@ -481,15 +477,6 @@ export function dispatchKanbanCardClick(
   handlers.onClick?.(task);
 }
 
-function useActiveWorkspaceRepositories() {
-  const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
-  return useAppStore((state) =>
-    activeWorkspaceId
-      ? (state.repositories.itemsByWorkspaceId[activeWorkspaceId] ?? EMPTY_REPOSITORIES)
-      : EMPTY_REPOSITORIES,
-  );
-}
-
 function KanbanCardFrame({
   task,
   repositoryChips,
@@ -522,30 +509,42 @@ function KanbanCardFrame({
   onClick: (e: React.MouseEvent) => void;
 }) {
   return (
-    <KanbanCardContextMenu entries={menu.contextMenuEntries}>
-      <KanbanCardShell
-        task={task}
-        repositoryChips={repositoryChips}
-        attributes={draggable.attributes}
-        listeners={draggable.listeners}
-        setNodeRef={draggable.setNodeRef}
-        transform={draggable.transform}
-        isDragging={draggable.isDragging}
-        isPreviewed={isPreviewed}
-        isSelected={isSelected}
-        isMultiSelectMode={isMultiSelectMode}
-        showMaximizeButton={showMaximizeButton}
-        isDeleting={isDeleting}
-        isArchiving={isArchiving}
-        menuEntries={menu.dropdownMenuEntries}
-        onClick={onClick}
-        onCheckboxClick={(e) => {
-          e.stopPropagation();
-          onToggleSelect?.(task.id);
-        }}
-        onOpenFullPage={onOpenFullPage}
+    <>
+      <div ref={menu.detachAnchorRef} className="w-full">
+        <KanbanCardContextMenu entries={menu.contextMenuEntries}>
+          <KanbanCardShell
+            task={task}
+            repositoryChips={repositoryChips}
+            attributes={draggable.attributes}
+            listeners={draggable.listeners}
+            setNodeRef={draggable.setNodeRef}
+            transform={draggable.transform}
+            isDragging={draggable.isDragging}
+            isPreviewed={isPreviewed}
+            isSelected={isSelected}
+            isMultiSelectMode={isMultiSelectMode}
+            showMaximizeButton={showMaximizeButton}
+            isDeleting={isDeleting}
+            isArchiving={isArchiving}
+            menuEntries={menu.dropdownMenuEntries}
+            onClick={onClick}
+            onCheckboxClick={(e) => {
+              e.stopPropagation();
+              onToggleSelect?.(task.id);
+            }}
+            onOpenFullPage={onOpenFullPage}
+          />
+        </KanbanCardContextMenu>
+      </div>
+      <TaskDetachConfirmationSurface
+        open={menu.showDetachConfirm}
+        anchorRef={menu.detachAnchorRef}
+        taskTitle={task.title}
+        sharesParentWorkspace={task.workspaceMode === "inherit_parent"}
+        onOpenChange={menu.setShowDetachConfirm}
+        onConfirm={menu.handleDetachConfirm}
       />
-    </KanbanCardContextMenu>
+    </>
   );
 }
 

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -5,6 +5,7 @@ import { useDraggable } from "@dnd-kit/core";
 import { KanbanCardContextMenu } from "@/components/kanban-card-context-menu";
 import { KanbanCardShell } from "@/components/kanban-card-content";
 import { useActiveWorkspaceRepositories } from "@/components/kanban-card-repositories";
+export { resolveTaskRepositoryChips } from "@/components/kanban-card-repositories";
 import {
   buildKanbanCardMenuEntries,
   useKanbanCardMoveTargets,
@@ -26,10 +27,7 @@ import { TaskMRLinkDialog } from "@/components/gitlab/task-mr-link-dialog";
 import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
 import { useTaskMultiSelectStore } from "@/hooks/use-task-multi-select";
 import { useDetachTask } from "@/hooks/use-detach-task";
-import { repositorySlug } from "@/lib/repository-slug";
-import { formatUserHomePath } from "@/lib/utils";
 import {
-  repositoryId as toRepositoryId,
   type ForegroundActivity,
   type Repository,
   type TaskPendingAction,
@@ -303,6 +301,7 @@ function useKanbanCardMenus({
   const dialogs = useKanbanCardDialogState();
   const { detachTask, detachingTaskId } = useDetachTask();
   const detachAnchorRef = useRef<HTMLDivElement>(null);
+  const detachFocusReturnRef = useRef<HTMLButtonElement>(null);
   const isDetaching = detachingTaskId === task.id;
   const disabled = Boolean(isDeleting || isArchiving || isDetaching);
   const actingOnMultiSelection = Boolean(isSelected && selectedIds && selectedIds.size > 1);
@@ -358,6 +357,7 @@ function useKanbanCardMenus({
     }),
     isDetaching,
     detachAnchorRef,
+    detachFocusReturnRef,
     handleDetachConfirm,
   };
 }
@@ -527,6 +527,7 @@ function KanbanCardFrame({
             isDeleting={isDeleting}
             isArchiving={isArchiving}
             menuEntries={menu.dropdownMenuEntries}
+            menuTriggerRef={menu.detachFocusReturnRef}
             onClick={onClick}
             onCheckboxClick={(e) => {
               e.stopPropagation();
@@ -539,6 +540,7 @@ function KanbanCardFrame({
       <TaskDetachConfirmationSurface
         open={menu.showDetachConfirm}
         anchorRef={menu.detachAnchorRef}
+        focusReturnRef={menu.detachFocusReturnRef}
         taskTitle={task.title}
         sharesParentWorkspace={task.workspaceMode === "inherit_parent"}
         onOpenChange={menu.setShowDetachConfirm}
@@ -629,34 +631,4 @@ export function KanbanCard({
       />
     </>
   );
-}
-
-/**
- * Resolves a task's linked repositories to card chip data. Primary first
- * (`task.repositoryId`), then any others ordered by `task.repositories[].position`.
- * Skips unresolved IDs (repo deleted / not yet hydrated).
- */
-export function resolveTaskRepositoryChips(
-  task: Task,
-  repositories: Repository[],
-): RepositoryChip[] {
-  const byId = new Map(repositories.map((repo) => [repo.id, repo]));
-  const seen = new Set<string>();
-  const chips: RepositoryChip[] = [];
-  const push = (id: string | undefined) => {
-    if (!id || seen.has(id)) return;
-    const repo = byId.get(toRepositoryId(id));
-    if (!repo) return;
-    seen.add(id);
-    const label = repositorySlug(repo);
-    if (!label) return;
-    chips.push({
-      label,
-      ...(repo.local_path ? { path: formatUserHomePath(repo.local_path) } : {}),
-    });
-  };
-  push(task.repositoryId);
-  const ordered = [...(task.repositories ?? [])].sort((a, b) => a.position - b.position);
-  for (const link of ordered) push(link.repository_id);
-  return chips;
 }

--- a/apps/web/components/task/simple/components/parent-picker.test.tsx
+++ b/apps/web/components/task/simple/components/parent-picker.test.tsx
@@ -15,6 +15,7 @@ const fetchTaskMock = vi.hoisted(() =>
   }),
 );
 const updateTaskMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
+const PARENT_PICKER_TRIGGER = "parent-picker-trigger";
 
 vi.mock("@/lib/api/domains/kanban-api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api/domains/kanban-api")>(
@@ -102,7 +103,7 @@ describe("ParentPicker", () => {
 
     await waitFor(() => expect(fetchTaskMock).toHaveBeenCalledWith(task.id));
 
-    fireEvent.click(screen.getByTestId("parent-picker-trigger"));
+    fireEvent.click(screen.getByTestId(PARENT_PICKER_TRIGGER));
     fireEvent.click(await screen.findByText("No parent"));
     const confirmation = await screen.findByRole("dialog", { name: "Detach task from parent?" });
     expect(screen.queryByRole("alertdialog")).toBeNull();
@@ -122,12 +123,40 @@ describe("ParentPicker", () => {
       </Wrapper>,
     );
 
-    fireEvent.click(screen.getByTestId("parent-picker-trigger"));
+    fireEvent.click(screen.getByTestId(PARENT_PICKER_TRIGGER));
     await act(async () => {
       fireEvent.click(await screen.findByText("Parent two"));
     });
 
     expect(updateTaskMock).toHaveBeenCalledWith(task.id, { parent_id: "parent-2" });
     expect(detachTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending detach confirmation when another parent is selected", async () => {
+    render(
+      <Wrapper>
+        <ParentPicker task={task} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId(PARENT_PICKER_TRIGGER));
+    const noParent = await screen.findByText("No parent");
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(noParent);
+      fireEvent.click(screen.getByTestId(PARENT_PICKER_TRIGGER));
+      await act(async () => {
+        fireEvent.click(screen.getByText("Parent two"));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(updateTaskMock).toHaveBeenCalledWith(task.id, { parent_id: "parent-2" });
+      expect(screen.queryByRole("dialog", { name: "Detach task from parent?" })).toBeNull();
+      expect(detachTaskMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/components/task/simple/components/parent-picker.test.tsx
+++ b/apps/web/components/task/simple/components/parent-picker.test.tsx
@@ -93,7 +93,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 }
 
 describe("ParentPicker", () => {
-  it("uses canonical detach after confirming No parent", async () => {
+  it("uses a local confirmation after selecting No parent", async () => {
     render(
       <Wrapper>
         <ParentPicker task={task} />
@@ -104,10 +104,11 @@ describe("ParentPicker", () => {
 
     fireEvent.click(screen.getByTestId("parent-picker-trigger"));
     fireEvent.click(await screen.findByText("No parent"));
-    const dialog = await screen.findByRole("alertdialog", { name: "Detach task from parent?" });
-    expect(dialog.textContent).toContain("shares its parent's workspace");
+    const confirmation = await screen.findByRole("dialog", { name: "Detach task from parent?" });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(confirmation.textContent).toContain("shares its parent's workspace");
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Detach" }));
+      fireEvent.click(screen.getByTestId("detach-task-confirm"));
     });
 
     expect(detachTaskMock).toHaveBeenCalledWith(task.id);

--- a/apps/web/components/task/simple/components/parent-picker.tsx
+++ b/apps/web/components/task/simple/components/parent-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { useAppStore } from "@/components/state-provider";
 import { TaskDetachConfirmationSurface } from "@/components/task/task-detach-confirm-dialog";
@@ -18,6 +18,27 @@ type ParentPickerProps = {
 };
 
 const NO_PARENT = "__none__";
+const DETACH_CONFIRMATION_DELAY_MS = 300;
+
+function useDeferredDetachConfirmation() {
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const cancelPending = useCallback(() => {
+    if (timerRef.current === null) return;
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+  const request = useCallback(() => {
+    cancelPending();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      setOpen(true);
+    }, DETACH_CONFIRMATION_DELAY_MS);
+  }, [cancelPending]);
+
+  useEffect(() => cancelPending, [cancelPending]);
+  return { open, setOpen, cancelPending, request };
+}
 
 function useTaskWorkspaceMode(task: Task) {
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode | undefined>(task.workspaceMode);
@@ -72,9 +93,9 @@ export function ParentPicker({ task }: ParentPickerProps) {
   const storeTasks = useAppStore((s) => s.office.tasks.items);
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const [fetched, setFetched] = useState<OfficeTask[]>([]);
-  const [detachRequested, setDetachRequested] = useState(false);
   const [isDetaching, setIsDetaching] = useState(false);
   const detachAnchorRef = useRef<HTMLButtonElement>(null);
+  const detachConfirmation = useDeferredDetachConfirmation();
   const workspaceMode = useTaskWorkspaceMode(task);
   const mutate = useOptimisticTaskMutation();
 
@@ -107,16 +128,13 @@ export function ParentPicker({ task }: ParentPickerProps) {
 
   const currentValue = task.parentId || NO_PARENT;
 
-  const requestDetachConfirmation = () => {
-    // Let the combobox finish closing before the local confirmation opens.
-    window.setTimeout(() => setDetachRequested(true), 300);
-  };
-
   const handleSelect = async (next: string) => {
+    detachConfirmation.cancelPending();
     const sendValue = next === NO_PARENT || next === "" ? "" : next;
     if (sendValue === (task.parentId ?? "")) return;
     if (!sendValue) {
-      requestDetachConfirmation();
+      // Let the combobox finish closing before the local confirmation opens.
+      detachConfirmation.request();
       return;
     }
     const matched = candidates.find((t) => t.id === sendValue);
@@ -148,7 +166,7 @@ export function ParentPicker({ task }: ParentPickerProps) {
         },
         () => detachTask(task.id),
       );
-      setDetachRequested(false);
+      detachConfirmation.setOpen(false);
     } catch {
       // useOptimisticTaskMutation restores state and reports the request error.
     } finally {
@@ -172,11 +190,11 @@ export function ParentPicker({ task }: ParentPickerProps) {
         testId="parent-picker-trigger"
       />
       <TaskDetachConfirmationSurface
-        open={detachRequested}
+        open={detachConfirmation.open}
         anchorRef={detachAnchorRef}
         taskTitle={task.title}
         sharesParentWorkspace={workspaceMode === "inherit_parent"}
-        onOpenChange={setDetachRequested}
+        onOpenChange={detachConfirmation.setOpen}
         onConfirm={handleDetachConfirm}
       />
     </>

--- a/apps/web/components/task/simple/components/parent-picker.tsx
+++ b/apps/web/components/task/simple/components/parent-picker.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { useAppStore } from "@/components/state-provider";
+import { TaskDetachConfirmationSurface } from "@/components/task/task-detach-confirm-dialog";
 import { searchTasks, updateTask } from "@/lib/api/domains/office-extended-api";
 import { detachTask, fetchTask } from "@/lib/api/domains/kanban-api";
 import { useOptimisticTaskMutation } from "@/hooks/use-optimistic-task-mutation";
-import { TaskDetachConfirmDialog } from "@/components/task/task-detach-confirm-dialog";
 import type { OfficeTask } from "@/lib/state/slices/office/types";
 import type { Task } from "@/app/office/tasks/[id]/types";
 import { workspaceModeFromMetadata, type WorkspaceMode } from "@/lib/kanban/map-task";
@@ -74,6 +74,7 @@ export function ParentPicker({ task }: ParentPickerProps) {
   const [fetched, setFetched] = useState<OfficeTask[]>([]);
   const [detachRequested, setDetachRequested] = useState(false);
   const [isDetaching, setIsDetaching] = useState(false);
+  const detachAnchorRef = useRef<HTMLButtonElement>(null);
   const workspaceMode = useTaskWorkspaceMode(task);
   const mutate = useOptimisticTaskMutation();
 
@@ -106,11 +107,16 @@ export function ParentPicker({ task }: ParentPickerProps) {
 
   const currentValue = task.parentId || NO_PARENT;
 
+  const requestDetachConfirmation = () => {
+    // Let the combobox finish closing before the local confirmation opens.
+    window.setTimeout(() => setDetachRequested(true), 300);
+  };
+
   const handleSelect = async (next: string) => {
     const sendValue = next === NO_PARENT || next === "" ? "" : next;
     if (sendValue === (task.parentId ?? "")) return;
     if (!sendValue) {
-      setDetachRequested(true);
+      requestDetachConfirmation();
       return;
     }
     const matched = candidates.find((t) => t.id === sendValue);
@@ -162,14 +168,15 @@ export function ParentPicker({ task }: ParentPickerProps) {
         disabled={isDetaching}
         triggerClassName="h-7 w-full justify-end px-2"
         popoverAlign="end"
+        triggerRef={detachAnchorRef}
         testId="parent-picker-trigger"
       />
-      <TaskDetachConfirmDialog
+      <TaskDetachConfirmationSurface
         open={detachRequested}
-        onOpenChange={setDetachRequested}
+        anchorRef={detachAnchorRef}
         taskTitle={task.title}
         sharesParentWorkspace={workspaceMode === "inherit_parent"}
-        isDetaching={isDetaching}
+        onOpenChange={setDetachRequested}
         onConfirm={handleDetachConfirm}
       />
     </>

--- a/apps/web/components/task/task-detach-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-detach-confirm-dialog.test.tsx
@@ -1,0 +1,86 @@
+import { useRef, useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TaskDetachConfirmPopover,
+  TaskDetachInlineConfirmation,
+  TaskDetachTargetConfirmDialog,
+} from "./task-detach-confirm-dialog";
+
+afterEach(cleanup);
+
+function PopoverHarness({ onConfirm = vi.fn() }: { onConfirm?: () => void | Promise<void> }) {
+  const [open, setOpen] = useState(true);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={anchorRef} type="button" data-testid="detach-anchor">
+        Child task
+      </button>
+      <TaskDetachConfirmPopover
+        open={open}
+        anchorRef={anchorRef}
+        taskTitle="Child task"
+        sharesParentWorkspace
+        onOpenChange={setOpen}
+        onConfirm={onConfirm}
+      />
+    </>
+  );
+}
+
+describe("task detach confirmation adapters", () => {
+  it("uses the local popover while preserving hierarchy-only copy", async () => {
+    render(<PopoverHarness />);
+
+    const confirmation = await screen.findByRole("dialog", { name: "Detach task from parent?" });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(confirmation.textContent).toContain("workflow, subtasks, and state will not change");
+    expect(confirmation.textContent).toContain("shares its parent's workspace");
+    expect(screen.getByTestId("detach-task-confirm").classList.contains("min-h-11")).toBe(true);
+  });
+
+  it("keeps inline touch actions local and closes before confirming", async () => {
+    let shellClosed = false;
+    const onConfirm = vi.fn(() => {
+      shellClosed = screen.queryByTestId("detach-task-inline-confirmation") === null;
+    });
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      if (!open) return null;
+      return (
+        <TaskDetachInlineConfirmation
+          taskTitle="Child task"
+          onCancel={() => setOpen(false)}
+          onClose={() => setOpen(false)}
+          onConfirm={onConfirm}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const confirm = screen.getByTestId("detach-task-confirm");
+    expect(confirm.classList.contains("h-11")).toBe(true);
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+    expect(shellClosed).toBe(true);
+    expect(screen.queryByTestId("detach-task-inline-confirmation")).toBeNull();
+  });
+
+  it("keeps task-switcher detachment on its existing modal branch", async () => {
+    render(
+      <TaskDetachTargetConfirmDialog
+        target={{ id: "child", title: "Child task", workspaceMode: "inherit_parent" }}
+        detachingTaskId={null}
+        onDismiss={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("alertdialog", { name: "Detach task from parent?" })).not.toBeNull(),
+    );
+  });
+});

--- a/apps/web/components/task/task-detach-confirm-dialog.tsx
+++ b/apps/web/components/task/task-detach-confirm-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode, RefObject } from "react";
 import { IconLoader } from "@tabler/icons-react";
 import {
   AlertDialog,
@@ -12,6 +13,165 @@ import {
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
 import { useTranslation } from "react-i18next";
+import { ActionConfirmPopover } from "@/components/confirmation/action-confirm-popover";
+import { InlineConfirmActions } from "@/components/confirmation/inline-confirm-actions";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
+
+const DETACH_TASK_FROM_PARENT_KEY = "task:detachTaskFromParent";
+const DETACH_LABEL_KEY = "task:detach";
+
+export type TaskDetachConfirmationCopyProps = {
+  taskTitle?: string;
+  sharesParentWorkspace?: boolean;
+};
+
+function TaskDetachDescription({
+  taskTitle,
+  sharesParentWorkspace,
+}: TaskDetachConfirmationCopyProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <span className="block space-y-2">
+      <span className="block">
+        {t("task:detachWillBecomeTopLevel", {
+          taskTitle: taskTitle || t("task:thisTask2"),
+        })}
+      </span>
+      <span className="block">{t("task:detachingChangesTheHierarchyOnlyAccess")}</span>
+      {sharesParentWorkspace && (
+        <span className="block font-medium text-foreground">
+          {t("task:thisTaskSharesItsParentS")}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function detachConfirmAriaLabel(t: (key: string) => string, taskTitle?: string): string {
+  return taskTitle ? `${t(DETACH_LABEL_KEY)} ${taskTitle}` : t(DETACH_TASK_FROM_PARENT_KEY);
+}
+
+export type TaskDetachConfirmPopoverProps = TaskDetachConfirmationCopyProps & {
+  open: boolean;
+  anchorRef: RefObject<HTMLElement | null>;
+  focusBoundaryRef?: RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
+  onCancel?: () => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+export function TaskDetachConfirmPopover({
+  open,
+  anchorRef,
+  focusBoundaryRef,
+  taskTitle,
+  sharesParentWorkspace,
+  onOpenChange,
+  onCancel,
+  onConfirm,
+}: TaskDetachConfirmPopoverProps) {
+  const { t } = useTranslation();
+  return (
+    <ActionConfirmPopover
+      open={open}
+      anchorRef={anchorRef}
+      focusBoundaryRef={focusBoundaryRef}
+      title={t(DETACH_TASK_FROM_PARENT_KEY)}
+      description={
+        <TaskDetachDescription
+          taskTitle={taskTitle}
+          sharesParentWorkspace={sharesParentWorkspace}
+        />
+      }
+      cancelLabel={t("common:cancel")}
+      confirmLabel={t(DETACH_LABEL_KEY)}
+      confirmAriaLabel={detachConfirmAriaLabel(t, taskTitle)}
+      confirmTestId="detach-task-confirm"
+      testId="detach-task-confirm-popover"
+      onOpenChange={onOpenChange}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+export type TaskDetachInlineConfirmationProps = TaskDetachConfirmationCopyProps & {
+  onCancel: () => void;
+  onClose?: () => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+export function TaskDetachInlineConfirmation({
+  taskTitle,
+  sharesParentWorkspace,
+  onCancel,
+  onClose,
+  onConfirm,
+}: TaskDetachInlineConfirmationProps) {
+  const { t } = useTranslation();
+  return (
+    <InlineConfirmActions
+      density="touch"
+      testId="detach-task-inline-confirmation"
+      ariaLabel={t(DETACH_TASK_FROM_PARENT_KEY)}
+      description={
+        <TaskDetachDescription
+          taskTitle={taskTitle}
+          sharesParentWorkspace={sharesParentWorkspace}
+        />
+      }
+      cancelLabel={t("common:cancel")}
+      confirmLabel={t(DETACH_LABEL_KEY)}
+      confirmAriaLabel={detachConfirmAriaLabel(t, taskTitle)}
+      confirmTestId="detach-task-confirm"
+      onCancel={onCancel}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+export type TaskDetachConfirmationSurfaceProps = TaskDetachConfirmationCopyProps & {
+  open: boolean;
+  anchorRef: RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+export function TaskDetachConfirmationSurface({
+  open,
+  anchorRef,
+  taskTitle,
+  sharesParentWorkspace,
+  onOpenChange,
+  onConfirm,
+}: TaskDetachConfirmationSurfaceProps) {
+  const { isFinePointer } = useResponsiveBreakpoint();
+  if (isFinePointer) {
+    return (
+      <TaskDetachConfirmPopover
+        open={open}
+        anchorRef={anchorRef}
+        focusBoundaryRef={anchorRef}
+        taskTitle={taskTitle}
+        sharesParentWorkspace={sharesParentWorkspace}
+        onOpenChange={onOpenChange}
+        onCancel={() => onOpenChange(false)}
+        onConfirm={onConfirm}
+      />
+    );
+  }
+  if (!open) return null;
+  return (
+    <TaskDetachInlineConfirmation
+      taskTitle={taskTitle}
+      sharesParentWorkspace={sharesParentWorkspace}
+      onCancel={() => onOpenChange(false)}
+      onClose={() => onOpenChange(false)}
+      onConfirm={onConfirm}
+    />
+  );
+}
 
 type TaskDetachConfirmDialogProps = {
   open: boolean;
@@ -40,18 +200,13 @@ export function TaskDetachConfirmDialog({
     >
       <AlertDialogContent onClick={(event) => event.stopPropagation()}>
         <AlertDialogHeader>
-          <AlertDialogTitle>{t("task:detachTaskFromParent")}</AlertDialogTitle>
+          <AlertDialogTitle>{t(DETACH_TASK_FROM_PARENT_KEY)}</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-2">
-              <p>
-                {t("task:detachWillBecomeTopLevel", {
-                  taskTitle: taskTitle || t("task:thisTask2"),
-                })}
-              </p>
-              <p>{t("task:detachingChangesTheHierarchyOnlyAccess")}</p>
-              {sharesParentWorkspace && (
-                <p className="font-medium text-foreground">{t("task:thisTaskSharesItsParentS")}</p>
-              )}
+            <div>
+              <TaskDetachDescription
+                taskTitle={taskTitle}
+                sharesParentWorkspace={sharesParentWorkspace}
+              />
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
@@ -69,7 +224,7 @@ export function TaskDetachConfirmDialog({
             }}
           >
             {isDetaching && <IconLoader className="mr-2 h-4 w-4 animate-spin" />}
-            {t("task:detach")}
+            {t(DETACH_LABEL_KEY)}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/web/components/task/task-detach-confirm-dialog.tsx
+++ b/apps/web/components/task/task-detach-confirm-dialog.tsx
@@ -54,6 +54,7 @@ function detachConfirmAriaLabel(t: (key: string) => string, taskTitle?: string):
 export type TaskDetachConfirmPopoverProps = TaskDetachConfirmationCopyProps & {
   open: boolean;
   anchorRef: RefObject<HTMLElement | null>;
+  focusReturnRef?: RefObject<HTMLElement | null>;
   focusBoundaryRef?: RefObject<HTMLElement | null>;
   onOpenChange: (open: boolean) => void;
   onCancel?: () => void;
@@ -63,6 +64,7 @@ export type TaskDetachConfirmPopoverProps = TaskDetachConfirmationCopyProps & {
 export function TaskDetachConfirmPopover({
   open,
   anchorRef,
+  focusReturnRef,
   focusBoundaryRef,
   taskTitle,
   sharesParentWorkspace,
@@ -75,6 +77,7 @@ export function TaskDetachConfirmPopover({
     <ActionConfirmPopover
       open={open}
       anchorRef={anchorRef}
+      focusReturnRef={focusReturnRef}
       focusBoundaryRef={focusBoundaryRef}
       title={t(DETACH_TASK_FROM_PARENT_KEY)}
       description={
@@ -134,6 +137,7 @@ export function TaskDetachInlineConfirmation({
 export type TaskDetachConfirmationSurfaceProps = TaskDetachConfirmationCopyProps & {
   open: boolean;
   anchorRef: RefObject<HTMLElement | null>;
+  focusReturnRef?: RefObject<HTMLElement | null>;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void | Promise<void>;
 };
@@ -141,6 +145,7 @@ export type TaskDetachConfirmationSurfaceProps = TaskDetachConfirmationCopyProps
 export function TaskDetachConfirmationSurface({
   open,
   anchorRef,
+  focusReturnRef,
   taskTitle,
   sharesParentWorkspace,
   onOpenChange,
@@ -152,6 +157,7 @@ export function TaskDetachConfirmationSurface({
       <TaskDetachConfirmPopover
         open={open}
         anchorRef={anchorRef}
+        focusReturnRef={focusReturnRef}
         focusBoundaryRef={anchorRef}
         taskTitle={taskTitle}
         sharesParentWorkspace={sharesParentWorkspace}

--- a/apps/web/e2e/tests/task/mobile-subtask-detachment.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-subtask-detachment.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
 import { SessionPage } from "../../pages/session-page";
 
 test.describe("Mobile subtask detachment", () => {
@@ -64,5 +65,51 @@ test.describe("Mobile subtask detachment", () => {
       .getByRole("button", { name: "Task actions" })
       .click();
     await expect(testPage.getByRole("menuitem", { name: "Detach from parent" })).toHaveCount(0);
+  });
+
+  test("keeps kanban detachment inline on a phone", async ({ testPage, apiClient, seedData }) => {
+    const placement = {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    };
+    const parent = await apiClient.createTask(
+      seedData.workspaceId,
+      "Mobile card parent",
+      placement,
+    );
+    const child = await apiClient.createTask(seedData.workspaceId, "Mobile card child", {
+      ...placement,
+      parent_id: parent.id,
+      workspace_mode: "new_workspace",
+    });
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    const card = mobile.taskCard(child.id);
+    await card.getByRole("button", { name: "More options" }).click();
+    let menu = testPage.locator('[data-slot="dropdown-menu-content"]:visible');
+    await menu.getByRole("menuitem", { name: "Detach from parent" }).click();
+
+    let inlineConfirmation = testPage.getByTestId("detach-task-inline-confirmation");
+    await expect(inlineConfirmation).toBeVisible();
+    await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
+    await expect(inlineConfirmation.getByTestId("detach-task-confirm")).toHaveClass(/h-11/);
+    await expect(inlineConfirmation.getByTestId("detach-task-confirm")).toHaveClass(/min-w-11/);
+    await expect
+      .poll(() => testPage.evaluate(() => document.documentElement.scrollWidth <= innerWidth))
+      .toBe(true);
+
+    await inlineConfirmation.getByRole("button", { name: "Cancel" }).click();
+    await expect(inlineConfirmation).toHaveCount(0);
+    await expect.poll(async () => (await apiClient.getTask(child.id)).parent_id).toBe(parent.id);
+
+    await card.getByRole("button", { name: "More options" }).click();
+    menu = testPage.locator('[data-slot="dropdown-menu-content"]:visible');
+    await menu.getByRole("menuitem", { name: "Detach from parent" }).click();
+    inlineConfirmation = testPage.getByTestId("detach-task-inline-confirmation");
+    await inlineConfirmation.getByTestId("detach-task-confirm").click();
+
+    await expect.poll(async () => (await apiClient.getTask(child.id)).parent_id ?? "").toBe("");
   });
 });

--- a/apps/web/e2e/tests/task/subtask-detachment.spec.ts
+++ b/apps/web/e2e/tests/task/subtask-detachment.spec.ts
@@ -113,6 +113,9 @@ test.describe("Subtask detachment", () => {
     await expect(contextConfirmation).toBeVisible();
     await contextConfirmation.getByRole("button", { name: "Cancel" }).click();
     await expect(contextConfirmation).toHaveCount(0);
+    await expect(
+      kanban.taskCard(child.id).getByRole("button", { name: "More options" }),
+    ).toBeFocused();
     await expect.poll(async () => (await apiClient.getTask(child.id)).parent_id).toBe(parent.id);
 
     await kanban.openTaskActionsMenu(child.id);

--- a/apps/web/e2e/tests/task/subtask-detachment.spec.ts
+++ b/apps/web/e2e/tests/task/subtask-detachment.spec.ts
@@ -108,11 +108,20 @@ test.describe("Subtask detachment", () => {
 
     await kanban.openTaskContextMenu(child.id);
     await expect(testPage.getByRole("menuitem", { name: DETACH_LABEL })).toBeVisible();
-    await testPage.keyboard.press("Escape");
+    await testPage.getByRole("menuitem", { name: DETACH_LABEL }).click();
+    const contextConfirmation = testPage.getByRole("dialog", { name: "Detach task from parent?" });
+    await expect(contextConfirmation).toBeVisible();
+    await contextConfirmation.getByRole("button", { name: "Cancel" }).click();
+    await expect(contextConfirmation).toHaveCount(0);
+    await expect.poll(async () => (await apiClient.getTask(child.id)).parent_id).toBe(parent.id);
 
     await kanban.openTaskActionsMenu(child.id);
     await testPage.getByRole("menuitem", { name: DETACH_LABEL }).click();
-    await testPage.getByRole("alertdialog").getByTestId("detach-task-confirm").click();
+    const confirmation = testPage.getByRole("dialog", { name: "Detach task from parent?" });
+    await expect(confirmation).toBeVisible();
+    await expect(testPage.getByRole("alertdialog")).toHaveCount(0);
+    await expect(confirmation).toContainText("workflow, subtasks, and state will not change");
+    await confirmation.getByTestId("detach-task-confirm").click();
 
     await expect(kanban.taskCardInColumn("Detach kanban child", seedData.startStepId)).toBeVisible({
       timeout: 10_000,


### PR DESCRIPTION
Detaching a subtask from a kanban card or Office parent picker now confirms beside the initiating action, so hierarchy-only consequences remain visible without blocking the page. Fine pointers use an anchored popover and phone layouts keep touch-sized inline actions, while task-switcher detachment retains its modal behavior.

## Validation

- `cd apps && pnpm install --frozen-lockfile`
- Focused Vitest: 4 files, 12 tests passed.
- `pnpm run typecheck`
- `pnpm run i18n:check`
- `pnpm run i18n:ratchet`
- Affected ESLint with `--max-warnings 0`.
- `pnpm run e2e:sleep-ratchet`
- Desktop detachment E2E: 2 passed.
- Mobile detachment E2E (`mobile-chrome`): 2 passed.
- Fresh desktop and mobile PR captures validated and PNG-compressed.
- No public documentation change needed for this UI-only presentation update.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- kandev-screenshots-start -->
## Screenshots

![Desktop task detach confirmation](https://raw.githubusercontent.com/kdlbs/kandev/5e772f25d624bae17fe118c34cb20644716f6be8/desktop-task-detach-confirmation.png)

![Mobile task detach inline confirmation](https://raw.githubusercontent.com/kdlbs/kandev/5e772f25d624bae17fe118c34cb20644716f6be8/mobile-task-detach-inline-confirmation.png)
<!-- kandev-screenshots-end -->