### PR TITLE
fix(web): virtualize large Kanban columns

### DIFF
--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tiptap/core':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/pm@3.19.0)
@@ -2630,9 +2633,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
@@ -8435,7 +8447,15 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -2,12 +2,7 @@
 
 import { useMemo } from "react";
 import { useDroppable } from "@dnd-kit/core";
-import {
-  KanbanCard,
-  resolveTaskRepositoryChips,
-  Task,
-  type KanbanPresentation,
-} from "./kanban-card";
+import { Task, type KanbanPresentation } from "./kanban-card";
 import { Badge } from "@kandev/ui/badge";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
@@ -16,6 +11,7 @@ import type { Repository } from "@/lib/types/http";
 import { countAdmittedTasks, formatWipCount, isOverWipLimit } from "@/lib/kanban/wip-limit";
 import { partitionWipTasks } from "@/lib/kanban/wip-queue";
 import { useTranslation } from "react-i18next";
+import { VirtualizedColumnTaskList } from "./kanban/virtualized-column-task-list";
 
 export interface WorkflowStep {
   id: string;
@@ -109,7 +105,6 @@ export function KanbanColumn({
   isMultiSelectMode,
   externalLinkAvailability,
 }: KanbanColumnProps) {
-  const { t } = useTranslation();
   const { setNodeRef, isOver } = useDroppable({
     id: step.id,
   });
@@ -125,8 +120,7 @@ export function KanbanColumn({
   // Ordered ids of the cards rendered in this column — the source of truth for
   // shift-click range selection (matches exactly what the user sees).
   const { admitted, queued } = useMemo(() => partitionWipTasks(tasks, step.id), [tasks, step.id]);
-  const orderedTasks = [...admitted, ...queued];
-  const columnTaskIds = useMemo(() => orderedTasks.map((task) => task.id), [orderedTasks]);
+  const orderedTasks = useMemo(() => [...admitted, ...queued], [admitted, queued]);
 
   return (
     <div
@@ -141,61 +135,30 @@ export function KanbanColumn({
       {/* Column Header */}
       {!hideHeader && <ColumnHeader step={step} tasks={tasks} />}
 
-      {/* Tasks */}
-      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden space-y-2 px-1 pt-1">
-        {orderedTasks.map((task, index) => (
-          <div key={task.id} className="space-y-2">
-            {queued.length > 0 && index === admitted.length && (
-              <div
-                className="flex items-center gap-2 border-t border-dashed border-border/60 pt-3 text-xs font-medium text-muted-foreground"
-                data-testid="kanban-queued-section"
-              >
-                <span>{t("kanban:queuedSection")}</span>
-                <span className="tabular-nums">{queued.length}</span>
-              </div>
-            )}
-            <KanbanCard
-              key={task.id}
-              task={queuedTaskWithTitle(task, steps, step)}
-              workspaceId={activeWorkspaceId}
-              presentation={presentation}
-              externalLinkAvailability={externalLinkAvailability}
-              repositoryChips={resolveTaskRepositoryChips(task, repositories)}
-              onClick={onPreviewTask}
-              onOpenFullPage={onOpenTask}
-              onEdit={onEditTask}
-              onDelete={onDeleteTask}
-              onArchive={onArchiveTask}
-              onMove={onMoveTask}
-              steps={steps}
-              showMaximizeButton={showMaximizeButton}
-              isDeleting={deletingTaskId === task.id}
-              isArchiving={archivingTaskId === task.id}
-              isSelected={selectedIds?.has(task.id)}
-              selectedIds={selectedIds}
-              onToggleSelect={onToggleSelect}
-              onRangeSelect={
-                onSelectRange ? (taskId) => onSelectRange(taskId, columnTaskIds) : undefined
-              }
-              isMultiSelectMode={isMultiSelectMode}
-            />
-          </div>
-        ))}
-      </div>
+      <VirtualizedColumnTaskList
+        orderedTasks={orderedTasks}
+        queuedStartIndex={admitted.length}
+        queuedCount={queued.length}
+        step={step}
+        steps={steps}
+        presentation={presentation}
+        workspaceId={activeWorkspaceId}
+        repositories={repositories}
+        externalLinkAvailability={externalLinkAvailability}
+        showMaximizeButton={showMaximizeButton}
+        deletingTaskId={deletingTaskId}
+        archivingTaskId={archivingTaskId}
+        selectedIds={selectedIds}
+        onPreviewTask={onPreviewTask}
+        onOpenTask={onOpenTask}
+        onEditTask={onEditTask}
+        onDeleteTask={onDeleteTask}
+        onArchiveTask={onArchiveTask}
+        onMoveTask={onMoveTask}
+        onToggleSelect={onToggleSelect}
+        onSelectRange={onSelectRange}
+        isMultiSelectMode={isMultiSelectMode}
+      />
     </div>
   );
-}
-
-function queuedTaskWithTitle(
-  task: Task,
-  steps: WorkflowStep[] | undefined,
-  step: WorkflowStep,
-): Task {
-  if (!task.queuedForStepId) return task;
-  return {
-    ...task,
-    queuedForStepTitle:
-      steps?.find((candidate) => candidate.id === task.queuedForStepId)?.title ??
-      (task.queuedForStepId === step.id ? step.title : undefined),
-  };
 }

--- a/apps/web/components/kanban/adaptive-desktop-kanban.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.tsx
@@ -11,18 +11,18 @@ type AdaptiveDesktopKanbanProps = {
 
 export function AdaptiveDesktopKanban({ steps, renderColumn }: AdaptiveDesktopKanbanProps) {
   return (
-    <div data-testid="desktop-kanban-layout" className="h-full min-w-0">
+    <div data-testid="desktop-kanban-layout" className="h-full min-h-0 min-w-0">
       <div
         data-testid="desktop-kanban-scroll-window"
-        className="h-full min-w-0 overflow-x-auto snap-x snap-mandatory"
+        className="h-full min-h-0 min-w-0 overflow-x-auto snap-x snap-mandatory"
       >
         <div
           data-testid="desktop-kanban-lane-grid"
-          className="grid h-full min-w-full gap-0"
+          className="grid h-full min-h-0 min-w-full gap-0"
           style={{ gridTemplateColumns: getKanbanColumnGridTemplate(steps.length) }}
         >
           {steps.map((step) => (
-            <div key={step.id} className="min-w-0 snap-start">
+            <div key={step.id} className="min-h-0 min-w-0 snap-start">
               {renderColumn(step)}
             </div>
           ))}

--- a/apps/web/components/kanban/swimlane-container.tsx
+++ b/apps/web/components/kanban/swimlane-container.tsx
@@ -183,7 +183,11 @@ function SortableWorkflowItem({
   };
   const dragHandleProps = isSortable && !hideHeader ? { ...attributes, ...listeners } : undefined;
   return (
-    <div ref={setNodeRef} style={style} className={fillHeight ? "min-h-0 flex-1" : undefined}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={fillHeight ? "h-full min-h-0 flex-1" : undefined}
+    >
       <WorkflowItemContent
         wf={wf}
         hideHeader={hideHeader}
@@ -239,6 +243,7 @@ function WorkflowItemContent({
       dragHandleProps={dragHandleProps}
       onToggleMultiSelect={onToggleMultiSelect}
       isMultiSelectMode={viewProps.isMultiSelectMode}
+      fillHeight={fillHeight}
       columnsMenu={
         <ColumnsMenu
           workflowId={wf.id}
@@ -554,7 +559,7 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
             ViewComponent={ViewComponent}
             hideHeaders={hideHeaders}
             onToggleStepVisibility={onToggleStepVisibility}
-            fillHeight={isMobileKanban}
+            fillHeight={view.id === "kanban"}
             canSortWorkflows={canSortWorkflows}
             isCollapsed={isCollapsed}
             toggleCollapse={toggleCollapse}

--- a/apps/web/components/kanban/swimlane-container.tsx
+++ b/apps/web/components/kanban/swimlane-container.tsx
@@ -402,6 +402,7 @@ type WorkflowItemsProps = {
   ViewComponent: ComponentType<ViewContentProps>;
   hideHeaders: boolean;
   fillHeight: boolean;
+  isMobileKanban: boolean;
   onToggleStepVisibility: (workflowId: string, stepId: string) => void;
   canSortWorkflows: boolean;
   isCollapsed: (workflowId: string) => boolean;
@@ -417,6 +418,7 @@ function WorkflowItems({
   ViewComponent,
   hideHeaders,
   fillHeight,
+  isMobileKanban,
   onToggleStepVisibility,
   canSortWorkflows,
   isCollapsed,
@@ -427,17 +429,18 @@ function WorkflowItems({
   return workflows.map((workflow, index) => {
     const snapshot = snapshots[workflow.id];
     if (!snapshot) return null;
+    const collapsed = isCollapsed(workflow.id);
     return (
       <SortableWorkflowItem
-        key={fillHeight ? "mobile-active-workflow" : workflow.id}
+        key={isMobileKanban ? "mobile-active-workflow" : workflow.id}
         wf={workflow}
         snapshot={snapshot}
         tasks={getFilteredTasks(workflow.id)}
         ViewComponent={ViewComponent}
         hideHeader={hideHeaders}
-        fillHeight={fillHeight}
-        isSortable={canSortWorkflows && !fillHeight}
-        isCollapsed={isCollapsed(workflow.id)}
+        fillHeight={fillHeight && !collapsed}
+        isSortable={canSortWorkflows && !isMobileKanban}
+        isCollapsed={collapsed}
         onToggleCollapse={() => toggleCollapse(workflow.id)}
         onPreviewTask={containerProps.onPreviewTask}
         onOpenTask={containerProps.onOpenTask}
@@ -560,6 +563,7 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
             hideHeaders={hideHeaders}
             onToggleStepVisibility={onToggleStepVisibility}
             fillHeight={view.id === "kanban"}
+            isMobileKanban={isMobileKanban}
             canSortWorkflows={canSortWorkflows}
             isCollapsed={isCollapsed}
             toggleCollapse={toggleCollapse}

--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -393,11 +393,11 @@ function TabletKanbanLayout({
 
   return (
     <div
-      className="flex overflow-x-auto snap-x snap-mandatory gap-2 h-full scrollbar-hide"
+      className="flex h-full min-h-0 gap-2 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
       data-testid="tablet-kanban-layout"
     >
       {steps.map((step) => (
-        <div key={step.id} className="flex-shrink-0 w-[calc(50%-4px)] snap-start h-full">
+        <div key={step.id} className="h-full min-h-0 w-[calc(50%-4px)] flex-shrink-0 snap-start">
           <KanbanColumn
             step={step}
             tasks={getTasksForStep(step.id)}

--- a/apps/web/components/kanban/swimlane-section.tsx
+++ b/apps/web/components/kanban/swimlane-section.tsx
@@ -12,6 +12,7 @@ export type SwimlaneSectionProps = {
   dragHandleProps?: HTMLAttributes<HTMLDivElement>;
   onToggleMultiSelect?: () => void;
   isMultiSelectMode?: boolean;
+  fillHeight?: boolean;
   columnsMenu?: ReactNode;
   children: ReactNode;
 };
@@ -24,11 +25,12 @@ export function SwimlaneSection({
   dragHandleProps,
   onToggleMultiSelect,
   isMultiSelectMode,
+  fillHeight = false,
   columnsMenu,
   children,
 }: SwimlaneSectionProps) {
   return (
-    <div>
+    <div className={fillHeight ? "flex h-full min-h-0 flex-col" : undefined}>
       <SwimlaneHeader
         workflowName={workflowName}
         taskCount={taskCount}
@@ -39,7 +41,7 @@ export function SwimlaneSection({
         isMultiSelectMode={isMultiSelectMode}
         columnsMenu={columnsMenu}
       />
-      {!isCollapsed && children}
+      {!isCollapsed && (fillHeight ? <div className="min-h-0 flex-1">{children}</div> : children)}
     </div>
   );
 }

--- a/apps/web/components/kanban/swipeable-columns.tsx
+++ b/apps/web/components/kanban/swipeable-columns.tsx
@@ -117,11 +117,11 @@ export function SwipeableColumns({
 
   return (
     <div className="flex-1 min-h-0 overflow-hidden" ref={emblaRef}>
-      <div className="flex h-full touch-pan-y">
+      <div className="flex h-full min-h-0 touch-pan-y">
         {steps.map((step) => (
           <div
             key={step.id}
-            className="flex-shrink-0 w-full h-full min-w-0 px-4 py-2 flex flex-col"
+            className="flex h-full min-h-0 w-full min-w-0 flex-shrink-0 flex-col px-4 py-2"
           >
             <KanbanColumn
               step={step}

--- a/apps/web/components/kanban/virtualized-column-task-list.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useTranslation } from "react-i18next";
+import {
+  KanbanCard,
+  resolveTaskRepositoryChips,
+  Task,
+  type KanbanPresentation,
+} from "../kanban-card";
+import type { Repository } from "@/lib/types/http";
+import type { WorkflowStep } from "../kanban-column";
+import type { KanbanExternalLinkAvailability } from "../kanban-external-link-availability";
+
+type VirtualizedColumnTaskListProps = {
+  orderedTasks: Task[];
+  queuedStartIndex: number;
+  queuedCount: number;
+  step: WorkflowStep;
+  steps?: WorkflowStep[];
+  presentation: KanbanPresentation;
+  workspaceId: string | null;
+  repositories: Repository[];
+  externalLinkAvailability: KanbanExternalLinkAvailability;
+  showMaximizeButton?: boolean;
+  deletingTaskId?: string | null;
+  archivingTaskId?: string | null;
+  selectedIds?: Set<string>;
+  onPreviewTask: (task: Task) => void;
+  onOpenTask: (task: Task) => void;
+  onEditTask: (task: Task) => void;
+  onDeleteTask: (task: Task) => void;
+  onArchiveTask?: (task: Task) => void;
+  onMoveTask?: (task: Task, targetStepId: string) => void;
+  onToggleSelect?: (taskId: string) => void;
+  onSelectRange?: (taskId: string, orderedIds: string[]) => void;
+  isMultiSelectMode?: boolean;
+};
+
+export function VirtualizedColumnTaskList({
+  orderedTasks,
+  queuedStartIndex,
+  queuedCount,
+  step,
+  steps,
+  presentation,
+  workspaceId,
+  repositories,
+  externalLinkAvailability,
+  showMaximizeButton,
+  deletingTaskId,
+  archivingTaskId,
+  selectedIds,
+  onPreviewTask,
+  onOpenTask,
+  onEditTask,
+  onDeleteTask,
+  onArchiveTask,
+  onMoveTask,
+  onToggleSelect,
+  onSelectRange,
+  isMultiSelectMode,
+}: VirtualizedColumnTaskListProps) {
+  const { t } = useTranslation();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const columnTaskIds = useMemo(() => orderedTasks.map((task) => task.id), [orderedTasks]);
+  const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+    count: orderedTasks.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 96,
+    getItemKey: (index) => orderedTasks[index]?.id ?? index,
+    overscan: 5,
+  });
+
+  return (
+    <div
+      ref={scrollRef}
+      className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-1 pt-1"
+      data-testid="kanban-column-scroll"
+    >
+      <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const task = orderedTasks[virtualItem.index];
+          if (!task) return null;
+
+          return (
+            <div
+              key={task.id}
+              ref={virtualizer.measureElement}
+              data-index={virtualItem.index}
+              className="absolute left-0 top-0 w-full pb-2"
+              style={{ transform: `translateY(${virtualItem.start}px)` }}
+            >
+              {queuedCount > 0 && virtualItem.index === queuedStartIndex && (
+                <div
+                  className="mb-2 flex items-center gap-2 border-t border-dashed border-border/60 pt-3 text-xs font-medium text-muted-foreground"
+                  data-testid="kanban-queued-section"
+                >
+                  <span>{t("kanban:queuedSection")}</span>
+                  <span className="tabular-nums">{queuedCount}</span>
+                </div>
+              )}
+              <KanbanCard
+                task={queuedTaskWithTitle(task, steps, step)}
+                workspaceId={workspaceId}
+                presentation={presentation}
+                externalLinkAvailability={externalLinkAvailability}
+                repositoryChips={resolveTaskRepositoryChips(task, repositories)}
+                onClick={onPreviewTask}
+                onOpenFullPage={onOpenTask}
+                onEdit={onEditTask}
+                onDelete={onDeleteTask}
+                onArchive={onArchiveTask}
+                onMove={onMoveTask}
+                steps={steps}
+                showMaximizeButton={showMaximizeButton}
+                isDeleting={deletingTaskId === task.id}
+                isArchiving={archivingTaskId === task.id}
+                isSelected={selectedIds?.has(task.id)}
+                selectedIds={selectedIds}
+                onToggleSelect={onToggleSelect}
+                onRangeSelect={
+                  onSelectRange ? (taskId) => onSelectRange(taskId, columnTaskIds) : undefined
+                }
+                isMultiSelectMode={isMultiSelectMode}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function queuedTaskWithTitle(
+  task: Task,
+  steps: WorkflowStep[] | undefined,
+  step: WorkflowStep,
+): Task {
+  if (!task.queuedForStepId) return task;
+  return {
+    ...task,
+    queuedForStepTitle:
+      steps?.find((candidate) => candidate.id === task.queuedForStepId)?.title ??
+      (task.queuedForStepId === step.id ? step.title : undefined),
+  };
+}

--- a/apps/web/components/kanban/virtualized-column-task-list.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.tsx
@@ -68,7 +68,7 @@ export function VirtualizedColumnTaskList({
   const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
     count: orderedTasks.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 96,
+    estimateSize: (index) => (queuedCount > 0 && index === queuedStartIndex ? 136 : 96),
     getItemKey: (index) => orderedTasks[index]?.id ?? index,
     overscan: 5,
   });

--- a/apps/web/components/kanban/virtualized-column-task-list.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.tsx
@@ -89,7 +89,7 @@ export function VirtualizedColumnTaskList({
               key={task.id}
               ref={virtualizer.measureElement}
               data-index={virtualItem.index}
-              className="absolute left-0 top-0 w-full pb-2"
+              className="absolute left-0 top-0 w-full"
               style={{ transform: `translateY(${virtualItem.start}px)` }}
             >
               {queuedCount > 0 && virtualItem.index === queuedStartIndex && (

--- a/apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts
+++ b/apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts
@@ -1,0 +1,48 @@
+import { expect, type Locator } from "@playwright/test";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+
+export const LARGE_COLUMN_TASK_COUNT = 440;
+const TASK_SEED_BATCH_SIZE = 25;
+
+export async function seedLargeColumnTasks(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  titlePrefix: string,
+  count = LARGE_COLUMN_TASK_COUNT,
+): Promise<void> {
+  for (let start = 0; start < count; start += TASK_SEED_BATCH_SIZE) {
+    const batchCount = Math.min(TASK_SEED_BATCH_SIZE, count - start);
+    await Promise.all(
+      Array.from({ length: batchCount }, (_, offset) =>
+        apiClient.createTask(seedData.workspaceId, `${titlePrefix} ${start + offset + 1}`, {
+          workflow_id: seedData.workflowId,
+          workflow_step_id: seedData.startStepId,
+        }),
+      ),
+    );
+  }
+}
+
+export function taskCards(column: Locator): Locator {
+  return column.locator('[data-slot="card"][data-testid^="task-card-"]');
+}
+
+export async function mountedTaskCardIds(column: Locator): Promise<string[]> {
+  return taskCards(column).evaluateAll((cards) =>
+    cards
+      .map((card) => card.getAttribute("data-testid"))
+      .filter((testId): testId is string => Boolean(testId)),
+  );
+}
+
+export async function expectBoundedMountedCards(column: Locator): Promise<void> {
+  await expect.poll(() => taskCards(column).count()).toBeLessThan(100);
+}
+
+export async function scrollColumnToBottom(scrollOwner: Locator): Promise<void> {
+  await scrollOwner.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+}

--- a/apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts
+++ b/apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts
@@ -3,6 +3,7 @@ import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 
 export const LARGE_COLUMN_TASK_COUNT = 440;
+const MAX_MOUNTED_TASK_CARDS = 50;
 const TASK_SEED_BATCH_SIZE = 25;
 
 export async function seedLargeColumnTasks(
@@ -37,7 +38,7 @@ export async function mountedTaskCardIds(column: Locator): Promise<string[]> {
 }
 
 export async function expectBoundedMountedCards(column: Locator): Promise<void> {
-  await expect.poll(() => taskCards(column).count()).toBeLessThan(100);
+  await expect.poll(() => taskCards(column).count()).toBeLessThan(MAX_MOUNTED_TASK_CARDS);
 }
 
 export async function scrollColumnToBottom(scrollOwner: Locator): Promise<void> {

--- a/apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts
+++ b/apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { useRegularMode } from "../../helpers/regular-mode";
+import {
+  expectBoundedMountedCards,
+  LARGE_COLUMN_TASK_COUNT,
+  mountedTaskCardIds,
+  scrollColumnToBottom,
+  seedLargeColumnTasks,
+  taskCards,
+} from "./large-column-virtualization-helpers";
+
+useRegularMode();
+
+test.setTimeout(120_000);
+
+test("virtualizes a large desktop column while preserving reached-card navigation", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  await seedLargeColumnTasks(apiClient, seedData, "Desktop large column task");
+
+  const kanban = new KanbanPage(testPage);
+  await kanban.goto();
+
+  const column = kanban.columnByStepId(seedData.startStepId);
+  await expect(column).toBeVisible();
+  await expect(column.getByText(String(LARGE_COLUMN_TASK_COUNT), { exact: true })).toBeVisible();
+  await expect.poll(() => taskCards(column).count()).toBeGreaterThan(0);
+
+  const initialCardIds = await mountedTaskCardIds(column);
+  await expectBoundedMountedCards(column);
+
+  const scrollOwner = column.getByTestId("kanban-column-scroll");
+  await expect(scrollOwner).toBeVisible();
+  await scrollColumnToBottom(scrollOwner);
+
+  await expect
+    .poll(async () => {
+      const mountedIds = await mountedTaskCardIds(column);
+      return mountedIds.some((id) => !initialCardIds.includes(id));
+    })
+    .toBe(true);
+  await expectBoundedMountedCards(column);
+
+  const reachedCard = taskCards(column).last();
+  await expect(reachedCard).toBeVisible();
+  const reachedCardTestId = await reachedCard.getAttribute("data-testid");
+  if (!reachedCardTestId) throw new Error("reached card has no stable test id");
+  const reachedTaskId = reachedCardTestId.replace(/^task-card-/, "");
+
+  await reachedCard.click();
+  await expect(testPage).toHaveURL(new RegExp(`/t/${reachedTaskId}`));
+});

--- a/apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "../../fixtures/test-base";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+import { useRegularMode } from "../../helpers/regular-mode";
+import {
+  expectBoundedMountedCards,
+  LARGE_COLUMN_TASK_COUNT,
+  mountedTaskCardIds,
+  scrollColumnToBottom,
+  seedLargeColumnTasks,
+  taskCards,
+} from "./large-column-virtualization-helpers";
+
+useRegularMode();
+
+test.setTimeout(120_000);
+
+test("keeps the focused mobile column virtualized and touch-navigable", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  await seedLargeColumnTasks(apiClient, seedData, "Mobile large column task");
+
+  const mobile = new MobileKanbanPage(testPage);
+  await mobile.goto();
+  await expect(mobile.mobileKanbanLayout()).toBeVisible();
+  await expect(testPage.getByTestId("desktop-kanban-stage-navigator")).toHaveCount(0);
+
+  await mobile.boardNavigator.click();
+  const startColumnTab = testPage
+    .getByTestId("mobile-board-navigator-drawer")
+    .locator('[data-testid^="column-tab-"]')
+    .filter({ hasText: String(LARGE_COLUMN_TASK_COUNT) });
+  await expect(startColumnTab).toHaveCount(1);
+  await startColumnTab.tap();
+
+  const column = testPage.getByTestId(`kanban-column-${seedData.startStepId}`);
+  await expect(column).toBeVisible();
+  await expect.poll(() => taskCards(column).count()).toBeGreaterThan(0);
+
+  const initialCardIds = await mountedTaskCardIds(column);
+  await expectBoundedMountedCards(column);
+
+  const pageWidth = await testPage.evaluate(() => ({
+    scroll: document.documentElement.scrollWidth,
+    client: document.documentElement.clientWidth,
+  }));
+  expect(pageWidth.scroll).toBeLessThanOrEqual(pageWidth.client);
+
+  const scrollOwner = column.getByTestId("kanban-column-scroll");
+  await expect(scrollOwner).toBeVisible();
+  await scrollColumnToBottom(scrollOwner);
+  await expect
+    .poll(async () => {
+      const mountedIds = await mountedTaskCardIds(column);
+      return mountedIds.some((id) => !initialCardIds.includes(id));
+    })
+    .toBe(true);
+  await expectBoundedMountedCards(column);
+
+  const reachedCard = taskCards(column).last();
+  await expect(reachedCard).toBeVisible();
+  const reachedCardTestId = await reachedCard.getAttribute("data-testid");
+  if (!reachedCardTestId) throw new Error("reached card has no stable test id");
+  const reachedTaskId = reachedCardTestId.replace(/^task-card-/, "");
+
+  await reachedCard.tap();
+  await expect(testPage).toHaveURL(new RegExp(`/t/${reachedTaskId}`));
+});

--- a/apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts
@@ -34,7 +34,7 @@ test("keeps the focused mobile column virtualized and touch-navigable", async ({
   await expect(startColumnTab).toHaveCount(1);
   await startColumnTab.tap();
 
-  const column = testPage.getByTestId(`kanban-column-${seedData.startStepId}`);
+  const column = mobile.mobileKanbanLayout().getByTestId(`kanban-column-${seedData.startStepId}`);
   await expect(column).toBeVisible();
   await expect.poll(() => taskCards(column).count()).toBeGreaterThan(0);
 
@@ -64,6 +64,6 @@ test("keeps the focused mobile column virtualized and touch-navigable", async ({
   if (!reachedCardTestId) throw new Error("reached card has no stable test id");
   const reachedTaskId = reachedCardTestId.replace(/^task-card-/, "");
 
-  await reachedCard.tap();
+  await column.getByTestId(reachedCardTestId).tap();
   await expect(testPage).toHaveURL(new RegExp(`/t/${reachedTaskId}`));
 });

--- a/apps/web/e2e/tests/kanban/tablet-large-column-virtualization.spec.ts
+++ b/apps/web/e2e/tests/kanban/tablet-large-column-virtualization.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "../../fixtures/test-base";
-import { KanbanPage } from "../../pages/kanban-page";
 import { useRegularMode } from "../../helpers/regular-mode";
 import {
   expectBoundedMountedCards,
@@ -14,17 +13,18 @@ useRegularMode();
 
 test.setTimeout(120_000);
 
-test("virtualizes a large desktop column while preserving reached-card navigation", async ({
-  testPage,
+test("virtualizes a large tablet column in the snap-scrolling layout", async ({
+  tabletTestPage,
   apiClient,
   seedData,
 }) => {
-  await seedLargeColumnTasks(apiClient, seedData, "Desktop large column task");
+  await seedLargeColumnTasks(apiClient, seedData, "Tablet large column task");
 
-  const kanban = new KanbanPage(testPage);
-  await kanban.goto();
+  await tabletTestPage.goto("/");
+  const layout = tabletTestPage.getByTestId("tablet-kanban-layout");
+  await expect(layout).toBeVisible();
 
-  const column = kanban.columnByStepId(seedData.startStepId);
+  const column = layout.getByTestId(`kanban-column-${seedData.startStepId}`);
   await expect(column).toBeVisible();
   await expect(column.getByText(String(LARGE_COLUMN_TASK_COUNT), { exact: true })).toBeVisible();
   await expect.poll(() => taskCards(column).count()).toBeGreaterThan(0);
@@ -51,5 +51,5 @@ test("virtualizes a large desktop column while preserving reached-card navigatio
   const reachedTaskId = reachedCardTestId.replace(/^task-card-/, "");
 
   await column.getByTestId(reachedCardTestId).click();
-  await expect(testPage).toHaveURL(new RegExp(`/t/${reachedTaskId}`));
+  await expect(tabletTestPage).toHaveURL(new RegExp(`/t/${reachedTaskId}`));
 });

--- a/apps/web/e2e/tests/kanban/virtualized-column-spacing.spec.ts
+++ b/apps/web/e2e/tests/kanban/virtualized-column-spacing.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { useRegularMode } from "../../helpers/regular-mode";
+
+useRegularMode();
+
+test("keeps the previous spacing between virtualized cards", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  await apiClient.createTask(seedData.workspaceId, "Spacing task one", {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+  });
+  await apiClient.createTask(seedData.workspaceId, "Spacing task two", {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+  });
+
+  const kanban = new KanbanPage(testPage);
+  await kanban.goto();
+
+  const cards = kanban
+    .columnByStepId(seedData.startStepId)
+    .locator('[data-slot="card"][data-testid^="task-card-"]');
+  await expect(cards).toHaveCount(2);
+
+  const gap = await cards.evaluateAll((elements) => {
+    const first = elements[0]?.getBoundingClientRect();
+    const second = elements[1]?.getBoundingClientRect();
+    if (!first || !second) throw new Error("expected two card boxes");
+    return second.top - first.bottom;
+  });
+
+  expect(gap).toBeLessThanOrEqual(9);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,6 +64,7 @@
     "@pierre/diffs": "^1.1.22",
     "@tabler/icons-react": "^3.36.1",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.10",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-bubble-menu": "^3.19.0",
     "@tiptap/extension-code": "^3.19.0",

--- a/docs/plans/kanban-large-column-virtualization/plan.md
+++ b/docs/plans/kanban-large-column-virtualization/plan.md
@@ -1,0 +1,115 @@
+---
+spec: docs/specs/ui/adaptive-kanban.md
+created: 2026-08-21
+status: complete
+issue: https://github.com/kdlbs/kandev/issues/2893
+---
+
+# Implementation Plan: Kanban Large-Column Virtualization
+
+## Overview
+
+The board mounts one complete `KanbanCard` tree for every task in every rendered column. An isolated
+production-build test mounted all 440 task titles and delayed board readiness from 1.24s to 5.66s.
+
+This repair adds vertical windowing to the shared column scroll area. The repair applies to desktop,
+tablet, and phone layouts because all three layouts use `KanbanColumn`.
+
+## Frontend
+
+### Virtualized column task list
+
+- Add `@tanstack/react-virtual` to `apps/web/package.json` and update `apps/pnpm-lock.yaml`.
+- Add `apps/web/components/kanban/virtualized-column-task-list.tsx`.
+- Use the current column scroll element as the virtualizer scroll element.
+- Use stable task IDs as item keys.
+- Measure each rendered row because card height changes with badges, plugin slots, and the WIP divider.
+- Render a small overscan to keep scrolling smooth without mounting the complete column.
+- Keep the full ordered task ID list for shift selection and bulk-action order.
+- Keep the queue divider inside its task row so its logical position and measured height stay correct.
+- Keep the outer column as the drop target. The existing `DragOverlay` keeps the dragged card visible
+  if vertical scrolling removes the source row.
+
+### Kanban column integration
+
+- Update `apps/web/components/kanban-column.tsx` to use the virtualized task list.
+- Add a stable test ID to the existing vertical scroll owner.
+- Preserve the header, counts, empty state, responsive composition, and card action props.
+- Do not add user-facing text or a new mobile surface.
+
+The phone contract does not change. Phone Kanban keeps one focused column, one vertical scroll owner,
+the current navigator, and direct card navigation.
+
+## Tests
+
+This visual performance fault has no useful pure-function boundary. Playwright is the regression level
+because it measures the mounted production DOM and operates the real card tree.
+
+- **What:** existing drag, open, selection, and WIP behavior remains available for small columns.
+- **Files:** existing Kanban E2E specifications.
+- **How:** run the focused existing desktop, mobile, and WIP specifications after the repair.
+
+## E2E Tests
+
+- **Scenario:** A desktop column contains 440 inert tasks.
+- **File:** `apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts`.
+- **What to validate:** fewer than 100 card bodies mount, the count remains 440, scrolling replaces the
+  mounted window, and a reached card opens normally.
+
+- **Scenario:** A phone column contains 440 inert tasks.
+- **File:** `apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts`.
+- **What to validate:** the focused-column layout remains present, fewer than 100 card bodies mount,
+  the document has no horizontal overflow, and a reached card opens by touch.
+
+- **Shared setup:** `apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts` seeds tasks in
+  bounded request batches and contains shared structural assertions.
+
+## Verification Results
+
+RED:
+
+- `pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts`: failed as expected before the
+  implementation because 440 card bodies were mounted.
+- `pnpm e2e:run --no-build --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts`:
+  failed as expected before the implementation because 440 card bodies were mounted.
+
+GREEN:
+
+- `pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts`:
+  8 passed.
+- `pnpm e2e:run --no-build --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts tests/kanban/mobile-kanban.spec.ts`:
+  28 passed.
+- `pnpm exec eslint components/kanban-column.tsx components/kanban/virtualized-column-task-list.tsx components/kanban/adaptive-desktop-kanban.tsx components/kanban/swimlane-container.tsx components/kanban/swimlane-kanban-content.tsx components/kanban/swimlane-section.tsx components/kanban/swipeable-columns.tsx e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/large-column-virtualization-helpers.ts`: passed.
+- `pnpm run typecheck`: passed.
+- `pnpm run build:e2e`: passed.
+
+The managed capture run produced and validated fresh synthetic desktop and phone PNGs in the ignored
+`.pr-assets` directory. The disposable capture specs were removed afterward.
+
+Diagnostic evidence before implementation:
+
+- `pnpm e2e:run --no-build tests/kanban/issue-2893-repro.spec.ts`: passed, 1 test.
+- 25 tasks mounted 25 title nodes. The board became visible in 1,238ms.
+- 440 tasks mounted 440 title nodes. The board became visible in 5,658ms.
+- The temporary diagnostic specification was removed after the run.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [completed] [task-01-virtualize-kanban-columns](task-01-virtualize-kanban-columns.md)
+
+The task is sequential because the source change, package lock, and E2E contract form one TDD cycle.
+
+## Risks
+
+- Dynamic card heights can cause incorrect offsets if rows are not measured after plugin or status changes.
+- A task move can change a row index. Stable task keys prevent measurement reuse for the wrong task.
+- A drag can auto-scroll the source row outside the mounted window. The existing drag overlay must stay active.
+- Queue-divider height belongs to the first queued task and must be part of that row measurement.
+
+## Out Of Scope
+
+- Backend response changes, including description removal or truncation.
+- Pipeline and List view virtualization.
+- New pagination controls or persisted scroll state.

--- a/docs/plans/kanban-large-column-virtualization/plan.md
+++ b/docs/plans/kanban-large-column-virtualization/plan.md
@@ -47,19 +47,24 @@ because it measures the mounted production DOM and operates the real card tree.
 
 - **What:** existing drag, open, selection, and WIP behavior remains available for small columns.
 - **Files:** existing Kanban E2E specifications.
-- **How:** run the focused existing desktop, mobile, and WIP specifications after the repair.
+- **How:** run the focused existing desktop, tablet, mobile, and WIP specifications after the repair.
 
 ## E2E Tests
 
 - **Scenario:** A desktop column contains 440 inert tasks.
 - **File:** `apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts`.
-- **What to validate:** fewer than 100 card bodies mount, the count remains 440, scrolling replaces the
+- **What to validate:** fewer than 50 card bodies mount, the count remains 440, scrolling replaces the
   mounted window, and a reached card opens normally.
 
 - **Scenario:** A phone column contains 440 inert tasks.
 - **File:** `apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts`.
 - **What to validate:** the focused-column layout remains present, fewer than 100 card bodies mount,
   the document has no horizontal overflow, and a reached card opens by touch.
+
+- **Scenario:** A coarse-pointer tablet column contains 440 inert tasks.
+- **File:** `apps/web/e2e/tests/kanban/tablet-large-column-virtualization.spec.ts`.
+- **What to validate:** the two-column snap-scrolling layout remains present, fewer than 50 card
+  bodies mount, scrolling replaces the mounted window, and a reached card opens normally.
 
 - **Shared setup:** `apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts` seeds tasks in
   bounded request batches and contains shared structural assertions.
@@ -75,11 +80,11 @@ RED:
 
 GREEN:
 
-- `pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts`:
-  8 passed.
+- `pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/tablet-large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts`:
+  9 passed after review remediation.
 - `pnpm e2e:run --no-build --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts tests/kanban/mobile-kanban.spec.ts`:
   28 passed.
-- `pnpm exec eslint components/kanban-column.tsx components/kanban/virtualized-column-task-list.tsx components/kanban/adaptive-desktop-kanban.tsx components/kanban/swimlane-container.tsx components/kanban/swimlane-kanban-content.tsx components/kanban/swimlane-section.tsx components/kanban/swipeable-columns.tsx e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/large-column-virtualization-helpers.ts`: passed.
+- `pnpm exec eslint components/kanban/swimlane-container.tsx components/kanban/virtualized-column-task-list.tsx e2e/tests/kanban/large-column-virtualization-helpers.ts e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/tablet-large-column-virtualization.spec.ts`: passed.
 - `pnpm run typecheck`: passed.
 - `pnpm run build:e2e`: passed.
 

--- a/docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md
+++ b/docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md
@@ -18,16 +18,16 @@ rows plus a small overscan.
 
 ## Acceptance
 
-- A 440-task desktop or phone column mounts fewer than 100 card bodies during initial display.
+- A 440-task desktop, tablet, or phone column mounts fewer than 50 card bodies during initial display.
 - Scrolling changes the mounted task window and keeps reached card actions available.
 - Counts, logical task order, shift selection, WIP queue placement, and drag behavior remain unchanged.
 
 ## TDD Sequence
 
-1. Add the desktop and phone large-column E2E specifications.
-2. Run both specifications and record the expected mounted-count failure.
+1. Add the desktop, tablet, and phone large-column E2E specifications.
+2. Run all three specifications and record the expected mounted-count failure.
 3. Add `@tanstack/react-virtual` and implement the virtualized column task list.
-4. Run the large-column specifications until both pass.
+4. Run the large-column specifications until all three pass.
 5. Run the existing focused Kanban behavior specifications.
 
 ## Verification
@@ -41,9 +41,9 @@ cd apps && pnpm install --frozen-lockfile
 Then run these final checks from `apps/web`:
 
 ```bash
-pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts
+pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/tablet-large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts
 pnpm e2e:run --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts tests/kanban/mobile-kanban.spec.ts
-pnpm exec eslint components/kanban-column.tsx components/kanban/virtualized-column-task-list.tsx e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/large-column-virtualization-helpers.ts
+pnpm exec eslint components/kanban/swimlane-container.tsx components/kanban/virtualized-column-task-list.tsx e2e/tests/kanban/large-column-virtualization-helpers.ts e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/tablet-large-column-virtualization.spec.ts
 pnpm run typecheck
 ```
 
@@ -63,6 +63,7 @@ only when the assets did not change after the desktop command.
 - `apps/web/components/kanban/virtualized-column-task-list.tsx`
 - `apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts`
 - `apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts`
+- `apps/web/e2e/tests/kanban/tablet-large-column-virtualization.spec.ts`
 - `apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts`
 - `docs/plans/kanban-large-column-virtualization/plan.md`
 - `docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md`
@@ -96,8 +97,11 @@ this task status, its Results section, and the plan verification results in the 
 - Bounded Kanban lane flex geometry across desktop, tablet, and phone so the column remains the
   virtualizer's scroll owner without changing non-Kanban swimlane sizing.
 - RED: both new large-column tests failed before the implementation with 440 mounted cards.
-- GREEN: desktop large-column plus Kanban/WIP suite passed 8 tests; mobile large-column plus mobile
-  Kanban suite passed 28 tests.
+- GREEN: desktop/tablet large-column plus Kanban/WIP suite passed 9 tests; mobile large-column plus
+  mobile Kanban suite passed 28 tests.
+- Review remediation added the coarse-pointer tablet large-column regression and tightened the
+  mounted-card bound to fewer than 50. It also preserved desktop/tablet workflow sorting and
+  collapsed-swimlane sizing while keeping the mobile single-workflow behavior unchanged.
 - Focused ESLint, `pnpm run typecheck`, and the pseudo-locale production E2E build passed.
 - Fresh desktop and phone screenshots were captured from synthetic 440-task boards, inspected,
   compressed, and retained in the ignored `.pr-assets` directory for PR publication. Disposable

--- a/docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md
+++ b/docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md
@@ -1,0 +1,107 @@
+---
+id: "01-virtualize-kanban-columns"
+title: "Virtualize Kanban columns"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/adaptive-kanban.md"
+parallelism: sequential
+---
+
+# Task 01: Virtualize Kanban Columns
+
+## Intent
+
+Keep each Kanban column responsive when it contains hundreds of tasks. Mount only the visible task
+rows plus a small overscan.
+
+## Acceptance
+
+- A 440-task desktop or phone column mounts fewer than 100 card bodies during initial display.
+- Scrolling changes the mounted task window and keeps reached card actions available.
+- Counts, logical task order, shift selection, WIP queue placement, and drag behavior remain unchanged.
+
+## TDD Sequence
+
+1. Add the desktop and phone large-column E2E specifications.
+2. Run both specifications and record the expected mounted-count failure.
+3. Add `@tanstack/react-virtual` and implement the virtualized column task list.
+4. Run the large-column specifications until both pass.
+5. Run the existing focused Kanban behavior specifications.
+
+## Verification
+
+If `apps/node_modules` is absent, first run:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+Then run these final checks from `apps/web`:
+
+```bash
+pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts
+pnpm e2e:run --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts tests/kanban/mobile-kanban.spec.ts
+pnpm exec eslint components/kanban-column.tsx components/kanban/virtualized-column-task-list.tsx e2e/tests/kanban/large-column-virtualization.spec.ts e2e/tests/kanban/mobile-large-column-virtualization.spec.ts e2e/tests/kanban/large-column-virtualization-helpers.ts
+pnpm run typecheck
+```
+
+The first `pnpm e2e:run` builds current production assets. The mobile command can use `--no-build`
+only when the assets did not change after the desktop command.
+
+## Files Likely Touched
+
+- `apps/web/package.json`
+- `apps/pnpm-lock.yaml`
+- `apps/web/components/kanban-column.tsx`
+- `apps/web/components/kanban/adaptive-desktop-kanban.tsx`
+- `apps/web/components/kanban/swimlane-container.tsx`
+- `apps/web/components/kanban/swimlane-kanban-content.tsx`
+- `apps/web/components/kanban/swimlane-section.tsx`
+- `apps/web/components/kanban/swipeable-columns.tsx`
+- `apps/web/components/kanban/virtualized-column-task-list.tsx`
+- `apps/web/e2e/tests/kanban/large-column-virtualization-helpers.ts`
+- `apps/web/e2e/tests/kanban/large-column-virtualization.spec.ts`
+- `apps/web/e2e/tests/kanban/mobile-large-column-virtualization.spec.ts`
+- `docs/plans/kanban-large-column-virtualization/plan.md`
+- `docs/plans/kanban-large-column-virtualization/task-01-virtualize-kanban-columns.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. This task updates a package lock and one shared UI path.
+
+## Inputs
+
+- `docs/specs/ui/adaptive-kanban.md`, large-column requirements and scenarios.
+- `docs/plans/kanban-large-column-virtualization/plan.md`, confirmed root cause and design.
+- `apps/web/components/kanban-column.tsx`, current full-list mount and scroll owner.
+- `apps/web/components/kanban/swimlane-kanban-content.tsx`, shared drag overlay and responsive layouts.
+- `apps/web/components/kanban/swipeable-columns.tsx`, phone column composition.
+- TanStack Virtual React documentation for dynamic measurement and stable item keys.
+
+## Output Contract
+
+Report the changed files, RED and GREEN results, exact commands, blockers, and remaining risks. Update
+this task status, its Results section, and the plan verification results in the same conversation.
+
+## Results
+
+- Implemented a shared TanStack Virtual task list with stable task keys, dynamic row measurement,
+  overscan, full ordered IDs for range selection, and queue-divider placement inside the measured row.
+- Bounded Kanban lane flex geometry across desktop, tablet, and phone so the column remains the
+  virtualizer's scroll owner without changing non-Kanban swimlane sizing.
+- RED: both new large-column tests failed before the implementation with 440 mounted cards.
+- GREEN: desktop large-column plus Kanban/WIP suite passed 8 tests; mobile large-column plus mobile
+  Kanban suite passed 28 tests.
+- Focused ESLint, `pnpm run typecheck`, and the pseudo-locale production E2E build passed.
+- Fresh desktop and phone screenshots were captured from synthetic 440-task boards, inspected,
+  compressed, and retained in the ignored `.pr-assets` directory for PR publication. Disposable
+  capture specs were removed.
+
+Remaining risk is the normal virtualization risk already recorded in the plan: dynamic card-height
+changes and drag auto-scroll must continue to use measured rows and the existing drag overlay.

--- a/docs/specs/ui/adaptive-kanban.md
+++ b/docs/specs/ui/adaptive-kanban.md
@@ -27,6 +27,12 @@ desktop.
   shown.
 - Existing desktop card interactions remain available in either composition, including pointer
   drag-and-drop between visible columns, multi-select, context actions, and `Move to` for any step.
+- At a fixed viewport size, each Kanban column keeps its mounted card count within the visible
+  vertical area plus a small overscan. The mounted count does not grow with the total task count.
+- Users can reach every task by scrolling or searching. Vertical windowing does not change the
+  column count, task order, WIP queue boundary, selection order, or card actions.
+- A column with 440 tasks mounts fewer than 100 card bodies during initial display on desktop,
+  tablet, and phone surfaces.
 - Opening or resizing the task preview may change the effective desktop composition without
   changing the user's saved Kanban, Pipeline, workflow, or preview preferences.
 - A subtask card presents its parent relationship as contained hierarchy metadata. Long or missing
@@ -68,6 +74,14 @@ desktop.
   navigator and mobile actions remain available and no desktop stage selector is mounted.
 - **GIVEN** the tablet Kanban, **WHEN** the same workflows render, **THEN** the existing two-column
   snap-scrolling layout remains active and no desktop stage selector is mounted.
+- **GIVEN** a desktop column with 440 tasks, **WHEN** Kanban renders, **THEN** fewer than 100 card
+  bodies are mounted and the visible cards respond to user input.
+- **GIVEN** a phone column with 440 tasks, **WHEN** Kanban renders, **THEN** fewer than 100 card
+  bodies are mounted inside the existing focused-column scroll area.
+- **GIVEN** a windowed column, **WHEN** the user scrolls from the first task to the last task,
+  **THEN** each reached card keeps its normal actions and the mounted card count stays bounded.
+- **GIVEN** a windowed WIP column with queued tasks, **WHEN** the user scrolls through the admission
+  boundary, **THEN** the queue divider appears at the correct logical position.
 
 ## Out of scope
 
@@ -75,7 +89,11 @@ desktop.
 - Redesigning Pipeline or List views.
 - Persisting a separate portrait-layout preference or horizontal scroll position.
 - Changing backend task, workflow, WIP-limit, or preview contracts.
+- Removing task descriptions from the board API response.
+- Adding pagination or a manual show-more control to Kanban columns.
 
-## Implementation plan
+## Implementation plans
 
 [Adaptive Kanban implementation plan](../../plans/adaptive-kanban/plan.md)
+
+[Large-column virtualization repair plan](../../plans/kanban-large-column-virtualization/plan.md)


### PR DESCRIPTION
The Kanban board mounted every task card in a large column, delaying rendering and making 440-task
boards difficult to use. This adds measured vertical windowing across desktop, tablet, and phone
Kanban layouts while preserving task order, WIP queues, actions, selection order, and navigation.

## Important Changes

- Added a shared TanStack Virtual task list with stable IDs, dynamic row measurement, overscan, and
  full ordered IDs for range selection.
- Bounded the Kanban lane flex geometry so each column remains the virtualizer's scroll owner.
- Added desktop, tablet, and phone 440-task Playwright regressions and retained the existing Kanban/WIP flows.
- Addressed review feedback for desktop/tablet workflow identity, collapsed swimlane sizing, queued-row estimation, and tighter mount bounds.

## Validation

- `pnpm e2e:run tests/kanban/large-column-virtualization.spec.ts tests/kanban/tablet-large-column-virtualization.spec.ts tests/kanban/kanban-board.spec.ts tests/kanban/wip-overflow-queue.spec.ts` (9 passed)
- `pnpm e2e:run --no-build --project mobile-chrome tests/kanban/mobile-large-column-virtualization.spec.ts tests/kanban/mobile-kanban.spec.ts` (28 passed)
- Focused ESLint for all changed Kanban components and E2E files
- `pnpm run typecheck`
- `pnpm run build:e2e`
- Pre-commit and commit-message hooks passed without bypass

## Possible Improvements

Low risk: future card-height or drag auto-scroll changes should continue to preserve row measurement
and the existing drag overlay behavior.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2893


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

Desktop large column with 440 tasks and a bounded mounted card window:

![Desktop large-column virtualization](https://raw.githubusercontent.com/kdlbs/kandev/5e35c65c3c5ace39b6406f2ca5cfe70a0f3d94cc/desktop-large-column-virtualization.png)

Phone focused column with 440 tasks and a bounded mounted card window:

![Mobile large-column virtualization](https://raw.githubusercontent.com/kdlbs/kandev/5e35c65c3c5ace39b6406f2ca5cfe70a0f3d94cc/mobile-large-column-virtualization.png)
<!-- kandev-screenshots-end -->
