### PR TITLE
fix(web): preserve review diff during PR refresh

### DIFF
--- a/apps/web/hooks/domains/github/use-pr-diff.test.ts
+++ b/apps/web/hooks/domains/github/use-pr-diff.test.ts
@@ -67,6 +67,19 @@ describe("resolvePRDiffView", () => {
 });
 
 describe("usePRDiff same-PR refresh", () => {
+  it("keeps the manual refresh callback stable when the automatic refresh key advances", () => {
+    requestMock.mockResolvedValue({ files: staleState.files });
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => usePRDiff("acme", "app", 1, refreshKey),
+      { initialProps: { refreshKey: "old-sync" }, wrapper },
+    );
+    const refresh = result.current.refresh;
+
+    rerender({ refreshKey: "new-sync" });
+
+    expect(result.current.refresh).toBe(refresh);
+  });
+
   it("keeps current files mounted without re-entering blocking loading", async () => {
     const initial = deferred<{ files: KeyedPRDiffState["files"] }>();
     const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();

--- a/apps/web/hooks/domains/github/use-pr-diff.test.ts
+++ b/apps/web/hooks/domains/github/use-pr-diff.test.ts
@@ -5,10 +5,13 @@ import { StateProvider } from "@/components/state-provider";
 import type { AppState } from "@/lib/state/store";
 import { resolvePRDiffView, usePRDiff, type KeyedPRDiffState } from "./use-pr-diff";
 
-const requestMock = vi.hoisted(() => vi.fn());
+const { requestMock, getWebSocketClientMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+  getWebSocketClientMock: vi.fn(),
+}));
 const FIRST_PR_FILENAME = "src/first-pr.ts";
 vi.mock("@/lib/ws/connection", () => ({
-  getWebSocketClient: () => ({ request: requestMock }),
+  getWebSocketClient: getWebSocketClientMock,
 }));
 
 function deferred<T>() {
@@ -23,6 +26,8 @@ function deferred<T>() {
 
 beforeEach(() => {
   requestMock.mockReset();
+  getWebSocketClientMock.mockReset();
+  getWebSocketClientMock.mockReturnValue({ request: requestMock });
 });
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -66,7 +71,7 @@ describe("resolvePRDiffView", () => {
   });
 });
 
-describe("usePRDiff same-PR refresh", () => {
+describe("usePRDiff refresh callback", () => {
   it("keeps the manual refresh callback stable when the automatic refresh key advances", () => {
     requestMock.mockResolvedValue({ files: staleState.files });
     const { result, rerender } = renderHook(
@@ -79,7 +84,46 @@ describe("usePRDiff same-PR refresh", () => {
 
     expect(result.current.refresh).toBe(refresh);
   });
+});
 
+describe("usePRDiff manual refresh", () => {
+  it("keeps resolved files mounted while a manual refresh is pending", async () => {
+    const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();
+    requestMock
+      .mockResolvedValueOnce({ files: staleState.files })
+      .mockReturnValueOnce(refreshed.promise);
+    const { result } = renderHook(() => usePRDiff("acme", "app", 1, "synced"), { wrapper });
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME);
+
+    await act(async () => {
+      refreshed.resolve({ files: staleState.files });
+      await refreshed.promise;
+    });
+  });
+
+  it("keeps resolved files mounted when a manual refresh has no WebSocket client", async () => {
+    requestMock.mockResolvedValueOnce({ files: staleState.files });
+    const { result } = renderHook(() => usePRDiff("acme", "app", 1, "synced"), { wrapper });
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+    getWebSocketClientMock.mockReturnValue(null);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME);
+  });
+});
+
+describe("usePRDiff automatic same-PR refresh", () => {
   it("keeps current files mounted without re-entering blocking loading", async () => {
     const initial = deferred<{ files: KeyedPRDiffState["files"] }>();
     const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();

--- a/apps/web/hooks/domains/github/use-pr-diff.test.ts
+++ b/apps/web/hooks/domains/github/use-pr-diff.test.ts
@@ -6,16 +6,19 @@ import type { AppState } from "@/lib/state/store";
 import { resolvePRDiffView, usePRDiff, type KeyedPRDiffState } from "./use-pr-diff";
 
 const requestMock = vi.hoisted(() => vi.fn());
+const FIRST_PR_FILENAME = "src/first-pr.ts";
 vi.mock("@/lib/ws/connection", () => ({
   getWebSocketClient: () => ({ request: requestMock }),
 }));
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 beforeEach(() => {
@@ -30,10 +33,11 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 const staleState: KeyedPRDiffState = {
-  sourceKey: "acme/app/1/old",
+  identityKey: "workspace-1/acme/app/1",
+  hasResolved: true,
   files: [
     {
-      filename: "src/first-pr.ts",
+      filename: FIRST_PR_FILENAME,
       status: "modified",
       patch: "@@ -1 +1 @@",
       additions: 1,
@@ -46,7 +50,7 @@ const staleState: KeyedPRDiffState = {
 
 describe("resolvePRDiffView", () => {
   it("masks the previous PR while a newly requested source starts loading", () => {
-    expect(resolvePRDiffView(staleState, "acme/app/2/new")).toEqual({
+    expect(resolvePRDiffView(staleState, "workspace-1/acme/app/2")).toEqual({
       files: [],
       loading: true,
       error: null,
@@ -62,7 +66,137 @@ describe("resolvePRDiffView", () => {
   });
 });
 
+describe("usePRDiff same-PR refresh", () => {
+  it("keeps current files mounted without re-entering blocking loading", async () => {
+    const initial = deferred<{ files: KeyedPRDiffState["files"] }>();
+    const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();
+    requestMock.mockReturnValueOnce(initial.promise).mockReturnValueOnce(refreshed.promise);
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => usePRDiff("acme", "app", 1, refreshKey),
+      { initialProps: { refreshKey: "old-sync" }, wrapper },
+    );
+
+    await act(async () => {
+      initial.resolve({ files: staleState.files });
+      await initial.promise;
+    });
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+
+    rerender({ refreshKey: "new-sync" });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME);
+  });
+
+  it("atomically replaces retained files when the same PR refresh succeeds", async () => {
+    const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();
+    requestMock
+      .mockResolvedValueOnce({ files: staleState.files })
+      .mockReturnValueOnce(refreshed.promise);
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => usePRDiff("acme", "app", 1, refreshKey),
+      { initialProps: { refreshKey: "old-sync" }, wrapper },
+    );
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+
+    rerender({ refreshKey: "new-sync" });
+    expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME);
+
+    await act(async () => {
+      refreshed.resolve({
+        files: [
+          {
+            filename: "src/refreshed.ts",
+            status: "modified",
+            patch: "@@refreshed@@",
+            additions: 2,
+            deletions: 1,
+          },
+        ],
+      });
+      await refreshed.promise;
+    });
+
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe("src/refreshed.ts"));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("retains resolved files when a same-PR background refresh fails", async () => {
+    const refreshed = deferred<{ files: KeyedPRDiffState["files"] }>();
+    requestMock
+      .mockResolvedValueOnce({ files: staleState.files })
+      .mockReturnValueOnce(refreshed.promise);
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => usePRDiff("acme", "app", 1, refreshKey),
+      { initialProps: { refreshKey: "old-sync" }, wrapper },
+    );
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+
+    rerender({ refreshKey: "new-sync" });
+    await act(async () => {
+      refreshed.reject(new Error("refresh failed"));
+      await refreshed.promise.catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("usePRDiff initial failure", () => {
+  it("exposes an initial request failure for retry", async () => {
+    requestMock.mockRejectedValueOnce(new Error("initial failed"));
+    const { result } = renderHook(() => usePRDiff("acme", "app", 1, "first-sync"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files).toEqual([]);
+    expect(result.current.error).toBe("initial failed");
+  });
+});
+
 describe("usePRDiff request ownership", () => {
+  it("ignores a superseded same-PR refresh that resolves last", async () => {
+    const superseded = deferred<{ files: KeyedPRDiffState["files"] }>();
+    const current = deferred<{ files: KeyedPRDiffState["files"] }>();
+    requestMock
+      .mockResolvedValueOnce({ files: staleState.files })
+      .mockReturnValueOnce(superseded.promise)
+      .mockReturnValueOnce(current.promise);
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => usePRDiff("acme", "app", 1, refreshKey),
+      { initialProps: { refreshKey: "old-sync" }, wrapper },
+    );
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe(FIRST_PR_FILENAME));
+
+    rerender({ refreshKey: "middle-sync" });
+    rerender({ refreshKey: "new-sync" });
+    await act(async () => {
+      current.resolve({
+        files: [
+          {
+            filename: "src/current.ts",
+            status: "modified",
+            patch: "@@current@@",
+            additions: 1,
+            deletions: 0,
+          },
+        ],
+      });
+      await current.promise;
+    });
+    await waitFor(() => expect(result.current.files[0]?.filename).toBe("src/current.ts"));
+
+    await act(async () => {
+      superseded.resolve({ files: staleState.files });
+      await superseded.promise;
+    });
+    expect(result.current.files[0]?.filename).toBe("src/current.ts");
+  });
+
   it("masks A immediately on B and ignores A when its request resolves late", async () => {
     const first = deferred<{ files: KeyedPRDiffState["files"] }>();
     const second = deferred<{ files: KeyedPRDiffState["files"] }>();
@@ -94,7 +228,7 @@ describe("usePRDiff request ownership", () => {
       first.resolve({
         files: [
           {
-            filename: "src/first-pr.ts",
+            filename: FIRST_PR_FILENAME,
             status: "modified",
             patch: "@@first@@",
             additions: 1,

--- a/apps/web/hooks/domains/github/use-pr-diff.ts
+++ b/apps/web/hooks/domains/github/use-pr-diff.ts
@@ -129,7 +129,7 @@ export function usePRDiff(
       if (requestId !== requestIdRef.current) return;
       setState(next);
     });
-  }, [workspaceId, owner, repo, prNumber, identityKey, requestKey]);
+  }, [workspaceId, owner, repo, prNumber, identityKey]);
 
   useEffect(() => {
     if (requestKey === requestKeyRef.current) return;

--- a/apps/web/hooks/domains/github/use-pr-diff.ts
+++ b/apps/web/hooks/domains/github/use-pr-diff.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useCallback, useState, useRef } from "react";
+import {
+  useEffect,
+  useCallback,
+  useState,
+  useRef,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useAppStore } from "@/components/state-provider";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { createDebugLogger } from "@/lib/debug/log";
@@ -16,7 +23,8 @@ type PRDiffView = {
 };
 
 export type KeyedPRDiffState = PRDiffView & {
-  sourceKey: string;
+  identityKey: string;
+  hasResolved: boolean;
 };
 
 type PRDiffRequest = {
@@ -24,31 +32,41 @@ type PRDiffRequest = {
   owner: string;
   repo: string;
   prNumber: number;
-  sourceKey: string;
+  identityKey: string;
 };
 
 const INITIAL_STATE: KeyedPRDiffState = {
-  sourceKey: "",
+  identityKey: "",
+  hasResolved: false,
   files: [],
   loading: false,
   error: null,
 };
 
-export function resolvePRDiffView(state: KeyedPRDiffState, requestedKey: string): PRDiffView {
-  if (state.sourceKey === requestedKey) {
+export function resolvePRDiffView(state: KeyedPRDiffState, requestedIdentity: string): PRDiffView {
+  if (state.identityKey === requestedIdentity) {
     return { files: state.files, loading: state.loading, error: state.error };
   }
-  return { files: [], loading: requestedKey !== "", error: null };
+  return { files: [], loading: requestedIdentity !== "", error: null };
 }
 
 async function fetchPRFiles(
-  { workspaceId, owner, repo, prNumber, sourceKey }: PRDiffRequest,
-  setState: (s: KeyedPRDiffState) => void,
+  { workspaceId, owner, repo, prNumber, identityKey }: PRDiffRequest,
+  setState: Dispatch<SetStateAction<KeyedPRDiffState>>,
 ) {
   const client = getWebSocketClient();
-  setState({ sourceKey, files: [], loading: true, error: null });
+  setState((previous) => {
+    const retainResolved = previous.identityKey === identityKey && previous.hasResolved;
+    return {
+      identityKey,
+      hasResolved: retainResolved,
+      files: retainResolved ? previous.files : [],
+      loading: !retainResolved,
+      error: null,
+    };
+  });
   if (!client) {
-    setState({ sourceKey, files: [], loading: false, error: null });
+    setState((previous) => ({ ...previous, loading: false }));
     return;
   }
   debug("fetch.start", { owner, repo, prNumber });
@@ -60,11 +78,28 @@ async function fetchPRFiles(
       number: prNumber,
     });
     const files = response?.files ?? [];
-    setState({ sourceKey, files, loading: false, error: null });
+    setState({
+      identityKey,
+      hasResolved: true,
+      files,
+      loading: false,
+      error: null,
+    });
     debug("fetch.success", { owner, repo, prNumber, fileCount: files.length });
   } catch (err) {
     const message = err instanceof Error ? err.message : t("github:failedToFetchPrFiles");
-    setState({ sourceKey, files: [], loading: false, error: message });
+    setState((previous) => {
+      if (previous.identityKey === identityKey && previous.hasResolved) {
+        return { ...previous, loading: false, error: null };
+      }
+      return {
+        identityKey,
+        hasResolved: false,
+        files: [],
+        loading: false,
+        error: message,
+      };
+    });
     debug("fetch.error", { owner, repo, prNumber, error: message });
   }
 }
@@ -82,34 +117,33 @@ export function usePRDiff(
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const [state, setState] = useState<KeyedPRDiffState>(INITIAL_STATE);
   const hasParams = !!workspaceId && !!owner && !!repo && !!prNumber;
-  const sourceKey = hasParams
-    ? `${workspaceId}/${owner}/${repo}/${prNumber}/${refreshKey ?? ""}`
-    : "";
-  const paramsKeyRef = useRef<string>("");
+  const identityKey = hasParams ? `${workspaceId}/${owner}/${repo}/${prNumber}` : "";
+  const requestKey = hasParams ? `${identityKey}/${refreshKey ?? ""}` : "";
+  const requestKeyRef = useRef<string>("");
   const requestIdRef = useRef(0);
 
   const refresh = useCallback(() => {
     if (!workspaceId || !owner || !repo || !prNumber) return;
     const requestId = ++requestIdRef.current;
-    void fetchPRFiles({ workspaceId, owner, repo, prNumber, sourceKey }, (next) => {
+    void fetchPRFiles({ workspaceId, owner, repo, prNumber, identityKey }, (next) => {
       if (requestId !== requestIdRef.current) return;
       setState(next);
     });
-  }, [workspaceId, owner, repo, prNumber, sourceKey]);
+  }, [workspaceId, owner, repo, prNumber, identityKey, requestKey]);
 
   useEffect(() => {
-    if (sourceKey === paramsKeyRef.current) return;
-    paramsKeyRef.current = sourceKey;
+    if (requestKey === requestKeyRef.current) return;
+    requestKeyRef.current = requestKey;
     if (!workspaceId || !owner || !repo || !prNumber) {
       requestIdRef.current++; // invalidate in-flight responses
       return;
     }
     const requestId = ++requestIdRef.current;
-    void fetchPRFiles({ workspaceId, owner, repo, prNumber, sourceKey }, (next) => {
+    void fetchPRFiles({ workspaceId, owner, repo, prNumber, identityKey }, (next) => {
       if (requestId !== requestIdRef.current) return;
       setState(next);
     });
-  }, [workspaceId, owner, repo, prNumber, sourceKey]);
+  }, [workspaceId, owner, repo, prNumber, identityKey, requestKey]);
 
-  return { ...resolvePRDiffView(state, sourceKey), refresh };
+  return { ...resolvePRDiffView(state, identityKey), refresh };
 }

--- a/docs/plans/stable-review-dialog-refresh/plan.md
+++ b/docs/plans/stable-review-dialog-refresh/plan.md
@@ -1,0 +1,77 @@
+---
+spec: docs/specs/tasks/multi-branch/spec.md
+created: 2026-08-21
+status: complete
+---
+
+# Implementation Plan: Stable Review Dialog Refresh
+
+## Overview
+
+The Review dialog reloads because `usePRDiff` uses one timestamped `sourceKey` for both request freshness and displayed-data identity. When `last_synced_at` advances for the same PR, `resolvePRDiffView` masks the resolved files and `fetchPRFiles` writes an empty loading state, causing `ReviewPRDiffBoundary` to unmount `ReviewDiffList` and discard its scroll container. Separate logical PR identity from the timestamped request key so same-PR refreshes retain resolved content while different PRs remain isolated.
+
+## Frontend
+
+### PR diff request and display identity
+
+- Update `apps/web/hooks/domains/github/use-pr-diff.ts` to derive:
+  - a logical identity for the workspace, owner, repository, and PR number; and
+  - a timestamped request key that still includes `refreshKey` and triggers replacement fetches.
+- During a same-identity refresh, keep the last resolved files in state and keep the returned loading state non-blocking. `ReviewPRDiffBoundary` treats `loading: true` as an initial-load replacement even when retained PR-only files exist, so only an identity without a resolved diff may report blocking loading. Replace retained files atomically only when the current request succeeds.
+- If a background refresh fails after files resolved, retain those files and avoid replacing the usable review with the initial-load error boundary. Preserve the existing empty/error/retry behavior when no diff has resolved.
+- Keep immediate masking and request ownership for a different workspace or PR. A late response from an older request must not overwrite the current selection.
+- Leave `ReviewDialog`, `ReviewDialogSurface`, and desktop/mobile composition unchanged. Keeping `ReviewDiffList` mounted preserves its scroll container and shared transient review state.
+
+### Mobile parity
+
+The repair is shared hook-level state normalization consumed by desktop, phone, and tablet Review mounts. It changes no entry point, layout, overlay, touch target, hierarchy, or scroll owner. Existing full-height mobile Review composition remains the closest shipped exemplar; the same retained diff contract applies without viewport-specific code.
+
+## Tests
+
+- **What:** A newer sync timestamp for the same PR starts a request while keeping resolved files observable.
+  - **File:** `apps/web/hooks/domains/github/use-pr-diff.test.ts`
+  - **How:** Keep the replacement WebSocket response deferred and assert the prior file remains while the hook does not re-enter its blocking loading state.
+- **What:** A current same-PR response replaces retained files atomically, while a different PR masks prior files and ignores late responses.
+  - **File:** `apps/web/hooks/domains/github/use-pr-diff.test.ts`
+  - **How:** Resolve controlled requests in normal and reverse order and assert only the current logical identity is exposed.
+- **What:** Background failure retains resolved files, while initial failure remains empty and exposes the error.
+  - **File:** `apps/web/hooks/domains/github/use-pr-diff.test.ts`
+  - **How:** Reject controlled initial and replacement requests and assert the two failure contracts separately.
+
+## E2E Tests
+
+No new polling-based Playwright spec is planned. The timing boundary is deterministic in the hook test, while reproducing it through the mock provider would require unrelated backend delay controls. Run the existing desktop and mobile multi-PR Review specs after the hook fix to prove rendered Review remains functional and different-PR isolation still holds:
+
+- `apps/web/e2e/tests/review/review-multi-pr.spec.ts`
+- `apps/web/e2e/tests/review/mobile-review-multi-pr.spec.ts`
+
+## Verification Results
+
+- RED confirmed before planning: `cd apps && pnpm --filter @kandev/web test -- --run hooks/domains/github/use-pr-diff.test.ts` failed because the same-PR refresh returned `undefined` instead of retaining `src/first-pr.ts`.
+- Expanded RED: three of eight focused tests failed while a pending or failed same-PR refresh cleared the resolved file.
+- QA RED: after initial retention was implemented, one of eight tests still failed because the hook returned blocking `loading: true`; tracing `ReviewPRDiffBoundary` proved that state would still unmount a PR-only diff.
+- GREEN: `cd apps && pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-diff.test.ts --reporter=dot` passed all 8 tests after resolved same-PR refreshes became non-blocking.
+- `cd apps && pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-workspace-scope.test.ts --reporter=dot` passed all 6 adjacent workspace-scope tests.
+- `cd apps && pnpm --filter @kandev/web lint` passed with zero warnings, and `cd apps && pnpm --filter @kandev/web typecheck` passed.
+- Fresh production-build desktop E2E passed 1 test: `cd apps/web && pnpm e2e:run tests/review/review-multi-pr.spec.ts`.
+- Mobile parity E2E passed both phone and coarse-pointer tablet tests: `cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/review/mobile-review-multi-pr.spec.ts`.
+
+## Implementation Waves And Parallel Candidates
+
+Sequential:
+
+- [x] [task-01-preserve-review-diff-refresh](task-01-preserve-review-diff-refresh.md)
+
+No parallel candidates. Production state and regression coverage share one hook contract.
+
+## Risks
+
+- A display identity that is too broad can expose files from another workspace or PR; retain workspace, owner, repository, and PR number in the logical identity.
+- Treating every failure as a background failure can hide an initial-load error; retain content only when that logical identity already has resolved files.
+- A genuinely changed replacement diff can alter document height after it lands. This repair guarantees no pending-refresh unmount or reset, not a fixed visual position after remote content itself changes.
+
+## Out of Scope
+
+- Changes to Review dialog layout, file ordering, comment persistence, or reviewed-file persistence.
+- Changes to synchronization cadence or the `TaskPR.last_synced_at` contract.
+- New backend delay controls solely for Playwright timing injection.

--- a/docs/plans/stable-review-dialog-refresh/task-01-preserve-review-diff-refresh.md
+++ b/docs/plans/stable-review-dialog-refresh/task-01-preserve-review-diff-refresh.md
@@ -1,0 +1,76 @@
+---
+id: "01-preserve-review-diff-refresh"
+title: "Preserve Review diff during refresh"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/multi-branch/spec.md"
+---
+
+# Task 01: Preserve Review diff during refresh
+
+## Acceptance
+
+- Advancing `last_synced_at` for the same workspace and PR triggers one replacement request without removing previously resolved files, reporting blocking loading, or remounting the Review diff while pending.
+- The current response atomically replaces retained files; a failed background refresh retains them, while an initial failure still exposes the existing error/retry state.
+- Workspace or PR changes mask incompatible files immediately, and late superseded responses cannot overwrite the current selection.
+
+## Verification
+
+```bash
+cd apps && pnpm install --frozen-lockfile && pnpm --filter @kandev/web test -- --run hooks/domains/github/use-pr-diff.test.ts && pnpm --filter @kandev/web lint && pnpm --filter @kandev/web typecheck
+```
+
+```bash
+cd apps/web && pnpm e2e:run tests/review/review-multi-pr.spec.ts
+```
+
+```bash
+cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/review/mobile-review-multi-pr.spec.ts
+```
+
+## Files likely touched
+
+- `apps/web/hooks/domains/github/use-pr-diff.ts`
+- `apps/web/hooks/domains/github/use-pr-diff.test.ts`
+- `docs/specs/tasks/multi-branch/spec.md`
+- `docs/plans/stable-review-dialog-refresh/plan.md`
+- this task file
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. Hook behavior and regression coverage share the same state contract.
+
+## Inputs
+
+- Multi-branch spec Review refresh scenarios.
+- Root cause and identity split in `plan.md`.
+- Existing stable request/display identity pattern in `use-active-task-pr-files.ts`.
+- Existing different-PR late-response regression in `use-pr-diff.test.ts`.
+
+## TDD sequence
+
+1. Re-run the existing same-PR refresh regression and confirm the expected missing-file assertion failure.
+2. Add controlled atomic-replacement and initial/background-failure cases.
+3. Implement the smallest logical-identity/request-key split in `use-pr-diff.ts`.
+4. Run the focused unit suite, lint, typecheck, then existing desktop and mobile Review E2E specs.
+
+## Output contract
+
+Report RED/GREEN evidence, logical and timestamped identity behavior, failure retention, exact commands/results, E2E cleanup, files changed, residual risks, and synchronize this task plus `plan.md` in the same primary conversation.
+
+## Results
+
+- RED: the original same-PR timestamp regression failed because the pending refresh returned no files; expanded success and failure coverage produced 3 failures among 8 focused tests.
+- QA RED: retaining files while returning `loading: true` still failed the mounted-surface contract because `ReviewPRDiffBoundary` uses that value to replace a PR-only diff with its blocking loader. The focused suite failed 1 of 8 tests until background refresh became non-blocking.
+- GREEN: `cd apps && pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-diff.test.ts --reporter=dot` passed 8 tests covering pending refresh, atomic replacement, background and initial failure, superseded timestamp responses, and different-PR isolation.
+- Adjacent scope: `cd apps && pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-workspace-scope.test.ts --reporter=dot` passed 6 tests.
+- Static checks: `cd apps && pnpm --filter @kandev/web lint` and `cd apps && pnpm --filter @kandev/web typecheck` passed.
+- Fresh production E2E: desktop Review passed 1 test; phone and coarse-pointer tablet Review passed 2 tests with the task-file commands above.
+- `usePRDiff` now separates logical display identity from timestamped request freshness, retains only a resolved diff for the same workspace/PR, treats that refresh as non-blocking, atomically replaces current responses, retains content on background failure, and ignores superseded responses.
+- No layout, touch, navigation, copy, backend, security/trust-boundary, or external-state changes were made. Managed E2E cleaned up its isolated processes.

--- a/docs/specs/tasks/multi-branch/spec.md
+++ b/docs/specs/tasks/multi-branch/spec.md
@@ -57,6 +57,7 @@ Workarounds (sibling tasks, manually managing two worktrees) lost shared context
 - Repository-chip tooltips keep long local paths inside a viewport-safe, wrapping surface. Closing a repository picker does not reveal its tooltip until the pointer leaves and deliberately hovers the chip again.
 - Review surfaces expose one linked pull request at a time when a task has multiple PRs. A task-scoped selector defaults to the primary (oldest) PR, remembers an in-session override, and falls back to the primary PR when that override disappears.
 - The Changes timeline keeps the last resolved PR file list visible while a background PR synchronization refresh is pending. A successful refresh replaces the list atomically, and a failed refresh retains the last resolved list; switching workspace/task or removing a PR must not expose files from the previous scope.
+- The Review dialog keeps the selected PR's last resolved diff mounted while a background synchronization refresh for that same PR is pending. The refresh must not replace the diff with a blocking loader or reset the review scroll position, file selection, reviewed state, or pending comments. A successful refresh replaces the selected PR's files atomically, while a failed background refresh retains the last resolved diff. Selecting a different PR or workspace must hide the previous PR's files immediately and retain the existing loading, error, and retry behavior for an initial request.
 - Selecting a PR changes the remote PR diff contribution while preserving the existing source precedence: uncommitted worktree changes, then cumulative committed changes, then the selected PR. PR-only views and PR timeline rows resolve the exact PR rather than the task primary.
 - The selector is available on desktop, phone, and coarse-pointer tablet. Phone uses a touch-sized bottom-menu treatment inside the existing Review surface; switching keeps Review open and exposes selected-PR loading, empty, and retry states.
 - Full "+ Branch" UI affordance and grouped repo > branch tabs are deferred — agents drive multi-branch via the MCP tool today.
@@ -78,6 +79,10 @@ Workarounds (sibling tasks, manually managing two worktrees) lost shared context
 - **GIVEN** the Changes timeline displays resolved files for a linked PR, **WHEN** background synchronization advances that PR's sync timestamp and the replacement file request is still pending, **THEN** the existing PR Changes section and count remain visible without moving or remounting.
 - **GIVEN** a background PR file refresh completes, **WHEN** the replacement response belongs to the current workspace, task, and PR, **THEN** the PR Changes section atomically displays the replacement file list without retaining removed files.
 - **GIVEN** the Changes timeline displays resolved files for a linked PR, **WHEN** a background refresh fails, **THEN** the last resolved PR Changes section and count remain visible.
+- **GIVEN** the Review dialog displays a resolved selected-PR diff and the reviewer has scrolled or created review state, **WHEN** background synchronization advances that same PR's sync timestamp and the replacement file request is pending, **THEN** the existing diff remains mounted without a blocking loader and the review position and transient state remain intact.
+- **GIVEN** the Review dialog retains a selected PR's resolved diff during refresh, **WHEN** the current replacement response succeeds, **THEN** the same Review surface atomically displays the replacement file list without retaining removed files.
+- **GIVEN** the Review dialog displays a resolved selected-PR diff, **WHEN** a background refresh fails, **THEN** the last resolved diff remains available; an initial request with no resolved diff still shows the existing error and retry state.
+- **GIVEN** the Review dialog displays one PR, **WHEN** the reviewer selects a different PR or workspace, **THEN** files from the previous PR are hidden immediately while the new selection loads.
 
 ## Non-goals
 
@@ -106,6 +111,7 @@ Workarounds (sibling tasks, manually managing two worktrees) lost shared context
 - Remote-entry component and mobile E2E coverage prove paste/typing remains editable until Enter, the `Remote URL` hint is visible, failures preserve the URL and expose retry, and retry completes resolution.
 - GitHub and GitLab backend tests prove public branch lookup works without configured credentials, while public GitHub PR/issue metadata lookup supplies the task-creation enrichment used by the Remote selector.
 - Web unit tests prove selected-PR default, override, task isolation, and removed-PR fallback behavior.
+- Web hook tests prove same-PR timestamp refreshes retain the mounted diff until atomic replacement, retain resolved files after a background failure, preserve initial-load errors, and never expose files from a different PR or workspace.
 - Desktop and mobile Playwright tests prove a two-PR task can switch Review from the primary PR to a sibling PR without stale files, overflow, or closing the surface.
 
 ## Open questions


### PR DESCRIPTION
Review refreshes could replace an in-progress PR diff with a blocking loader, resetting scroll and transient review state. Resolved same-PR content now stays mounted through background refreshes while different PRs remain isolated.

## Validation

- `pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-diff.test.ts --reporter=dot`
- `pnpm --filter @kandev/web exec vitest run hooks/domains/github/use-pr-workspace-scope.test.ts --reporter=dot`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web typecheck`
- `pnpm e2e:run tests/review/review-multi-pr.spec.ts`
- `pnpm e2e:run --no-build --project mobile-chrome tests/review/mobile-review-multi-pr.spec.ts`
- Public docs unchanged; this repairs existing Review behavior.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- pr-assets:start -->
## Screenshots

**Desktop**

![Loaded PR content in the stable desktop Review dialog](https://raw.githubusercontent.com/kdlbs/kandev/fd273b45c5c5b474e26e5bb17efcbc1c6b0e5415/review-refresh-pr-capture--review-refresh-desktop.png)

**Mobile**

![The same stable Review state at a phone viewport](https://raw.githubusercontent.com/kdlbs/kandev/fd273b45c5c5b474e26e5bb17efcbc1c6b0e5415/review-refresh-pr-capture--review-refresh-mobile.png)
<!-- pr-assets:end -->