### PR TITLE
feat(web): name each task's repository in the sidebar and task header

### DIFF
--- a/apps/web/components/page-topbar.tsx
+++ b/apps/web/components/page-topbar.tsx
@@ -270,9 +270,14 @@ function ParentCrumbLabel({ crumb }: { crumb: ParentCrumb }) {
       </>
     );
   }
-  // Static crumb: orientation only, dimmed so it does not read as a link.
+  // Static crumb: orientation only, dimmed so it does not read as a link. The
+  // `title` is what makes a name longer than `max-w-40` readable at all, since
+  // truncation is the only thing standing between a long label and a squeezed
+  // page title.
   return (
-    <span className="max-w-40 cursor-default truncate text-muted-foreground/60">{crumb.label}</span>
+    <span title={crumb.label} className="max-w-40 cursor-default truncate text-muted-foreground/60">
+      {crumb.label}
+    </span>
   );
 }
 

--- a/apps/web/components/task/mobile/session-mobile-layout.tsx
+++ b/apps/web/components/task/mobile/session-mobile-layout.tsx
@@ -80,6 +80,8 @@ type SessionMobileLayoutProps = {
   baseBranch?: string;
   worktreeBranch?: string | null;
   taskTitle?: string;
+  /** `owner/repo` (or the repository name) of the task's primary repository. */
+  repositoryLabel?: string | null;
   isRemoteExecutor?: boolean;
   remoteExecutorType?: string | null;
   remoteExecutorName?: string | null;
@@ -352,6 +354,8 @@ type MobileTopBarStickyProps = {
   activeTaskId: string | null;
   workspaceId: string | null;
   taskTitle?: string;
+  /** `owner/repo` (or the repository name) of the task's primary repository. */
+  repositoryLabel?: string | null;
   effectiveSessionId: string | null;
   baseBranch?: string;
   worktreeBranch?: string | null;
@@ -378,6 +382,7 @@ function MobileTopBarSticky(props: MobileTopBarStickyProps) {
         taskId={props.activeTaskId}
         workspaceId={props.workspaceId}
         taskTitle={props.taskTitle}
+        repositoryLabel={props.repositoryLabel}
         sessionId={props.effectiveSessionId}
         baseBranch={props.baseBranch}
         worktreeBranch={props.worktreeBranch}

--- a/apps/web/components/task/mobile/session-mobile-top-bar-repository.test.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar-repository.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { ToastProvider } from "@/components/toast-provider";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { SessionMobileTopBar } from "./session-mobile-top-bar";
+
+afterEach(cleanup);
+
+// The phone bar's git machinery is not what this file is about; stub the two
+// hooks that reach for session state so the header renders standalone.
+vi.mock("@/hooks/domains/session/use-session-git-status", () => ({
+  useSessionGitStatus: () => ({ files: [] }),
+  useSessionGitStatusByRepo: () => [],
+}));
+
+vi.mock("@/hooks/domains/session/use-session-commits", () => ({
+  useSessionCommits: () => ({ commits: [] }),
+}));
+
+vi.mock("@/hooks/domains/session/use-remote-contribution-relation", () => ({
+  useRemoteContributionRelation: () => ({
+    relation: { action: "none", canPull: false, canReplaceRemote: false, canUseRemote: false },
+  }),
+}));
+
+// Trailing controls the header composes but this file does not exercise.
+vi.mock("@/components/task/port-forward-dialog", () => ({
+  PortForwardButton: () => null,
+}));
+
+vi.mock("@/components/task/task-top-bar-plugin-actions", () => ({
+  TaskTopBarPluginActions: () => null,
+}));
+
+vi.mock("@/components/gitlab/mr-topbar-button", () => ({
+  MRTopbarButton: () => null,
+}));
+
+const REPOSITORY_TEST_ID = "mobile-task-repository";
+
+function renderTopBar(props: Record<string, unknown> = {}) {
+  return render(
+    <StateProvider>
+      <ToastProvider>
+        <TooltipProvider>
+          <SessionMobileTopBar
+            taskId="task-1"
+            workspaceId="ws-1"
+            taskTitle="Pin the RDS engine version"
+            sessionId="session-1"
+            onMenuClick={vi.fn()}
+            {...props}
+          />
+        </TooltipProvider>
+      </ToastProvider>
+    </StateProvider>,
+  );
+}
+
+describe("SessionMobileTopBar repository", () => {
+  it("names the task's repository, so the phone header says which project this is", () => {
+    renderTopBar({ repositoryLabel: "kdlbs/kandev" });
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe("kdlbs/kandev");
+  });
+
+  it("keeps the full repository name reachable on hover when it is truncated", () => {
+    renderTopBar({ repositoryLabel: "acme-platform/infra-terraform-modules" });
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).getAttribute("title")).toBe(
+      "acme-platform/infra-terraform-modules",
+    );
+  });
+
+  it("renders nothing when the task has no repository", () => {
+    renderTopBar();
+
+    expect(screen.queryByTestId(REPOSITORY_TEST_ID)).toBeNull();
+  });
+});

--- a/apps/web/components/task/mobile/session-mobile-top-bar.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar.tsx
@@ -38,6 +38,8 @@ type SessionMobileTopBarProps = {
   taskId?: string | null;
   workspaceId?: string | null;
   taskTitle?: string;
+  /** `owner/repo` (or the repository name) of the task's primary repository. */
+  repositoryLabel?: string | null;
   sessionId?: string | null;
   baseBranch?: string;
   worktreeBranch?: string | null;
@@ -56,11 +58,13 @@ type SessionMobileTopBarProps = {
 
 function MobileTaskTitle({
   taskTitle,
+  repositoryLabel,
   displayBranch,
   totalAdditions,
   totalDeletions,
 }: {
   taskTitle?: string;
+  repositoryLabel?: string | null;
   displayBranch?: string;
   totalAdditions: number;
   totalDeletions: number;
@@ -69,15 +73,32 @@ function MobileTaskTitle({
   return (
     <div className="flex flex-col min-w-0 flex-1">
       <span className="text-sm font-medium truncate">{taskTitle ?? t("task:taskDetails")}</span>
-      {displayBranch && (
-        <div className="flex items-center gap-1.5">
-          <IconGitBranch className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-          <span className="text-xs text-muted-foreground truncate">{displayBranch}</span>
-          {(totalAdditions > 0 || totalDeletions > 0) && (
-            <LineStat added={totalAdditions} removed={totalDeletions} />
-          )}
-        </div>
-      )}
+      {/* The phone bar has no breadcrumb, so the repository rides the same
+          secondary line as the branch. It shrinks first: on a phone the branch
+          and diff stats are the denser signal, and the full name stays in
+          `title`. */}
+      <div className="flex items-center gap-1.5 min-w-0">
+        {repositoryLabel && (
+          <span
+            data-testid="mobile-task-repository"
+            title={repositoryLabel}
+            className="min-w-0 truncate text-xs text-muted-foreground/70"
+          >
+            {repositoryLabel}
+          </span>
+        )}
+        {displayBranch && (
+          <>
+            <IconGitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 max-w-[45%] truncate text-xs text-muted-foreground">
+              {displayBranch}
+            </span>
+            {(totalAdditions > 0 || totalDeletions > 0) && (
+              <LineStat added={totalAdditions} removed={totalDeletions} />
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }
@@ -494,6 +515,7 @@ export const SessionMobileTopBar = memo(function SessionMobileTopBar(
         </Button>
         <MobileTaskTitle
           taskTitle={props.taskTitle}
+          repositoryLabel={props.repositoryLabel}
           displayBranch={displayBranch}
           totalAdditions={totalAdditions}
           totalDeletions={totalDeletions}

--- a/apps/web/components/task/task-archived-context.tsx
+++ b/apps/web/components/task/task-archived-context.tsx
@@ -8,7 +8,12 @@ type TaskArchivedState = {
   isArchived: boolean;
   archivedTaskId?: string;
   archivedTaskTitle?: string;
-  archivedTaskRepositoryPath?: string;
+  /**
+   * The archived task's repository as a stable `owner/repo` slug (or name).
+   * Sidebar rows render this, so it must be the same identity ordinary rows
+   * carry, never a local clone path.
+   */
+  archivedTaskRepositoryLabel?: string;
   archivedTaskUpdatedAt?: string;
 };
 

--- a/apps/web/components/task/task-item-repository.test.tsx
+++ b/apps/web/components/task/task-item-repository.test.tsx
@@ -41,20 +41,6 @@ describe("TaskItem repository label", () => {
     expect(screen.queryByTestId(REPOSITORY_TEST_ID)).toBeNull();
   });
 
-  it("still names every repository of a multi-repo task while grouped by repository", () => {
-    // Grouped by repository, a multi-repo task lands in the unnamed "Multiple
-    // repositories" bucket, so the header cannot stand in for the row.
-    renderTaskItem({
-      repositories: [PRIMARY_REPOSITORY, "kdlbs/kandev-web"],
-      repositoryPath: PRIMARY_REPOSITORY,
-      showRepository: false,
-    });
-
-    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe(
-      "kdlbs/kandev · kdlbs/kandev-web",
-    );
-  });
-
   it("renders nothing when the task has no repository", () => {
     renderTaskItem({});
 

--- a/apps/web/components/task/task-item-repository.test.tsx
+++ b/apps/web/components/task/task-item-repository.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { StateProvider } from "@/components/state-provider";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { TaskItem } from "./task-item";
+
+afterEach(() => cleanup());
+
+const REPOSITORY_TEST_ID = "sidebar-task-repository";
+const PRIMARY_REPOSITORY = "kdlbs/kandev";
+
+function renderTaskItem(props: Partial<ComponentProps<typeof TaskItem>> = {}) {
+  return render(
+    <StateProvider>
+      <TooltipProvider>
+        <TaskItem title="Needs answer" state="REVIEW" {...props} />
+      </TooltipProvider>
+    </StateProvider>,
+  );
+}
+
+describe("TaskItem repository label", () => {
+  it("names the repository the task belongs to", () => {
+    renderTaskItem({ repositoryPath: PRIMARY_REPOSITORY });
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe(PRIMARY_REPOSITORY);
+  });
+
+  it("keeps the full repository name reachable on hover when it is truncated", () => {
+    renderTaskItem({ repositoryPath: "a-very-long-org-name/a-very-long-repository-name" });
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).getAttribute("title")).toBe(
+      "a-very-long-org-name/a-very-long-repository-name",
+    );
+  });
+
+  it("omits the repository when the list already groups by it", () => {
+    renderTaskItem({ repositoryPath: PRIMARY_REPOSITORY, showRepository: false });
+
+    expect(screen.queryByTestId(REPOSITORY_TEST_ID)).toBeNull();
+  });
+
+  it("still names every repository of a multi-repo task while grouped by repository", () => {
+    // Grouped by repository, a multi-repo task lands in the unnamed "Multiple
+    // repositories" bucket, so the header cannot stand in for the row.
+    renderTaskItem({
+      repositories: [PRIMARY_REPOSITORY, "kdlbs/kandev-web"],
+      repositoryPath: PRIMARY_REPOSITORY,
+      showRepository: false,
+    });
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe(
+      "kdlbs/kandev · kdlbs/kandev-web",
+    );
+  });
+
+  it("renders nothing when the task has no repository", () => {
+    renderTaskItem({});
+
+    expect(screen.queryByTestId(REPOSITORY_TEST_ID)).toBeNull();
+  });
+});

--- a/apps/web/components/task/task-item-stats-row.tsx
+++ b/apps/web/components/task/task-item-stats-row.tsx
@@ -25,18 +25,39 @@ const POLL_MODE_CONFIG: Record<
 };
 
 /**
- * The sidebar row's metadata line: relative last-update time, PR number,
+ * The repository a task belongs to. The one element of the stats row allowed to
+ * shrink: a long `owner/repo` truncates rather than pushing the PR number and
+ * badges out of the row, and `title` keeps the full name reachable on hover.
+ */
+function RepositoryLabel({ label }: { label?: string }) {
+  if (!label) return null;
+  return (
+    <span
+      data-testid="sidebar-task-repository"
+      title={label}
+      className="min-w-0 truncate text-muted-foreground/50"
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
+ * The sidebar row's metadata line: relative last-update time, repository, PR number,
  * queued-prompt mail badge, WIP queue icon, and (debug UI only) the session
  * poll-mode letter.
  */
 export function TaskItemStatsRow({
   updatedAt,
+  repositoryLabel,
   prInfo,
   primarySessionId,
   queuedCount,
   wipQueue,
 }: {
   updatedAt?: string;
+  /** Repository the task belongs to; already resolved to a slug or name. */
+  repositoryLabel?: string;
   prInfo?: { number: number; state: string; aggregateState?: string };
   primarySessionId?: string | null;
   queuedCount?: number;
@@ -49,7 +70,9 @@ export function TaskItemStatsRow({
       : null,
   );
 
-  if (!updatedAt && !prInfo && !pollMode && !queuedCount && !wipQueue) return null;
+  if (!updatedAt && !repositoryLabel && !prInfo && !pollMode && !queuedCount && !wipQueue) {
+    return null;
+  }
 
   const modeConfig = pollMode ? POLL_MODE_CONFIG[pollMode] : null;
   const modeLabel = modeConfig ? t(modeConfig.labelKey) : "";
@@ -62,17 +85,18 @@ export function TaskItemStatsRow({
     : "";
 
   return (
-    <span className="flex items-center gap-1.5 text-[11px]">
+    <span className="flex min-w-0 items-center gap-1.5 text-[11px]">
       {updatedAt && (
         <span
           data-testid="sidebar-task-time"
           data-time-value={updatedAt}
-          className="text-muted-foreground/50"
+          className="shrink-0 text-muted-foreground/50"
         >
           {formatRelativeTime(updatedAt)}
         </span>
       )}
-      {prInfo && <span className="text-muted-foreground/50">#{prInfo.number}</span>}
+      <RepositoryLabel label={repositoryLabel} />
+      {prInfo && <span className="shrink-0 text-muted-foreground/50">#{prInfo.number}</span>}
       {queuedCount ? (
         <span
           data-testid="sidebar-task-queued-count"

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -96,6 +96,13 @@ type TaskItemProps = {
   /** Toggles subtask visibility when the chevron is clicked. */
   onToggleSubtasks?: () => void;
   repositories?: string[];
+  /** Slug (or name) of the task's repository, for the single-repository case. */
+  repositoryPath?: string;
+  /**
+   * Whether this row should name its repository. False when the list is grouped
+   * by repository, where the section header already says it.
+   */
+  showRepository?: boolean;
   prInfo?: { number: number; state: string; aggregateState?: string };
   /** Number of prompts currently en-queued for this task (mail badge). */
   queuedCount?: number;
@@ -105,6 +112,23 @@ type TaskItemProps = {
   isPinned?: boolean;
   agentErrorMessage?: string | null;
 };
+
+/**
+ * The repository text a row shows in its stats line, or `undefined` for none.
+ *
+ * A multi-repository task always names its repositories: its only repository
+ * group is the unnamed "Multiple repositories" bucket, so the header never
+ * covers for the row. A single-repository task defers to the header when the
+ * list is grouped by repository.
+ */
+function resolveRowRepositoryLabel(
+  repositories: string[] | undefined,
+  repositoryPath: string | undefined,
+  showRepository: boolean,
+): string | undefined {
+  if (repositories && repositories.length > 1) return repositories.join(" · ");
+  return showRepository ? repositoryPath : undefined;
+}
 
 // Delegates to the shared classifier in task-switcher so the sidebar bucket
 // and the per-task running spinner always agree. A task whose workflow state
@@ -342,6 +366,8 @@ function TaskItemContent({
   isArchived,
   isPinned,
   repositories,
+  repositoryPath,
+  showRepository,
   updatedAt,
   lastActivityAt,
   showActivityTime,
@@ -363,6 +389,8 @@ function TaskItemContent({
   isArchived?: boolean;
   isPinned?: boolean;
   repositories?: string[];
+  repositoryPath?: string;
+  showRepository: boolean;
   updatedAt?: string;
   lastActivityAt?: string;
   showActivityTime?: boolean;
@@ -402,11 +430,6 @@ function TaskItemContent({
           </span>
         )}
       </span>
-      {repositories && repositories.length > 1 && (
-        <span className="truncate text-[11px] text-muted-foreground/50">
-          {repositories.join(" · ")}
-        </span>
-      )}
       {taskId && (
         <TaskRowMetadata
           taskId={taskId}
@@ -416,6 +439,7 @@ function TaskItemContent({
       )}
       <TaskItemStatsRow
         updatedAt={showActivityTime ? (lastActivityAt ?? updatedAt) : updatedAt}
+        repositoryLabel={resolveRowRepositoryLabel(repositories, repositoryPath, showRepository)}
         prInfo={prInfo}
         primarySessionId={primarySessionId}
         queuedCount={queuedCount}
@@ -462,6 +486,8 @@ export const TaskItem = memo(function TaskItem({
   subtasksCollapsed,
   onToggleSubtasks,
   repositories,
+  repositoryPath,
+  showRepository = true,
   prInfo,
   queuedCount,
   wipQueue,
@@ -511,6 +537,8 @@ export const TaskItem = memo(function TaskItem({
         isArchived={isArchived}
         isPinned={isPinned}
         repositories={repositories}
+        repositoryPath={repositoryPath}
+        showRepository={showRepository}
         updatedAt={updatedAt}
         lastActivityAt={lastActivityAt}
         showActivityTime={showActivityTime}

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -95,8 +95,11 @@ type TaskItemProps = {
   subtasksCollapsed?: boolean;
   /** Toggles subtask visibility when the chevron is clicked. */
   onToggleSubtasks?: () => void;
-  repositories?: string[];
-  /** Slug (or name) of the task's repository, for the single-repository case. */
+  /**
+   * The task's repository as a stable slug (or name). A multi-repository task
+   * carries its primary repository here; enumerating the rest is deferred,
+   * since `TaskSwitcherItem.repositories` is not populated from live data.
+   */
   repositoryPath?: string;
   /**
    * Whether this row should name its repository. False when the list is grouped
@@ -112,23 +115,6 @@ type TaskItemProps = {
   isPinned?: boolean;
   agentErrorMessage?: string | null;
 };
-
-/**
- * The repository text a row shows in its stats line, or `undefined` for none.
- *
- * A multi-repository task always names its repositories: its only repository
- * group is the unnamed "Multiple repositories" bucket, so the header never
- * covers for the row. A single-repository task defers to the header when the
- * list is grouped by repository.
- */
-function resolveRowRepositoryLabel(
-  repositories: string[] | undefined,
-  repositoryPath: string | undefined,
-  showRepository: boolean,
-): string | undefined {
-  if (repositories && repositories.length > 1) return repositories.join(" · ");
-  return showRepository ? repositoryPath : undefined;
-}
 
 // Delegates to the shared classifier in task-switcher so the sidebar bucket
 // and the per-task running spinner always agree. A task whose workflow state
@@ -365,7 +351,6 @@ function TaskItemContent({
   primarySessionId,
   isArchived,
   isPinned,
-  repositories,
   repositoryPath,
   showRepository,
   updatedAt,
@@ -388,7 +373,6 @@ function TaskItemContent({
   primarySessionId?: string | null;
   isArchived?: boolean;
   isPinned?: boolean;
-  repositories?: string[];
   repositoryPath?: string;
   showRepository: boolean;
   updatedAt?: string;
@@ -439,7 +423,7 @@ function TaskItemContent({
       )}
       <TaskItemStatsRow
         updatedAt={showActivityTime ? (lastActivityAt ?? updatedAt) : updatedAt}
-        repositoryLabel={resolveRowRepositoryLabel(repositories, repositoryPath, showRepository)}
+        repositoryLabel={showRepository ? repositoryPath : undefined}
         prInfo={prInfo}
         primarySessionId={primarySessionId}
         queuedCount={queuedCount}
@@ -485,7 +469,6 @@ export const TaskItem = memo(function TaskItem({
   subtaskCount,
   subtasksCollapsed,
   onToggleSubtasks,
-  repositories,
   repositoryPath,
   showRepository = true,
   prInfo,
@@ -536,7 +519,6 @@ export const TaskItem = memo(function TaskItem({
         primarySessionId={primarySessionId}
         isArchived={isArchived}
         isPinned={isPinned}
-        repositories={repositories}
         repositoryPath={repositoryPath}
         showRepository={showRepository}
         updatedAt={updatedAt}

--- a/apps/web/components/task/task-layout-repository.test.tsx
+++ b/apps/web/components/task/task-layout-repository.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TaskLayout } from "./task-layout";
+
+afterEach(cleanup);
+
+// Every hop between the task page and the phone header is an optional prop, so
+// a dropped one is not a type error. This asserts the hop TaskLayout owns: the
+// repository label reaches the phone layout. `session-mobile-top-bar-repository`
+// covers what the header does with it.
+vi.mock("./mobile", () => ({
+  SessionMobileLayout: ({ repositoryLabel }: { repositoryLabel?: string | null }) => (
+    <div data-testid="mobile-layout" data-repository-label={repositoryLabel ?? ""} />
+  ),
+  SessionTabletLayout: () => <div data-testid="tablet-layout" />,
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: true, usesDesktopWorkbench: false }),
+}));
+
+vi.mock("./task-launch-error-context", () => ({
+  useTaskLaunchErrorContext: () => ({ error: null, repositories: [] }),
+}));
+
+describe("TaskLayout repository label", () => {
+  it("hands the repository label to the phone layout", () => {
+    render(<TaskLayout workspaceId="ws-1" workflowId="wf-1" repositoryLabel="kdlbs/kandev" />);
+
+    expect(screen.getByTestId("mobile-layout").getAttribute("data-repository-label")).toBe(
+      "kdlbs/kandev",
+    );
+  });
+
+  it("passes nothing along for a task with no repository", () => {
+    render(<TaskLayout workspaceId="ws-1" workflowId="wf-1" />);
+
+    expect(screen.getByTestId("mobile-layout").getAttribute("data-repository-label")).toBe("");
+  });
+});

--- a/apps/web/components/task/task-layout.tsx
+++ b/apps/web/components/task/task-layout.tsx
@@ -29,6 +29,8 @@ type TaskLayoutProps = {
   initialTerminals?: Terminal[];
   defaultLayouts?: Record<string, Layout>;
   taskTitle?: string;
+  /** `owner/repo` (or the repository name) of the task's primary repository. */
+  repositoryLabel?: string | null;
   baseBranch?: string;
   worktreeBranch?: string | null;
   isRemoteExecutor?: boolean;
@@ -51,6 +53,7 @@ export const TaskLayout = memo(function TaskLayout({
   initialTerminals,
   defaultLayouts = {},
   taskTitle,
+  repositoryLabel,
   baseBranch,
   worktreeBranch,
   isRemoteExecutor,
@@ -94,6 +97,7 @@ export const TaskLayout = memo(function TaskLayout({
         baseBranch={baseBranch}
         worktreeBranch={worktreeBranch}
         taskTitle={taskTitle}
+        repositoryLabel={repositoryLabel}
         isRemoteExecutor={isRemoteExecutor}
         remoteExecutorType={remoteExecutorType}
         remoteExecutorName={remoteExecutorName}

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -145,6 +145,41 @@ describe("resolveTaskProps", () => {
   });
 });
 
+describe("buildArchivedValue repository identity", () => {
+  // The archived row renders this value, so a local clone path here would put
+  // "/home/dev/src/kandev" in the sidebar and give archived tasks a different
+  // repository grouping key from every ordinary task.
+  it("carries the provider slug, not the local clone path", () => {
+    const value = buildArchivedValue(
+      { id: "task-1", title: "Any", archived_at: ARCHIVED_AT } as unknown as Task,
+      {
+        id: "repo-1",
+        name: "kandev",
+        local_path: "/home/dev/src/kandev",
+        provider_owner: "kdlbs",
+        provider_name: "kandev",
+      } as unknown as Repository,
+    );
+
+    expect(value.archivedTaskRepositoryLabel).toBe("kdlbs/kandev");
+  });
+
+  it("leaves the label unset for a task that is not archived", () => {
+    const value = buildArchivedValue(
+      { id: "task-1", title: "Any" } as unknown as Task,
+      {
+        id: "repo-1",
+        name: "kandev",
+        local_path: "/home/dev/src/kandev",
+        provider_owner: "kdlbs",
+        provider_name: "kandev",
+      } as unknown as Repository,
+    );
+
+    expect(value.archivedTaskRepositoryLabel).toBeUndefined();
+  });
+});
+
 describe("resolveTaskContentState", () => {
   it("keeps showing the loading state until the component mounts", () => {
     expect(

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   taskId as toTaskId,
   workflowId as toWorkflowId,
   workspaceId as toWorkspaceId,
+  type Repository,
   type Task,
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
@@ -107,6 +108,40 @@ describe("resolveTaskProps", () => {
 
     expect(props.issueUrl).toBe("https://github.com/kdlbs/kandev/issues/1470");
     expect(props.issueNumber).toBe(1470);
+  });
+
+  it("labels the repository by its provider slug, not its local clone path", () => {
+    const props = resolveTaskProps(
+      { id: "task-1", title: "Any" } as unknown as Task,
+      {
+        id: "repo-1",
+        name: "kandev",
+        local_path: "/home/dev/src/kandev",
+        provider_owner: "kdlbs",
+        provider_name: "kandev",
+      } as unknown as Repository,
+    );
+
+    expect(props.repositoryLabel).toBe("kdlbs/kandev");
+  });
+
+  it("falls back to the repository name when no provider owns it", () => {
+    const props = resolveTaskProps(
+      { id: "task-1", title: "Any" } as unknown as Task,
+      {
+        id: "repo-1",
+        name: "scratchpad",
+        local_path: "/home/dev/src/scratchpad",
+      } as unknown as Repository,
+    );
+
+    expect(props.repositoryLabel).toBe("scratchpad");
+  });
+
+  it("has no repository label for a task with no repository", () => {
+    const props = resolveTaskProps({ id: "task-1", title: "Any" } as unknown as Task, null);
+
+    expect(props.repositoryLabel).toBeNull();
   });
 });
 

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -170,7 +170,7 @@ export function buildArchivedValue(task: Task | null, repository: Repository | n
     isArchived,
     archivedTaskId: isArchived ? task?.id : undefined,
     archivedTaskTitle: isArchived ? task?.title : undefined,
-    archivedTaskRepositoryPath: isArchived ? (repository?.local_path ?? undefined) : undefined,
+    archivedTaskRepositoryLabel: isArchived && repository ? repositorySlug(repository) : undefined,
     archivedTaskUpdatedAt: isArchived ? task?.updated_at : undefined,
   };
 }

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
 import { issueFieldsFromMetadata } from "@/lib/metadata-utils";
+import { repositorySlug } from "@/lib/repository-slug";
 
 type ACPDebugInfo = {
   sessionId: unknown;
@@ -238,6 +239,12 @@ export function resolveTaskProps(task: Task | null, repository: Repository | nul
     issueNumber: issue.issueNumber,
     repositoryPath: repository?.local_path ?? null,
     repositoryName: repository?.name ?? null,
+    /**
+     * What the top bar shows so a user can tell which project an open task
+     * belongs to: the same `owner/repo` identity the sidebar rows and the
+     * repository filter use, never the local clone path.
+     */
+    repositoryLabel: repository ? repositorySlug(repository) : null,
     /**
      * Total number of repositories linked to the task. Used by the top-bar
      * breadcrumb to render a "+N" chip next to the primary repo name when

--- a/apps/web/components/task/task-page-inner.tsx
+++ b/apps/web/components/task/task-page-inner.tsx
@@ -111,6 +111,7 @@ function buildTaskTopBarProps(params: {
     taskId: taskProps.taskId,
     activeSessionId: params.effectiveSessionId,
     taskTitle: taskProps.taskTitle,
+    repositoryLabel: taskProps.repositoryLabel,
     showDebugOverlay,
     onToggleDebugOverlay,
     workflowSteps,

--- a/apps/web/components/task/task-page-inner.tsx
+++ b/apps/web/components/task/task-page-inner.tsx
@@ -151,6 +151,7 @@ function buildTaskLayoutProps(params: {
     defaultLayouts: params.defaultLayouts,
     initialLayout: params.initialLayout,
     taskTitle: taskProps.taskTitle,
+    repositoryLabel: taskProps.repositoryLabel,
     baseBranch: taskProps.baseBranch,
     worktreeBranch: params.merged.worktreeBranch,
     isRemoteExecutor: params.remote.isRemoteExecutor,

--- a/apps/web/components/task/task-session-sidebar-archived-item.ts
+++ b/apps/web/components/task/task-session-sidebar-archived-item.ts
@@ -15,7 +15,7 @@ export function buildArchivedSidebarItem(
     workflowName: undefined,
     workflowStepId: undefined,
     workflowStepTitle: undefined,
-    repositoryPath: s.archivedTaskRepositoryPath,
+    repositoryPath: s.archivedTaskRepositoryLabel,
     diffStats: undefined,
     isRemoteExecutor: false,
     remoteExecutorType: undefined,

--- a/apps/web/components/task/task-switcher-row.tsx
+++ b/apps/web/components/task/task-switcher-row.tsx
@@ -22,6 +22,8 @@ export type TaskRowProps = {
   activeTaskId: string | null;
   selectedTaskId: string | null;
   showActivityTime?: boolean;
+  /** False when the list is grouped by repository and the header already names it. */
+  showRepository?: boolean;
   onSelectTask: (taskId: string) => void;
   onEditTask?: (task: TaskSwitcherItem) => void;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
@@ -93,6 +95,7 @@ type TaskRowItemProps = Pick<
   | "activeTaskId"
   | "selectedTaskId"
   | "showActivityTime"
+  | "showRepository"
   | "onSelectTask"
   | "selectedTaskIds"
   | "onToggleSelectTask"
@@ -110,6 +113,7 @@ function TaskRowItem({
   activeTaskId,
   selectedTaskId,
   showActivityTime,
+  showRepository,
   onSelectTask,
   selectedTaskIds,
   onToggleSelectTask,
@@ -162,6 +166,8 @@ function TaskRowItem({
       lastActivityAt={task.lastActivityAt}
       showActivityTime={showActivityTime}
       repositories={task.repositories}
+      repositoryPath={task.repositoryPath}
+      showRepository={showRepository}
       prInfo={task.prInfo}
       queuedCount={task.queuedCount}
       wipQueue={task.wipQueue}

--- a/apps/web/components/task/task-switcher-row.tsx
+++ b/apps/web/components/task/task-switcher-row.tsx
@@ -165,7 +165,6 @@ function TaskRowItem({
       updatedAt={task.updatedAt}
       lastActivityAt={task.lastActivityAt}
       showActivityTime={showActivityTime}
-      repositories={task.repositories}
       repositoryPath={task.repositoryPath}
       showRepository={showRepository}
       prInfo={task.prInfo}

--- a/apps/web/components/task/task-switcher.test.tsx
+++ b/apps/web/components/task/task-switcher.test.tsx
@@ -531,3 +531,46 @@ describe("TaskSwitcher — external issue link menu", () => {
     expect(closeMenu).toHaveBeenCalledOnce();
   });
 });
+
+describe("TaskSwitcher repository labels", () => {
+  const REPOSITORY_TEST_ID = "sidebar-task-repository";
+  const REPOSITORY_SLUG = "kdlbs/kandev";
+
+  function renderGroupedBy(
+    groupKey: GroupedSidebarList["groupKey"],
+    groups: GroupedSidebarList["groups"],
+  ) {
+    return render(
+      <Providers>
+        <TaskSwitcher
+          grouped={{ groups, subTasksByParentId: new Map(), groupKey }}
+          activeTaskId={null}
+          selectedTaskId={null}
+          onSelectTask={vi.fn()}
+        />
+      </Providers>,
+    );
+  }
+
+  const REPO_TASK = item("Task A", undefined, { repositoryPath: REPOSITORY_SLUG });
+
+  it("names each task's repository in a flat, ungrouped list", () => {
+    renderGroupedBy("none", [{ key: "__all__", label: "All", tasks: [REPO_TASK] }]);
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe(REPOSITORY_SLUG);
+  });
+
+  it("names each task's repository when grouped by a dimension other than repository", () => {
+    renderGroupedBy("workflowStep", [{ key: "step-1", label: "In progress", tasks: [REPO_TASK] }]);
+
+    expect(screen.getByTestId(REPOSITORY_TEST_ID).textContent).toBe(REPOSITORY_SLUG);
+  });
+
+  it("leaves the repository off the rows when the group header already names it", () => {
+    renderGroupedBy("repository", [
+      { key: REPOSITORY_SLUG, label: REPOSITORY_SLUG, tasks: [REPO_TASK] },
+    ]);
+
+    expect(screen.queryByTestId(REPOSITORY_TEST_ID)).toBeNull();
+  });
+});

--- a/apps/web/components/task/task-switcher.tsx
+++ b/apps/web/components/task/task-switcher.tsx
@@ -14,6 +14,15 @@ export type {
 } from "./task-switcher-types";
 export { dispatchSidebarRowClick } from "./task-switcher-click";
 
+/**
+ * Rows name their repository unless the list is already grouped by it, where
+ * the section header says it once for the whole group. A list whose grouping is
+ * unknown (a hand-built `grouped` without `groupKey`) shows the label.
+ */
+function shouldShowRowRepository(grouped: TaskSwitcherProps["grouped"]): boolean {
+  return grouped.groupKey !== "repository";
+}
+
 function buildTaskRowProps(props: TaskSwitcherProps): TaskRowBaseProps {
   return {
     workflows: props.workflows,
@@ -21,6 +30,7 @@ function buildTaskRowProps(props: TaskSwitcherProps): TaskRowBaseProps {
     activeTaskId: props.activeTaskId,
     selectedTaskId: props.selectedTaskId,
     showActivityTime: props.showActivityTime,
+    showRepository: shouldShowRowRepository(props.grouped),
     onSelectTask: props.onSelectTask,
     onEditTask: props.onEditTask,
     onRenameTask: props.onRenameTask,

--- a/apps/web/components/task/task-top-bar.test.tsx
+++ b/apps/web/components/task/task-top-bar.test.tsx
@@ -172,9 +172,11 @@ describe("TaskTopBar repository crumb", () => {
   it("renders no repository crumb for a task with no repository", () => {
     renderTopBar(<TaskTopBar taskId="task-1" taskTitle="Fix the sidebar" />);
 
-    expect(
-      within(screen.getByRole("navigation", { name: "breadcrumb" })).queryByTitle(/\//),
-    ).toBeNull();
+    // Any static crumb, not just a slug-shaped one: a repository with no
+    // provider falls back to a bare name like "scratchpad", which a
+    // slash-matching query would happily miss.
+    const breadcrumb = screen.getByRole("navigation", { name: "breadcrumb" });
+    expect(breadcrumb.querySelector("[title]")).toBeNull();
   });
 });
 

--- a/apps/web/components/task/task-top-bar.test.tsx
+++ b/apps/web/components/task/task-top-bar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { StateProvider } from "@/components/state-provider";
 import { TaskTopBar } from "./task-top-bar";
@@ -148,6 +148,33 @@ describe("TaskTopBar registered change requests", () => {
 
     expect(plugin.textContent).toBe("task-1:session-1");
     expect(native.compareDocumentPosition(plugin) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe("TaskTopBar repository crumb", () => {
+  function repositoryCrumb(label: string) {
+    return within(screen.getByRole("navigation", { name: "breadcrumb" })).queryByText(label);
+  }
+
+  it("names the task's repository so an open task says which project it belongs to", () => {
+    renderTopBar(
+      <TaskTopBar taskId="task-1" taskTitle="Fix the sidebar" repositoryLabel="kdlbs/kandev" />,
+    );
+
+    const crumb = repositoryCrumb("kdlbs/kandev");
+    expect(crumb).toBeTruthy();
+    // Orientation, not navigation: there is no repository route to land on.
+    expect(crumb!.closest("a")).toBeNull();
+    // Truncation is what protects the title, so the full name lives in `title`.
+    expect(crumb!.getAttribute("title")).toBe("kdlbs/kandev");
+  });
+
+  it("renders no repository crumb for a task with no repository", () => {
+    renderTopBar(<TaskTopBar taskId="task-1" taskTitle="Fix the sidebar" />);
+
+    expect(
+      within(screen.getByRole("navigation", { name: "breadcrumb" })).queryByTitle(/\//),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -5,7 +5,7 @@ import Link from "@/components/routing/app-link";
 import { IconBug, IconCircleDot } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { PageTopbar } from "@/components/page-topbar";
+import { PageTopbar, type ParentCrumb } from "@/components/page-topbar";
 import { useOfficeProject } from "@/hooks/use-office-workspace-data";
 import { TaskTopBarTitle } from "@/components/task/task-top-bar-title";
 import { EditorsMenu } from "@/components/task/editors-menu";
@@ -31,6 +31,8 @@ type TaskTopBarProps = {
   taskId?: string | null;
   activeSessionId?: string | null;
   taskTitle?: string;
+  /** `owner/repo` (or the repository name) of the task's primary repository. */
+  repositoryLabel?: string | null;
   showDebugOverlay?: boolean;
   onToggleDebugOverlay?: () => void;
   workflowSteps?: WorkflowStepperStep[];
@@ -51,6 +53,7 @@ const TaskTopBar = memo(function TaskTopBar({
   taskId,
   activeSessionId,
   taskTitle,
+  repositoryLabel,
   showDebugOverlay,
   onToggleDebugOverlay,
   workflowSteps,
@@ -72,6 +75,7 @@ const TaskTopBar = memo(function TaskTopBar({
   const project = useOfficeProject(projectId);
   const showExecutorSettings =
     !isArchived && shouldShowExecutorEnvironmentControls(remoteExecutorType);
+  const parents = buildTaskCrumbs(project, repositoryLabel);
   return (
     <PageTopbar
       testId="task-topbar"
@@ -79,9 +83,7 @@ const TaskTopBar = memo(function TaskTopBar({
       // name and the measured width never diverge from what is shown.
       title={taskTitle ?? t("task:taskDetails")}
       titleSlot={<TaskTopBarTitle taskId={taskId} taskTitle={taskTitle} isArchived={isArchived} />}
-      parents={
-        project ? [{ label: project.name, href: `/office/projects/${project.id}` }] : undefined
-      }
+      parents={parents}
       // This bar is desktop-only (the mobile session bar owns phones), so the
       // phone-only home crumb and status trigger have no surface here.
       homeAffordance="none"
@@ -124,6 +126,25 @@ const TaskTopBar = memo(function TaskTopBar({
     />
   );
 });
+
+/**
+ * Ancestry crumbs for the open task: its office project (when it has one) and
+ * then its repository, closest to the title. The repository crumb carries no
+ * `href` on purpose: it orients ("this task is in kdlbs/kandev") rather than
+ * navigating, since there is no repository route to land on.
+ *
+ * A multi-repository task names its primary repository only, which is the same
+ * one the rest of the page (branch pickers, Changes) treats as primary.
+ */
+function buildTaskCrumbs(
+  project: { id: string; name: string } | null | undefined,
+  repositoryLabel: string | null | undefined,
+): ParentCrumb[] | undefined {
+  const crumbs: ParentCrumb[] = [];
+  if (project) crumbs.push({ label: project.name, href: `/office/projects/${project.id}` });
+  if (repositoryLabel) crumbs.push({ label: repositoryLabel });
+  return crumbs.length > 0 ? crumbs : undefined;
+}
 
 // IssueTrackerButtons picks the right ticket status button for a task whose
 // title already carries an external issue key. Jira and Linear use the same

--- a/apps/web/lib/sidebar/apply-view-labels.test.ts
+++ b/apps/web/lib/sidebar/apply-view-labels.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, expect } from "vitest";
 import type { TaskSwitcherItem } from "@/components/task/task-switcher";
-import { applyGroup } from "./apply-view";
+import { applyGroup, applyView } from "./apply-view";
 import { i18n } from "@/lib/i18n";
 import type { TaskState } from "@/lib/types/http";
 
@@ -85,5 +85,33 @@ describe("applyGroup — group labels are catalog-backed", () => {
     expect(groups[0].key).toBe("__all__");
     expect(groups[0].label).not.toBe("All");
     expect(groups[0].label).toMatch(/[^\p{ASCII}]/u);
+  });
+});
+
+describe("applyGroup — grouping dimension is reported back", () => {
+  // Rows read `groupKey` to decide whether naming their own repository would
+  // just repeat the section header, so the grouped list has to carry it.
+  it("reports the dimension it grouped by", () => {
+    expect(applyGroup(REPO_TASKS, "repository").groupKey).toBe("repository");
+    expect(applyGroup(REPO_TASKS, "workflowStep").groupKey).toBe("workflowStep");
+  });
+
+  it("reports an ungrouped flat list as such", () => {
+    expect(applyGroup(REPO_TASKS, "none").groupKey).toBe("none");
+  });
+
+  // applyView post-processes the grouped list (pinning, subtask order); the
+  // dimension has to survive that trip, since the rows read it from there.
+  it("survives applyView's post-processing", () => {
+    const view = {
+      filters: [],
+      sort: { key: "createdAt", direction: "desc" },
+      group: "repository",
+      collapsedGroups: [],
+    } as unknown as Parameters<typeof applyView>[1];
+
+    expect(applyView(REPO_TASKS, view, { pinnedTaskIds: ["a"], orderedTaskIds: [] }).groupKey).toBe(
+      "repository",
+    );
   });
 });

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -23,6 +23,13 @@ export type SidebarGroup = {
 export type GroupedSidebarList = {
   groups: SidebarGroup[];
   subTasksByParentId: Map<string, TaskSwitcherItem[]>;
+  /**
+   * Which dimension produced `groups`. Rows read it to decide whether their own
+   * repository label is redundant: grouped by repository, the section header
+   * already names it. Optional so a hand-built list (tests, fixtures) keeps
+   * meaning "unknown grouping" and falls back to showing the label.
+   */
+  groupKey?: GroupKey;
 };
 
 export type SidebarTaskPrefs = {
@@ -336,6 +343,7 @@ export function applyGroup(
     return {
       groups: [{ key: "__all__", label: t(ALL_GROUP_LABEL_KEY), tasks: rootTasks }],
       subTasksByParentId,
+      groupKey,
     };
   }
 
@@ -360,7 +368,7 @@ export function applyGroup(
     sortRepoGroups(groups);
   }
   if (groupKey === "state") sortStateGroups(groups);
-  return { groups, subTasksByParentId };
+  return { groups, subTasksByParentId, groupKey };
 }
 
 function mergeSingleRepoUnassigned(groups: SidebarGroup[]): void {


### PR DESCRIPTION
Working across several repositories with the `TASKS` sidebar ungrouped, a task row showed only its title, so there was no way to tell which project it belonged to, and opening the task did not help because the repository appeared nowhere on the task page either. Task rows and the task top bar now name the repository, using the same `owner/repo` identity the repository filter and grouping already use.

## Important Changes

- Sidebar rows carry the repository in the existing stats line (next to the relative time) rather than on a new line, so the label costs no extra vertical height and cannot push the title out. It is the only shrinkable element in that line, so a long name truncates and keeps the full name in `title` for hover.
- `applyGroup` now reports the dimension it grouped by on the returned list, so rows can drop their own label when the list is already grouped by repository and the section header says it once for the whole group. A multi-repository task keeps naming its repositories either way, since the "Multiple repositories" header does not name them.
- Archived tasks carry `repositorySlug()` rather than `repository.local_path`. That value was previously only an invisible grouping key, so rendering it is what made the wrong identity a bug; archived rows now also share a grouping and filtering key with ordinary rows.
- The phone task header names the repository too. The desktop top bar owns the crumb and `TaskPageInner` skips that bar below the mobile breakpoint, so the label is threaded through to `SessionMobileTopBar` separately.
- The task top bar gains a repository crumb between the project and the title. It carries no `href` on purpose: there is no repository route to land on, so it orients rather than navigates. Static crumbs also gained a `title`, which is what makes a name longer than the crumb's max width readable at all.

## Validation

Verified in a running app: an isolated backend seeded with three repositories (`kdlbs/kandev`, `kdlbs/kandev-web`, `acme-platform/infra-terraform-modules`) and six tasks spread across them, driven through Playwright.

- `pnpm test` (apps/web): 1567 files, 13224 passed, 4 skipped, 0 failed
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run i18n:check`, `pnpm run i18n:ratchet`: all clean
- Each new test was mutation-checked: ignoring `showRepository`, dropping the `title` attribute, not reporting `groupKey`, labelling with `local_path` instead of the slug, removing the crumb, and deleting either mobile forwarding line each kill exactly the intended test.
- **CI note:** the `Build`, `E2E Tests Passed`, `Merge E2E Reports` and `deploy-same-repo` failures on this PR are inherited from `main`, which does not compile: `internal/github/service_pr_watch.go:1024` references `taskID` and `status`, neither of which is in scope in `persistAndPublishTaskPRSync`. It landed in #2614 and every `main` commit since has failed E2E. This branch touches no Go.

### Ungrouped list, every row names its repository

![Ungrouped TASKS sidebar with a repository name under each task title](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/B-ungrouped-sidebar.png)

### Grouped by repository, rows stay clean

![TASKS sidebar grouped by repository, headers name the repo and rows do not repeat it](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/A-grouped-sidebar.png)

### Task view header

![Task top bar showing a kdlbs/kandev crumb before the task title](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/C-topbar-short-repo.png)

A long repository name truncates, with the full name on hover (`title="acme-platform/infra-terraform-modules"`):

![Task top bar with a truncated acme-platform/infra-t… crumb](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/D-topbar-long-repo.png)

### Mobile

The phone task header names the repository on its secondary line, beside the branch:

![Phone task header showing acme-platform/infra-terraform-modules under the task title](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/H-mobile-header-closeup.png)

![Mobile task board with repository names on the cards](https://raw.githubusercontent.com/kdlbs/kandev/01b794767f4687db05ad9c638f25739ca7ea88c7/F-mobile.png)

## Possible Improvements

Low risk, display-only. Two known limits: a multi-repository task names its primary repository only, on every surface (`TaskSwitcherItem.repositories` is not populated from live data, and wiring it would move those tasks into the `__multi__` grouping and filter bucket, which is a behavior change this issue did not ask for); and the phone task-switcher sheet was verified by assertion rather than screenshot, since it renders the same `TaskItem` through the same `applyView` path but would not open reliably headless.

Closes #2912

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.