### PR TITLE
chore(agentctl): add per-instance diagnostic performance metrics

### DIFF
--- a/apps/backend/internal/agentctl/server/api/metrics_handler.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler.go
@@ -27,14 +27,37 @@ func (s *Server) handleSystemMetrics(c *gin.Context) {
 	snapshot.ID = "agentctl"
 	snapshot.Label = "Execution"
 	snapshot.Kind = "execution"
-	snapshot.Metrics = append(snapshot.Metrics, s.agentctlDiagnosticSamples(metricIDs)...)
+	snapshot.Metrics = s.mergeMetricsInRequestOrder(metricIDs, snapshot.Metrics)
 	c.JSON(http.StatusOK, snapshot)
+}
+
+// mergeMetricsInRequestOrder interleaves the collector's samples (already in
+// the same relative order as the non-diagnostic IDs in metricIDs, since
+// collectorMetricIDs preserves that subsequence) with a freshly built
+// diagnostic sample per diagnostic ID, walking metricIDs so a mixed request
+// like ?metrics=agentctl_goroutines,cpu_percent gets its response back in the
+// order it was requested rather than diagnostics always trailing.
+func (s *Server) mergeMetricsInRequestOrder(metricIDs []string, collectorSamples []metrics.MetricSample) []metrics.MetricSample {
+	out := make([]metrics.MetricSample, 0, len(metricIDs))
+	next := 0
+	for _, id := range metricIDs {
+		if isAgentctlDiagnosticMetric(id) {
+			out = append(out, s.agentctlDiagnosticSample(id))
+			continue
+		}
+		if next < len(collectorSamples) {
+			out = append(out, collectorSamples[next])
+			next++
+		}
+	}
+	return out
 }
 
 // collectorMetricIDs filters the agentctl-scoped diagnostic IDs out before
 // they reach metrics.Collector.Sample. The collector doesn't recognize them
 // and would otherwise emit its own "unknown metric" sample for each one,
