### PR TITLE
fix(credentials): authorize managed fork credential leases

### DIFF
--- a/apps/backend/internal/agentctl/server/process/runner_test.go
+++ b/apps/backend/internal/agentctl/server/process/runner_test.go
@@ -123,6 +123,27 @@ func TestProcessRunnerStopLogsSignalAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to start process: %v", err)
 	}
+
+	ready := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		proc, ok := runner.Get(info.ID, true)
+		if ok {
+			for _, chunk := range proc.Output {
+				if strings.Contains(chunk.Data, "fixture ready") {
+					ready = true
+					break
+				}
+			}
+		}
+		if ready {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("signal-ignoring fixture did not become ready")
+	}
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
@@ -145,7 +166,7 @@ func TestProcessRunnerStopLogsSignalAttempts(t *testing.T) {
 		}
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline = time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if _, ok := runner.Get(info.ID, false); !ok {
 			return

--- a/apps/backend/internal/agentctl/server/process/testmain_test.go
+++ b/apps/backend/internal/agentctl/server/process/testmain_test.go
@@ -97,6 +97,7 @@ func runFixture(spec string) {
 			os.Exit(2)
 		}
 		signal.Ignore(os.Interrupt)
+		fmt.Println("fixture ready")
 		time.Sleep(time.Duration(secs) * time.Second)
 	case "echo":
 		fmt.Println(strings.Join(parts[1:], " "))

--- a/apps/backend/internal/backendapp/git_credentials.go
+++ b/apps/backend/internal/backendapp/git_credentials.go
@@ -255,9 +255,10 @@ func (a *githubBrokerScopeAuthorizer) AuthorizeGitCredential(ctx context.Context
 		return nil
 	}
 	// Legacy GitHub rows may omit ProviderHost while their persisted clone URL
-	// still proves github.com. This exact-identity fallback is upstream-only;
-	// fork credentials must pass the server-authored destination check above.
-	return a.authorizeRepositoryIdentity(ctx, scope)
+	// still proves github.com. This fallback is upstream-only. Preserve any
+	// provider identity carried by the lease before using that legacy proof;
+	// fork credentials must pass the destination check above.
+	return a.authorizeLegacyGitHubRepositoryIdentity(ctx, scope)
 }
 
 func gitCredentialScopeOwnerRepo(path string) (string, string, error) {
@@ -274,6 +275,27 @@ func (a *githubBrokerScopeAuthorizer) authorizeRepositoryIdentity(ctx context.Co
 	if err != nil {
 		return err
 	}
+	return authorizeRepositoryIdentityRecord(repository, scope)
+}
+
+func (a *githubBrokerScopeAuthorizer) authorizeLegacyGitHubRepositoryIdentity(
+	ctx context.Context, scope gitcredentials.Scope,
+) error {
+	if strings.TrimSpace(scope.ParentProviderID) != "" {
+		return fmt.Errorf("repository parent identity does not match lease scope")
+	}
+	repository, err := a.repo.GetRepository(ctx, scope.RepositoryID)
+	if err != nil {
+		return err
+	}
+	if identity := strings.TrimSpace(scope.IdentityProviderID); identity != "" &&
+		(repository == nil || !strings.EqualFold(strings.TrimSpace(repository.ProviderRepoID), identity)) {
+		return fmt.Errorf("repository provider identity does not match lease scope")
+	}
+	return authorizeRepositoryIdentityRecord(repository, scope)
+}
+
+func authorizeRepositoryIdentityRecord(repository *taskmodels.Repository, scope gitcredentials.Scope) error {
 	if repository == nil {
 		return fmt.Errorf("repository identity does not match lease scope")
 	}

--- a/apps/backend/internal/backendapp/git_credentials.go
+++ b/apps/backend/internal/backendapp/git_credentials.go
@@ -222,16 +222,29 @@ func pluginCredentialExpiry(raw string) (time.Time, error) {
 }
 
 func (a *githubBrokerScopeAuthorizer) AuthorizeGitCredential(ctx context.Context, scope gitcredentials.Scope) error {
-	if a == nil || a.repo == nil {
-		return fmt.Errorf("task repository is unavailable")
-	}
-	if err := a.authorizeTaskSession(ctx, scope.WorkspaceID, scope.TaskID, scope.SessionID); err != nil {
+	owner, repo, err := gitCredentialScopeOwnerRepo(scope.Path)
+	if err != nil {
 		return err
 	}
-	if _, err := a.authorizeTaskRepository(ctx, scope.TaskID, scope.RepositoryID); err != nil {
-		return err
+	if err := a.AuthorizeGitHubRepositoryWithIdentity(
+		ctx, scope.WorkspaceID, scope.TaskID, scope.SessionID, scope.RepositoryID,
+		owner, repo, scope.IdentityProviderID, scope.ParentProviderID,
+	); err == nil {
+		return nil
 	}
+	// Legacy GitHub rows may omit ProviderHost while their persisted clone
+	// URL still proves github.com. Retain that exact-identity compatibility
+	// path after checking server-authored contribution destinations.
 	return a.authorizeRepositoryIdentity(ctx, scope)
+}
+
+func gitCredentialScopeOwnerRepo(path string) (string, string, error) {
+	trimmed := strings.TrimSuffix(strings.Trim(path, "/"), ".git")
+	owner, repo, found := strings.Cut(trimmed, "/")
+	if !found || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return "", "", fmt.Errorf("repository identity does not match lease scope")
+	}
+	return owner, repo, nil
 }
 
 func (a *githubBrokerScopeAuthorizer) authorizeRepositoryIdentity(ctx context.Context, scope gitcredentials.Scope) error {

--- a/apps/backend/internal/backendapp/git_credentials.go
+++ b/apps/backend/internal/backendapp/git_credentials.go
@@ -222,6 +222,19 @@ func pluginCredentialExpiry(raw string) (time.Time, error) {
 }
 
 func (a *githubBrokerScopeAuthorizer) AuthorizeGitCredential(ctx context.Context, scope gitcredentials.Scope) error {
+	if a == nil || a.repo == nil {
+		return fmt.Errorf("task repository is unavailable")
+	}
+	if err := a.authorizeTaskSession(ctx, scope.WorkspaceID, scope.TaskID, scope.SessionID); err != nil {
+		return err
+	}
+	if _, err := a.authorizeTaskRepository(ctx, scope.TaskID, scope.RepositoryID); err != nil {
+		return err
+	}
+	if !strings.EqualFold(scope.ProviderID, gitCredentialGitHubProviderID) ||
+		!strings.EqualFold(scope.Host, gitCredentialGitHubHost) {
+		return a.authorizeRepositoryIdentity(ctx, scope)
+	}
 	owner, repo, err := gitCredentialScopeOwnerRepo(scope.Path)
 	if err != nil {
 		return err
@@ -232,9 +245,9 @@ func (a *githubBrokerScopeAuthorizer) AuthorizeGitCredential(ctx context.Context
 	); err == nil {
 		return nil
 	}
-	// Legacy GitHub rows may omit ProviderHost while their persisted clone
-	// URL still proves github.com. Retain that exact-identity compatibility
-	// path after checking server-authored contribution destinations.
+	// Legacy GitHub rows may omit ProviderHost while their persisted clone URL
+	// still proves github.com. This exact-identity fallback is upstream-only;
+	// fork credentials must pass the server-authored destination check above.
 	return a.authorizeRepositoryIdentity(ctx, scope)
 }
 

--- a/apps/backend/internal/backendapp/git_credentials.go
+++ b/apps/backend/internal/backendapp/git_credentials.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/gitcredentials"
-	githubpkg "github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/githubauth"
 	"github.com/kandev/kandev/internal/plugins"
 	"github.com/kandev/kandev/internal/repoclone"
@@ -21,6 +20,13 @@ const (
 	gitCredentialGitHubHost       = "github.com"
 )
 
+type gitHubCredentialSource interface {
+	GitCredentialResolver() gitcredentials.Resolver
+	VerifyContributionDestinationForWorkspace(
+		context.Context, string, string, string, string, string, string, string,
+	) error
+}
+
 type gitCredentialTaskRepository interface {
 	GetTask(context.Context, string) (*taskmodels.Task, error)
 	GetTaskSession(context.Context, string) (*taskmodels.TaskSession, error)
@@ -29,7 +35,7 @@ type gitCredentialTaskRepository interface {
 }
 
 func newGitCredentialBroker(
-	githubSvc *githubpkg.Service,
+	githubSvc gitHubCredentialSource,
 	pluginSvc *plugins.Service,
 	repo gitCredentialTaskRepository,
 	reissueSigningKey string,
@@ -41,7 +47,10 @@ func newGitCredentialBroker(
 	if pluginSvc != nil {
 		resolvers = append(resolvers, pluginGitCredentialResolver{service: pluginCredentialServiceAdapter{service: pluginSvc}})
 	}
-	broker := gitcredentials.NewBroker(gitcredentials.NewCompositeResolver(resolvers...), &githubBrokerScopeAuthorizer{repo: repo})
+	broker := gitcredentials.NewBroker(
+		gitcredentials.NewCompositeResolver(resolvers...),
+		&githubBrokerScopeAuthorizer{repo: repo, provider: githubSvc},
+	)
 	if signer, err := gitcredentials.NewReissueCapabilitySigner(reissueSigningKey); err == nil {
 		broker.SetReissueCapabilitySigner(signer)
 	}

--- a/apps/backend/internal/backendapp/git_credentials_scope_test.go
+++ b/apps/backend/internal/backendapp/git_credentials_scope_test.go
@@ -107,6 +107,47 @@ func TestGitHubBrokerScopeAuthorizerRejectsForeignRepositoryScope(t *testing.T) 
 	}
 }
 
+func TestGitHubBrokerScopeAuthorizerRechecksTaskScopeBeforeLegacyFallback(t *testing.T) {
+	for name, mutate := range map[string]func(*fakeGitHubBrokerTaskRepository){
+		"terminal session": func(repo *fakeGitHubBrokerTaskRepository) {
+			repo.session.State = taskmodels.TaskSessionStateCompleted
+		},
+		"session for another task": func(repo *fakeGitHubBrokerTaskRepository) {
+			repo.session.TaskID = "other-task"
+		},
+		"unlinked repository": func(repo *fakeGitHubBrokerTaskRepository) {
+			repo.links = nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := gitCredentialScopeTestRepository("https://github.com/acme/widgets.git")
+			mutate(repo)
+			authorizer := &githubBrokerScopeAuthorizer{repo: repo}
+
+			if err := authorizer.AuthorizeGitCredential(
+				context.Background(), gitCredentialScopeForPath("/acme/widgets.git"),
+			); err == nil {
+				t.Fatal("AuthorizeGitCredential() error = nil, want live task scope denial")
+			}
+		})
+	}
+}
+
+func TestGitHubBrokerScopeAuthorizerAcceptsPluginRepositoryScope(t *testing.T) {
+	repository := &taskmodels.Repository{
+		ID: "repository-1", WorkspaceID: "workspace-1", Provider: "bitbucket",
+		ProviderHost: "https://bitbucket.example", RemoteURL: "https://bitbucket.example/scm/ENG/widgets.git",
+	}
+	authorizer := &githubBrokerScopeAuthorizer{repo: gitCredentialScopeTaskRepository(repository)}
+
+	if err := authorizer.AuthorizeGitCredential(context.Background(), gitcredentials.Scope{
+		ProviderID: "bitbucket", WorkspaceID: "workspace-1", TaskID: "task-1", SessionID: "session-1",
+		RepositoryID: "repository-1", Host: "bitbucket.example", Path: "/scm/ENG/widgets.git",
+	}); err != nil {
+		t.Fatalf("AuthorizeGitCredential() error = %v", err)
+	}
+}
+
 // An SSH URL cannot express the provider's HTTPS port, so the persisted
 // provider identity, not a rewrite of the remote, decides the origin.
 func TestGitHubBrokerScopeAuthorizerUsesProviderHostPortForSSHRemote(t *testing.T) {

--- a/apps/backend/internal/backendapp/git_credentials_scope_test.go
+++ b/apps/backend/internal/backendapp/git_credentials_scope_test.go
@@ -133,6 +133,31 @@ func TestGitHubBrokerScopeAuthorizerRechecksTaskScopeBeforeLegacyFallback(t *tes
 	}
 }
 
+func TestGitHubBrokerScopeAuthorizerDoesNotBypassProviderIdentityOnLegacyFallback(t *testing.T) {
+	for name, identity := range map[string]gitcredentials.Scope{
+		"mismatched provider identity": {
+			IdentityProviderID: "999",
+		},
+		"unexpected parent identity": {
+			IdentityProviderID: "100", ParentProviderID: "200",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := gitCredentialScopeTestRepository("https://github.com/acme/widgets.git")
+			repo.repository.ProviderHost = ""
+			repo.repository.ProviderRepoID = "100"
+			authorizer := &githubBrokerScopeAuthorizer{repo: repo}
+			scope := gitCredentialScopeForPath("/acme/widgets.git")
+			scope.IdentityProviderID = identity.IdentityProviderID
+			scope.ParentProviderID = identity.ParentProviderID
+
+			if err := authorizer.AuthorizeGitCredential(context.Background(), scope); err == nil {
+				t.Fatal("AuthorizeGitCredential() error = nil, want provider identity denial")
+			}
+		})
+	}
+}
+
 func TestGitHubBrokerScopeAuthorizerAcceptsPluginRepositoryScope(t *testing.T) {
 	repository := &taskmodels.Repository{
 		ID: "repository-1", WorkspaceID: "workspace-1", Provider: "bitbucket",

--- a/apps/backend/internal/backendapp/services_github_broker_test.go
+++ b/apps/backend/internal/backendapp/services_github_broker_test.go
@@ -36,6 +36,37 @@ type fakeContributionDestinationVerifier struct {
 	calls int
 }
 
+type factoryTestGitCredentialResolver struct{}
+
+func (factoryTestGitCredentialResolver) Supports(providerID string) bool {
+	return strings.EqualFold(providerID, "github")
+}
+
+func (factoryTestGitCredentialResolver) Binding(context.Context, gitcredentials.Scope) (string, error) {
+	return "generation-1", nil
+}
+
+func (factoryTestGitCredentialResolver) Resolve(context.Context, gitcredentials.Scope) (gitcredentials.Credential, error) {
+	return gitcredentials.Credential{Username: "x-access-token", Password: "secret"}, nil
+}
+
+type factoryTestGitHubCredentialSource struct {
+	verifier *fakeContributionDestinationVerifier
+}
+
+func (s *factoryTestGitHubCredentialSource) GitCredentialResolver() gitcredentials.Resolver {
+	return factoryTestGitCredentialResolver{}
+}
+
+func (s *factoryTestGitHubCredentialSource) VerifyContributionDestinationForWorkspace(
+	ctx context.Context,
+	workspaceID, sourceOwner, sourceRepo, sourceProviderID, targetOwner, targetRepo, targetProviderID string,
+) error {
+	return s.verifier.VerifyContributionDestinationForWorkspace(
+		ctx, workspaceID, sourceOwner, sourceRepo, sourceProviderID, targetOwner, targetRepo, targetProviderID,
+	)
+}
+
 func (f *fakeContributionDestinationVerifier) VerifyContributionDestinationForWorkspace(
 	context.Context, string, string, string, string, string, string, string,
 ) error {
@@ -351,6 +382,42 @@ func TestGitHubBrokerScopeAuthorizerAllowsOnlyTheBoundContributionDestination(t 
 	}
 	if err := authorizer.AuthorizeGitHubRepository(context.Background(), "workspace-destination", "task-destination", "session-destination", "repository-destination", "automation", "other"); err == nil || !strings.Contains(err.Error(), "identity does not match") {
 		t.Fatalf("unbound destination error = %v, want identity denial", err)
+	}
+}
+
+func TestGitCredentialBrokerFactoryWiresGitHubDestinationVerifier(t *testing.T) {
+	destination := taskmodels.ContributionDestination{
+		Version:  taskmodels.ContributionDestinationVersion,
+		Provider: taskmodels.ContributionDestinationProviderGitHub,
+		SourceRepository: taskmodels.ContributionDestinationRepository{
+			Host: "github.com", Path: "kdlbs/kandev", ProviderID: "100", RemoteURL: "https://github.com/kdlbs/kandev.git",
+		},
+		TargetRepository: taskmodels.ContributionDestinationRepository{
+			Host: "github.com", Path: "automation/kandev", ProviderID: "200", RemoteURL: "https://github.com/automation/kandev.git",
+		},
+	}
+	metadata := map[string]interface{}{}
+	if err := taskmodels.PutContributionDestination(metadata, &destination); err != nil {
+		t.Fatalf("PutContributionDestination() = %v", err)
+	}
+	repo := &fakeGitHubBrokerTaskRepository{
+		task:       &taskmodels.Task{ID: "task-factory", WorkspaceID: "workspace-factory"},
+		session:    &taskmodels.TaskSession{ID: "session-factory", TaskID: "task-factory", State: taskmodels.TaskSessionStateRunning},
+		repository: &taskmodels.Repository{ID: "repository-factory", WorkspaceID: "workspace-factory", Provider: "github", ProviderHost: "https://github.com", ProviderRepoID: "100", ProviderOwner: "kdlbs", ProviderName: "kandev"},
+		links:      []*taskmodels.TaskRepository{{TaskID: "task-factory", RepositoryID: "repository-factory", Metadata: metadata}},
+	}
+	verifier := &fakeContributionDestinationVerifier{}
+	broker := newGitCredentialBroker(&factoryTestGitHubCredentialSource{verifier: verifier}, nil, repo, "")
+
+	if _, err := broker.Issue(context.Background(), gitcredentials.Scope{
+		ProviderID: "github", WorkspaceID: "workspace-factory", TaskID: "task-factory", SessionID: "session-factory",
+		RepositoryID: "repository-factory", Host: "github.com", Path: "/automation/kandev.git",
+		IdentityProviderID: "200", ParentProviderID: "100",
+	}); err != nil {
+		t.Fatalf("managed fork lease issuance = %v", err)
+	}
+	if verifier.calls != 1 {
+		t.Fatalf("destination verifier calls = %d, want 1", verifier.calls)
 	}
 }
 

--- a/apps/backend/internal/backendapp/services_github_broker_test.go
+++ b/apps/backend/internal/backendapp/services_github_broker_test.go
@@ -329,8 +329,15 @@ func TestGitHubBrokerScopeAuthorizerAllowsOnlyTheBoundContributionDestination(t 
 	); err != nil {
 		t.Fatalf("bound destination identity was denied: %v", err)
 	}
-	if verifier.calls != 1 {
-		t.Fatalf("provider verification calls = %d, want 1", verifier.calls)
+	if err := authorizer.AuthorizeGitCredential(context.Background(), gitcredentials.Scope{
+		ProviderID: "github", WorkspaceID: "workspace-destination", TaskID: "task-destination", SessionID: "session-destination",
+		RepositoryID: "repository-destination", Host: "github.com", Path: "/automation/kandev.git",
+		IdentityProviderID: "200", ParentProviderID: "100",
+	}); err != nil {
+		t.Fatalf("authorized contribution-destination lease was denied: %v", err)
+	}
+	if verifier.calls != 2 {
+		t.Fatalf("provider verification calls = %d, want 2", verifier.calls)
 	}
 	if err := authorizer.AuthorizeGitHubRepositoryWithIdentity(
 		context.Background(), "workspace-destination", "task-destination", "session-destination", "repository-destination", "automation", "kandev", "201", "100",


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2940/8454924b5e72.html)
<!-- kandev-pr-walkthrough-end -->

## Important Changes

- Generic Git credential authorization now validates the live task/session and
  task-repository link before choosing a destination-aware GitHub authorization
  path or the legacy exact-identity fallback.
- Managed GitHub fork leases must prove both the target provider identity and
  canonical parent identity. Non-GitHub plugin scopes retain provider-neutral
  exact-identity authorization.
- The process-runner signal-escalation test now waits until its fixture has
  installed the interrupt-ignore handler, removing a CI timing race without
  changing production process behavior.

## Validation

- `cd apps/backend && go test ./internal/backendapp`
- `cd apps/backend && go test -race -v -run 'TestGitHubBrokerScopeAuthorizerRechecksTaskScopeBeforeLegacyFallback|TestGitHubBrokerScopeAuthorizerAcceptsPluginRepositoryScope|TestGitHubBrokerScopeAuthorizerAllowsOnlyTheBoundContributionDestination|TestGitHubBrokerScopeAuthorizerAcceptsEquivalentRepositorySpellings|TestGitHubBrokerScopeAuthorizerRejectsForeignRepositoryScope|TestGitHubBrokerScopeAuthorizerRejectsNonPublicProviderHostsForDestination' ./internal/backendapp`
- `cd apps/backend && go test -count=20 -run '^TestProcessRunnerStopLogsSignalAttempts$' ./internal/agentctl/server/process`
- `cd apps/backend && go test -race -count=5 -run '^TestProcessRunnerStopLogsSignalAttempts$' ./internal/agentctl/server/process`
- Required CI: 5/5 checks passing at `f56598ee4c7b4b26115ffb4cd786eddee599333d`.

## Human QA Review

- All review threads have technical responses and are resolved.
- This is a non-visual authorization and test-stability change. No interactive
  server, database, or preview instance is required for review.
- `VISUAL_EVIDENCE=NOT_APPLICABLE`: no user-facing UI, visual state, or layout
  changed.

## Review Instructions

1. Review the live authorization guards and destination-versus-canonical
   fallback in `apps/backend/internal/backendapp/git_credentials.go`.
2. Run the focused authorization and process-runner commands above from
   `apps/backend`.
3. Confirm denied terminal-session, unlinked-repository, foreign-fork, and
   plugin-provider scenarios remain covered by the focused tests.

## Related PRs

- [yattdev/kandev-plugin-redmine#1](https://github.com/yattdev/kandev-plugin-redmine/pull/1) exercised this managed publication path during Human QA. It is a related consumer/reproducer, not a functional dependency of this platform fix.