### PR TITLE
docs: explain agent Git permission boundary (#2951)

### DIFF
--- a/docs/plans/git-operations-permission-boundary/plan.md
+++ b/docs/plans/git-operations-permission-boundary/plan.md
@@ -58,7 +58,9 @@ change the UI, WebSocket contract, or Git execution path.
 - `rtk git diff --check`: passed.
 - Acceptance-term search passed for the agent shell, `.git/index.lock`, Changes
   panel, agent mode, permission path, and `agentctl` wording.
-- No source-code, navigation, or page-frontmatter changes were made.
+- No source-code, public navigation, or public-page frontmatter changes were made.
+- PR review remediation added lock-specific recovery guidance and marked the
+  implemented specification as `shipped`.
 
 ## Implementation Waves And Parallel Candidates
 

--- a/docs/plans/git-operations-permission-boundary/plan.md
+++ b/docs/plans/git-operations-permission-boundary/plan.md
@@ -1,0 +1,80 @@
+---
+spec: docs/specs/agents/git-operations-permission-boundary.md
+created: 2026-08-23
+status: implemented
+---
+
+# Implementation Plan: Agent Git Permission Boundary
+
+## Overview
+
+Issue [#2951](https://github.com/kdlbs/kandev/issues/2951) requests public
+documentation for the difference between Git commands from an agent shell and
+Git operations from the Changes panel. Source inspection confirms that the
+panel sends `worktree.commit` through Kandev's backend and `agentctl` Git
+operator, while the agent shell remains subject to the installed agent's mode.
+
+The implementation updates the existing Git reference and the Changes-panel
+guide. It does not change backend, frontend, agent, or permission behavior.
+
+## Public documentation
+
+### Git operations reference
+
+Update `docs/public/git-operations.md` in **Prerequisites and trust boundary**.
+Explain the separate permission paths, the `git status` versus write failure
+case, the `.git/index.lock` diagnostic, the Changes-panel recovery path, and
+agent-specific mode names.
+
+### Sessions and review guide
+
+Update `docs/public/sessions-and-review.md` in **Inspect changes**. State that
+Changes-panel Git operations use Kandev's control path rather than the agent's
+shell, and link readers to the Git reference for the permission-boundary
+troubleshooting steps.
+
+## Tests
+
+- **What:** The updated pages retain valid frontmatter, navigation, links, and
+  published-page structure.
+  **File:** `docs/public/git-operations.md` and
+  `docs/public/sessions-and-review.md`.
+  **How:** Run the public-docs unit tests and validator.
+- **What:** The copy covers the issue acceptance criteria without changing
+  implementation behavior.
+  **File:** the same two public-doc pages.
+  **How:** Review the diff and search for the permission-boundary terms listed
+  in the task file.
+
+## E2E Tests
+
+No E2E test is planned. This change documents existing behavior and does not
+change the UI, WebSocket contract, or Git execution path.
+
+## Verification Results
+
+- `rtk node --test scripts/validate-public-docs.test.mjs`: 61 passed.
+- `rtk node scripts/validate-public-docs.mjs`: 41 published pages validated.
+- `rtk git diff --check`: passed.
+- Acceptance-term search passed for the agent shell, `.git/index.lock`, Changes
+  panel, agent mode, permission path, and `agentctl` wording.
+- No source-code, navigation, or page-frontmatter changes were made.
+
+## Implementation Waves And Parallel Candidates
+
+The default execution order is sequential in the primary conversation.
+
+Wave 1:
+
+- [x] [task-01-document-permission-boundary](task-01-document-permission-boundary.md)
+
+The task owns both public-doc files because the copy and terminology must stay
+consistent. It is not parallel-safe.
+
+## Risks And Out-of-scope Work
+
+- Do not imply that the Changes panel changes the agent's permission mode.
+- Do not describe mode names as Kandev-wide labels. Names come from the
+  installed agent.
+- Do not promise that an agent can write Git metadata in every executor.
+- Do not change Git execution, sandbox, or permission behavior in this task.

--- a/docs/plans/git-operations-permission-boundary/task-01-document-permission-boundary.md
+++ b/docs/plans/git-operations-permission-boundary/task-01-document-permission-boundary.md
@@ -76,5 +76,13 @@ contractions, or banned modal wording in the added text.
 - `rtk git diff --check`: passed.
 - Acceptance-term search: found `agent shell`, `index.lock`, `Changes panel`,
   `agent mode`, `permission path`, and `agentctl` in the changed docs.
-- No source-code, navigation, or page-frontmatter changes were made.
+- No source-code, public navigation, or public-page frontmatter changes were made.
 - No temporary files or runtime resources were created.
+
+PR review remediation:
+
+- Added separate guidance for permission-denied failures and active or stale
+  `.git/index.lock` contention. The docs now explain that the Changes panel
+  uses the same worktree and does not bypass an active lock.
+- Updated the specification and specification index status to `shipped`.
+- Re-ran the public-doc validation and diff checks after the remediation.

--- a/docs/plans/git-operations-permission-boundary/task-01-document-permission-boundary.md
+++ b/docs/plans/git-operations-permission-boundary/task-01-document-permission-boundary.md
@@ -1,0 +1,80 @@
+---
+id: "01-document-permission-boundary"
+title: "Document the Git permission boundary"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/agents/git-operations-permission-boundary.md"
+---
+
+# Task 01: Document the Git permission boundary
+
+## Acceptance
+
+- `docs/public/git-operations.md` explains that the Changes panel and agent
+  shell use different Git permission paths.
+- The public docs explain the `.git/index.lock` symptom, the Changes-panel
+  recovery path, and agent-specific mode names.
+- `docs/public/sessions-and-review.md` explains that Changes-panel commits use
+  Kandev's control path and links to the Git reference.
+
+## Verification
+
+```shell
+node --test scripts/validate-public-docs.test.mjs
+node scripts/validate-public-docs.mjs
+git diff --check
+```
+
+Search the changed docs for `agent shell`, `index.lock`, `Changes panel`, and
+`agent-specific` or equivalent wording. Confirm that the diff does not change
+source code, navigation, or page frontmatter.
+
+## Files likely touched
+
+- `docs/public/git-operations.md`
+- `docs/public/sessions-and-review.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. Both pages share the same terminology and acceptance criteria.
+
+## Inputs
+
+- Spec: `docs/specs/agents/git-operations-permission-boundary.md`.
+- Plan: `docs/plans/git-operations-permission-boundary/plan.md`.
+- Issue: [#2951](https://github.com/kdlbs/kandev/issues/2951).
+- Existing Git execution path in `apps/backend/internal/agent/handlers/git_handlers.go`,
+  `apps/backend/internal/agent/runtime/agentctl/git.go`, and
+  `apps/backend/internal/agentctl/server/process/git.go`.
+- Existing public-doc conventions in `docs/public/README.md`.
+
+## Output contract
+
+Report the exact public-doc validation results, changed sections, copy-review
+terms, and any remaining wording risk. Update this task and `plan.md` in the
+same conversation.
+
+## Results
+
+Updated the **Prerequisites and trust boundary** section in
+`docs/public/git-operations.md` and the **Inspect changes** section in
+`docs/public/sessions-and-review.md`.
+
+The docs now explain the separate agent-shell and Changes-panel permission
+paths, the `.git/index.lock` symptom, the Changes-panel recovery path, and
+agent-specific mode names. The copy review found no new em dashes, semicolons,
+contractions, or banned modal wording in the added text.
+
+- `rtk node --test scripts/validate-public-docs.test.mjs`: 61 passed.
+- `rtk node scripts/validate-public-docs.mjs`: 41 published pages validated.
+- `rtk git diff --check`: passed.
+- Acceptance-term search: found `agent shell`, `index.lock`, `Changes panel`,
+  `agent mode`, `permission path`, and `agentctl` in the changed docs.
+- No source-code, navigation, or page-frontmatter changes were made.
+- No temporary files or runtime resources were created.

--- a/docs/public/git-operations.md
+++ b/docs/public/git-operations.md
@@ -22,7 +22,11 @@ The repository must be a valid Git checkout in the executor workspace and the se
 
 Git commands from the agent shell and Git actions from the **Changes** panel use different permission paths. The Changes panel sends its Git action through Kandev to `agentctl`. It does not run the action inside the agent shell. The agent shell remains subject to the selected agent's permission mode.
 
-In a restricted agent mode, `git status` can work while `git add` or `git commit` fails. These write Git metadata, including `.git/index.lock`. A failure to create `.git/index.lock` usually means that the agent mode blocks the metadata write. It does not by itself mean that the repository or Kandev Git integration is broken.
+In a restricted agent mode, `git status` can work while `git add` or `git commit` fails. These write Git metadata, including `.git/index.lock`.
+
+If the error says that `.git/index.lock` already exists or is held, another Git process can own the lock. Stop other Git operations and inspect the lock before retrying. Remove a stale lock only after you confirm that no Git process owns it. The Changes panel uses the same worktree, so it does not bypass an active lock.
+
+If the agent cannot create `.git/index.lock` because its permission mode blocks the metadata write, the repository and Kandev Git integration can still work.
 
 To commit agent edits, use the **Changes** panel. No mode change is needed. If the agent shell must commit, select an agent mode that allows Git metadata writes. Mode names come from the installed agent. For example, Codex can expose `Agent (default)` and `Agent (full access)`.
 

--- a/docs/public/git-operations.md
+++ b/docs/public/git-operations.md
@@ -20,6 +20,12 @@ Use the task's **Changes** panel to inspect, stage, discard, commit, push, reset
 
 The repository must be a valid Git checkout in the executor workspace and the session's `agentctl` must be reachable. Remote commands use the remote named `origin`; configure its URL and credentials before relying on Pull, Push, or change-request creation. Rebase and Merge use `origin` when it exists, or a local base branch when it does not.
 
+Git commands from the agent shell and Git actions from the **Changes** panel use different permission paths. The Changes panel sends its Git action through Kandev to `agentctl`. It does not run the action inside the agent shell. The agent shell remains subject to the selected agent's permission mode.
+
+In a restricted agent mode, `git status` can work while `git add` or `git commit` fails. These write Git metadata, including `.git/index.lock`. A failure to create `.git/index.lock` usually means that the agent mode blocks the metadata write. It does not by itself mean that the repository or Kandev Git integration is broken.
+
+To commit agent edits, use the **Changes** panel. No mode change is needed. If the agent shell must commit, select an agent mode that allows Git metadata writes. Mode names come from the installed agent. For example, Codex can expose `Agent (default)` and `Agent (full access)`.
+
 Managed Improve Kandev tasks are the exception to the ordinary single-remote push description. The
 canonical `origin` still identifies `kdlbs/kandev` for pulls, base comparisons, issue lookup, and
 the pull-request target. Before launch, Kandev prepares one exact fork remote for the task branch

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -161,7 +161,7 @@ Changes are grouped by repository and then by state:
 
 From this panel you can stage or unstage files, discard working-tree changes, commit, amend, reset or revert commits, pull, rebase, merge, push, force-push, rename the task branch, choose a base branch, and create or open a pull request or merge request. Operations apply to the selected repository. Discarding a file is permanent, and history-changing operations can lose work or invalidate review; read [Git operations](git-operations.md) before using them.
 
-Changes-panel Git operations use Kandev's control path, not the agent's shell. They can work when a restricted agent mode blocks shell writes to Git metadata. If an agent commit fails with `.git/index.lock`, use the Changes panel. Read [Git operations](git-operations.md#prerequisites-and-trust-boundary) before you change the agent mode.
+Changes-panel Git operations use Kandev's control path, not the agent's shell. They can work when a restricted agent mode blocks shell writes to Git metadata. If the error says that `.git/index.lock` already exists or is held, stop other Git operations and inspect the lock before retrying. Remove a stale lock only after you confirm that no Git process owns it. The Changes panel uses the same worktree, so it does not bypass an active lock. If the agent cannot create `.git/index.lock` because of its permission mode, use the Changes panel. Read [Git operations](git-operations.md#prerequisites-and-trust-boundary) before you change the agent mode.
 
 For a linked fork pull request, the Changes header shows the exact comparison target, such as
 `upstream/widget:main`. Kandev keeps this target separate from `origin`, the checked-out branch,

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -161,6 +161,8 @@ Changes are grouped by repository and then by state:
 
 From this panel you can stage or unstage files, discard working-tree changes, commit, amend, reset or revert commits, pull, rebase, merge, push, force-push, rename the task branch, choose a base branch, and create or open a pull request or merge request. Operations apply to the selected repository. Discarding a file is permanent, and history-changing operations can lose work or invalidate review; read [Git operations](git-operations.md) before using them.
 
+Changes-panel Git operations use Kandev's control path, not the agent's shell. They can work when a restricted agent mode blocks shell writes to Git metadata. If an agent commit fails with `.git/index.lock`, use the Changes panel. Read [Git operations](git-operations.md#prerequisites-and-trust-boundary) before you change the agent mode.
+
 For a linked fork pull request, the Changes header shows the exact comparison target, such as
 `upstream/widget:main`. Kandev keeps this target separate from `origin`, the checked-out branch,
 and the push remote. Desktop hover details and the mobile touch drawer show the same target.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -141,6 +141,7 @@ Roles, governance gates, and granular permissions that apply across human users 
 | [governance](agents/governance.md) | shipped |
 | [granular-permissions](agents/granular-permissions.md) | draft |
 | [external-permission-resolution](agents/external-permission-resolution.md) | draft |
+| [git-operations-permission-boundary](agents/git-operations-permission-boundary.md) | building |
 
 ## integrations/ — external service integrations
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -141,7 +141,7 @@ Roles, governance gates, and granular permissions that apply across human users 
 | [governance](agents/governance.md) | shipped |
 | [granular-permissions](agents/granular-permissions.md) | draft |
 | [external-permission-resolution](agents/external-permission-resolution.md) | draft |
-| [git-operations-permission-boundary](agents/git-operations-permission-boundary.md) | building |
+| [git-operations-permission-boundary](agents/git-operations-permission-boundary.md) | shipped |
 
 ## integrations/ — external service integrations
 

--- a/docs/specs/agents/git-operations-permission-boundary.md
+++ b/docs/specs/agents/git-operations-permission-boundary.md
@@ -1,5 +1,5 @@
 ---
-status: building
+status: shipped
 created: 2026-08-23
 owner: kandev
 ---

--- a/docs/specs/agents/git-operations-permission-boundary.md
+++ b/docs/specs/agents/git-operations-permission-boundary.md
@@ -1,0 +1,47 @@
+---
+status: building
+created: 2026-08-23
+owner: kandev
+---
+
+# Agent Git permission boundary
+
+## Why
+
+Users can edit files and read Git status in a restricted agent mode, then see
+the agent fail when it runs `git add` or `git commit`. The failure can make the
+repository or Kandev appear broken, even though the Changes panel can commit
+the same work through a different permission path.
+
+## What
+
+- Public Git documentation explains that Changes-panel Git operations and
+  agent-shell Git commands use different permission paths.
+- The documentation explains that `git status` can work while a shell commit
+  fails because the agent cannot write Git metadata such as `.git/index.lock`.
+- The documentation directs users to commit from the Changes panel without
+  changing the agent mode.
+- The documentation explains that a user who needs the agent shell to commit
+  must select an agent mode that allows Git metadata writes.
+- The documentation states that mode names come from the installed agent and
+  uses Codex mode names only as examples.
+
+## Scenarios
+
+- **GIVEN** an agent edits files in a restricted mode, **WHEN** `git status`
+  works but `git commit` fails with an `.git/index.lock` error, **THEN** the
+  public Git guide explains the permission boundary and the Changes-panel
+  recovery path.
+- **GIVEN** a user opens the Changes panel with agent edits present, **WHEN**
+  the user chooses Commit Changes, **THEN** the public Git guide explains that
+  Kandev performs the Git operation outside the agent shell sandbox.
+- **GIVEN** a user wants the agent shell to commit, **WHEN** the user reads the
+  public Git guide, **THEN** the guide explains that the user must choose an
+  agent-specific mode that permits Git metadata writes.
+
+## Out of scope
+
+- Changing agent sandbox behavior or permission modes.
+- Changing the Changes-panel Git implementation.
+- Adding a new Kandev-wide permission-mode name.
+- Changing Git error handling or automatically changing a session mode.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2953/0a746b0b54769bb832c35f13ca458ef236c5d2cc.html)
<!-- kandev-pr-walkthrough-end -->

Restricted agent modes can block shell Git writes even when `git status` works, which makes users think Git is broken. The public docs now explain the separate permission paths and the Changes-panel recovery path without requiring a mode change.

## Validation

- `rtk node --test scripts/validate-public-docs.test.mjs` (61 passed)
- `rtk node scripts/validate-public-docs.mjs` (41 published pages validated)
- `rtk git diff --check` (passed)
- Commit hooks passed without bypassing verification.
- No screenshots were required because this PR changes documentation only.
- Public docs updated: Git Operations reference and Sessions and Review guide.
- Primary content types: reference and how-to guidance.

## Possible Improvements

Low risk: agent mode labels can change with agent releases. The docs describe them as agent-specific examples.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2951


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->