### PR TITLE
fix(office): count a reassigned task's cost under its new project

### DIFF
--- a/apps/backend/internal/office/costs/service_test.go
+++ b/apps/backend/internal/office/costs/service_test.go
@@ -59,6 +59,7 @@ func newTestCostService(t *testing.T) (*costs.CostService, func(string, ...inter
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS tasks (
 		id TEXT PRIMARY KEY,
 		workspace_id TEXT NOT NULL DEFAULT '',
+		project_id TEXT DEFAULT '',
 		state TEXT NOT NULL DEFAULT 'TODO',
 		title TEXT DEFAULT '',
 		description TEXT DEFAULT '',
@@ -217,8 +218,11 @@ func TestGetCostsBreakdown_ReturnsAllViews(t *testing.T) {
 	svc, execSQL := newTestCostService(t)
 	ctx := context.Background()
 
-	execSQL(`INSERT OR IGNORE INTO tasks (id, workspace_id) VALUES ('task-1', 'ws-1')`)
-	execSQL(`INSERT OR IGNORE INTO tasks (id, workspace_id) VALUES ('task-2', 'ws-1')`)
+	// GetCostsByProject attributes by the task's live project_id, not the
+	// event snapshot, so each task must carry the assignment it is meant to
+	// group under.
+	execSQL(`INSERT OR IGNORE INTO tasks (id, workspace_id, project_id) VALUES ('task-1', 'ws-1', 'proj-X')`)
+	execSQL(`INSERT OR IGNORE INTO tasks (id, workspace_id, project_id) VALUES ('task-2', 'ws-1', 'proj-Y')`)
 
 	_, _ = svc.RecordCostEvent(ctx,
 		"sess-1", "task-1", "agent-A", "proj-X",

--- a/apps/backend/internal/office/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/office/repository/sqlite/base_migrations.go
@@ -465,6 +465,7 @@ func taskPriorityMigrationStatements() []string {
 		`CREATE INDEX IF NOT EXISTS idx_tasks_archived_at ON tasks(archived_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_tasks_workspace_id ON tasks(workspace_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_tasks_workspace_archived ON tasks(workspace_id, archived_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)`,
 		// idx_tasks_assignee was removed in ADR 0005 Wave F when the
 		// per-task assignee moved to workflow_step_participants.
 		//

--- a/apps/backend/internal/office/repository/sqlite/costs.go
+++ b/apps/backend/internal/office/repository/sqlite/costs.go
@@ -160,21 +160,28 @@ func (r *Repository) GetCostsByAgent(ctx context.Context, workspaceID string) ([
 	return results, nil
 }
 
-// GetCostsByProject returns aggregated costs grouped by project, filtered by workspace.
-// group_label resolves to the project name; empty when project_id is unset
-// or the project row has been deleted.
+// GetCostsByProject returns aggregated costs grouped by project, filtered by
+// workspace. Attribution is live: it groups by the task's *current*
+// project_id, not the office_cost_events.project_id snapshot written at
+// usage-event time. Unlike agent attribution (see GetCostsByAgent, and
+// costContractVersion's doc comment in prompt_usage_cost.go), a task's
+// project is an organisational grouping the user is expected to change
+// after the work is done — reassigning a finished task must move its whole
+// cost history onto the new project immediately, not strand it as
+// "unassigned". group_label resolves to the project name; empty when
+// project_id is unset or the project row has been deleted.
 func (r *Repository) GetCostsByProject(ctx context.Context, workspaceID string) ([]*models.CostBreakdown, error) {
 	var results []*models.CostBreakdown
 	err := r.ro.SelectContext(ctx, &results, r.ro.Rebind(`
-		SELECT e.project_id AS group_key,
+		SELECT COALESCE(t.project_id, '') AS group_key,
 			COALESCE(MAX(NULLIF(op.name, '')), '') AS group_label,
 			SUM(e.cost_subcents) AS total_subcents,
 			COUNT(*) AS count
 		FROM office_cost_events e
 		JOIN tasks t ON t.id = e.task_id
-		LEFT JOIN office_projects op ON op.id = e.project_id
+		LEFT JOIN office_projects op ON op.id = t.project_id
 		WHERE t.workspace_id = ?
-		GROUP BY e.project_id
+		GROUP BY COALESCE(t.project_id, '')
 	`), workspaceID)
 	if err != nil {
 		return nil, err
@@ -310,13 +317,19 @@ func (r *Repository) GetCostForAgentSince(ctx context.Context, agentID string, s
 	return total, err
 }
 
-// GetCostForProject returns the total cost in subcents for a specific project.
+// GetCostForProject returns the total cost in subcents for a specific
+// project. Like GetCostsByProject, this joins to tasks and uses the task's
+// current project_id rather than the office_cost_events.project_id
+// snapshot, so a project budget (costs/budgets.go) counts the same set of
+// events as the "cost by project" panel — see GetCostsByProject's doc
+// comment for why project attribution is live.
 func (r *Repository) GetCostForProject(ctx context.Context, projectID string) (int64, error) {
 	var total int64
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
-		SELECT COALESCE(SUM(cost_subcents), 0)
-		FROM office_cost_events
-		WHERE project_id = ?
+		SELECT COALESCE(SUM(e.cost_subcents), 0)
+		FROM office_cost_events e
+		JOIN tasks t ON t.id = e.task_id
+		WHERE t.project_id = ?
 	`), projectID).Scan(&total)
 	return total, err
 }
@@ -329,9 +342,10 @@ func (r *Repository) GetCostForProjectSince(ctx context.Context, projectID strin
 	}
 	var total int64
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
-		SELECT COALESCE(SUM(cost_subcents), 0)
-		FROM office_cost_events
-		WHERE project_id = ? AND occurred_at >= ?
+		SELECT COALESCE(SUM(e.cost_subcents), 0)
+		FROM office_cost_events e
+		JOIN tasks t ON t.id = e.task_id
+		WHERE t.project_id = ? AND e.occurred_at >= ?
 	`), projectID, since.UTC()).Scan(&total)
 	return total, err
 }

--- a/apps/backend/internal/office/repository/sqlite/costs_test.go
+++ b/apps/backend/internal/office/repository/sqlite/costs_test.go
@@ -198,6 +198,9 @@ func TestCostBreakdowns(t *testing.T) {
 		(id, workspace_id, name, created_at, updated_at)
 		VALUES ('proj-1', 'ws-1', 'Acme Migration',
 		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	// GetCostsByProject attributes by the task's live project_id, not the
+	// event snapshot, so the task itself must carry the assignment.
+	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-1' WHERE id = 'task-bd'`)
 
 	for i := 0; i < 3; i++ {
 		event := &models.CostEvent{
@@ -264,6 +267,63 @@ func TestCostBreakdowns(t *testing.T) {
 	if byProvider[0].GroupKey != "unknown" || byProvider[0].GroupLabel != "(unknown)" {
 		t.Errorf("by provider = (key=%q,label=%q), want (unknown,(unknown))",
 			byProvider[0].GroupKey, byProvider[0].GroupLabel)
+	}
+}
+
+// TestGetCostsByProject_FollowsLiveReassignment confirms a task's entire
+// cost history moves to a project the moment the task is assigned to it,
+// even though the cost events were recorded before the assignment existed.
+// office_cost_events.project_id is a write-time snapshot (event_subscribers.go)
+// and must never be consulted for attribution; only the task's current
+// project_id is authoritative. This is the regression for the "assigning a
+// finished task to a project doesn't move its cost" report.
+func TestGetCostsByProject_FollowsLiveReassignment(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	seedTasksTable(t, repo, "task-reassign", "ws-reassign")
+	mustExec(t, repo, `INSERT INTO office_projects
+		(id, workspace_id, name, created_at, updated_at)
+		VALUES ('proj-reassign', 'ws-reassign', 'Kandev',
+		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+
+	// Recorded while the task had no project assigned, so the snapshot
+	// column (office_cost_events.project_id) is empty on this row.
+	event := &models.CostEvent{
+		TaskID:       "task-reassign",
+		CostSubcents: 2013,
+		OccurredAt:   time.Now().UTC(),
+	}
+	if err := repo.CreateCostEvent(ctx, event); err != nil {
+		t.Fatalf("create cost: %v", err)
+	}
+
+	byProject, err := repo.GetCostsByProject(ctx, "ws-reassign")
+	if err != nil {
+		t.Fatalf("by project (before assignment): %v", err)
+	}
+	if len(byProject) != 1 || byProject[0].GroupKey != "" || byProject[0].TotalSubcents != 2013 {
+		t.Fatalf("before assignment: got %+v, want one unassigned row of 2013", byProject)
+	}
+
+	// The user assigns the (already-finished) task to the project. No new
+	// cost event is recorded.
+	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-reassign' WHERE id = 'task-reassign'`)
+
+	byProject, err = repo.GetCostsByProject(ctx, "ws-reassign")
+	if err != nil {
+		t.Fatalf("by project (after assignment): %v", err)
+	}
+	if len(byProject) != 1 {
+		t.Fatalf("after assignment: got %+v, want a single row", byProject)
+	}
+	if byProject[0].GroupKey != "proj-reassign" || byProject[0].GroupLabel != "Kandev" {
+		t.Errorf("after assignment: got key=%q label=%q, want proj-reassign/Kandev",
+			byProject[0].GroupKey, byProject[0].GroupLabel)
+	}
+	if byProject[0].TotalSubcents != 2013 {
+		t.Errorf("after assignment: total = %d, want 2013 (unchanged, just re-attributed)",
+			byProject[0].TotalSubcents)
 	}
 }
 
@@ -394,7 +454,11 @@ func TestGetCostForProject(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
 
+	seedTasksTable(t, repo, "task-proj-y", "ws-proj-y")
+	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-y' WHERE id = 'task-proj-y'`)
+
 	event := &models.CostEvent{
+		TaskID:       "task-proj-y",
 		ProjectID:    "proj-y",
 		CostSubcents: 25,
 		OccurredAt:   time.Now().UTC(),
@@ -419,6 +483,7 @@ func TestPeriodAwareRollups(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
 	seedTasksTable(t, repo, "task-month", "ws-period")
+	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-period' WHERE id = 'task-month'`)
 
 	now := time.Now().UTC()
 	thisMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)

--- a/apps/backend/internal/office/repository/sqlite/costs_test.go
+++ b/apps/backend/internal/office/repository/sqlite/costs_test.go
@@ -277,6 +277,14 @@ func TestCostBreakdowns(t *testing.T) {
 // and must never be consulted for attribution; only the task's current
 // project_id is authoritative. This is the regression for the "assigning a
 // finished task to a project doesn't move its cost" report.
+//
+// It also covers the project-budget reads (GetCostForProject,
+// GetCostForProjectSince), which switched from the snapshot filter to the
+// same live tasks.project_id join in the same change. The seeded event's
+// snapshot project_id is left empty (never set on the event below) so these
+// assertions actually discriminate the live join from the old snapshot
+// filter: a snapshot-based implementation would return 0 in both the
+// "before" and "after" case, since the snapshot column never changes.
 func TestGetCostsByProject_FollowsLiveReassignment(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
@@ -286,6 +294,8 @@ func TestGetCostsByProject_FollowsLiveReassignment(t *testing.T) {
 		(id, workspace_id, name, created_at, updated_at)
 		VALUES ('proj-reassign', 'ws-reassign', 'Kandev',
 		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+
+	windowStart := time.Now().UTC().Add(-time.Hour)
 
 	// Recorded while the task had no project assigned, so the snapshot
 	// column (office_cost_events.project_id) is empty on this row.
@@ -306,6 +316,23 @@ func TestGetCostsByProject_FollowsLiveReassignment(t *testing.T) {
 		t.Fatalf("before assignment: got %+v, want one unassigned row of 2013", byProject)
 	}
 
+	budgetTotal, err := repo.GetCostForProject(ctx, "proj-reassign")
+	if err != nil {
+		t.Fatalf("budget total (before assignment): %v", err)
+	}
+	if budgetTotal != 0 {
+		t.Errorf("budget total (before assignment) = %d, want 0 (task not yet assigned to the project)",
+			budgetTotal)
+	}
+	budgetSince, err := repo.GetCostForProjectSince(ctx, "proj-reassign", windowStart)
+	if err != nil {
+		t.Fatalf("budget since (before assignment): %v", err)
+	}
+	if budgetSince != 0 {
+		t.Errorf("budget since (before assignment) = %d, want 0 (task not yet assigned to the project)",
+			budgetSince)
+	}
+
 	// The user assigns the (already-finished) task to the project. No new
 	// cost event is recorded.
 	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-reassign' WHERE id = 'task-reassign'`)
@@ -324,6 +351,23 @@ func TestGetCostsByProject_FollowsLiveReassignment(t *testing.T) {
 	if byProject[0].TotalSubcents != 2013 {
 		t.Errorf("after assignment: total = %d, want 2013 (unchanged, just re-attributed)",
 			byProject[0].TotalSubcents)
+	}
+
+	budgetTotal, err = repo.GetCostForProject(ctx, "proj-reassign")
+	if err != nil {
+		t.Fatalf("budget total (after assignment): %v", err)
+	}
+	if budgetTotal != 2013 {
+		t.Errorf("budget total (after assignment) = %d, want 2013 (budget must count the reassigned event)",
+			budgetTotal)
+	}
+	budgetSince, err = repo.GetCostForProjectSince(ctx, "proj-reassign", windowStart)
+	if err != nil {
+		t.Fatalf("budget since (after assignment): %v", err)
+	}
+	if budgetSince != 2013 {
+		t.Errorf("budget since (after assignment) = %d, want 2013 (budget must count the reassigned event)",
+			budgetSince)
 	}
 }
 

--- a/apps/backend/internal/office/repository/sqlite/costs_test.go
+++ b/apps/backend/internal/office/repository/sqlite/costs_test.go
@@ -502,8 +502,9 @@ func TestGetCostForProject(t *testing.T) {
 	mustExec(t, repo, `UPDATE tasks SET project_id = 'proj-y' WHERE id = 'task-proj-y'`)
 
 	event := &models.CostEvent{
-		TaskID:       "task-proj-y",
-		ProjectID:    "proj-y",
+		TaskID: "task-proj-y",
+		// Leave the event snapshot empty so this assertion requires the live
+		// task.project_id join instead of passing from the legacy field.
 		CostSubcents: 25,
 		OccurredAt:   time.Now().UTC(),
 	}

--- a/apps/backend/internal/office/repository/sqlite/migrations_priority_external_id_test.go
+++ b/apps/backend/internal/office/repository/sqlite/migrations_priority_external_id_test.go
@@ -10,16 +10,15 @@ import (
 	"github.com/kandev/kandev/internal/office/repository/sqlite"
 )
 
-// TestMigrate_PriorityRebuildPreservesExternalIDUniqueIndex is a regression
+// TestMigrate_PriorityRebuildPreservesRequiredIndexes is a regression
 // test: the priority-to-TEXT rebuild (docs: taskPriorityMigrationStatements)
 // recreates the tasks table via DROP TABLE + CREATE TABLE, which silently
-// drops every index on the old table — uniq_tasks_external_id included —
-// unless it is explicitly relisted among the indexes the rebuild recreates.
-// Without that, task create-idempotency (external-id-idempotency spec) loses
-// its uniqueness guarantee on any install that still needs this historical
-// rebuild, with no compile-time or single-connection-serial-insert signal
-// that anything is wrong.
-func TestMigrate_PriorityRebuildPreservesExternalIDUniqueIndex(t *testing.T) {
+// drops every index on the old table — including the project cost lookup and
+// external-id uniqueness indexes — unless each is explicitly relisted among
+// the indexes the rebuild recreates. Without that, task create-idempotency
+// loses its uniqueness guarantee and project budget queries lose their index
+// on any install that still needs this historical rebuild.
+func TestMigrate_PriorityRebuildPreservesRequiredIndexes(t *testing.T) {
 	dbPath := t.TempDir() + "/test.db?_journal_mode=WAL"
 	db, err := sqlx.Open("sqlite3", dbPath)
 	if err != nil {
@@ -55,6 +54,9 @@ func TestMigrate_PriorityRebuildPreservesExternalIDUniqueIndex(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("seed legacy schema: %v", err)
 	}
+	if _, err := db.Exec(`CREATE INDEX idx_tasks_project_id ON tasks(project_id)`); err != nil {
+		t.Fatalf("seed project_id index: %v", err)
+	}
 
 	if _, err := sqlite.NewWithDB(db, db, nil); err != nil {
 		t.Fatalf("init office repo (run migrations): %v", err)
@@ -65,6 +67,11 @@ func TestMigrate_PriorityRebuildPreservesExternalIDUniqueIndex(t *testing.T) {
 		SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'uniq_tasks_external_id'
 	`); err != nil {
 		t.Fatalf("uniq_tasks_external_id index missing after priority rebuild: %v", err)
+	}
+	if err := db.Get(&indexName, `
+		SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_tasks_project_id'
+	`); err != nil {
+		t.Fatalf("idx_tasks_project_id index missing after priority rebuild: %v", err)
 	}
 
 	now := time.Now().UTC()

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -263,6 +263,7 @@ func (r *Repository) runMigrations() error {
 	// therefore not added or dropped here.
 	r.migrate.Apply("tasks.origin", `ALTER TABLE tasks ADD COLUMN origin TEXT DEFAULT 'manual'`)
 	r.migrate.Apply("tasks.project_id", `ALTER TABLE tasks ADD COLUMN project_id TEXT DEFAULT ''`)
+	r.migrate.Apply("idx_tasks_project_id", `CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)`)
 	r.migrate.Apply("tasks.labels", `ALTER TABLE tasks ADD COLUMN labels TEXT DEFAULT '[]'`)
 	r.migrate.Apply("tasks.identifier", `ALTER TABLE tasks ADD COLUMN identifier TEXT`)
 	// Office task-handoffs phase 6 - tag tasks archived as part of a cascade so

--- a/apps/backend/internal/task/repository/sqlite/project_index_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/project_index_migration_test.go
@@ -1,0 +1,19 @@
+package sqlite
+
+import "testing"
+
+func TestTasksProjectIDIndexExistsAfterMigration(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	var indexName string
+	if err := repo.db.Get(&indexName, `
+		SELECT name
+		FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_tasks_project_id'
+	`); err != nil {
+		t.Fatalf("project_id index missing after task repository migration: %v", err)
+	}
+	if indexName != "idx_tasks_project_id" {
+		t.Fatalf("index name = %q, want idx_tasks_project_id", indexName)
+	}
+}

--- a/docs/specs/office/costs.md
+++ b/docs/specs/office/costs.md
@@ -38,7 +38,7 @@ Office adds per-session cost estimation, aggregated views by agent/project/model
 | `session_id` | string | FK -> `task_sessions.id` |
 | `task_id` | string | FK -> `tasks.id` |
 | `agent_instance_id` | string | null for non-office sessions |
-| `project_id` | string | null if unassigned |
+| `project_id` | string | write-time project snapshot, null if unassigned at event time |
 | `model` | string | e.g. `claude-sonnet-4-20250514` |
 | `provider` | string | e.g. `anthropic`, `openai` |
 | `tokens_in` | int64 | input token count |
@@ -59,6 +59,11 @@ Office adds per-session cost estimation, aggregated views by agent/project/model
 | `occurred_at` | timestamp | when the cost was incurred |
 
 Disk-runner rows are upserted by `(session_id, provider_event_id)`. For codex, after a successful aggregate row lands, the wire-side `estimated=true` rows for the same session are deleted to avoid double-counting.
+
+Project cost attribution uses the current task assignment:
+
+- `office_cost_events.project_id` is a write-time snapshot retained for cleanup and historical inspection.
+- `tasks.project_id` is the current source of truth for project cost views and project budget totals.
 
 **Contract v2 columns** (`tokens_cached_read`, `tokens_cached_write`, `turn_id`, `usage_event_id`, `cost_source`, the four `rate_*_per_million` columns, `pricing_catalog_version`, `cost_contract_version`) were added via an idempotent nullable-column migration (`migrateCostEventContract`); every legacy row reads NULL for all of them, never `0` - see the cross-cutting rule in `Persistence guarantees` below. Postgres parity follows the same migration shape per ADR 0027.
 


### PR DESCRIPTION
**Today:** Assigning an already-finished task to an Office project doesn't move its historical cost. The per-project cost panel and that project's budget stay short of the workspace total, because the cost row is keyed to a write-time snapshot of whatever project the task belonged to *when the cost event was recorded* rather than the task's current project.

**After this:** The cost panel and project budgets follow the task's live project assignment, so reassigning a task (finished or not) immediately reflects its full spend under the new project, and the by-project rows now sum to the workspace total.

**Who hits this:** Anyone using Office mode with projects who assigns or reassigns tasks after they've already run — the reported case was assigning every task to a "Kandev" project and finding the cost panel still short of 100%.

**Scope:** standalone — three read-only queries in one backend file, plus tests. No frontend, migration, or write-path change.

**Not here:** cost events for a *deleted* task (already excluded from the panel before this change, via the join it already had; unchanged here) and the write-time snapshot column itself (`office_cost_events.project_id`), which stays as-is since `workspace_deletion.go` still uses it for cleanup.

Assigning all tasks to a project should account for 100% of that project's spend, not leave part of it invisible.

## Validation

Backend-only change (all 3 files under `apps/backend/`), so no E2E run required per this repo's changed-path rule.

```
go test ./internal/office/... -v -run 'Cost'                                          # PASS, incl. the new regression test
go test ./internal/office/costs/... -v -run 'TestGetCostsBreakdown|TestRecordCostEvent|TestGetCostSummary'  # PASS
make test        # test-backend ok except a pre-existing, proven-unrelated
                  # internal/system/storage/workspaces failure (identical against merge-base)
make lint        # golangci-lint: 0 issues; web eslint clean; harness/architecture lint clean
make lint-format  # prettier clean
make fmt          # clean
make typecheck    # clean
```

The new regression test (`TestGetCostsByProject_FollowsLiveReassignment`) seeds a cost event on a project-less task, asserts it groups as unassigned, then reassigns the task with **no new cost event** and asserts the same spend now attributes to the new project across all three affected reads (panel + both budget queries). Mutation-tested by reverting the fix and confirming the test fails for the root-caused reason, then restoring it.

## Possible Improvements

Low risk (three read-only SELECTs). One residual, deliberately left for a future card: cost events for deleted tasks now drop out of project budgets the same way they already dropped out of the panel and workspace budgets — consistent with existing behavior elsewhere, but there's no test coverage yet for project-scoped budget policies specifically (`budgets_test.go` only covers agent-scoped policies today).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->