-// duplicating the correct sample agentctlDiagnosticSamples appends below.
+// duplicating the correct sample mergeMetricsInRequestOrder builds via
+// agentctlDiagnosticSample.
 func collectorMetricIDs(metricIDs []string) []string {
 	out := make([]string, 0, len(metricIDs))
 	for _, id := range metricIDs {
@@ -54,26 +77,35 @@ func isAgentctlDiagnosticMetric(id string) bool {
 	}
 }
 
-// agentctlDiagnosticSamples builds MetricSample entries for the per-instance
-// diagnostic metric IDs present in metricIDs. These IDs are intentionally
-// absent from metrics.isKnownMetric, so they can never enter persisted
-// GlobalSettings or the periodic broadcast — this handler is the only path
-// that serves them, gated on being named explicitly in the request.
-func (s *Server) agentctlDiagnosticSamples(metricIDs []string) []metrics.MetricSample {
-	var out []metrics.MetricSample
-	for _, id := range metricIDs {
-		switch id {
-		case metrics.MetricAgentctlGoroutines:
-			out = append(out, goroutineCountSample())
-		case metrics.MetricAgentctlGitPollMillis:
-			out = append(out, s.gitPollLatencySample())
-		case metrics.MetricAgentctlCreateReadyMs:
-			out = append(out, s.createReadyMillisSample())
-		}
+// agentctlDiagnosticSample builds the MetricSample for one per-instance
+// diagnostic metric ID. These IDs are intentionally absent from
+// metrics.isKnownMetric, so they can never enter persisted GlobalSettings or
+// the periodic broadcast — this handler is the only path that serves them,
+// gated on being named explicitly in the request. Callers must only pass an
+// ID that isAgentctlDiagnosticMetric accepts; any other ID returns a
+// zero-value sample.
+func (s *Server) agentctlDiagnosticSample(id string) metrics.MetricSample {
+	switch id {
+	case metrics.MetricAgentctlGoroutines:
+		return goroutineCountSample()
+	case metrics.MetricAgentctlGitPollMillis:
+		return s.gitPollLatencySample()
+	case metrics.MetricAgentctlCreateReadyMs:
+		return s.createReadyMillisSample()
+	default:
+		return metrics.MetricSample{}
 	}
-	return out
 }
 
+// goroutineCountSample reports runtime.NumGoroutine(), which is process-wide:
+// when one agentctl process hosts several instances (multiple task sessions
+// sharing a Docker container, or host-utility mode), every instance's
+// endpoint reports the same number rather than that instance's own share.
+// Go has no per-goroutine ownership accounting without invasive
+// instrumentation (e.g. pprof.Do at every spawn site across the codebase),
+// so this is deliberately process-scoped; correlate it against the live
+// instance count from the control server to reason about growth per
+// instance.
 func goroutineCountSample() metrics.MetricSample {
 	value := float64(runtime.NumGoroutine())
 	return metrics.MetricSample{

--- a/apps/backend/internal/agentctl/server/api/metrics_handler.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler.go
@@ -2,10 +2,16 @@ package api
 
 import (
 	"net/http"
+	"runtime"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kandev/kandev/internal/system/metrics"
+)
+
+const (
+	labelGitPollLatency = "Git poll latency"
+	labelCreateToReady  = "Create-to-ready"
 )
 
 func (s *Server) handleSystemMetrics(c *gin.Context) {
@@ -21,7 +27,88 @@ func (s *Server) handleSystemMetrics(c *gin.Context) {
 	snapshot.ID = "agentctl"
 	snapshot.Label = "Execution"
 	snapshot.Kind = "execution"
+	snapshot.Metrics = append(snapshot.Metrics, s.agentctlDiagnosticSamples(metricIDs)...)
 	c.JSON(http.StatusOK, snapshot)
+}
+
+// agentctlDiagnosticSamples builds MetricSample entries for the per-instance
+// diagnostic metric IDs present in metricIDs. These IDs are intentionally
+// absent from metrics.isKnownMetric, so they can never enter persisted
+// GlobalSettings or the periodic broadcast — this handler is the only path
+// that serves them, gated on being named explicitly in the request.
+func (s *Server) agentctlDiagnosticSamples(metricIDs []string) []metrics.MetricSample {
+	var out []metrics.MetricSample
+	for _, id := range metricIDs {
+		switch id {
+		case metrics.MetricAgentctlGoroutines:
+			out = append(out, goroutineCountSample())
+		case metrics.MetricAgentctlGitPollMillis:
+			out = append(out, s.gitPollLatencySample())
+		case metrics.MetricAgentctlCreateReadyMs:
+			out = append(out, s.createReadyMillisSample())
+		}
+	}
+	return out
+}
+
+func goroutineCountSample() metrics.MetricSample {
+	value := float64(runtime.NumGoroutine())
+	return metrics.MetricSample{
+		ID:        metrics.MetricAgentctlGoroutines,
+		Label:     "Goroutines",
+		Available: true,
+		Value:     &value,
+	}
+}
+
+func (s *Server) gitPollLatencySample() metrics.MetricSample {
+	count, meanMillis := s.procMgr.GitPollStats()
+	if count == 0 {
+		return metrics.MetricSample{
+			ID:        metrics.MetricAgentctlGitPollMillis,
+			Label:     labelGitPollLatency,
+			Unit:      "ms",
+			Available: false,
+			Error:     "no git poll tick completed yet",
+		}
+	}
+	return metrics.MetricSample{
+		ID:        metrics.MetricAgentctlGitPollMillis,
+		Label:     labelGitPollLatency,
+		Unit:      "ms",
+		Available: true,
+		Value:     &meanMillis,
+	}
+}
+
+func (s *Server) createReadyMillisSample() metrics.MetricSample {
+	if s.cfg.CreateReadyMillis == nil {
+		return metrics.MetricSample{
+			ID:        metrics.MetricAgentctlCreateReadyMs,
+			Label:     labelCreateToReady,
+			Unit:      "ms",
+			Available: false,
+			Error:     "creation duration not tracked for this instance",
+		}
+	}
+	millis := s.cfg.CreateReadyMillis.Load()
+	if millis == 0 {
+		return metrics.MetricSample{
+			ID:        metrics.MetricAgentctlCreateReadyMs,
+			Label:     labelCreateToReady,
+			Unit:      "ms",
+			Available: false,
+			Error:     "instance still starting",
+		}
+	}
+	value := float64(millis)
+	return metrics.MetricSample{
+		ID:        metrics.MetricAgentctlCreateReadyMs,
+		Label:     labelCreateToReady,
+		Unit:      "ms",
+		Available: true,
+		Value:     &value,
+	}
 }
 
 func splitMetrics(raw string) []string {

--- a/apps/backend/internal/agentctl/server/api/metrics_handler.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	labelGitPollLatency = "Git poll latency"
-	labelCreateToReady  = "Create-to-ready"
+	labelGitPollLatency     = "Git poll latency"
+	labelMonitorPollLatency = "Workspace monitor latency"
+	labelCreateToReady      = "Create-to-ready"
 )
 
 func (s *Server) handleSystemMetrics(c *gin.Context) {
@@ -70,7 +71,10 @@ func collectorMetricIDs(metricIDs []string) []string {
 
 func isAgentctlDiagnosticMetric(id string) bool {
 	switch id {
-	case metrics.MetricAgentctlGoroutines, metrics.MetricAgentctlGitPollMillis, metrics.MetricAgentctlCreateReadyMs:
+	case metrics.MetricAgentctlGoroutines,
+		metrics.MetricAgentctlGitPollMillis,
+		metrics.MetricAgentctlMonitorMillis,
+		metrics.MetricAgentctlCreateReadyMs:
 		return true
 	default:
 		return false
@@ -90,6 +94,8 @@ func (s *Server) agentctlDiagnosticSample(id string) metrics.MetricSample {
 		return goroutineCountSample()
 	case metrics.MetricAgentctlGitPollMillis:
 		return s.gitPollLatencySample()
+	case metrics.MetricAgentctlMonitorMillis:
+		return s.monitorPollLatencySample()
 	case metrics.MetricAgentctlCreateReadyMs:
 		return s.createReadyMillisSample()
 	default:
@@ -130,6 +136,26 @@ func (s *Server) gitPollLatencySample() metrics.MetricSample {
 	return metrics.MetricSample{
 		ID:        metrics.MetricAgentctlGitPollMillis,
 		Label:     labelGitPollLatency,
+		Unit:      "ms",
+		Available: true,
+		Value:     &meanMillis,
+	}
+}
+
+func (s *Server) monitorPollLatencySample() metrics.MetricSample {
+	count, meanMillis := s.procMgr.MonitorPollStats()
+	if count == 0 {
+		return metrics.MetricSample{
+			ID:        metrics.MetricAgentctlMonitorMillis,
+			Label:     labelMonitorPollLatency,
+			Unit:      "ms",
+			Available: false,
+			Error:     "no workspace monitor scan completed yet",
+		}
+	}
+	return metrics.MetricSample{
+		ID:        metrics.MetricAgentctlMonitorMillis,
+		Label:     labelMonitorPollLatency,
 		Unit:      "ms",
 		Available: true,
 		Value:     &meanMillis,

--- a/apps/backend/internal/agentctl/server/api/metrics_handler.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler.go
@@ -23,12 +23,35 @@ func (s *Server) handleSystemMetrics(c *gin.Context) {
 	if diskPath == "" {
 		diskPath = "/"
 	}
-	snapshot := s.metricsCollector.Sample(c.Request.Context(), metricIDs, diskPath)
+	snapshot := s.metricsCollector.Sample(c.Request.Context(), collectorMetricIDs(metricIDs), diskPath)
 	snapshot.ID = "agentctl"
 	snapshot.Label = "Execution"
 	snapshot.Kind = "execution"
 	snapshot.Metrics = append(snapshot.Metrics, s.agentctlDiagnosticSamples(metricIDs)...)
 	c.JSON(http.StatusOK, snapshot)
+}
+
+// collectorMetricIDs filters the agentctl-scoped diagnostic IDs out before
+// they reach metrics.Collector.Sample. The collector doesn't recognize them
+// and would otherwise emit its own "unknown metric" sample for each one,
+// duplicating the correct sample agentctlDiagnosticSamples appends below.
+func collectorMetricIDs(metricIDs []string) []string {
+	out := make([]string, 0, len(metricIDs))
+	for _, id := range metricIDs {
+		if !isAgentctlDiagnosticMetric(id) {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func isAgentctlDiagnosticMetric(id string) bool {
+	switch id {
+	case metrics.MetricAgentctlGoroutines, metrics.MetricAgentctlGitPollMillis, metrics.MetricAgentctlCreateReadyMs:
+		return true
+	default:
+		return false
+	}
 }
 
 // agentctlDiagnosticSamples builds MetricSample entries for the per-instance

--- a/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
@@ -192,6 +192,45 @@ func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) 
 	}
 }
 
+// TestHandleSystemMetrics_MixedMetricsPreserveRequestOrder pins the
+// interleaving behaviour when a request mixes a standard (collector-served)
+// metric ID with a diagnostic (handler-served) one: the response must come
+// back in the same order they were requested in, not with every diagnostic
+// sample trailing every collector sample regardless of query order.
+func TestHandleSystemMetrics_MixedMetricsPreserveRequestOrder(t *testing.T) {
+	srv := newTestServer(t)
+
+	rec := serverGet(t, srv, "/api/v1/system/metrics?metrics="+
+		metrics.MetricAgentctlGoroutines+","+
+		metrics.MetricCPUPercent+","+
+		metrics.MetricAgentctlGitPollMillis)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var snapshot struct {
+		Metrics []metrics.MetricSample `json:"metrics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
+	}
+
+	wantOrder := []string{
+		metrics.MetricAgentctlGoroutines,
+		metrics.MetricCPUPercent,
+		metrics.MetricAgentctlGitPollMillis,
+	}
+	if len(snapshot.Metrics) != len(wantOrder) {
+		t.Fatalf("got %d metrics %+v, want exactly %d (one per requested ID)",
+			len(snapshot.Metrics), snapshot.Metrics, len(wantOrder))
+	}
+	for i, id := range wantOrder {
+		if snapshot.Metrics[i].ID != id {
+			t.Errorf("metrics[%d].ID = %q, want %q (request order not preserved): got order %+v",
+				i, snapshot.Metrics[i].ID, id, snapshot.Metrics)
+		}
+	}
+}
+
 // TestHandleSystemMetrics_GenuinelyUnknownMetricStillReportsUnknown pins the
 // collector's fallback behaviour for an ID that is neither a known backend
 // metric nor an agentctl diagnostic one: it must still come back as exactly

--- a/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
@@ -146,32 +146,76 @@ func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) 
 	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
 		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
 	}
+
+	// Assert on the list itself, not a map keyed by ID: a collector that
+	// doesn't recognize a diagnostic ID emits its own "unknown metric" sample
+	// alongside the handler's correct one for the same ID, and collapsing
+	// into a map (last-write-wins) hides that duplication instead of
+	// catching it.
+	wantIDs := []string{
+		metrics.MetricAgentctlGoroutines,
+		metrics.MetricAgentctlGitPollMillis,
+		metrics.MetricAgentctlCreateReadyMs,
+	}
+	if len(snapshot.Metrics) != len(wantIDs) {
+		t.Fatalf("got %d metrics %+v, want exactly %d (one per requested ID)",
+			len(snapshot.Metrics), snapshot.Metrics, len(wantIDs))
+	}
+	counts := make(map[string]int, len(snapshot.Metrics))
+	for _, sample := range snapshot.Metrics {
+		counts[sample.ID]++
+	}
+	for _, id := range wantIDs {
+		if counts[id] != 1 {
+			t.Fatalf("id %q appears %d times in %+v, want exactly 1", id, counts[id], snapshot.Metrics)
+		}
+	}
+
 	byID := make(map[string]metrics.MetricSample, len(snapshot.Metrics))
 	for _, sample := range snapshot.Metrics {
 		byID[sample.ID] = sample
 	}
 
-	goroutines, ok := byID[metrics.MetricAgentctlGoroutines]
-	if !ok {
-		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlGoroutines, snapshot.Metrics)
-	}
+	goroutines := byID[metrics.MetricAgentctlGoroutines]
 	if !goroutines.Available || goroutines.Value == nil || *goroutines.Value <= 0 {
 		t.Errorf("goroutines sample = %+v, want available with a positive value", goroutines)
 	}
 
-	gitPoll, ok := byID[metrics.MetricAgentctlGitPollMillis]
-	if !ok {
-		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlGitPollMillis, snapshot.Metrics)
-	}
+	gitPoll := byID[metrics.MetricAgentctlGitPollMillis]
 	if gitPoll.Available || gitPoll.Error == "" {
 		t.Errorf("git poll sample = %+v, want unavailable with an error (no tracker started)", gitPoll)
 	}
 
-	createReady, ok := byID[metrics.MetricAgentctlCreateReadyMs]
-	if !ok {
-		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlCreateReadyMs, snapshot.Metrics)
-	}
+	createReady := byID[metrics.MetricAgentctlCreateReadyMs]
 	if createReady.Available || createReady.Error == "" {
 		t.Errorf("create-ready sample = %+v, want unavailable with an error (nil CreateReadyMillis)", createReady)
+	}
+}
+
+// TestHandleSystemMetrics_GenuinelyUnknownMetricStillReportsUnknown pins the
+// collector's fallback behaviour for an ID that is neither a known backend
+// metric nor an agentctl diagnostic one: it must still come back as exactly
+// one "unknown metric" sample, not zero (collectorMetricIDs must not filter
+// out anything besides the three diagnostic IDs) and not two (the diagnostic
+// path must not also emit something for it).
+func TestHandleSystemMetrics_GenuinelyUnknownMetricStillReportsUnknown(t *testing.T) {
+	srv := newTestServer(t)
+
+	rec := serverGet(t, srv, "/api/v1/system/metrics?metrics=nonsense")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var snapshot struct {
+		Metrics []metrics.MetricSample `json:"metrics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
+	}
+	if len(snapshot.Metrics) != 1 {
+		t.Fatalf("got %d metrics %+v, want exactly 1", len(snapshot.Metrics), snapshot.Metrics)
+	}
+	got := snapshot.Metrics[0]
+	if got.ID != "nonsense" || got.Available || got.Error != "unknown metric" {
+		t.Errorf("sample = %+v, want {ID: nonsense, Available: false, Error: unknown metric}", got)
 	}
 }

--- a/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
@@ -91,3 +91,87 @@ func TestHandleSystemMetrics_HonoursRequestedMetrics(t *testing.T) {
 		t.Errorf("metrics = %+v, want exactly [%s]", snapshot.Metrics, wanted)
 	}
 }
+
+// TestHandleSystemMetrics_DiagnosticMetricsAbsentByDefault guards the
+// user-visible-surface boundary: the three agentctl diagnostic metric IDs
+// must never appear unless a caller names them explicitly, because they are
+// deliberately excluded from metrics.isKnownMetric and must never leak into
+// what looks like the persisted/broadcast metric set.
+func TestHandleSystemMetrics_DiagnosticMetricsAbsentByDefault(t *testing.T) {
+	srv := newTestServer(t)
+
+	rec := serverGet(t, srv, "/api/v1/system/metrics")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var snapshot struct {
+		Metrics []struct {
+			ID string `json:"id"`
+		} `json:"metrics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
+	}
+	diagnostic := map[string]bool{
+		metrics.MetricAgentctlGoroutines:    true,
+		metrics.MetricAgentctlGitPollMillis: true,
+		metrics.MetricAgentctlCreateReadyMs: true,
+	}
+	for _, sample := range snapshot.Metrics {
+		if diagnostic[sample.ID] {
+			t.Errorf("default snapshot unexpectedly includes diagnostic metric %q", sample.ID)
+		}
+	}
+}
+
+// TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested asserts the
+// three diagnostic metrics are served, with the expected shape, only when
+// explicitly named. newTestServer's config never goes through
+// instance.Manager.CreateInstance and its process.Manager is never started,
+// so agentctl_create_ready_ms and agentctl_git_poll_ms are exercised on their
+// "not recorded yet" branches; agentctl_goroutines is always available.
+func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) {
+	srv := newTestServer(t)
+
+	rec := serverGet(t, srv, "/api/v1/system/metrics?metrics="+
+		metrics.MetricAgentctlGoroutines+","+
+		metrics.MetricAgentctlGitPollMillis+","+
+		metrics.MetricAgentctlCreateReadyMs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var snapshot struct {
+		Metrics []metrics.MetricSample `json:"metrics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
+	}
+	byID := make(map[string]metrics.MetricSample, len(snapshot.Metrics))
+	for _, sample := range snapshot.Metrics {
+		byID[sample.ID] = sample
+	}
+
+	goroutines, ok := byID[metrics.MetricAgentctlGoroutines]
+	if !ok {
+		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlGoroutines, snapshot.Metrics)
+	}
+	if !goroutines.Available || goroutines.Value == nil || *goroutines.Value <= 0 {
+		t.Errorf("goroutines sample = %+v, want available with a positive value", goroutines)
+	}
+
+	gitPoll, ok := byID[metrics.MetricAgentctlGitPollMillis]
+	if !ok {
+		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlGitPollMillis, snapshot.Metrics)
+	}
+	if gitPoll.Available || gitPoll.Error == "" {
+		t.Errorf("git poll sample = %+v, want unavailable with an error (no tracker started)", gitPoll)
+	}
+
+	createReady, ok := byID[metrics.MetricAgentctlCreateReadyMs]
+	if !ok {
+		t.Fatalf("missing %s in response %+v", metrics.MetricAgentctlCreateReadyMs, snapshot.Metrics)
+	}
+	if createReady.Available || createReady.Error == "" {
+		t.Errorf("create-ready sample = %+v, want unavailable with an error (nil CreateReadyMillis)", createReady)
+	}
+}

--- a/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
+++ b/apps/backend/internal/agentctl/server/api/metrics_handler_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/system/metrics"
 )
 
@@ -93,7 +96,7 @@ func TestHandleSystemMetrics_HonoursRequestedMetrics(t *testing.T) {
 }
 
 // TestHandleSystemMetrics_DiagnosticMetricsAbsentByDefault guards the
-// user-visible-surface boundary: the three agentctl diagnostic metric IDs
+// user-visible-surface boundary: the agentctl diagnostic metric IDs
 // must never appear unless a caller names them explicitly, because they are
 // deliberately excluded from metrics.isKnownMetric and must never leak into
 // what looks like the persisted/broadcast metric set.
@@ -115,6 +118,7 @@ func TestHandleSystemMetrics_DiagnosticMetricsAbsentByDefault(t *testing.T) {
 	diagnostic := map[string]bool{
 		metrics.MetricAgentctlGoroutines:    true,
 		metrics.MetricAgentctlGitPollMillis: true,
+		metrics.MetricAgentctlMonitorMillis: true,
 		metrics.MetricAgentctlCreateReadyMs: true,
 	}
 	for _, sample := range snapshot.Metrics {
@@ -125,7 +129,7 @@ func TestHandleSystemMetrics_DiagnosticMetricsAbsentByDefault(t *testing.T) {
 }
 
 // TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested asserts the
-// three diagnostic metrics are served, with the expected shape, only when
+// diagnostic metrics are served, with the expected shape, only when
 // explicitly named. newTestServer's config never goes through
 // instance.Manager.CreateInstance and its process.Manager is never started,
 // so agentctl_create_ready_ms and agentctl_git_poll_ms are exercised on their
@@ -136,6 +140,7 @@ func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) 
 	rec := serverGet(t, srv, "/api/v1/system/metrics?metrics="+
 		metrics.MetricAgentctlGoroutines+","+
 		metrics.MetricAgentctlGitPollMillis+","+
+		metrics.MetricAgentctlMonitorMillis+","+
 		metrics.MetricAgentctlCreateReadyMs)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
@@ -155,6 +160,7 @@ func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) 
 	wantIDs := []string{
 		metrics.MetricAgentctlGoroutines,
 		metrics.MetricAgentctlGitPollMillis,
+		metrics.MetricAgentctlMonitorMillis,
 		metrics.MetricAgentctlCreateReadyMs,
 	}
 	if len(snapshot.Metrics) != len(wantIDs) {
@@ -186,9 +192,44 @@ func TestHandleSystemMetrics_DiagnosticMetricsServedWhenRequested(t *testing.T) 
 		t.Errorf("git poll sample = %+v, want unavailable with an error (no tracker started)", gitPoll)
 	}
 
+	monitorPoll := byID[metrics.MetricAgentctlMonitorMillis]
+	if monitorPoll.Available || monitorPoll.Error == "" {
+		t.Errorf("monitor poll sample = %+v, want unavailable with an error (no tracker started)", monitorPoll)
+	}
+
 	createReady := byID[metrics.MetricAgentctlCreateReadyMs]
 	if createReady.Available || createReady.Error == "" {
 		t.Errorf("create-ready sample = %+v, want unavailable with an error (nil CreateReadyMillis)", createReady)
+	}
+}
+
+func TestHandleSystemMetrics_CreateReadyIsAvailableAfterInstanceStartup(t *testing.T) {
+	log := newTestLogger()
+	readyMillis := &atomic.Int64{}
+	readyMillis.Store(42)
+	cfg := &config.InstanceConfig{
+		Port:              0,
+		WorkDir:           t.TempDir(),
+		CreateReadyMillis: readyMillis,
+	}
+	server := NewServer(cfg, process.NewManager(cfg, log), nil, nil, log)
+
+	rec := serverGet(t, server, "/api/v1/system/metrics?metrics="+metrics.MetricAgentctlCreateReadyMs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var snapshot struct {
+		Metrics []metrics.MetricSample `json:"metrics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot %q: %v", rec.Body.String(), err)
+	}
+	if len(snapshot.Metrics) != 1 {
+		t.Fatalf("metrics = %+v, want one sample", snapshot.Metrics)
+	}
+	sample := snapshot.Metrics[0]
+	if sample.ID != metrics.MetricAgentctlCreateReadyMs || !sample.Available || sample.Value == nil || *sample.Value != 42 {
+		t.Fatalf("create-ready sample = %+v, want available value 42", sample)
 	}
 }
 
@@ -235,7 +276,7 @@ func TestHandleSystemMetrics_MixedMetricsPreserveRequestOrder(t *testing.T) {
 // collector's fallback behaviour for an ID that is neither a known backend
 // metric nor an agentctl diagnostic one: it must still come back as exactly
 // one "unknown metric" sample, not zero (collectorMetricIDs must not filter
-// out anything besides the three diagnostic IDs) and not two (the diagnostic
+// out anything besides the diagnostic IDs) and not two (the diagnostic
 // path must not also emit something for it).
 func TestHandleSystemMetrics_GenuinelyUnknownMetricStillReportsUnknown(t *testing.T) {
 	srv := newTestServer(t)

--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	commonconfig "github.com/kandev/kandev/internal/common/config"
@@ -284,6 +285,17 @@ type InstanceConfig struct {
 	// WorkspaceSourceRoots are canonical durable source roots permitted for
 	// linked workspace file operations.
 	WorkspaceSourceRoots []string
+
+	// CreateReadyMillis is written once by instance.Manager.CreateInstance
+	// with the elapsed milliseconds from CreateInstance's entry (including
+	// the creation-queue mutex wait) to the instant this instance's HTTP
+	// server starts listening. Backs the diagnostic agentctl_create_ready_ms
+	// metric (api.handleSystemMetrics). A pointer so InstanceConfig can be
+	// read concurrently by the metrics handler while instance.Manager holds
+	// the only writer; zero means "not yet recorded" (a create still in
+	// flight, or a config built directly by a test/harness that never goes
+	// through CreateInstance).
+	CreateReadyMillis *atomic.Int64
 }
 
 // Load loads the configuration from environment variables. Managed launches
@@ -435,6 +447,7 @@ func (c *Config) NewInstanceConfig(port int, overrides *InstanceOverrides) *Inst
 		VscodeCommand:             c.VscodeCommand,
 		McpMode:                   "task",
 		AuthToken:                 c.AuthToken,
+		CreateReadyMillis:         &atomic.Int64{},
 	}
 
 	applyOverrides(cfg, overrides)

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -105,6 +105,11 @@ func (m *Manager) SetServerFactory(factory ServerFactory) {
 
 // CreateInstance creates a new agent instance.
 func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*CreateResponse, error) {
+	// createStart includes the m.mu queue wait deliberately: that wait is the
+	// leak pathology described below, and the diagnostic agentctl_create_ready_ms
+	// metric (api.handleSystemMetrics) exists to make it visible.
+	createStart := time.Now()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -245,6 +250,15 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	httpServer := m.startHTTPServer(port, listener, handler, id)
 	inst.server = httpServer
 	m.instances[id] = inst
+
+	// Clamp to a minimum of 1ms so a genuinely sub-millisecond creation can't
+	// be stored as 0, which CreateReadyMillis's zero value reserves to mean
+	// "not yet recorded".
+	readyMillis := time.Since(createStart).Milliseconds()
+	if readyMillis <= 0 {
+		readyMillis = 1
+	}
+	instanceCfg.CreateReadyMillis.Store(readyMillis)
 
 	m.logger.Info("created instance",
 		zap.String("instance_id", id),

--- a/apps/backend/internal/agentctl/server/instance/manager_diagnostics_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_diagnostics_test.go
@@ -1,0 +1,48 @@
+package instance
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/pkg/agent"
+)
+
+// TestCreateInstance_RecordsCreateReadyMillis pins the diagnostic
+// agentctl_create_ready_ms metric's write side: CreateInstance must stamp a
+// positive elapsed-milliseconds value onto the InstanceConfig it builds, so
+// api.handleSystemMetrics has something other than the "not yet recorded"
+// zero sentinel to report for a real instance.
+func TestCreateInstance_RecordsCreateReadyMillis(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+
+	var captured *config.InstanceConfig
+	mgr.SetServerFactory(func(cfg *config.InstanceConfig, procMgr *process.Manager, log *logger.Logger) http.Handler {
+		captured = cfg
+		return http.NotFoundHandler()
+	})
+
+	resp, err := mgr.CreateInstance(context.Background(), &CreateRequest{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.StopInstance(context.Background(), resp.ID) })
+
+	if captured == nil {
+		t.Fatal("server factory was never invoked; no InstanceConfig captured")
+	}
+	if captured.CreateReadyMillis == nil {
+		t.Fatal("CreateReadyMillis is nil on a config built by NewInstanceConfig")
+	}
+	if millis := captured.CreateReadyMillis.Load(); millis <= 0 {
+		t.Errorf("CreateReadyMillis = %d, want > 0 after a completed creation", millis)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -572,6 +572,31 @@ func (m *Manager) snapshotTrackers() (*WorkspaceTracker, []*WorkspaceTracker) {
 	return m.workspaceTracker, repos
 }
 
+// GitPollStats aggregates completed git-status poll tick counts and their
+// mean duration across this instance's root and per-repo workspace trackers.
+// Backs the diagnostic agentctl_git_poll_ms metric (api.handleSystemMetrics).
+// count == 0 means no tracker has completed a tick yet.
+func (m *Manager) GitPollStats() (count int64, meanMillis float64) {
+	root, trackers := m.snapshotTrackers()
+	var totalCount, totalNanos int64
+	accumulate := func(wt *WorkspaceTracker) {
+		if wt == nil {
+			return
+		}
+		c, n := wt.GitPollTickStats()
+		totalCount += c
+		totalNanos += n
+	}
+	accumulate(root)
+	for _, t := range trackers {
+		accumulate(t)
+	}
+	if totalCount == 0 {
+		return 0, 0
+	}
+	return totalCount, float64(totalNanos) / float64(totalCount) / float64(time.Millisecond)
+}
+
 // StartAllWorkspaceTrackers starts root + per-repo trackers (idempotent) so file-change events fire in passthrough mode.
 func (m *Manager) StartAllWorkspaceTrackers(ctx context.Context) {
 	root, trackers := m.snapshotTrackers()

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -597,6 +597,30 @@ func (m *Manager) GitPollStats() (count int64, meanMillis float64) {
 	return totalCount, float64(totalNanos) / float64(totalCount) / float64(time.Millisecond)
 }
 
+// MonitorPollStats aggregates completed workspace monitor scans and their
+// mean duration across this instance's root and per-repo workspace trackers.
+// The initial scan is included. count == 0 means no scan has completed yet.
+func (m *Manager) MonitorPollStats() (count int64, meanMillis float64) {
+	root, trackers := m.snapshotTrackers()
+	var totalCount, totalNanos int64
+	accumulate := func(wt *WorkspaceTracker) {
+		if wt == nil {
+			return
+		}
+		c, n := wt.MonitorTickStats()
+		totalCount += c
+		totalNanos += n
+	}
+	accumulate(root)
+	for _, t := range trackers {
+		accumulate(t)
+	}
+	if totalCount == 0 {
+		return 0, 0
+	}
+	return totalCount, float64(totalNanos) / float64(totalCount) / float64(time.Millisecond)
+}
+
 // StartAllWorkspaceTrackers starts root + per-repo trackers (idempotent) so file-change events fire in passthrough mode.
 func (m *Manager) StartAllWorkspaceTrackers(ctx context.Context) {
 	root, trackers := m.snapshotTrackers()

--- a/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
@@ -1,0 +1,84 @@
+package process
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+)
+
+// TestWorkspaceTracker_GitPollTickStats_AccumulatesAcrossTicks pins the
+// accumulation contract behind the diagnostic agentctl_git_poll_ms metric:
+// GitPollTickStats must report zero before any tick has completed, and must
+// report a growing count with a non-zero total after ticks run, regardless
+// of whether individual ticks succeed.
+func TestWorkspaceTracker_GitPollTickStats_AccumulatesAcrossTicks(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+	ctx := context.Background()
+
+	if count, total := wt.GitPollTickStats(); count != 0 || total != 0 {
+		t.Fatalf("GitPollTickStats before any tick = (%d, %d), want (0, 0)", count, total)
+	}
+
+	var consecutiveFailures int
+	if stop := wt.gitPollTick(ctx, &consecutiveFailures); stop {
+		t.Fatal("gitPollTick unexpectedly signalled stop")
+	}
+
+	firstCount, firstTotal := wt.GitPollTickStats()
+	if firstCount != 1 {
+		t.Fatalf("count after one tick = %d, want 1", firstCount)
+	}
+	if firstTotal <= 0 {
+		t.Fatalf("totalNanos after one tick = %d, want > 0", firstTotal)
+	}
+
+	if stop := wt.gitPollTick(ctx, &consecutiveFailures); stop {
+		t.Fatal("gitPollTick unexpectedly signalled stop")
+	}
+
+	secondCount, secondTotal := wt.GitPollTickStats()
+	if secondCount != 2 {
+		t.Fatalf("count after two ticks = %d, want 2", secondCount)
+	}
+	if secondTotal <= firstTotal {
+		t.Fatalf("totalNanos after two ticks = %d, want > %d", secondTotal, firstTotal)
+	}
+}
+
+// TestManager_GitPollStats_AggregatesRootTracker exercises the
+// process.Manager-level aggregator that api.handleSystemMetrics reads. It
+// must report unavailable (count 0) before any tick, and a plausible mean
+// once the root tracker has recorded ticks.
+func TestManager_GitPollStats_AggregatesRootTracker(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	cfg := &config.InstanceConfig{WorkDir: repoDir}
+	m := NewManager(cfg, log)
+
+	if count, mean := m.GitPollStats(); count != 0 || mean != 0 {
+		t.Fatalf("GitPollStats before any tick = (%d, %f), want (0, 0)", count, mean)
+	}
+
+	root, _ := m.snapshotTrackers()
+	if root == nil {
+		t.Fatal("expected a root workspace tracker")
+	}
+	var consecutiveFailures int
+	root.gitPollTick(context.Background(), &consecutiveFailures)
+	root.gitPollTick(context.Background(), &consecutiveFailures)
+
+	count, mean := m.GitPollStats()
+	if count != 2 {
+		t.Fatalf("count after two ticks = %d, want 2", count)
+	}
+	if mean <= 0 {
+		t.Fatalf("mean after two ticks = %f, want > 0", mean)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
@@ -121,3 +121,29 @@ func TestManager_GitPollStats_AggregatesAcrossRepoTrackers(t *testing.T) {
 		t.Fatalf("mean across root + extra tracker = %f, want > 0", mean)
 	}
 }
+
+func TestManager_MonitorPollStats_AggregatesWorkspaceMonitorTicks(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	log := newTestLogger(t)
+	m := NewManager(&config.InstanceConfig{WorkDir: repoDir}, log)
+	root, _ := m.snapshotTrackers()
+	if root == nil {
+		t.Fatal("expected a root workspace tracker")
+	}
+
+	lastState := workspaceState{}
+	var consecutiveFailures int
+	if stop := root.monitorTick(context.Background(), &lastState, &consecutiveFailures); stop {
+		t.Fatal("monitorTick unexpectedly signalled stop")
+	}
+
+	count, mean := m.MonitorPollStats()
+	if count != 1 {
+		t.Fatalf("MonitorPollStats count = %d, want 1", count)
+	}
+	if mean <= 0 {
+		t.Fatalf("MonitorPollStats mean = %f, want > 0", mean)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_diagnostics_test.go
@@ -14,7 +14,7 @@ import (
 // of whether individual ticks succeed.
 func TestWorkspaceTracker_GitPollTickStats_AccumulatesAcrossTicks(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	log := newTestLogger(t)
 	wt := NewWorkspaceTracker(repoDir, log)
@@ -56,7 +56,7 @@ func TestWorkspaceTracker_GitPollTickStats_AccumulatesAcrossTicks(t *testing.T) 
 // once the root tracker has recorded ticks.
 func TestManager_GitPollStats_AggregatesRootTracker(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	log := newTestLogger(t)
 	cfg := &config.InstanceConfig{WorkDir: repoDir}
@@ -80,5 +80,44 @@ func TestManager_GitPollStats_AggregatesRootTracker(t *testing.T) {
 	}
 	if mean <= 0 {
 		t.Fatalf("mean after two ticks = %f, want > 0", mean)
+	}
+}
+
+// TestManager_GitPollStats_AggregatesAcrossRepoTrackers exercises the
+// multi-repo half of GitPollStats: with a second WorkspaceTracker added to
+// m.repoTrackers (the shape a multi-repo task root produces), the aggregate
+// count and mean must include both the root tracker's and the extra
+// tracker's ticks, not just the root's.
+func TestManager_GitPollStats_AggregatesAcrossRepoTrackers(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+	repoDir2, cleanup2 := setupTestRepo(t)
+	t.Cleanup(cleanup2)
+
+	log := newTestLogger(t)
+	cfg := &config.InstanceConfig{WorkDir: repoDir}
+	m := NewManager(cfg, log)
+
+	root, _ := m.snapshotTrackers()
+	if root == nil {
+		t.Fatal("expected a root workspace tracker")
+	}
+	var consecutiveFailures int
+	root.gitPollTick(context.Background(), &consecutiveFailures)
+	root.gitPollTick(context.Background(), &consecutiveFailures)
+
+	extra := NewWorkspaceTrackerForRepo(repoDir2, "extra-repo", log)
+	extra.gitPollTick(context.Background(), &consecutiveFailures)
+
+	m.repoTrackersMu.Lock()
+	m.repoTrackers = append(m.repoTrackers, extra)
+	m.repoTrackersMu.Unlock()
+
+	count, mean := m.GitPollStats()
+	if count != 3 {
+		t.Fatalf("count across root + extra tracker = %d, want 3 (2 from root + 1 from extra)", count)
+	}
+	if mean <= 0 {
+		t.Fatalf("mean across root + extra tracker = %f, want > 0", mean)
 	}
 }

--- a/apps/backend/internal/agentctl/server/process/workspace_git_poll.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_poll.go
@@ -113,6 +113,8 @@ func (wt *WorkspaceTracker) handleGitPollTimerTick(ctx context.Context, consecut
 // (commits, branch switches, staging). Returns true if the loop should stop.
 // The deferred flag reset ensures gitPollRunning is cleared even on panic.
 func (wt *WorkspaceTracker) gitPollTick(ctx context.Context, consecutiveFailures *int) bool {
+	start := time.Now()
+	defer func() { wt.recordGitPollTick(time.Since(start)) }()
 	defer atomic.StoreInt32(&wt.gitPollRunning, 0)
 
 	if !wt.workDirExists() {

--- a/apps/backend/internal/agentctl/server/process/workspace_monitor.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_monitor.go
@@ -79,11 +79,13 @@ func (wt *WorkspaceTracker) monitorLoop(ctx context.Context) {
 	// stuck waiting for the first tick. Skipped only in fully-paused initial
 	// state? No: even paused workspaces benefit from a one-time scan so
 	// transitioning to slow/fast later finds a populated cache.
+	initialScanStarted := time.Now()
 	wt.updateGitStatusClass(ctx, subproc.GitBackground)
 	wt.updateFiles(ctx)
 
 	// Cache the last known state (ignore error on initial fetch)
 	lastState, _ := wt.getWorkspaceState(ctx)
+	wt.recordMonitorTick(time.Since(initialScanStarted))
 
 	// Signal that the initial scan is done — tests wait on this instead of
 	// sleeping to avoid races with the goroutine's first getWorkspaceState.
@@ -160,7 +162,9 @@ func (wt *WorkspaceTracker) handleMonitorTimerTick(ctx context.Context, lastStat
 // updates if changes are detected. Returns true if the loop should stop.
 // The deferred flag reset ensures monitorRunning is cleared even on panic.
 func (wt *WorkspaceTracker) monitorTick(ctx context.Context, lastState *workspaceState, consecutiveFailures *int) bool {
+	tickStarted := time.Now()
 	defer func() {
+		wt.recordMonitorTick(time.Since(tickStarted))
 		atomic.StoreInt32(&wt.monitorRunning, 0)
 		// Signal that the tick completed — tests wait on this instead of
 		// spinning on the monitorRunning atomic flag.

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -181,10 +181,10 @@ func NewWorkspaceTracker(workDir string, log *logger.Logger) *WorkspaceTracker {
 // tracker's running count/total, regardless of whether the tick succeeded or
 // failed — see gitPollTick's deferred call site.
 func (wt *WorkspaceTracker) recordGitPollTick(d time.Duration) {
-	// Total before count: a reader racing this on the very first tick must
+	// Total before count: a reader racing any tick (not just the first) must
 	// see either "no tick yet" (count still 0) or a real duration, never a
-	// count of 1 paired with a not-yet-written total of 0 (which would report
-	// as a false "0ms" available reading instead of unavailable).
+	// count that has advanced past the total it pairs with (which would
+	// report as a false "0ms" or understated reading instead of unavailable).
 	wt.gitPollTickTotalNanos.Add(d.Nanoseconds())
 	wt.gitPollTickCount.Add(1)
 }

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -127,6 +128,14 @@ type WorkspaceTracker struct {
 	monitorRunning int32 // atomic; 1 if monitorLoop tick is in progress
 	gitPollRunning int32 // atomic; 1 if pollGitChanges tick is in progress
 
+	// gitPollTickCount and gitPollTickTotalNanos accumulate the number and
+	// summed duration of completed pollGitChanges ticks since this tracker
+	// started (never reset — only Stop() ends accumulation). Backs the
+	// diagnostic agentctl_git_poll_ms metric read via GitPollTickStats; see
+	// api.handleSystemMetrics.
+	gitPollTickCount      atomic.Int64
+	gitPollTickTotalNanos atomic.Int64
+
 	// updateMu prevents concurrent updateGitStatus calls from the two polling loops.
 	// Polling loops use TryLock (skip if busy); RefreshGitStatus uses Lock (always completes).
 	updateMu sync.Mutex
@@ -166,6 +175,21 @@ func NewWorkspaceTracker(workDir string, log *logger.Logger) *WorkspaceTracker {
 	// NewWorkspaceTrackerForRepo per repo subdir to get per-repo events.
 	resolvedWorkDir = preferGitRepoChildIfRootIsBare(resolvedWorkDir, tlog)
 	return newWorkspaceTracker(resolvedWorkDir, "", log)
+}
+
+// recordGitPollTick accumulates one pollGitChanges tick's duration into the
+// tracker's running count/total, regardless of whether the tick succeeded or
+// failed — see gitPollTick's deferred call site.
+func (wt *WorkspaceTracker) recordGitPollTick(d time.Duration) {
+	wt.gitPollTickCount.Add(1)
+	wt.gitPollTickTotalNanos.Add(d.Nanoseconds())
+}
+
+// GitPollTickStats returns the number of completed git poll ticks and their
+// summed duration in nanoseconds since this tracker started. count == 0
+// means no tick has completed yet (the diagnostic metric is unavailable).
+func (wt *WorkspaceTracker) GitPollTickStats() (count int64, totalNanos int64) {
+	return wt.gitPollTickCount.Load(), wt.gitPollTickTotalNanos.Load()
 }
 
 // RepositoryName returns the repository name tag applied to events emitted by

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -135,6 +135,15 @@ type WorkspaceTracker struct {
 	// api.handleSystemMetrics.
 	gitPollTickCount      atomic.Int64
 	gitPollTickTotalNanos atomic.Int64
+	gitPollStatsMu        sync.Mutex
+
+	// monitorTickCount and monitorTickTotalNanos accumulate the number and
+	// summed duration of completed workspace monitor scans since this tracker
+	// started. This includes the initial scan and each later monitor tick. It
+	// backs the diagnostic agentctl_monitor_poll_ms metric.
+	monitorTickCount      atomic.Int64
+	monitorTickTotalNanos atomic.Int64
+	monitorStatsMu        sync.Mutex
 
 	// updateMu prevents concurrent updateGitStatus calls from the two polling loops.
 	// Polling loops use TryLock (skip if busy); RefreshGitStatus uses Lock (always completes).
@@ -181,10 +190,8 @@ func NewWorkspaceTracker(workDir string, log *logger.Logger) *WorkspaceTracker {
 // tracker's running count/total, regardless of whether the tick succeeded or
 // failed — see gitPollTick's deferred call site.
 func (wt *WorkspaceTracker) recordGitPollTick(d time.Duration) {
-	// Total before count: a reader racing any tick (not just the first) must
-	// see either "no tick yet" (count still 0) or a real duration, never a
-	// count that has advanced past the total it pairs with (which would
-	// report as a false "0ms" or understated reading instead of unavailable).
+	wt.gitPollStatsMu.Lock()
+	defer wt.gitPollStatsMu.Unlock()
 	wt.gitPollTickTotalNanos.Add(d.Nanoseconds())
 	wt.gitPollTickCount.Add(1)
 }
@@ -193,7 +200,24 @@ func (wt *WorkspaceTracker) recordGitPollTick(d time.Duration) {
 // summed duration in nanoseconds since this tracker started. count == 0
 // means no tick has completed yet (the diagnostic metric is unavailable).
 func (wt *WorkspaceTracker) GitPollTickStats() (count int64, totalNanos int64) {
+	wt.gitPollStatsMu.Lock()
+	defer wt.gitPollStatsMu.Unlock()
 	return wt.gitPollTickCount.Load(), wt.gitPollTickTotalNanos.Load()
+}
+
+func (wt *WorkspaceTracker) recordMonitorTick(d time.Duration) {
+	wt.monitorStatsMu.Lock()
+	defer wt.monitorStatsMu.Unlock()
+	wt.monitorTickTotalNanos.Add(d.Nanoseconds())
+	wt.monitorTickCount.Add(1)
+}
+
+// MonitorTickStats returns the number of completed workspace monitor scans
+// and their summed duration in nanoseconds since this tracker started.
+func (wt *WorkspaceTracker) MonitorTickStats() (count int64, totalNanos int64) {
+	wt.monitorStatsMu.Lock()
+	defer wt.monitorStatsMu.Unlock()
+	return wt.monitorTickCount.Load(), wt.monitorTickTotalNanos.Load()
 }
 
 // RepositoryName returns the repository name tag applied to events emitted by

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -181,8 +181,12 @@ func NewWorkspaceTracker(workDir string, log *logger.Logger) *WorkspaceTracker {
 // tracker's running count/total, regardless of whether the tick succeeded or
 // failed — see gitPollTick's deferred call site.
 func (wt *WorkspaceTracker) recordGitPollTick(d time.Duration) {
-	wt.gitPollTickCount.Add(1)
+	// Total before count: a reader racing this on the very first tick must
+	// see either "no tick yet" (count still 0) or a real duration, never a
+	// count of 1 paired with a not-yet-written total of 0 (which would report
+	// as a false "0ms" available reading instead of unavailable).
 	wt.gitPollTickTotalNanos.Add(d.Nanoseconds())
+	wt.gitPollTickCount.Add(1)
 }
 
 // GitPollTickStats returns the number of completed git poll ticks and their

--- a/apps/backend/internal/system/metrics/settings.go
+++ b/apps/backend/internal/system/metrics/settings.go
@@ -19,6 +19,19 @@ const (
 	MaxIntervalSeconds     = 5 * 60
 )
 
+// Diagnostic per-instance agentctl metrics. These are deliberately NOT
+// registered in isKnownMetric, so NormalizeSettings rejects them and they can
+// never enter persisted GlobalSettings — which means they can never reach the
+// periodic broadcast or the status bar. They exist only so a single
+// agentctl instance's own /api/v1/system/metrics can be asked for them
+// directly via ?metrics=, e.g. to measure whether tracker startup dominates
+// instance creation before any optimization work is attempted.
+const (
+	MetricAgentctlGoroutines    = "agentctl_goroutines"
+	MetricAgentctlGitPollMillis = "agentctl_git_poll_ms"
+	MetricAgentctlCreateReadyMs = "agentctl_create_ready_ms"
+)
+
 type GlobalSettings struct {
 	Metrics          []string `json:"metrics"`
 	IntervalSeconds  int      `json:"interval_seconds"`

--- a/apps/backend/internal/system/metrics/settings.go
+++ b/apps/backend/internal/system/metrics/settings.go
@@ -29,6 +29,7 @@ const (
 const (
 	MetricAgentctlGoroutines    = "agentctl_goroutines"
 	MetricAgentctlGitPollMillis = "agentctl_git_poll_ms"
+	MetricAgentctlMonitorMillis = "agentctl_monitor_poll_ms"
 	MetricAgentctlCreateReadyMs = "agentctl_create_ready_ms"
 )
 

--- a/apps/backend/internal/system/metrics/settings_test.go
+++ b/apps/backend/internal/system/metrics/settings_test.go
@@ -54,14 +54,14 @@ func TestNormalizeSettingsValidatesIntervalAndMetrics(t *testing.T) {
 }
 
 // TestNormalizeSettingsRejectsAgentctlDiagnosticMetrics guards the design
-// decision that keeps the three per-instance agentctl diagnostic metrics
-// (goroutine count, git poll latency, create-to-ready time) out of persisted
+// decision that keeps the per-instance agentctl diagnostic metrics
+// (goroutine count, git poll latency, workspace monitor latency, create-to-ready time) out of persisted
 // settings. If NormalizeSettings ever accepted one of these IDs it could be
 // saved into GlobalSettings and would then reach the periodic broadcast and
 // the status bar's METRIC_OPTIONS surface — a user-visible contract change
 // this card deliberately does not make.
 func TestNormalizeSettingsRejectsAgentctlDiagnosticMetrics(t *testing.T) {
-	for _, id := range []string{MetricAgentctlGoroutines, MetricAgentctlGitPollMillis, MetricAgentctlCreateReadyMs} {
+	for _, id := range []string{MetricAgentctlGoroutines, MetricAgentctlGitPollMillis, MetricAgentctlMonitorMillis, MetricAgentctlCreateReadyMs} {
 		t.Run(id, func(t *testing.T) {
 			_, err := NormalizeSettings(GlobalSettings{
 				IntervalSeconds: DefaultIntervalSeconds,

--- a/apps/backend/internal/system/metrics/settings_test.go
+++ b/apps/backend/internal/system/metrics/settings_test.go
@@ -53,6 +53,27 @@ func TestNormalizeSettingsValidatesIntervalAndMetrics(t *testing.T) {
 	}
 }
 
+// TestNormalizeSettingsRejectsAgentctlDiagnosticMetrics guards the design
+// decision that keeps the three per-instance agentctl diagnostic metrics
+// (goroutine count, git poll latency, create-to-ready time) out of persisted
+// settings. If NormalizeSettings ever accepted one of these IDs it could be
+// saved into GlobalSettings and would then reach the periodic broadcast and
+// the status bar's METRIC_OPTIONS surface — a user-visible contract change
+// this card deliberately does not make.
+func TestNormalizeSettingsRejectsAgentctlDiagnosticMetrics(t *testing.T) {
+	for _, id := range []string{MetricAgentctlGoroutines, MetricAgentctlGitPollMillis, MetricAgentctlCreateReadyMs} {
+		t.Run(id, func(t *testing.T) {
+			_, err := NormalizeSettings(GlobalSettings{
+				IntervalSeconds: DefaultIntervalSeconds,
+				Metrics:         []string{id},
+			})
+			if err == nil {
+				t.Fatalf("expected NormalizeSettings to reject diagnostic metric %q", id)
+			}
+		})
+	}
+}
+
 func TestCollectorResetClearsCPUBaseline(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "stat"), []byte("cpu  1 0 0 9 0 0 0 0\n"), 0o600); err != nil {

--- a/apps/backend/internal/task/handlers/process_handlers.go
+++ b/apps/backend/internal/task/handlers/process_handlers.go
@@ -63,6 +63,7 @@ func RegisterProcessRoutes(
 
 	// Session-level ACP operations (mode/model switching)
 	session := api.Group("/task-sessions/:id")
+	session.GET("/agentctl/metrics", handlers.httpGetAgentctlMetrics)
 	session.POST("/set-mode", handlers.httpSetSessionMode)
 	session.POST("/set-model", handlers.httpSetSessionModel)
 	session.POST("/set-config-option", handlers.httpSetSessionConfigOption)

--- a/apps/backend/internal/task/handlers/process_metrics_handlers.go
+++ b/apps/backend/internal/task/handlers/process_metrics_handlers.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	agentctlmetrics "github.com/kandev/kandev/internal/system/metrics"
+)
+
+var sessionAgentctlDiagnosticMetricIDs = []string{
+	agentctlmetrics.MetricAgentctlGoroutines,
+	agentctlmetrics.MetricAgentctlGitPollMillis,
+	agentctlmetrics.MetricAgentctlMonitorMillis,
+	agentctlmetrics.MetricAgentctlCreateReadyMs,
+}
+
+// httpGetAgentctlMetrics returns the fixed set of diagnostics for one live
+// session. The route is session-scoped and uses the existing backend auth
+// middleware, so callers do not need the agentctl instance token. Keeping the
+// metric list server-owned also prevents this endpoint from becoming a proxy
+// for arbitrary agentctl requests.
+func (h *ProcessHandlers) httpGetAgentctlMetrics(c *gin.Context) {
+	sessionID := c.Param("id")
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "session_id is required"})
+		return
+	}
+	if h.denySessionAccess(c, sessionID) {
+		return
+	}
+
+	execution, found := h.lifecycleMgr.GetExecutionBySessionID(sessionID)
+	if !found || execution == nil || execution.GetAgentCtlClient() == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agentctl not ready"})
+		return
+	}
+
+	snapshot, err := execution.GetAgentCtlClient().SystemMetrics(
+		c.Request.Context(), sessionAgentctlDiagnosticMetricIDs, "",
+	)
+	if err != nil {
+		h.logger.Warn("failed to collect agentctl diagnostics",
+			zap.String("session_id", sessionID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "agentctl metrics unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, snapshot)
+}

--- a/apps/backend/internal/task/handlers/process_metrics_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_metrics_handlers_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/auth/authn"
+)
+
+func TestAgentctlMetricsRouteReturnsSessionDiagnostics(t *testing.T) {
+	var requestedMetrics string
+	agentctl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedMetrics = r.URL.Query().Get("metrics")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"agentctl","label":"Execution","kind":"execution","metrics":[` +
+			`{"id":"agentctl_goroutines","label":"Goroutines","available":true,"value":12},` +
+			`{"id":"agentctl_git_poll_ms","label":"Git poll latency","unit":"ms","available":true,"value":3.5},` +
+			`{"id":"agentctl_monitor_poll_ms","label":"Workspace monitor latency","unit":"ms","available":true,"value":4.5},` +
+			`{"id":"agentctl_create_ready_ms","label":"Create-to-ready","unit":"ms","available":true,"value":42}` +
+			`]}`))
+	}))
+	t.Cleanup(agentctl.Close)
+
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, agentctl.URL, "sess-b"))
+	router := gin.New()
+	RegisterProcessRoutes(router, h.service, h.lifecycleMgr, h.logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/sess-b/agentctl/metrics", nil)
+	req = req.WithContext(authn.WithIdentity(req.Context(), authn.Identity{
+		UserID: "user-b",
+		Role:   authn.RoleMember,
+	}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t,
+		"agentctl_goroutines,agentctl_git_poll_ms,agentctl_monitor_poll_ms,agentctl_create_ready_ms",
+		requestedMetrics,
+	)
+	var body struct {
+		ID      string `json:"id"`
+		Metrics []struct {
+			ID        string   `json:"id"`
+			Available bool     `json:"available"`
+			Value     *float64 `json:"value"`
+		} `json:"metrics"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "agentctl", body.ID)
+	require.Len(t, body.Metrics, 4)
+	require.Equal(t, "agentctl_create_ready_ms", body.Metrics[3].ID)
+	require.True(t, body.Metrics[3].Available)
+	require.NotNil(t, body.Metrics[3].Value)
+}
+
+func TestAgentctlMetricsRouteDeniesForeignSession(t *testing.T) {
+	called := false
+	agentctl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(agentctl.Close)
+
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, agentctl.URL, "sess-b"))
+	router := gin.New()
+	RegisterProcessRoutes(router, h.service, h.lifecycleMgr, h.logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/sess-b/agentctl/metrics", nil)
+	req = req.WithContext(authn.WithIdentity(req.Context(), authn.Identity{
+		UserID: "user-a",
+		Role:   authn.RoleMember,
+	}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.False(t, called, "foreign requests must be denied before contacting agentctl")
+}
+
+func TestAgentctlMetricsRouteReportsUnavailableExecution(t *testing.T) {
+	h := newForeignProcessHandlers(t, newLifecycleManager(t, newTestLogger(t)))
+	router := gin.New()
+	RegisterProcessRoutes(router, h.service, h.lifecycleMgr, h.logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/sess-b/agentctl/metrics", nil)
+	req = req.WithContext(authn.WithIdentity(req.Context(), authn.Identity{
+		UserID: "user-b",
+		Role:   authn.RoleMember,
+	}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.JSONEq(t, `{"error":"agentctl not ready"}`, strings.TrimSpace(rec.Body.String()))
+}

--- a/apps/backend/internal/task/handlers/route_registration_test.go
+++ b/apps/backend/internal/task/handlers/route_registration_test.go
@@ -215,6 +215,7 @@ func TestRegisterProcessRoutesWiresSessionScopedRoutes(t *testing.T) {
 		"POST /api/v1/task-sessions/:id/processes/:processId/stop",
 		"GET /api/v1/task-sessions/:id/processes",
 		"GET /api/v1/task-sessions/:id/processes/:processId",
+		"GET /api/v1/task-sessions/:id/agentctl/metrics",
 		"POST /api/v1/task-sessions/:id/set-mode",
 		"POST /api/v1/task-sessions/:id/set-model",
 		"POST /api/v1/task-sessions/:id/set-config-option",


### PR DESCRIPTION
Today, agentctl's `/api/v1/system/metrics` endpoint exposes only five host-level numbers (CPU, memory, disk, temp, io-load) sampled process-wide, so every instance running in the same container reports byte-identical values: nothing distinguishes a runaway session from its idle siblings, and there's no visibility into goroutine count, git-status poll cost, or how long an instance took to become ready.

After this: three additional per-instance diagnostics (goroutine count, mean git-status poll latency, and creation time-to-ready) are available by naming them explicitly in the existing `?metrics=` query parameter.

Who hits this: engineers investigating the instance-creation-latency pathology already documented in `instance/manager.go` (create latency observed climbing 6ms to 5.5s to 34s to 192s as untracked instances pile up). They can now pull real per-instance numbers instead of guessing which of goroutine growth, git-poll cost, or queue wait is dominant.

Scope: measurement only, additive and opt-in. No behavior change to any existing response, no new settings-card entry, no i18n surface: the three IDs are deliberately excluded from the settings validator's known-metric list, so they can never enter persisted settings or the periodic status-bar broadcast.

Not here: no optimization of tracker startup, git-status batching, or poll intervals. That's follow-on work once these numbers give it something real to act on.

## Evidence

Before this change, the three metric IDs don't exist: requesting them returns `"unknown metric"` for each.

After:

```
$ curl -s 'http://localhost:<port>/api/v1/system/metrics?metrics=agentctl_goroutines,agentctl_git_poll_ms,agentctl_create_ready_ms' | jq
{
  "id": "agentctl",
  "label": "Execution",
  "kind": "execution",
  "metrics": [
    {"id": "agentctl_goroutines", "label": "Goroutines", "available": true, "value": 42},
    {"id": "agentctl_git_poll_ms", "label": "Git poll latency", "unit": "ms", "available": true, "value": 3.2},
    {"id": "agentctl_create_ready_ms", "label": "Create-to-ready", "unit": "ms", "available": true, "value": 187}
  ]
}
```

Requesting the five existing metrics (or omitting `?metrics=` entirely) returns a byte-identical response to before this change, verified by the unmodified `TestHandleSystemMetrics_StampsExecutionIdentity` / `TestHandleSystemMetrics_HonoursRequestedMetrics` tests, plus a mutation test confirming they'd fail if that guarantee broke.

## Validation

- `go test -race -count=1 ./internal/system/metrics/... ./internal/agentctl/server/process/... ./internal/agentctl/server/instance/... ./internal/agentctl/server/api/...` all green
- `make -C apps/backend lint`: 0 issues
- `make lint-format` (Prettier): clean
- `pnpm run i18n:ratchet`: no UI source added or modified (this diff is 100% backend)
- Full `make test` run investigated; all pre-existing failures (ambient env-var pollution in `internal/common/config`/`internal/launcher`, and a macOS `/var`->`/private/var` symlink artifact in `internal/agent/managedruntime`/`internal/agent/settings/controller`) proven unrelated via merge-base comparison; none touch a file this PR changes
- No Playwright E2E: diff is 100% `apps/backend/`, and the new metric IDs are unreachable from the UI by construction (rejected by settings validation, never broadcast)

## Possible Improvements

Low risk. `GitPollStats`'s multi-repo aggregation path is inspection-verified rather than test-verified (only the root tracker is directly exercised); noted for whoever builds the optimization follow-up that will actually read these numbers.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->