### PR TITLE
fix: pass walkthrough reasoning variant separately

### DIFF
--- a/.github/scripts/pr-walkthrough-workflow-contract_test.py
+++ b/.github/scripts/pr-walkthrough-workflow-contract_test.py
@@ -75,10 +75,14 @@ class PRWalkthroughWorkflowContractTest(unittest.TestCase):
         self.assertIn("arbitrary Git or shell commands", self.skill)
 
     def test_generation_uses_requested_model_native_high_reasoning_variant(self) -> None:
-        model = "opencode-go/muse-spark-1.2-contributor#high"
+        model = "opencode-go/muse-spark-1.2-contributor"
+        variant = "high"
         self.assertIn(f"PR_WALKTHROUGH_MODEL: {model}", self.workflow)
+        self.assertIn(f"PR_WALKTHROUGH_VARIANT: {variant}", self.workflow)
         self.assertIn(f'model: "{model}"', self.generation)
         self.assertIn('--model "$PR_WALKTHROUGH_MODEL"', self.generation)
+        self.assertIn('--variant "$PR_WALKTHROUGH_VARIANT"', self.generation)
+        self.assertNotIn("#high", self.workflow)
         self.assertNotIn("reasoningEffort", self.generation)
 
     def test_generation_keeps_untrusted_head_out_of_secret_bearing_workspace(self) -> None:

--- a/.github/workflows/pr-walkthrough.yml
+++ b/.github/workflows/pr-walkthrough.yml
@@ -8,7 +8,8 @@ on:
     types: [opened, ready_for_review, reopened, synchronize, labeled]
 
 env:
-  PR_WALKTHROUGH_MODEL: opencode-go/muse-spark-1.2-contributor#high
+  PR_WALKTHROUGH_MODEL: opencode-go/muse-spark-1.2-contributor
+  PR_WALKTHROUGH_VARIANT: high
 
 concurrency:
   group: pr-walkthrough-${{ github.event.pull_request.number }}
@@ -135,7 +136,7 @@ jobs:
           ---
           description: Generate and render a visual pull request walkthrough.
           mode: primary
-          model: "opencode-go/muse-spark-1.2-contributor#high"
+          model: "opencode-go/muse-spark-1.2-contributor"
           temperature: 0.1
           permission:
             "*": deny
@@ -183,6 +184,7 @@ jobs:
           "$HOME/.opencode/bin/opencode" run \
             --agent github-pr-walkthrough \
             --model "$PR_WALKTHROUGH_MODEL" \
+            --variant "$PR_WALKTHROUGH_VARIANT" \
             --title "PR #${PR_NUMBER} walkthrough" \
             --file .pr-walkthrough/guidelines.md \
             --file .pr-walkthrough/walkthrough.patch \

--- a/docs/plans/pr-walkthrough/plan.md
+++ b/docs/plans/pr-walkthrough/plan.md
@@ -56,14 +56,13 @@ Add `.github/workflows/pr-walkthrough.yml` as a dedicated workflow using the
 `pull_request_target` event family. Gate it with the independent
 `PR_WALKTHROUGH_ENABLED` variable, not `OPENCODE_REVIEW_ENABLED`, and keep it
 decoupled from the code-review App token. The job runs for `opened`,
-`reopened`, and `ready_for_review`, plus a label-triggered rerun only when the
-label is `generate-pr-walkthrough`. The workflow does not subscribe to
-`synchronize` in this increment.
+`reopened`, `ready_for_review`, and `synchronize`. A label-triggered rerun also
+runs when the label is `generate-pr-walkthrough`.
 
 Use the shared base-controlled setup action for OpenCode. Select
-`opencode-go/muse-spark-1.2-contributor#high`. The pinned OpenCode 1.17.7 model
-catalog declares reasoning support and built-in `high` and `xhigh` variants for
-this model, so no custom provider override is needed.
+`opencode-go/muse-spark-1.2-contributor` with `--model`. Select its built-in
+`high` reasoning variant with `--variant`. The pinned OpenCode 1.17.7 model
+catalog declares this variant, so no custom provider override is necessary.
 
 The job will:
 

--- a/docs/plans/pr-walkthrough/task-03-workflow-artifact-generation.md
+++ b/docs/plans/pr-walkthrough/task-03-workflow-artifact-generation.md
@@ -19,8 +19,8 @@ the separate R2 publication job.
 - **Acceptance:** A non-draft authorized pull request event invokes OpenCode,
   creates distinct `docs/pr-walkthrough/pr-<number>.json` and `.html` files,
   and uploads them as an artifact. The generation job runs on `opened`,
-  `reopened`, `ready_for_review`, and the `generate-pr-walkthrough` label, but
-  not on `synchronize`.
+  `reopened`, `ready_for_review`, `synchronize`, and the
+  `generate-pr-walkthrough` label.
 - **Acceptance:** The job cannot execute PR-owned scripts through OpenCode or
   modify source. OpenCode may invoke only the base-controlled rendering
   adapter, which writes the fixed walkthrough outputs. The job does not request
