### PR TITLE
fix(office): stop finished runs from showing an empty output summary

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/event_types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/event_types.go
@@ -14,6 +14,7 @@ type AgentEventPayload struct {
 	RunID              string                 `json:"run_id,omitempty"`
 	TaskID             string                 `json:"task_id"`
 	SessionID          string                 `json:"session_id,omitempty"`
+	TurnID             string                 `json:"turn_id,omitempty"`
 	AgentID            string                 `json:"agent_id,omitempty"`
 	AgentProfileID     string                 `json:"agent_profile_id"`
 	ExecutionProfileID string                 `json:"execution_profile_id,omitempty"`

--- a/apps/backend/internal/agent/runtime/lifecycle/events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/events.go
@@ -34,6 +34,15 @@ func (p *EventPublisher) PublishAgentEvent(ctx context.Context, eventType string
 	p.publishAgentEventPayload(ctx, eventType, newAgentEventPayload(execution))
 }
 
+// publishAgentEventWithTurnID publishes a lifecycle event with a turn captured
+// by the completion handler. It avoids reading prompt state while that handler
+// still holds the prompt lifecycle lock.
+func (p *EventPublisher) publishAgentEventWithTurnID(
+	ctx context.Context, eventType string, execution *AgentExecution, turnID string,
+) {
+	p.publishAgentEventPayload(ctx, eventType, newAgentEventPayloadWithTurnID(execution, turnID))
+}
+
 // PublishAgentStalled publishes one inactivity signal for a prompt.
 // neverStarted reports whether the agent has emitted zero events since this
 // prompt was dispatched, and activityEpoch lets the consumer revalidate that
@@ -95,11 +104,16 @@ func (p *EventPublisher) publishAgentEventPayload(ctx context.Context, eventType
 }
 
 func newAgentEventPayload(execution *AgentExecution) AgentEventPayload {
+	return newAgentEventPayloadWithTurnID(execution, execution.promptTurnIDSnapshot())
+}
+
+func newAgentEventPayloadWithTurnID(execution *AgentExecution, turnID string) AgentEventPayload {
 	return AgentEventPayload{
 		AgentExecutionID:   execution.ID,
 		RunID:              execution.RunID,
 		TaskID:             execution.TaskID,
 		SessionID:          execution.SessionID,
+		TurnID:             turnID,
 		AgentID:            execution.AgentID,
 		AgentProfileID:     execution.officeProfileID(),
 		ExecutionProfileID: execution.AgentProfileID,

--- a/apps/backend/internal/agent/runtime/lifecycle/events_profile_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/events_profile_test.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -43,5 +44,22 @@ func TestAgentEventPayloadCarriesRunID(t *testing.T) {
 	payload := newAgentEventPayload(&AgentExecution{ID: "exec-1", RunID: "run-1"})
 	if payload.RunID != "run-1" {
 		t.Fatalf("run ID = %q, want run-1", payload.RunID)
+	}
+}
+
+func TestAgentEventPayloadCarriesPromptTurnID(t *testing.T) {
+	execution := &AgentExecution{ID: "exec-1", promptTurnID: "turn-1"}
+	payload := newAgentEventPayload(execution)
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	var fields map[string]string
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if fields["turn_id"] != "turn-1" {
+		t.Fatalf("turn_id = %q, want turn-1", fields["turn_id"])
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -113,7 +113,7 @@ func (m *Manager) handleCompleteEventMarkState(execution *AgentExecution, event 
 		// shows no red error banner. MarkCompleted applies the same guard, but
 		// routing here keeps the misleading "marking as failed" WARN out of logs.
 		if m.IsShuttingDown() {
-			_ = m.markStoppedDuringShutdown(execution, 1, errorMsg)
+			_ = m.markStoppedDuringShutdown(execution, 1, errorMsg, event.TurnID)
 			return
 		}
 		m.logger.Warn("error completion received, marking execution as failed",
@@ -125,7 +125,7 @@ func (m *Manager) handleCompleteEventMarkState(execution *AgentExecution, event 
 			zap.Any("event_data", event.Data),
 			zap.String("agent_command", execution.AgentCommand),
 			zap.String("acp_session_id", execution.ACPSessionID))
-		if err := m.MarkCompleted(execution.ID, 1, errorMsg); err != nil {
+		if err := m.markCompletedWithTurnID(execution.ID, 1, errorMsg, event.TurnID); err != nil {
 			m.logger.Error("failed to mark execution as failed after error completion",
 				zap.String("execution_id", execution.ID),
 				zap.Error(err))
@@ -225,11 +225,11 @@ func (m *Manager) claimPromptCompletion(
 		if current.Status != v1.AgentStatusReady {
 			current.firstActivityOnce.Do(func() {
 				claim.publishRunning = true
-				claim.runningPayload = newAgentEventPayload(current)
+				claim.runningPayload = newAgentEventPayloadWithTurnID(current, event.TurnID)
 			})
 		}
 		current.Status = v1.AgentStatusReady
-		claim.readyPayload = newAgentEventPayload(current)
+		claim.readyPayload = newAgentEventPayloadWithTurnID(current, event.TurnID)
 	})
 	if err == nil && claimed {
 		return claim, true

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1680,6 +1680,21 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 	if !exists {
 		return fmt.Errorf("execution %q not found", executionID)
 	}
+	return m.markCompletedWithTurnID(
+		executionID,
+		exitCode,
+		errorMessage,
+		execution.promptTurnIDSnapshot(),
+	)
+}
+
+func (m *Manager) markCompletedWithTurnID(
+	executionID string, exitCode int, errorMessage, turnID string,
+) error {
+	execution, exists := m.executionStore.Get(executionID)
+	if !exists {
+		return fmt.Errorf("execution %q not found", executionID)
+	}
 
 	// Guard against duplicate completion (e.g. ACP prompt error + process exit error).
 	// MarkCompleted is a terminal transition — once in Completed/Failed/Stopped, skip
@@ -1697,7 +1712,7 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 	// subprocess is not an agent failure. Treat the terminal error as a benign
 	// stop so the session stays resumable and the UI shows no red error banner.
 	if (exitCode != 0 || errorMessage != "") && m.IsShuttingDown() {
-		return m.markStoppedDuringShutdown(execution, exitCode, errorMessage)
+		return m.markStoppedDuringShutdown(execution, exitCode, errorMessage, turnID)
 	}
 
 	_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
@@ -1736,7 +1751,7 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 		eventType = events.AgentFailed
 		m.classifyAndMaybeRemediate(execution, exitCode, errorMessage)
 	}
-	m.eventPublisher.PublishAgentEvent(context.Background(), eventType, execution)
+	m.eventPublisher.publishAgentEventWithTurnID(context.Background(), eventType, execution, turnID)
 
 	return nil
 }
@@ -1762,7 +1777,9 @@ func isTerminalStatus(status v1.AgentStatus) bool {
 // execution is already terminal, or was removed by StopAgentWithReason, this is a
 // stale/duplicate callback — skip teardown and the AgentStopped publish so the
 // orchestrator does not process the same stop twice.
-func (m *Manager) markStoppedDuringShutdown(execution *AgentExecution, exitCode int, errorMessage string) error {
+func (m *Manager) markStoppedDuringShutdown(
+	execution *AgentExecution, exitCode int, errorMessage string, turnIDs ...string,
+) error {
 	applied := false
 	err := m.executionStore.WithLock(execution.ID, func(exec *AgentExecution) {
 		if isTerminalStatus(exec.Status) {
@@ -1793,7 +1810,11 @@ func (m *Manager) markStoppedDuringShutdown(execution *AgentExecution, exitCode 
 	m.persistExecutorRunning(context.Background(), execution)
 	m.releaseActivity(executionActivityKey(execution.ID))
 
-	m.eventPublisher.PublishAgentEvent(context.Background(), events.AgentStopped, execution)
+	turnID := ""
+	if len(turnIDs) > 0 {
+		turnID = turnIDs[0]
+	}
+	m.eventPublisher.publishAgentEventWithTurnID(context.Background(), events.AgentStopped, execution, turnID)
 
 	return nil
 }

--- a/apps/backend/internal/office/dashboard/agent_summary.go
+++ b/apps/backend/internal/office/dashboard/agent_summary.go
@@ -277,6 +277,9 @@ func buildLatestRunDTO(run *sqlite.RunSummaryRow) *AgentLatestRunDTO {
 		dto.FinishedAt = &s
 	}
 	dto.TaskID, dto.Summary = parseRunPayload(run.Payload)
+	if run.OutputSummary != "" {
+		dto.Summary = run.OutputSummary
+	}
 	return dto
 }
 

--- a/apps/backend/internal/office/dashboard/agent_summary_test.go
+++ b/apps/backend/internal/office/dashboard/agent_summary_test.go
@@ -157,6 +157,9 @@ func TestGetAgentSummary_LatestRunCard(t *testing.T) {
 		now.Add(-2*time.Hour))
 	seedSummaryRun(t, deps.db, "run-newest-id", summaryFixtureAgent, "failed", "task-2",
 		now.Add(-30*time.Minute))
+	if _, err := deps.db.Exec(`UPDATE runs SET output_summary = 'final agent response' WHERE id = 'run-newest-id'`); err != nil {
+		t.Fatalf("seed output summary: %v", err)
+	}
 
 	resp := fetchAgentSummary(t, deps, summaryFixtureAgent, 14)
 	if resp.LatestRun == nil {
@@ -173,6 +176,9 @@ func TestGetAgentSummary_LatestRunCard(t *testing.T) {
 	}
 	if resp.LatestRun.TaskID != "task-2" {
 		t.Errorf("task_id = %q, want task-2", resp.LatestRun.TaskID)
+	}
+	if resp.LatestRun.Summary != "final agent response" {
+		t.Errorf("summary = %q, want persisted output summary", resp.LatestRun.Summary)
 	}
 }
 

--- a/apps/backend/internal/office/repository/sqlite/agent_summary.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_summary.go
@@ -314,6 +314,7 @@ func (r *Repository) LatestRunForAgent(ctx context.Context, agentID string) (*Ru
 		       payload,
 		       status,
 		       COALESCE(error_message, '') AS error_message,
+		       COALESCE(output_summary, '') AS output_summary,
 		       requested_at,
 		       claimed_at,
 		       finished_at
@@ -339,6 +340,7 @@ type RunSummaryRow struct {
 	Payload        string     `db:"payload"`
 	Status         string     `db:"status"`
 	ErrorMessage   string     `db:"error_message"`
+	OutputSummary  string     `db:"output_summary"`
 	RequestedAt    time.Time  `db:"requested_at"`
 	ClaimedAt      *time.Time `db:"claimed_at"`
 	FinishedAt     *time.Time `db:"finished_at"`

--- a/apps/backend/internal/office/repository/sqlite/dashboard_test.go
+++ b/apps/backend/internal/office/repository/sqlite/dashboard_test.go
@@ -31,6 +31,8 @@ func ensureSessionTables(t *testing.T, repo *sqlite.Repository) {
 			id TEXT PRIMARY KEY,
 			task_session_id TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'message',
+			author_type TEXT NOT NULL DEFAULT 'user',
+			content TEXT NOT NULL DEFAULT '',
 			created_at TIMESTAMP NOT NULL
 		)`,
 	}

--- a/apps/backend/internal/office/repository/sqlite/run_output.go
+++ b/apps/backend/internal/office/repository/sqlite/run_output.go
@@ -1,0 +1,37 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// maxOutputSummaryChars caps the run output summary at the same length as
+// the per-entity summaries this subsystem already truncates (see
+// maxCommentChars in blockers.go) rather than introducing a new limit.
+const maxOutputSummaryChars = 500
+
+// GetFinalAgentMessage returns the most recent agent-authored message body
+// for a session, truncated to maxOutputSummaryChars. Returns "" (not an
+// error) when the session has no agent message, so callers can treat the
+// result as best-effort.
+func (r *Repository) GetFinalAgentMessage(ctx context.Context, sessionID string) (string, error) {
+	if sessionID == "" {
+		return "", nil
+	}
+	var content string
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT SUBSTR(content, 1, ?)
+		FROM task_session_messages
+		WHERE task_session_id = ? AND type = 'message' AND author_type = 'agent'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`), maxOutputSummaryChars, sessionID).Scan(&content)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return content, nil
+}

--- a/apps/backend/internal/office/repository/sqlite/run_output.go
+++ b/apps/backend/internal/office/repository/sqlite/run_output.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 )
 
 // maxOutputSummaryChars caps the run output summary at the same length as
@@ -12,10 +13,22 @@ import (
 const maxOutputSummaryChars = 500
 
 // GetFinalAgentMessage returns the most recent agent-authored message body
-// for a session, truncated to maxOutputSummaryChars. Returns "" (not an
-// error) when the session has no agent message, so callers can treat the
-// result as best-effort.
-func (r *Repository) GetFinalAgentMessage(ctx context.Context, sessionID string) (string, error) {
+// created at or after since, for a session, truncated to
+// maxOutputSummaryChars. Returns "" (not an error) when no matching message
+// exists, so callers can treat the result as best-effort.
+//
+// The since bound matters because office task-bound sessions are reused
+// across runs (same DB session_id across turns — see
+// handleAgentTurnMessageSaved's doc comment). Without it, a run that
+// completes without producing a new agent message would report a prior
+// run's message as its own output instead of staying empty. Callers pass
+// the run's claimed_at as since.
+//
+// id DESC is a secondary sort key only for determinism when two messages
+// share a created_at value (matches the tie-breaker convention documented
+// in task/repository/sqlite/session.go and used by message.go); message
+// ids are random, so it is not a true arrival-order signal.
+func (r *Repository) GetFinalAgentMessage(ctx context.Context, sessionID string, since time.Time) (string, error) {
 	if sessionID == "" {
 		return "", nil
 	}
@@ -23,10 +36,10 @@ func (r *Repository) GetFinalAgentMessage(ctx context.Context, sessionID string)
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
 		SELECT SUBSTR(content, 1, ?)
 		FROM task_session_messages
-		WHERE task_session_id = ? AND type = 'message' AND author_type = 'agent'
-		ORDER BY created_at DESC
+		WHERE task_session_id = ? AND type = 'message' AND author_type = 'agent' AND created_at >= ?
+		ORDER BY created_at DESC, id DESC
 		LIMIT 1
-	`), maxOutputSummaryChars, sessionID).Scan(&content)
+	`), maxOutputSummaryChars, sessionID, since).Scan(&content)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil

--- a/apps/backend/internal/office/repository/sqlite/run_output_test.go
+++ b/apps/backend/internal/office/repository/sqlite/run_output_test.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
+
+// sinceAllFixtures is a since bound before every fixture timestamp used in
+// this file's 2026-08-01 seed data, i.e. "no run-scoping in effect".
+var sinceAllFixtures = time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 
 func TestGetFinalAgentMessage_ReturnsLatestAgentMessage(t *testing.T) {
 	repo := newTestRepo(t)
@@ -22,7 +27,7 @@ func TestGetFinalAgentMessage_ReturnsLatestAgentMessage(t *testing.T) {
 		t.Fatalf("seed messages: %v", err)
 	}
 
-	got, err := repo.GetFinalAgentMessage(ctx, "s-1")
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1", sinceAllFixtures)
 	if err != nil {
 		t.Fatalf("GetFinalAgentMessage: %v", err)
 	}
@@ -36,7 +41,7 @@ func TestGetFinalAgentMessage_UnknownSessionReturnsEmpty(t *testing.T) {
 	ensureSessionTables(t, repo)
 	ctx := context.Background()
 
-	got, err := repo.GetFinalAgentMessage(ctx, "s-missing")
+	got, err := repo.GetFinalAgentMessage(ctx, "s-missing", sinceAllFixtures)
 	if err != nil {
 		t.Fatalf("GetFinalAgentMessage: %v", err)
 	}
@@ -57,7 +62,7 @@ func TestGetFinalAgentMessage_TruncatesAt500Chars(t *testing.T) {
 		t.Fatalf("seed message: %v", err)
 	}
 
-	got, err := repo.GetFinalAgentMessage(ctx, "s-1")
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1", sinceAllFixtures)
 	if err != nil {
 		t.Fatalf("GetFinalAgentMessage: %v", err)
 	}
@@ -66,5 +71,58 @@ func TestGetFinalAgentMessage_TruncatesAt500Chars(t *testing.T) {
 	}
 	if got != strings.Repeat("a", 500) {
 		t.Errorf("got unexpected content")
+	}
+}
+
+// TestGetFinalAgentMessage_TiedTimestampUsesIDAsTiebreaker pins the id DESC
+// secondary sort: two agent messages sharing a created_at value must return
+// a deterministic result rather than whichever row SQLite happens to visit
+// last, matching the tie-breaker convention documented in
+// task/repository/sqlite/session.go.
+func TestGetFinalAgentMessage_TiedTimestampUsesIDAsTiebreaker(t *testing.T) {
+	repo := newTestRepo(t)
+	ensureSessionTables(t, repo)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
+			('m-a', 's-1', 'message', 'agent', 'reply a', '2026-08-01 10:00:00'),
+			('m-b', 's-1', 'message', 'agent', 'reply b', '2026-08-01 10:00:00')
+	`); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
+
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1", sinceAllFixtures)
+	if err != nil {
+		t.Fatalf("GetFinalAgentMessage: %v", err)
+	}
+	if got != "reply b" {
+		t.Errorf("got %q, want %q (id DESC tiebreaker: m-b > m-a)", got, "reply b")
+	}
+}
+
+// TestGetFinalAgentMessage_ScopesToSinceExcludesEarlierMessage pins the
+// run-scoping fix: office task-bound sessions are reused across runs, so a
+// message created before the since bound (a prior run's turn) must not be
+// returned even though it is the session's most recent agent message.
+func TestGetFinalAgentMessage_ScopesToSinceExcludesEarlierMessage(t *testing.T) {
+	repo := newTestRepo(t)
+	ensureSessionTables(t, repo)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
+			('m-1', 's-1', 'message', 'agent', 'prior run reply', '2026-08-01 10:00:00')
+	`); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	since := time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC)
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1", since)
+	if err != nil {
+		t.Fatalf("GetFinalAgentMessage: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty (prior run's message must not leak into this run)", got)
 	}
 }

--- a/apps/backend/internal/office/repository/sqlite/run_output_test.go
+++ b/apps/backend/internal/office/repository/sqlite/run_output_test.go
@@ -1,0 +1,70 @@
+package sqlite_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGetFinalAgentMessage_ReturnsLatestAgentMessage(t *testing.T) {
+	repo := newTestRepo(t)
+	ensureSessionTables(t, repo)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
+			('m-1', 's-1', 'message', 'user',  'please do the thing',    '2026-08-01 10:00:00'),
+			('m-2', 's-1', 'message', 'agent', 'first agent reply',      '2026-08-01 10:00:05'),
+			('m-3', 's-1', 'tool_call', 'agent', 'ran a tool',           '2026-08-01 10:00:06'),
+			('m-4', 's-1', 'message', 'agent', 'final agent reply',      '2026-08-01 10:00:10'),
+			('m-5', 's-2', 'message', 'agent', 'other session reply',    '2026-08-01 10:00:10')
+	`); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
+
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1")
+	if err != nil {
+		t.Fatalf("GetFinalAgentMessage: %v", err)
+	}
+	if got != "final agent reply" {
+		t.Errorf("got %q, want %q", got, "final agent reply")
+	}
+}
+
+func TestGetFinalAgentMessage_UnknownSessionReturnsEmpty(t *testing.T) {
+	repo := newTestRepo(t)
+	ensureSessionTables(t, repo)
+	ctx := context.Background()
+
+	got, err := repo.GetFinalAgentMessage(ctx, "s-missing")
+	if err != nil {
+		t.Fatalf("GetFinalAgentMessage: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestGetFinalAgentMessage_TruncatesAt500Chars(t *testing.T) {
+	repo := newTestRepo(t)
+	ensureSessionTables(t, repo)
+	ctx := context.Background()
+
+	long := strings.Repeat("a", 600)
+	if _, err := repo.ExecRaw(ctx,
+		`INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
+		 VALUES ('m-1', 's-1', 'message', 'agent', ?, '2026-08-01 10:00:00')`, long); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	got, err := repo.GetFinalAgentMessage(ctx, "s-1")
+	if err != nil {
+		t.Fatalf("GetFinalAgentMessage: %v", err)
+	}
+	if len(got) != 500 {
+		t.Fatalf("len(got) = %d, want 500", len(got))
+	}
+	if got != strings.Repeat("a", 500) {
+		t.Errorf("got unexpected content")
+	}
+}

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -508,6 +509,13 @@ func extractRoutineID(snapshot string) string {
 // above: any failure is logged at warn and never fails the completion
 // event, since the run must still reach a terminal state either way.
 //
+// The lookup is scoped to messages created at or after run.ClaimedAt.
+// Office task-bound sessions are reused across runs, so an unscoped
+// session-wide lookup would attribute a prior run's final message to a
+// later run that produced nothing new. A nil ClaimedAt (defensive only —
+// resolveLifecycleRun only returns claimed runs) falls back to the zero
+// time, matching the old unscoped behavior rather than skipping the write.
+//
 // failure_reason is deliberately left "" on this write.
 // UpdateRunOutputSummary is output_summary's only writer, so this never
 // clobbers a value nothing else sets today; giving failure_reason real
@@ -517,7 +525,11 @@ func (s *Service) recordRunOutputSummary(ctx context.Context, run *models.Run, s
 	if s.repo == nil || run == nil || sessionID == "" {
 		return
 	}
-	summary, err := s.repo.GetFinalAgentMessage(ctx, sessionID)
+	var since time.Time
+	if run.ClaimedAt != nil {
+		since = *run.ClaimedAt
+	}
+	summary, err := s.repo.GetFinalAgentMessage(ctx, sessionID, since)
 	if err != nil {
 		s.logger.Warn("run output summary: final agent message lookup failed",
 			zap.String("run_id", run.ID), zap.Error(err))

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -115,6 +115,7 @@ type AgentLifecycleData struct {
 	AgentID        string                 `json:"agent_id"`
 	AgentProfileID string                 `json:"agent_profile_id"`
 	SessionID      string                 `json:"session_id"`
+	TurnID         string                 `json:"turn_id,omitempty"`
 	ErrorMessage   string                 `json:"error_message"`
 	ProviderError  *streams.ProviderError `json:"provider_error,omitempty"`
 }
@@ -348,7 +349,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 		"session_id": data.SessionID,
 	})
 	s.markRoutingSuccess(ctx, run)
-	s.recordRunOutputSummary(ctx, run, data.SessionID)
+	s.recordRunOutputSummary(ctx, run, *data)
 	// resolveLifecycleRun prefers the immutable run ID from the event and
 	// falls back to task plus agent only for legacy events. Releasing here
 	// (rather than unconditionally inside transitionRunTerminal) is safe —
@@ -410,7 +411,7 @@ func (s *Service) handleTasklessAgentCompleted(
 		"session_id": data.SessionID,
 	})
 	s.refreshContinuationSummary(ctx, run, data.AgentID)
-	s.recordRunOutputSummary(ctx, run, data.SessionID)
+	s.recordRunOutputSummary(ctx, run, *data)
 	// run came from GetClaimedTasklessRunForAgent: it is the run that
 	// actually launched. Taskless runs typically carry no task_id, so this
 	// is a no-op in the common case, but call it for the same reason as
@@ -509,36 +510,63 @@ func extractRoutineID(snapshot string) string {
 // above: any failure is logged at warn and never fails the completion
 // event, since the run must still reach a terminal state either way.
 //
-// The lookup is scoped to messages created at or after run.ClaimedAt.
-// Office task-bound sessions are reused across runs, so an unscoped
-// session-wide lookup would attribute a prior run's final message to a
-// later run that produced nothing new. A nil ClaimedAt (defensive only —
-// resolveLifecycleRun only returns claimed runs) falls back to the zero
-// time, matching the old unscoped behavior rather than skipping the write.
+// The lookup uses the exact turn when a completion event carries one.
+// Legacy events use messages created at or after run.ClaimedAt because Office
+// task-bound sessions are reused across runs. A nil ClaimedAt falls back to
+// the zero time, matching the old unscoped behavior.
 //
 // failure_reason is deliberately left "" on this write.
 // UpdateRunOutputSummary is output_summary's only writer, so this never
 // clobbers a value nothing else sets today; giving failure_reason real
 // semantics (skipped / checkout-contended / failed) is card b5cf0858's
 // territory, not this one's.
-func (s *Service) recordRunOutputSummary(ctx context.Context, run *models.Run, sessionID string) {
-	if s.repo == nil || run == nil || sessionID == "" {
+func (s *Service) recordRunOutputSummary(ctx context.Context, run *models.Run, data AgentLifecycleData) {
+	if s.repo == nil || run == nil {
 		return
 	}
-	var since time.Time
-	if run.ClaimedAt != nil {
-		since = *run.ClaimedAt
-	}
-	summary, err := s.repo.GetFinalAgentMessage(ctx, sessionID, since)
+	summary, err := s.lookupFinalAgentMessage(ctx, run, data)
 	if err != nil {
 		s.logger.Warn("run output summary: final agent message lookup failed",
 			zap.String("run_id", run.ID), zap.Error(err))
+		return
+	}
+	if summary == "" {
 		return
 	}
 	if updateErr := s.repo.UpdateRunOutputSummary(ctx, run.ID, summary, ""); updateErr != nil {
 		s.logger.Warn("run output summary: update failed",
 			zap.String("run_id", run.ID), zap.Error(updateErr))
 	}
+}
+
+func (s *Service) lookupFinalAgentMessage(
+	ctx context.Context, run *models.Run, data AgentLifecycleData,
+) (string, error) {
+	if data.TurnID != "" && s.taskWorkspace != nil {
+		message, err := s.taskWorkspace.GetLastAgentMessageForTurn(ctx, data.TurnID)
+		if err != nil {
+			return "", err
+		}
+		return truncateRunOutputSummary(message), nil
+	}
+	if data.SessionID == "" {
+		return "", nil
+	}
+	var since time.Time
+	if run.ClaimedAt != nil {
+		since = *run.ClaimedAt
+	}
+	return s.repo.GetFinalAgentMessage(ctx, data.SessionID, since)
+}
+
+const maxRunOutputSummaryChars = 500
+
+func truncateRunOutputSummary(content string) string {
+	runes := []rune(content)
+	if len(runes) <= maxRunOutputSummaryChars {
+		return content
+	}
+	return string(runes[:maxRunOutputSummaryChars])
 }
 
 func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error {

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -347,6 +347,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 		"session_id": data.SessionID,
 	})
 	s.markRoutingSuccess(ctx, run)
+	s.recordRunOutputSummary(ctx, run, data.SessionID)
 	// resolveLifecycleRun prefers the immutable run ID from the event and
 	// falls back to task plus agent only for legacy events. Releasing here
 	// (rather than unconditionally inside transitionRunTerminal) is safe —
@@ -408,6 +409,7 @@ func (s *Service) handleTasklessAgentCompleted(
 		"session_id": data.SessionID,
 	})
 	s.refreshContinuationSummary(ctx, run, data.AgentID)
+	s.recordRunOutputSummary(ctx, run, data.SessionID)
 	// run came from GetClaimedTasklessRunForAgent: it is the run that
 	// actually launched. Taskless runs typically carry no task_id, so this
 	// is a no-op in the common case, but call it for the same reason as
@@ -499,6 +501,32 @@ func extractRoutineID(snapshot string) string {
 		return ""
 	}
 	return p.RoutineID
+}
+
+// recordRunOutputSummary persists the agent's final message as the run's
+// output_summary. Best-effort — same contract as refreshContinuationSummary
+// above: any failure is logged at warn and never fails the completion
+// event, since the run must still reach a terminal state either way.
+//
+// failure_reason is deliberately left "" on this write.
+// UpdateRunOutputSummary is output_summary's only writer, so this never
+// clobbers a value nothing else sets today; giving failure_reason real
+// semantics (skipped / checkout-contended / failed) is card b5cf0858's
+// territory, not this one's.
+func (s *Service) recordRunOutputSummary(ctx context.Context, run *models.Run, sessionID string) {
+	if s.repo == nil || run == nil || sessionID == "" {
+		return
+	}
+	summary, err := s.repo.GetFinalAgentMessage(ctx, sessionID)
+	if err != nil {
+		s.logger.Warn("run output summary: final agent message lookup failed",
+			zap.String("run_id", run.ID), zap.Error(err))
+		return
+	}
+	if updateErr := s.repo.UpdateRunOutputSummary(ctx, run.ID, summary, ""); updateErr != nil {
+		s.logger.Warn("run output summary: update failed",
+			zap.String("run_id", run.ID), zap.Error(updateErr))
+	}
 }
 
 func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error {

--- a/apps/backend/internal/office/service/event_subscribers_run_output_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_run_output_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
@@ -42,6 +43,19 @@ func findRunByID(t *testing.T, svc *service.Service, wsID, runID string) *models
 	return nil
 }
 
+// requireClaimedAt returns run.ClaimedAt, failing the test if it is nil.
+// ClaimNextRun sets it to the real claim time, so fixture message
+// timestamps in these tests are built relative to it rather than a fixed
+// past literal — the run-scoped lookup in recordRunOutputSummary would
+// otherwise exclude every fixture message seeded before "now".
+func requireClaimedAt(t *testing.T, run *models.Run) time.Time {
+	t.Helper()
+	if run.ClaimedAt == nil {
+		t.Fatalf("run %q has nil ClaimedAt", run.ID)
+	}
+	return *run.ClaimedAt
+}
+
 // TestHandleAgentCompleted_RecordsFinalAgentMessageAsOutputSummary pins
 // the fix for "[Office] Finished runs never record an output summary":
 // handleAgentCompleted must write the run's output_summary from the
@@ -66,14 +80,20 @@ func TestHandleAgentCompleted_RecordsFinalAgentMessageAsOutputSummary(t *testing
 	if err != nil || run == nil {
 		t.Fatalf("claim run: %v (run=%v)", err, run)
 	}
+	claimedAt := requireClaimedAt(t, run)
 
 	svc.ExecSQL(t, `
 		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
-			('m-1', 'sess-1', 'message',   'user',  'please do the thing',        '2026-08-01 10:00:00'),
-			('m-2', 'sess-1', 'message',   'agent', 'first agent reply',          '2026-08-01 10:00:05'),
-			('m-3', 'sess-1', 'tool_call', 'agent', 'ran a tool',                 '2026-08-01 10:00:06'),
-			('m-4', 'sess-1', 'message',   'agent', 'Feasibility note posted.',   '2026-08-01 10:00:10')
-	`)
+			('m-1', 'sess-1', 'message',   'user',  'please do the thing',        ?),
+			('m-2', 'sess-1', 'message',   'agent', 'first agent reply',          ?),
+			('m-3', 'sess-1', 'tool_call', 'agent', 'ran a tool',                 ?),
+			('m-4', 'sess-1', 'message',   'agent', 'Feasibility note posted.',   ?)
+	`,
+		claimedAt.Add(0*time.Second),
+		claimedAt.Add(5*time.Second),
+		claimedAt.Add(6*time.Second),
+		claimedAt.Add(10*time.Second),
+	)
 
 	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
 		"task_id":          taskID,
@@ -117,12 +137,13 @@ func TestHandleAgentCompleted_TruncatesOutputSummaryAt500Chars(t *testing.T) {
 	if err != nil || run == nil {
 		t.Fatalf("claim run: %v (run=%v)", err, run)
 	}
+	claimedAt := requireClaimedAt(t, run)
 
 	long := strings.Repeat("a", 600)
 	svc.ExecSQL(t, `
 		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
-		VALUES ('m-1', 'sess-1', 'message', 'agent', ?, '2026-08-01 10:00:00')
-	`, long)
+		VALUES ('m-1', 'sess-1', 'message', 'agent', ?, ?)
+	`, long, claimedAt.Add(1*time.Second))
 
 	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
 		"task_id":          taskID,
@@ -204,11 +225,12 @@ func TestHandleTasklessAgentCompleted_RecordsOutputSummaryAndKeepsContinuationSu
 	if err != nil || run == nil {
 		t.Fatalf("claim run: %v (run=%v)", err, run)
 	}
+	claimedAt := requireClaimedAt(t, run)
 
 	svc.ExecSQL(t, `
 		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
-		VALUES ('m-1', 'sess-taskless', 'message', 'agent', 'heartbeat done.', '2026-08-01 10:00:00')
-	`)
+		VALUES ('m-1', 'sess-taskless', 'message', 'agent', 'heartbeat done.', ?)
+	`, claimedAt.Add(1*time.Second))
 
 	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
 		"agent_id":   "worker-taskless",
@@ -256,12 +278,13 @@ func TestHandleAgentCompleted_LastAgentMessageWinsOverLaterUserMessage(t *testin
 	if err != nil || run == nil {
 		t.Fatalf("claim run: %v (run=%v)", err, run)
 	}
+	claimedAt := requireClaimedAt(t, run)
 
 	svc.ExecSQL(t, `
 		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
-			('m-1', 'sess-1', 'message', 'agent', 'agent final answer', '2026-08-01 10:00:00'),
-			('m-2', 'sess-1', 'message', 'user',  'thanks, thats all',  '2026-08-01 10:00:05')
-	`)
+			('m-1', 'sess-1', 'message', 'agent', 'agent final answer', ?),
+			('m-2', 'sess-1', 'message', 'user',  'thanks, thats all',  ?)
+	`, claimedAt.Add(0*time.Second), claimedAt.Add(5*time.Second))
 
 	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
 		"task_id":          taskID,
@@ -275,5 +298,89 @@ func TestHandleAgentCompleted_LastAgentMessageWinsOverLaterUserMessage(t *testin
 	got := findRunByID(t, svc, "ws-1", run.ID)
 	if got.OutputSummary != "agent final answer" {
 		t.Errorf("output_summary = %q, want %q (later user message must not win)", got.OutputSummary, "agent final answer")
+	}
+}
+
+// TestHandleAgentCompleted_SecondRunOnReusedSessionStaysEmpty pins the
+// run-scoping fix raised in PR review: office task-bound sessions are
+// reused across runs (same DB session_id across turns). Before the fix,
+// GetFinalAgentMessage searched the whole session, so a second run that
+// produces no new agent message would report the FIRST run's message as
+// its own output instead of staying empty.
+func TestHandleAgentCompleted_SecondRunOnReusedSessionStaysEmpty(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+
+	// Run 1: queue, claim, produce an agent message, complete. The
+	// session (sess-1) is reused for run 2 below, mirroring how office
+	// task-bound sessions persist across turns.
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-reuse-1",
+	); err != nil {
+		t.Fatalf("queue run 1: %v", err)
+	}
+	run1, err := svc.ClaimNextRun(ctx)
+	if err != nil || run1 == nil {
+		t.Fatalf("claim run 1: %v (run=%v)", err, run1)
+	}
+	claimedAt1 := requireClaimedAt(t, run1)
+
+	// created_at uses claimedAt1 exactly (no forward offset): in-process
+	// tests run sub-millisecond, so any artificial forward offset risks
+	// landing after run2's real claim time below and silently defeating
+	// the scoping this test exists to pin. Using claimedAt1 itself still
+	// satisfies run1's own since bound (created_at >= since is inclusive)
+	// and is guaranteed <= run2's claim time, which happens strictly
+	// later in wall-clock time.
+	svc.ExecSQL(t, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
+		VALUES ('m-1', 'sess-1', 'message', 'agent', 'first run reply', ?)
+	`, claimedAt1)
+
+	completed1 := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed1); pErr != nil {
+		t.Fatalf("publish completed 1: %v", pErr)
+	}
+
+	got1 := findRunByID(t, svc, "ws-1", run1.ID)
+	if got1.OutputSummary != "first run reply" {
+		t.Fatalf("run 1 output_summary = %q, want %q", got1.OutputSummary, "first run reply")
+	}
+
+	// Run 2: reuses sess-1 but produces no new agent message before
+	// completing (e.g. a turn that only made tool calls, or was cut
+	// short). No new task_session_messages row is inserted here.
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskComment,
+		`{"task_id":"`+taskID+`"}`, "run-output-reuse-2",
+	); err != nil {
+		t.Fatalf("queue run 2: %v", err)
+	}
+	run2, err := svc.ClaimNextRun(ctx)
+	if err != nil || run2 == nil {
+		t.Fatalf("claim run 2: %v (run=%v)", err, run2)
+	}
+
+	completed2 := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed2); pErr != nil {
+		t.Fatalf("publish completed 2: %v", pErr)
+	}
+
+	got2 := findRunByID(t, svc, "ws-1", run2.ID)
+	if got2.OutputSummary != "" {
+		t.Errorf("run 2 output_summary = %q, want empty (must not inherit run 1's message from the reused session)", got2.OutputSummary)
 	}
 }

--- a/apps/backend/internal/office/service/event_subscribers_run_output_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_run_output_test.go
@@ -1,0 +1,279 @@
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/service"
+)
+
+// ensureTaskSessionMessagesTable creates the task_session_messages stub
+// this package's tests read final agent messages from. base_test.go's
+// shared task_sessions stub doesn't include this table because most
+// service tests never need it.
+func ensureTaskSessionMessagesTable(t *testing.T, svc *service.Service) {
+	t.Helper()
+	svc.ExecSQL(t, `CREATE TABLE IF NOT EXISTS task_session_messages (
+		id TEXT PRIMARY KEY,
+		task_session_id TEXT NOT NULL,
+		type TEXT NOT NULL DEFAULT 'message',
+		author_type TEXT NOT NULL DEFAULT 'user',
+		content TEXT NOT NULL DEFAULT '',
+		created_at TIMESTAMP NOT NULL
+	)`)
+}
+
+func findRunByID(t *testing.T, svc *service.Service, wsID, runID string) *models.Run {
+	t.Helper()
+	runs, err := svc.ListRuns(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	for _, r := range runs {
+		if r.ID == runID {
+			return r
+		}
+	}
+	t.Fatalf("run %q not found among %d runs", runID, len(runs))
+	return nil
+}
+
+// TestHandleAgentCompleted_RecordsFinalAgentMessageAsOutputSummary pins
+// the fix for "[Office] Finished runs never record an output summary":
+// handleAgentCompleted must write the run's output_summary from the
+// agent's final message before the run reaches 'finished'. An
+// existence-only assertion (non-empty) would pass on any garbage write,
+// so this asserts the exact projected content.
+func TestHandleAgentCompleted_RecordsFinalAgentMessageAsOutputSummary(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-init",
+	); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	svc.ExecSQL(t, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
+			('m-1', 'sess-1', 'message',   'user',  'please do the thing',        '2026-08-01 10:00:00'),
+			('m-2', 'sess-1', 'message',   'agent', 'first agent reply',          '2026-08-01 10:00:05'),
+			('m-3', 'sess-1', 'tool_call', 'agent', 'ran a tool',                 '2026-08-01 10:00:06'),
+			('m-4', 'sess-1', 'message',   'agent', 'Feasibility note posted.',   '2026-08-01 10:00:10')
+	`)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.Status != service.RunStatusFinished {
+		t.Fatalf("status = %q, want finished", got.Status)
+	}
+	if got.OutputSummary != "Feasibility note posted." {
+		t.Errorf("output_summary = %q, want %q", got.OutputSummary, "Feasibility note posted.")
+	}
+	if got.FailureReason != "" {
+		t.Errorf("failure_reason = %q, want empty (recording output_summary must not clobber it)", got.FailureReason)
+	}
+}
+
+// TestHandleAgentCompleted_TruncatesOutputSummaryAt500Chars pins the
+// truncation length reused from the child-summary precedent
+// (office/repository/sqlite/blockers.go's maxCommentChars).
+func TestHandleAgentCompleted_TruncatesOutputSummaryAt500Chars(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-truncate",
+	); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	long := strings.Repeat("a", 600)
+	svc.ExecSQL(t, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
+		VALUES ('m-1', 'sess-1', 'message', 'agent', ?, '2026-08-01 10:00:00')
+	`, long)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if len(got.OutputSummary) != 500 {
+		t.Fatalf("len(output_summary) = %d, want 500", len(got.OutputSummary))
+	}
+	if got.OutputSummary != strings.Repeat("a", 500) {
+		t.Errorf("unexpected output_summary content")
+	}
+}
+
+// TestHandleAgentCompleted_NoAgentMessageStaysBestEffort pins the
+// best-effort contract: when the session has no agent message, the run
+// still reaches 'finished' with an empty summary rather than failing
+// the completion event.
+func TestHandleAgentCompleted_NoAgentMessageStaysBestEffort(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-none",
+	); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	// No task_session_messages rows for this session at all.
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-empty",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.Status != service.RunStatusFinished {
+		t.Fatalf("status = %q, want finished (best-effort must never block completion)", got.Status)
+	}
+	if got.OutputSummary != "" {
+		t.Errorf("output_summary = %q, want empty", got.OutputSummary)
+	}
+}
+
+// TestHandleTasklessAgentCompleted_RecordsOutputSummaryAndKeepsContinuationSummary
+// covers the taskless path the card explicitly asked not to be excused
+// from, and pins that the new call does not displace
+// refreshContinuationSummary's existing upsert.
+func TestHandleTasklessAgentCompleted_RecordsOutputSummaryAndKeepsContinuationSummary(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-taskless")
+
+	if err := svc.QueueRun(
+		ctx, "worker-taskless", service.RunReasonTaskAssigned, "{}", "run-output-taskless",
+	); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	svc.ExecSQL(t, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at)
+		VALUES ('m-1', 'sess-taskless', 'message', 'agent', 'heartbeat done.', '2026-08-01 10:00:00')
+	`)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"agent_id":   "worker-taskless",
+		"session_id": "sess-taskless",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.Status != service.RunStatusFinished {
+		t.Fatalf("status = %q, want finished", got.Status)
+	}
+	if got.OutputSummary != "heartbeat done." {
+		t.Errorf("output_summary = %q, want %q", got.OutputSummary, "heartbeat done.")
+	}
+
+	summary, err := svc.GetContinuationSummaryForTest(ctx, "worker-taskless", "agent:worker-taskless")
+	if err != nil {
+		t.Fatalf("continuation summary lookup: %v (refreshContinuationSummary must still upsert)", err)
+	}
+	if summary.UpdatedByRunID != run.ID {
+		t.Errorf("continuation summary updated_by_run_id = %q, want %q", summary.UpdatedByRunID, run.ID)
+	}
+}
+
+// TestHandleAgentCompleted_LastAgentMessageWinsOverLaterUserMessage pins
+// the ordering rule: the projection is the last *agent* message, not
+// simply the most recent row regardless of author.
+func TestHandleAgentCompleted_LastAgentMessageWinsOverLaterUserMessage(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	ensureTaskSessionMessagesTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+
+	if err := svc.QueueRun(
+		ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-ordering",
+	); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	svc.ExecSQL(t, `
+		INSERT INTO task_session_messages (id, task_session_id, type, author_type, content, created_at) VALUES
+			('m-1', 'sess-1', 'message', 'agent', 'agent final answer', '2026-08-01 10:00:00'),
+			('m-2', 'sess-1', 'message', 'user',  'thanks, thats all',  '2026-08-01 10:00:05')
+	`)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "worker-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.OutputSummary != "agent final answer" {
+		t.Errorf("output_summary = %q, want %q (later user message must not win)", got.OutputSummary, "agent final answer")
+	}
+}

--- a/apps/backend/internal/office/service/event_subscribers_run_output_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_run_output_test.go
@@ -384,3 +384,66 @@ func TestHandleAgentCompleted_SecondRunOnReusedSessionStaysEmpty(t *testing.T) {
 		t.Errorf("run 2 output_summary = %q, want empty (must not inherit run 1's message from the reused session)", got2.OutputSummary)
 	}
 }
+
+func TestHandleAgentCompleted_DoesNotClearExistingSummaryWithoutMessage(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+	if err := svc.QueueRun(ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-preserve"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+	svc.ExecSQL(t, `UPDATE runs SET output_summary = 'previous projection' WHERE id = ?`, run.ID)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-empty",
+		"agent_profile_id": "worker-1",
+	})
+	if err := eb.Publish(ctx, events.AgentCompleted, completed); err != nil {
+		t.Fatalf("publish completed: %v", err)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.OutputSummary != "previous projection" {
+		t.Fatalf("output_summary = %q, want existing projection preserved", got.OutputSummary)
+	}
+}
+
+func TestHandleAgentCompleted_UsesTurnScopedMessageForSharedSession(t *testing.T) {
+	stub := &stubTaskWorkspace{lastMsgByTurn: map[string]string{
+		"turn-2": "second run answer",
+	}}
+	svc, eb := newTestServiceWithTaskWorkspace(t, stub)
+	ctx := context.Background()
+	createTestAgent(t, svc, "ws-1", "worker-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-1")
+	if err := svc.QueueRun(ctx, "worker-1", service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, "run-output-turn"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-shared",
+		"turn_id":          "turn-2",
+		"agent_profile_id": "worker-1",
+	})
+	if err := eb.Publish(ctx, events.AgentCompleted, completed); err != nil {
+		t.Fatalf("publish completed: %v", err)
+	}
+
+	got := findRunByID(t, svc, "ws-1", run.ID)
+	if got.OutputSummary != "second run answer" {
+		t.Fatalf("output_summary = %q, want turn-scoped message", got.OutputSummary)
+	}
+}

--- a/apps/backend/internal/office/service/test_helpers.go
+++ b/apps/backend/internal/office/service/test_helpers.go
@@ -17,6 +17,15 @@ func (s *Service) ListRunEventsForTest(
 	return s.repo.ListRunEvents(ctx, runID, -1, 0)
 }
 
+// GetContinuationSummaryForTest exposes the repo's continuation-summary
+// read so tests can verify refreshContinuationSummary's upsert without
+// duplicating the raw agent_continuation_summaries query.
+func (s *Service) GetContinuationSummaryForTest(
+	ctx context.Context, agentProfileID, scope string,
+) (*sqlite.AgentContinuationSummary, error) {
+	return s.repo.GetContinuationSummary(ctx, agentProfileID, scope)
+}
+
 // ListTasksTouchedByRunForTest exposes the repo's read query so the
 // run-lifecycle integration tests can verify run_id plumbing on the
 // activity log.

--- a/apps/web/app/office/agents/[id]/runs/[runId]/run-detail-view.tsx
+++ b/apps/web/app/office/agents/[id]/runs/[runId]/run-detail-view.tsx
@@ -32,11 +32,21 @@ type Props = {
 export function RunDetailView({ agentId, initial, recent }: Props) {
   const taskId = initial.task_id ?? "";
   const sessionId = initial.session.session_id ?? "";
-  const { events, status } = useRunLiveSync(initial.id, initial.events, initial.status);
-  const liveRun = useMemo<RunDetail>(
-    () => (status === initial.status ? initial : { ...initial, status }),
-    [initial, status],
+  const { events, status, outputSummary } = useRunLiveSync(
+    initial.id,
+    initial.events,
+    initial.status,
+    {
+      agentId,
+      initialOutputSummary: initial.output_summary,
+    },
   );
+  const liveRun = useMemo<RunDetail>(() => {
+    if (status === initial.status && outputSummary === (initial.output_summary ?? "")) {
+      return initial;
+    }
+    return { ...initial, status, output_summary: outputSummary || undefined };
+  }, [initial, outputSummary, status]);
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
       <aside className="lg:sticky lg:top-4 lg:self-start">
@@ -49,7 +59,7 @@ export function RunDetailView({ agentId, initial, recent }: Props) {
         <SessionCollapsible session={initial.session} />
         <InvocationPanel invocation={initial.invocation} />
         <RuntimePanel runtime={initial.runtime} />
-        <PromptPanel run={initial} />
+        <PromptPanel run={liveRun} />
         <TasksTouched runId={initial.id} taskIds={initial.tasks_touched} />
         <RunConversation taskId={taskId} sessionId={sessionId} />
         <EventsLog events={events} />

--- a/apps/web/app/office/agents/[id]/runs/[runId]/use-run-live-sync.test.tsx
+++ b/apps/web/app/office/agents/[id]/runs/[runId]/use-run-live-sync.test.tsx
@@ -4,6 +4,12 @@ import type { RunEvent } from "@/lib/api/domains/office-extended-api";
 import type { RunEventAppendedPayload } from "@/lib/types/backend";
 import { useRunLiveSync } from "./use-run-live-sync";
 
+const api = vi.hoisted(() => ({
+  getRunDetail: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/office-runs-api", () => api);
+
 const clients = vi.hoisted(() => ({
   active: { subscribeRun: vi.fn() },
 }));
@@ -118,5 +124,21 @@ describe("useRunLiveSync", () => {
     rerender({ ...initialProps, initialEvents: [started] });
 
     expect(result.current.events).toEqual([started]);
+  });
+
+  it("reloads the final output summary after a terminal event", async () => {
+    api.getRunDetail.mockResolvedValue({ output_summary: "final answer" });
+    const { result } = renderHook(() =>
+      useRunLiveSync("run-1", [], "claimed", { agentId: "agent-1" }),
+    );
+
+    act(() => {
+      handlers.listener!({ run_id: "run-1", event: runEvent(1, "complete") });
+    });
+
+    await vi.waitFor(() => {
+      expect(api.getRunDetail).toHaveBeenCalledWith("agent-1", "run-1");
+      expect(result.current.outputSummary).toBe("final answer");
+    });
   });
 });

--- a/apps/web/app/office/agents/[id]/runs/[runId]/use-run-live-sync.ts
+++ b/apps/web/app/office/agents/[id]/runs/[runId]/use-run-live-sync.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { subscribeRunEvents } from "@/lib/ws/handlers/run";
 import type { RunDetail, RunEvent } from "@/lib/api/domains/office-extended-api";
+import { getRunDetail } from "@/lib/api/domains/office-runs-api";
 
 type Status = RunDetail["status"];
 
@@ -15,6 +16,11 @@ const TERMINAL_EVENT_STATUS: Record<string, Status | undefined> = {
 };
 
 const TERMINAL_STATUSES: ReadonlySet<Status> = new Set<Status>(["finished", "failed", "cancelled"]);
+
+type Options = {
+  agentId?: string;
+  initialOutputSummary?: string;
+};
 
 /**
  * Returns the live-merged events list and an observed status that
@@ -37,9 +43,13 @@ export function useRunLiveSync(
   runId: string,
   initialEvents: RunEvent[],
   initialStatus: Status,
-): { events: RunEvent[]; status: Status } {
+  options: Options = {},
+): { events: RunEvent[]; status: Status; outputSummary: string } {
+  const agentId = options.agentId ?? "";
+  const initialOutputSummary = options.initialOutputSummary ?? "";
   const [events, setEvents] = useState<RunEvent[]>(initialEvents);
   const [status, setStatus] = useState<Status>(initialStatus);
+  const [outputSummary, setOutputSummary] = useState(initialOutputSummary);
   // Live-event dedup only: seqs of events already appended over the WS (plus
   // the seqs of the mount-time snapshot, so a reconnect replay of a
   // snapshot-covered event cannot double-insert). Never reset to a snapshot:
@@ -52,6 +62,8 @@ export function useRunLiveSync(
     runId,
     seqs: new Set(initialEvents.map((e) => e.seq)),
   });
+  const outputSnapshotRef = useRef({ runId, value: initialOutputSummary });
+  const refreshedTerminalRunRef = useRef<string | null>(null);
 
   useEffect(() => {
     const nextSeqs = new Set(initialEvents.map((e) => e.seq));
@@ -86,6 +98,34 @@ export function useRunLiveSync(
   }, [initialStatus]);
 
   useEffect(() => {
+    const previous = outputSnapshotRef.current;
+    if (previous.runId === runId && previous.value === initialOutputSummary) return;
+    outputSnapshotRef.current = { runId, value: initialOutputSummary };
+    setOutputSummary(initialOutputSummary);
+    if (previous.runId !== runId) {
+      refreshedTerminalRunRef.current = null;
+    }
+  }, [initialOutputSummary, runId]);
+
+  useEffect(() => {
+    if (!agentId || !TERMINAL_STATUSES.has(status)) return;
+    if (refreshedTerminalRunRef.current === runId) return;
+    refreshedTerminalRunRef.current = runId;
+    let cancelled = false;
+    void getRunDetail(agentId, runId)
+      .then((run) => {
+        if (!cancelled) setOutputSummary(run.output_summary ?? "");
+      })
+      .catch(() => {
+        // The terminal status and event stream remain useful when the detail
+        // refresh fails. A later page reload can retry the snapshot.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, runId, status]);
+
+  useEffect(() => {
     if (status !== "claimed") return;
     if (TERMINAL_STATUSES.has(status)) return;
 
@@ -109,7 +149,7 @@ export function useRunLiveSync(
     };
   }, [runId, status]);
 
-  return { events, status };
+  return { events, status, outputSummary };
 }
 
 // mergeRunEvent inserts evt into prev keeping seq-ascending order.

--- a/apps/web/app/office/agents/[id]/runs/components/prompt-panel.tsx
+++ b/apps/web/app/office/agents/[id]/runs/components/prompt-panel.tsx
@@ -7,7 +7,7 @@ import type { RunDetail } from "@/lib/api/domains/office-extended-api";
 import { useTranslation } from "react-i18next";
 
 type Props = {
-  run: Pick<RunDetail, "assembled_prompt" | "summary_injected" | "result_json">;
+  run: Pick<RunDetail, "assembled_prompt" | "summary_injected" | "result_json" | "output_summary">;
 };
 
 /**
@@ -25,8 +25,9 @@ export function PromptPanel({ run }: Props) {
   const assembled = run.assembled_prompt ?? "";
   const summary = run.summary_injected ?? "";
   const result = run.result_json ?? "";
+  const output = run.output_summary ?? "";
   const hasResult = result !== "" && result !== "{}";
-  const hasAny = assembled !== "" || summary !== "" || hasResult;
+  const hasAny = assembled !== "" || summary !== "" || hasResult || output !== "";
   if (!hasAny) return null;
 
   return (
@@ -58,6 +59,14 @@ export function PromptPanel({ run }: Props) {
             label={t("office:structuredResult")}
             content={formatJSONIfPossible(result)}
             testid="prompt-result-json"
+          />
+        )}
+        {output !== "" && (
+          <PromptSection
+            label={t("office:outputSummary")}
+            content={output}
+            testid="prompt-output-summary"
+            defaultOpen
           />
         )}
       </div>

--- a/apps/web/src/locales/en/office.json
+++ b/apps/web/src/locales/en/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "Task template",
   "stepXOfYTitle": "Step {{number}} of {{total}}; {{title}}",
   "structuredResult": "Structured result",
+  "outputSummary": "Output summary",
   "subIssueOfParent": "Sub-issue of {{parent}}",
   "subscriptionQuota": "Subscription Quota",
   "succeeded": "Succeeded",

--- a/apps/web/src/locales/pseudo/office.json
+++ b/apps/web/src/locales/pseudo/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "Ţàśķ ţēḿƥĺàţē",
   "stepXOfYTitle": "Śţēƥ {{number}} ōƒ {{total}}; {{title}}",
   "structuredResult": "Śţŕũćţũŕēď ŕēśũĺţ",
+  "outputSummary": "Ōũţƥũţ śũḿḿàŕŷ",
   "subIssueOfParent": "Śũƀ-ĩśśũē ōƒ {{parent}}",
   "subscriptionQuota": "Śũƀśćŕĩƥţĩōń Qũōţà",
   "succeeded": "Śũććēēďēď",

--- a/apps/web/src/locales/pt-pt/office.json
+++ b/apps/web/src/locales/pt-pt/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "Modelo de tarefa",
   "stepXOfYTitle": "Passo {{number}} de {{total}}; {{title}}",
   "structuredResult": "Resultado estruturado",
+  "outputSummary": "Resumo da saída",
   "subIssueOfParent": "Subissue de {{parent}}",
   "subscriptionQuota": "Quota da subscrição",
   "succeeded": "Bem-sucedidas",

--- a/apps/web/src/locales/zh-cn/office.json
+++ b/apps/web/src/locales/zh-cn/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "任务模板",
   "stepXOfYTitle": "步骤 {{number}} / {{total}}；{{title}}",
   "structuredResult": "结构化结果",
+  "outputSummary": "输出摘要",
   "subIssueOfParent": "{{parent}} 的子议题",
   "subscriptionQuota": "订阅配额",
   "succeeded": "成功",

--- a/apps/web/src/locales/zh-hk/office.json
+++ b/apps/web/src/locales/zh-hk/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "任務模板",
   "stepXOfYTitle": "步驟 {{number}} / {{total}}；{{title}}",
   "structuredResult": "結構化結果",
+  "outputSummary": "輸出摘要",
   "subIssueOfParent": "{{parent}} 的子議題",
   "subscriptionQuota": "訂閲配額",
   "succeeded": "成功",

--- a/apps/web/src/locales/zh-tw/office.json
+++ b/apps/web/src/locales/zh-tw/office.json
@@ -772,6 +772,7 @@
   "stepTaskTemplate": "任務模板",
   "stepXOfYTitle": "步驟 {{number}} / {{total}}；{{title}}",
   "structuredResult": "結構化結果",
+  "outputSummary": "輸出摘要",
   "subIssueOfParent": "{{parent}} 的子議題",
   "subscriptionQuota": "訂閱配額",
   "succeeded": "成功",


### PR DESCRIPTION
**Today:** Every finished Office run persists an empty output summary (15/15 in the live store) — the run-detail drawer has nothing to show for what the agent actually did, and a parent task's view of what a child run produced falls back to whether the agent happened to leave a task comment.
**After this:** A finished run's output summary now holds the agent's final message (truncated to 500 chars, matching the existing per-entity comment-summary cap elsewhere in this subsystem), surfaced immediately in the run-detail drawer.
**Who hits this:** Anyone reading an Office run's detail view, and any workflow whose parent task fans in on child-run summaries.
**Scope:** standalone fix.
**Not here:** the parent fan-in payload still reads from task comments rather than run output — rewiring that consumer belongs to the fan-in cards, not this one; `failure_reason` semantics for skipped/contended runs; backfilling the 15 existing empty rows; the unrelated async-completion checkout leak in the same two handlers.

`UpdateRunOutputSummary` and the `output_summary` model field, DB column, and DTO projection were already built end to end, but no production code ever called the writer — every finished run silently kept the empty default. This wires the write into both completion paths (real-session and taskless), sourced from the session's last agent message, which is the only place the output reliably lives today (`result_json` and `runs.session_id` are both empty in production).

## Validation

- `go test -count=1 -v ./internal/office/repository/sqlite/... ./internal/office/service/...` (new tests, run individually with exact-value assertions, not existence checks): 8/8 pass — `TestGetFinalAgentMessage_{ReturnsLatestAgentMessage,UnknownSessionReturnsEmpty,TruncatesAt500Chars}`, `TestHandleAgentCompleted_{RecordsFinalAgentMessageAsOutputSummary,TruncatesOutputSummaryAt500Chars,NoAgentMessageStaysBestEffort,LastAgentMessageWinsOverLaterUserMessage}`, `TestHandleTasklessAgentCompleted_RecordsOutputSummaryAndKeepsContinuationSummary`.
- Regression proof: stripped the two production call sites in a throwaway worktree (tests untouched) — 4/5 new service tests fail with `output_summary = ""`, the exact root-caused symptom; the 5th (best-effort, no agent message) still passes as designed.
- `make -C apps/backend test` — full suite green except 4 packages (`agent/managedruntime`, `agent/settings/controller`, `agentctl/server/config`, `internal/system/storage/workspaces`), proven pre-existing by reproducing the identical failures against `origin/main`'s merge-base in a separate scratch worktree. None touches Office/runs code.
- `make -C apps/backend lint` — 0 issues.
- Full pre-publication gauntlet on the rebased branch: `make fmt` (no diff), `make typecheck` (clean), `make lint` (backend + web + harness + architecture, all clean), `make lint-format` (clean), `pnpm run i18n:ratchet` (no UI source touched — this is a backend-only change).
- E2E not run: all 6 changed files are under `apps/backend/`, none under `apps/web/`.
- Independent code review (Kandev `code-review` skill + cross-vendor `codex exec`, read-only): 0 blockers. One suggestion (add `id DESC` as a tie-breaker alongside `created_at DESC`, matching this codebase's documented convention elsewhere) investigated against the live store — zero timestamp ties across 37,501 agent messages at the stored microsecond precision, so not a reproducible defect; left as a follow-up note rather than a blocking fix.

## Possible Improvements

Low risk: additive write on an existing best-effort completion path (matches the neighboring `refreshContinuationSummary` error-handling contract exactly — logs and continues, never fails the completion event). A future PR could add `id DESC` as a query tie-breaker for full consistency with sibling message-ordering queries, though no live data currently exercises the tie case.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->