### PR TITLE
fix: improve agent model picker layout

### DIFF
--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -474,6 +474,8 @@ export type ModelConfigSelectorProps = {
   placeholder?: string;
   ariaLabel?: string;
   variant?: "compact" | "field";
+  /** Aligns the picker with the trigger edge for context-specific settings surfaces. */
+  popoverAlign?: "start" | "center" | "end";
   popoverSide?: "top" | "bottom";
   triggerClassName?: string;
   triggerSummary?: "all" | "changed";
@@ -565,6 +567,7 @@ export const ModelConfigSelector = memo(function ModelConfigSelector({
   placeholder,
   ariaLabel,
   variant = "field",
+  popoverAlign = "end",
   popoverSide = "bottom",
   triggerClassName: customTriggerClassName,
   triggerSummary = "all",
@@ -626,7 +629,7 @@ export const ModelConfigSelector = memo(function ModelConfigSelector({
         variant={variant}
       />
       <PopoverContent
-        align="end"
+        align={popoverAlign}
         side={popoverSide}
         className="w-[min(24rem,calc(100vw-1rem))] max-h-[min(32rem,calc(100vh-1rem))] gap-2 overflow-hidden p-2"
       >

--- a/apps/web/components/settings/profile-form-fields.test.tsx
+++ b/apps/web/components/settings/profile-form-fields.test.tsx
@@ -198,6 +198,13 @@ describe("ProfileFormFields no-silent-model-fallback rows", () => {
 });
 
 describe("ProfileFormFields model options", () => {
+  it("constrains a single start model field on desktop", () => {
+    renderForm(formData());
+
+    const row = screen.getByTestId("profile-capabilities-model-row");
+    expect(row.firstElementChild?.className).toContain("md:max-w-xl");
+  });
+
   it("loads model-specific options in the profile model selector", async () => {
     const dynamicModelConfig: ModelConfig = {
       default_model: "model-a",

--- a/apps/web/components/settings/profile-form-fields.test.tsx
+++ b/apps/web/components/settings/profile-form-fields.test.tsx
@@ -205,6 +205,18 @@ describe("ProfileFormFields model options", () => {
     expect(row.firstElementChild?.className).toContain("md:max-w-xl");
   });
 
+  it("keeps the model and mode fields balanced when modes are available", () => {
+    renderForm(formData({ mode: "default" }), {
+      ...modelConfig,
+      available_modes: [{ id: "default", name: "Default" }],
+      current_mode_id: "default",
+    });
+
+    const row = screen.getByTestId("profile-capabilities-model-row");
+    expect(row.firstElementChild?.className).toContain("flex-1");
+    expect(screen.getByTestId("profile-mode-field")).not.toBeNull();
+  });
+
   it("loads model-specific options in the profile model selector", async () => {
     const dynamicModelConfig: ModelConfig = {
       default_model: "model-a",

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -338,7 +338,7 @@ function CapabilitiesRowContent({
     <div className={gapCls}>
       <div className="flex items-end gap-2" data-testid="profile-capabilities-model-row">
         <div
-          className={`flex-1 min-w-0 ${gapCls}`}
+          className={`${hasModes ? "flex-1" : "w-full md:max-w-xl"} min-w-0 ${gapCls}`}
           data-settings-dirty={profileModelIsDirty(profile, baselineProfile)}
           data-settings-dirty-level="container"
         >

--- a/apps/web/components/settings/profile-model-fields.tsx
+++ b/apps/web/components/settings/profile-model-fields.tsx
@@ -109,6 +109,7 @@ export function ModelPicker({
       }
       placeholder={placeholder ?? t("settings:selectAModel")}
       ariaLabel={ariaLabel}
+      popoverAlign="start"
       disabled={disabled}
       configOptionsLoading={configOptionsLoading}
       keepOpenOnModelChange={keepOpenOnModelChange}

--- a/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
@@ -52,6 +52,31 @@ test.describe("Agent profile — ACP-first", () => {
     await expect(testPage.getByTestId("profile-mode-field")).toBeVisible({ timeout: 10_000 });
   });
 
+  test("profile model picker opens from the field start edge", async ({ testPage, apiClient }) => {
+    test.setTimeout(60_000);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents.find((item) => item.name === "mock-agent") ?? agents[0];
+    const profile = agent.profiles[0];
+
+    await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+
+    const selector = testPage.getByRole("button", { name: "Profile start model settings" });
+    await expect(selector).toBeVisible({ timeout: 15_000 });
+    await selector.click();
+
+    const [selectorBox, popoverBox] = await Promise.all([
+      selector.boundingBox(),
+      testPage.locator('[data-slot="popover-content"]').boundingBox(),
+    ]);
+
+    expect(selectorBox).not.toBeNull();
+    expect(popoverBox).not.toBeNull();
+    // Radix may nudge the content by a few pixels to satisfy collision padding;
+    // the regression is the old end alignment, which placed it ~50px inward.
+    expect(Math.abs(popoverBox!.x - selectorBox!.x)).toBeLessThanOrEqual(12);
+  });
+
   test("profile name edits persist across reload", async ({ testPage, apiClient }) => {
     test.setTimeout(60_000);
 

--- a/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
@@ -61,13 +61,26 @@ test.describe("Agent profile — ACP-first", () => {
 
     await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
 
-    const selector = testPage.getByRole("button", { name: "Profile start model settings" });
+    const profileSettingsPanel = testPage.locator(
+      '[data-settings-target^="setting-agent-profile-"][data-settings-target$="-profile-settings"]',
+    );
+    const selector = profileSettingsPanel.getByRole("button", {
+      name: "Profile start model settings",
+    });
     await expect(selector).toBeVisible({ timeout: 15_000 });
     await selector.click();
 
+    const popoverContent = testPage.locator('[data-slot="popover-content"]:visible');
+    await expect(popoverContent).toBeVisible();
+    await popoverContent.evaluate(async (element) => {
+      await Promise.all(
+        element.getAnimations().map((animation) => animation.finished.catch(() => undefined)),
+      );
+    });
+
     const [selectorBox, popoverBox] = await Promise.all([
       selector.boundingBox(),
-      testPage.locator('[data-slot="popover-content"]').boundingBox(),
+      popoverContent.boundingBox(),
     ]);
 
     expect(selectorBox).not.toBeNull();


### PR DESCRIPTION
Agent profile pages gave a model-only start-model selector the full settings-row width, while its configuration popover opened from the trailing edge. The layout now caps model-only controls on desktop and anchors profile model pickers to the field start while preserving full-width mobile controls.

## Validation

- `pnpm --filter @kandev/web test -- --run components/model-config-selector.test.tsx components/settings/profile-form-fields.test.tsx`
- `pnpm e2e:run --no-build --project chromium tests/settings/agent-profile-acp.spec.ts`
- `pnpm e2e:run --no-build --project mobile-chrome tests/settings/mobile-agent-profile-config-selector.spec.ts`
- `pnpm --filter @kandev/web exec eslint components/model-config-selector.tsx components/settings/profile-model-fields.tsx components/settings/profile-form-fields.tsx components/settings/profile-form-fields.test.tsx e2e/tests/settings/agent-profile-acp.spec.ts`
- `pnpm --filter @kandev/web run typecheck`
- Commit hooks passed, including changed-file web lint, i18n guard, and E2E sleep guard.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop agent profile model picker anchored to the field](https://raw.githubusercontent.com/kdlbs/kandev/8a0d22e7db5130820e010824e5e48d545bd10485/desktop-agent-profile-model-picker.png)

![Mobile agent profile model picker reachable by touch](https://raw.githubusercontent.com/kdlbs/kandev/8a0d22e7db5130820e010824e5e48d545bd10485/mobile-agent-profile-model-picker.png)
<!-- kandev-screenshots-end -->