@@ -31,9 +31,10 @@ the separate R2 publication job.
   boundary. The artifact handoff is explicit for the dependent R2 publication
   job.
 - **Acceptance:** The workflow uses `PR_WALKTHROUGH_ENABLED`, the
-  `opencode-go/muse-spark-1.2-contributor#high` model reference and the model's
-  native high-reasoning variant. The normal review workflow remains
-  independently gated by `OPENCODE_REVIEW_ENABLED`.
+  `opencode-go/muse-spark-1.2-contributor` model reference, and the model's
+  native `high` reasoning variant. The workflow passes the variant through
+  `--variant`. The normal review workflow remains independently gated by
+  `OPENCODE_REVIEW_ENABLED`.
 - **Verification:**
 
   ```text
@@ -77,9 +78,9 @@ per-PR concurrency serializes generation, publication, and linking, and the
 walkthrough label no longer runs the normal code-review job.
 
 The walkthrough has its own enable variable and uses the Muse Spark contributor
-model with its native high-reasoning variant. The pinned OpenCode 1.17.7 CLI
-catalog reports reasoning support plus built-in `high` and `xhigh` variants,
-and the CLI resolved the default-deny agent permissions.
+model with its native high-reasoning variant. The workflow passes the model and
+variant through separate OpenCode 1.17.7 CLI options. Live validation on PR
+`#2936` found and removed the invalid `#high` model suffix.
 
 Verification: workflow contract tests passed; action pinning tests and linter
 passed; `actionlint` passed; `git diff --check` passed. The targeted `zizmor`

--- a/docs/plans/pr-walkthrough/task-05-dedicated-workflow-pr-link.md
+++ b/docs/plans/pr-walkthrough/task-05-dedicated-workflow-pr-link.md
@@ -21,8 +21,8 @@ taking ownership of contributor-authored PR content.
 - **Acceptance:** `PR_WALKTHROUGH_ENABLED` controls the walkthrough workflow
   independently of `OPENCODE_REVIEW_ENABLED`.
 - **Acceptance:** The walkthrough runner selects
-  `opencode-go/muse-spark-1.2-contributor#high`, which selects the model's
-  native high-reasoning variant in pinned OpenCode 1.17.7.
+  `opencode-go/muse-spark-1.2-contributor` and passes `high` through the
+  OpenCode 1.17.7 `--variant` option.
 - **Acceptance:** Only the final job receives `pull-requests: write`. It runs
   after public R2 validation, uses the trusted base-commit helper, and receives
   no OpenCode or R2 credential.
@@ -47,8 +47,7 @@ taking ownership of contributor-authored PR content.
 
 ## Results
 
-Created the dedicated workflow and independent gate. Selected Muse Spark's
-native high-reasoning variant and validated it in the pinned 1.17.7 model
-catalog. Added the marker-owned PR-body helper and a
-minimum-permission link job after R2 public validation. Contract and helper
-tests pass.
+Created the dedicated workflow and independent gate. The workflow passes the
+Muse Spark model and its native `high` variant through separate OpenCode 1.17.7
+CLI options. Added the marker-owned PR-body helper and a minimum-permission link
+job after R2 public validation. Contract and helper tests pass.

--- a/docs/specs/pr-walkthrough/spec.md
+++ b/docs/specs/pr-walkthrough/spec.md
@@ -58,10 +58,9 @@ lifecycle policy.
 - Walkthrough automation lives in `.github/workflows/pr-walkthrough.yml` and
   is enabled independently with the `PR_WALKTHROUGH_ENABLED` repository
   variable. It does not share the `OPENCODE_REVIEW_ENABLED` code-review gate.
-- The initial runner uses
-  `opencode-go/muse-spark-1.2-contributor#high`. OpenCode 1.17.7 reports native
-  reasoning support for the model and resolves `#high` to its built-in high
-  reasoning variant.
+- The initial runner uses `opencode-go/muse-spark-1.2-contributor` and its
+  built-in `high` reasoning variant. The workflow passes these values with the
+  OpenCode 1.17.7 `--model` and `--variant` options.
 - The workflow preserves the generated JSON and HTML as CI artifacts and
   uploads only the HTML to the `kandev-pr-walkthroughs` R2 bucket.
 - Each published object uses the key


### PR DESCRIPTION
OpenCode rejects `#high` when it is appended to the walkthrough model ID, so live generation stops before rendering. This change passes the model and `high` reasoning variant through separate CLI options and aligns the durable spec and plans.

## Validation

- `python3 .github/scripts/pr-walkthrough-workflow-contract_test.py` (20 passed)
- `python3 .github/scripts/lint-action-pinning_test.py` (9 passed)
- `python3 .github/scripts/lint-action-pinning.py`
- `/root/go/bin/actionlint .github/workflows/pr-walkthrough.yml`
- `opencode models opencode-go`
- `opencode run --help`
- `git diff --check`
- `zizmor .github/workflows/pr-walkthrough.yml` (existing `pull_request_target` warning only)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2949-bwo7.sprites.app |
| **Commit** | `e13524c` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->