### PR TITLE
fix(office): stop task wakeups from falling back to a generic prompt

### DIFF
--- a/apps/backend/config/workflows/office-default.yml
+++ b/apps/backend/config/workflows/office-default.yml
@@ -42,13 +42,13 @@ steps:
           config:
             target: primary
             task_id: this
-            reason: blockers_resolved
+            reason: task_blockers_resolved
       on_children_completed:
         - type: queue_run
           config:
             target: primary
             task_id: this
-            reason: children_completed
+            reason: task_children_completed
       on_agent_error:
         - type: queue_run
           config:
@@ -73,7 +73,9 @@ steps:
         - type: queue_run_for_each_participant
           config:
             role: reviewer
-            reason: review_started
+            reason: task_assigned
+            payload:
+              stage_type: review
       on_turn_complete:
         - type: move_to_step
           config:
@@ -101,7 +103,9 @@ steps:
         - type: queue_run_for_each_participant
           config:
             role: approver
-            reason: approval_started
+            reason: task_assigned
+            payload:
+              stage_type: approval
       on_turn_complete:
         - type: move_to_step
           config:

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -52,7 +52,7 @@ type PromptContext struct {
 	// Stage fields (execution policy)
 	StageID         string   // execution policy stage ID
 	StageType       string   // "work", "review", "approval", "ship"
-	BuilderComments []string // latest comments from the builder/assignee
+	BuilderComments []string // recent task comments
 	ReviewFeedback  string   // aggregated feedback from rejected review
 
 	// Runtime fields
@@ -76,11 +76,19 @@ func BuildPrompt(pc *PromptContext) string {
 	switch pc.Reason {
 	case RunReasonTaskAssigned:
 		prompt = buildTaskAssignedPrompt(pc)
+	case legacyRunReasonReviewStarted:
+		prompt = buildLegacyStagePrompt(pc, stageTypeReview)
+	case legacyRunReasonApprovalStarted:
+		prompt = buildLegacyStagePrompt(pc, stageTypeApproval)
 	case RunReasonTaskComment:
 		prompt = buildTaskCommentPrompt(pc)
 	case RunReasonTaskBlockersResolved:
 		prompt = buildBlockersResolvedPrompt(pc)
+	case legacyRunReasonBlockersResolved:
+		prompt = buildBlockersResolvedPrompt(pc)
 	case RunReasonTaskChildrenCompleted:
+		prompt = buildChildrenCompletedPrompt(pc)
+	case legacyRunReasonChildrenCompleted:
 		prompt = buildChildrenCompletedPrompt(pc)
 	case RunReasonApprovalResolved:
 		prompt = buildApprovalResolvedPrompt(pc)
@@ -223,9 +231,9 @@ func appendRuntimeContext(prompt string, pc *PromptContext) string {
 
 func buildTaskAssignedPrompt(pc *PromptContext) string {
 	switch pc.StageType {
-	case "review":
+	case stageTypeReview:
 		return buildReviewStagePrompt(pc)
-	case "approval":
+	case stageTypeApproval:
 		return buildApprovalStagePrompt(pc)
 	case stageTypeShip:
 		return buildShipStagePrompt(pc)
@@ -235,6 +243,12 @@ func buildTaskAssignedPrompt(pc *PromptContext) string {
 		}
 	}
 	return buildDefaultWorkPrompt(pc)
+}
+
+func buildLegacyStagePrompt(pc *PromptContext, stageType string) string {
+	legacy := *pc
+	legacy.StageType = stageType
+	return buildTaskAssignedPrompt(&legacy)
 }
 
 func buildDefaultWorkPrompt(pc *PromptContext) string {
@@ -260,7 +274,7 @@ func buildReviewStagePrompt(pc *PromptContext) string {
 		fmt.Fprintf(&b, "\nTask description:\n%s\n", pc.TaskDescription)
 	}
 	if len(pc.BuilderComments) > 0 {
-		fmt.Fprintf(&b, "\nBuilder's comments:\n%s\n", strings.Join(pc.BuilderComments, "\n"))
+		fmt.Fprintf(&b, "\nRecent task comments:\n%s\n", strings.Join(pc.BuilderComments, "\n"))
 	}
 	b.WriteString("\nReview the implementation carefully. Check for correctness, edge cases, and code quality.\n")
 	b.WriteString("Submit your verdict: approve if the work is satisfactory, or reject with specific feedback on what needs to change.")
@@ -274,10 +288,10 @@ func buildApprovalStagePrompt(pc *PromptContext) string {
 		fmt.Fprintf(&b, "\nTask description:\n%s\n", pc.TaskDescription)
 	}
 	if len(pc.BuilderComments) > 0 {
-		fmt.Fprintf(&b, "\nBuilder's comments:\n%s\n", strings.Join(pc.BuilderComments, "\n"))
+		fmt.Fprintf(&b, "\nRecent task comments:\n%s\n", strings.Join(pc.BuilderComments, "\n"))
 	}
-	b.WriteString("\nAll reviewers have approved this work. Confirm it is ready to ship.\n")
-	b.WriteString("Submit your verdict: approve to mark the task done, or reject with specific feedback on what needs to change.")
+	b.WriteString("\nConfirm that the approval requirements are met for this workflow.\n")
+	b.WriteString("Submit your verdict: approve if the requirements are met, or reject with specific feedback on what needs to change.")
 	return b.String()
 }
 

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -223,8 +223,10 @@ func appendRuntimeContext(prompt string, pc *PromptContext) string {
 
 func buildTaskAssignedPrompt(pc *PromptContext) string {
 	switch pc.StageType {
-	case "review", "approval":
+	case "review":
 		return buildReviewStagePrompt(pc)
+	case "approval":
+		return buildApprovalStagePrompt(pc)
 	case stageTypeShip:
 		return buildShipStagePrompt(pc)
 	case stageTypeWork:
@@ -262,6 +264,20 @@ func buildReviewStagePrompt(pc *PromptContext) string {
 	}
 	b.WriteString("\nReview the implementation carefully. Check for correctness, edge cases, and code quality.\n")
 	b.WriteString("Submit your verdict: approve if the work is satisfactory, or reject with specific feedback on what needs to change.")
+	return b.String()
+}
+
+func buildApprovalStagePrompt(pc *PromptContext) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are approving task %s: %s.\n", taskRef(pc), pc.TaskTitle)
+	if pc.TaskDescription != "" {
+		fmt.Fprintf(&b, "\nTask description:\n%s\n", pc.TaskDescription)
+	}
+	if len(pc.BuilderComments) > 0 {
+		fmt.Fprintf(&b, "\nBuilder's comments:\n%s\n", strings.Join(pc.BuilderComments, "\n"))
+	}
+	b.WriteString("\nAll reviewers have approved this work. Confirm it is ready to ship.\n")
+	b.WriteString("Submit your verdict: approve to mark the task done, or reject with specific feedback on what needs to change.")
 	return b.String()
 }
 

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -223,7 +223,7 @@ func appendRuntimeContext(prompt string, pc *PromptContext) string {
 
 func buildTaskAssignedPrompt(pc *PromptContext) string {
 	switch pc.StageType {
-	case "review":
+	case "review", "approval":
 		return buildReviewStagePrompt(pc)
 	case stageTypeShip:
 		return buildShipStagePrompt(pc)

--- a/apps/backend/internal/office/service/prompt_builder_test.go
+++ b/apps/backend/internal/office/service/prompt_builder_test.go
@@ -75,6 +75,32 @@ func TestBuildPrompt_BlockersResolved(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_LegacyRunReasonsRemainCompatible(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   string
+		contains string
+	}{
+		{name: "blockers resolved", reason: "blockers_resolved", contains: "All blockers"},
+		{name: "children completed", reason: "children_completed", contains: "All child tasks"},
+		{name: "review started", reason: "review_started", contains: "You are reviewing"},
+		{name: "approval started", reason: "approval_started", contains: "You are approving"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := service.BuildPrompt(&service.PromptContext{
+				Reason:         tt.reason,
+				TaskIdentifier: "KAN-legacy",
+				TaskTitle:      "Legacy workflow task",
+			})
+			if !strings.Contains(prompt, tt.contains) {
+				t.Errorf("legacy reason %q should use its existing prompt, got:\n%s", tt.reason, prompt)
+			}
+		})
+	}
+}
+
 func TestBuildPrompt_ApprovalResolved(t *testing.T) {
 	pc := &service.PromptContext{
 		Reason:         service.RunReasonApprovalResolved,
@@ -342,7 +368,7 @@ func TestBuildPrompt_ReviewStage(t *testing.T) {
 		"Auth service",
 		"Task description:",
 		"Implement OAuth2 flow.",
-		"Builder's comments:",
+		"Recent task comments:",
 		"Done the implementation",
 		"Added tests",
 		"Review the implementation carefully",
@@ -358,6 +384,25 @@ func TestBuildPrompt_ReviewStage(t *testing.T) {
 	// Should NOT contain the default work assignment phrasing.
 	if strings.Contains(prompt, "You have been assigned") {
 		t.Errorf("review prompt should not contain assignment phrasing:\n%s", prompt)
+	}
+}
+
+func TestBuildPrompt_ApprovalStageUsesNeutralLifecycleLanguage(t *testing.T) {
+	prompt := service.BuildPrompt(&service.PromptContext{
+		Reason:         service.RunReasonTaskAssigned,
+		TaskIdentifier: "KAN-11",
+		TaskTitle:      "Approve the deployment",
+		StageType:      "approval",
+	})
+
+	if !strings.Contains(prompt, "Confirm that the approval requirements are met") {
+		t.Errorf("approval prompt should describe its own requirements:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "All reviewers have approved") {
+		t.Errorf("approval prompt should not assume a prior review:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "mark the task done") {
+		t.Errorf("approval prompt should not assume approval is the final lifecycle step:\n%s", prompt)
 	}
 }
 

--- a/apps/backend/internal/office/service/prompt_reason_contract_test.go
+++ b/apps/backend/internal/office/service/prompt_reason_contract_test.go
@@ -89,20 +89,46 @@ func TestPromptReasonContract_AllShippedReasonsResolve(t *testing.T) {
 
 // TestPromptReasonContract_ReviewAndApprovalStagesRouteToVerdictPrompt pins
 // the office-default review/approval fan-out contract: reason task_assigned
-// with payload stage_type "review" or "approval" must both produce the
-// reviewer verdict prompt, not the generic "start working" default prompt.
-// This guards the YAML's payload-based routing so it cannot silently rot.
+// with payload stage_type "review" or "approval" must both produce a
+// verdict-submission prompt, not the generic "start working" default
+// prompt. This guards the YAML's payload-based routing so it cannot
+// silently rot.
+//
+// Round 1 review (R1) caught that asserting only "both contain 'Submit
+// your verdict'" is not enough: it let stage_type "approval" silently
+// reuse the reviewer's "You are reviewing" framing (and its
+// builder-comments block, which was dead by construction for approvers —
+// see scheduler_integration.go's enrichBuilderComments guard). Assert the
+// two stages are actually distinguishable, not just both non-default.
 func TestPromptReasonContract_ReviewAndApprovalStagesRouteToVerdictPrompt(t *testing.T) {
-	for _, stage := range []string{"review", "approval"} {
-		pc := &PromptContext{
+	buildFor := func(stage string) string {
+		return BuildPrompt(&PromptContext{
 			Reason:    RunReasonTaskAssigned,
 			StageType: stage,
 			TaskID:    "T-1",
 			TaskTitle: "Add auth",
-		}
-		got := BuildPrompt(pc)
+		})
+	}
+
+	review := buildFor("review")
+	approval := buildFor("approval")
+
+	for stage, got := range map[string]string{"review": review, "approval": approval} {
 		if !strings.Contains(got, "Submit your verdict") {
-			t.Errorf("stage_type=%q: expected reviewer verdict prompt, got %q", stage, got)
+			t.Errorf("stage_type=%q: expected a verdict-submission prompt, got %q", stage, got)
 		}
+		if strings.HasPrefix(got, "You have been assigned task") {
+			t.Errorf("stage_type=%q: fell through to the generic default work prompt: %q", stage, got)
+		}
+	}
+
+	if review == approval {
+		t.Errorf("review and approval stages produced identical prompts — approval is not distinguishable from review: %q", review)
+	}
+	if !strings.HasPrefix(review, "You are reviewing") {
+		t.Errorf("review stage: expected reviewer framing, got %q", review)
+	}
+	if !strings.HasPrefix(approval, "You are approving") {
+		t.Errorf("approval stage: expected approver framing, got %q", approval)
 	}
 }

--- a/apps/backend/internal/office/service/prompt_reason_contract_test.go
+++ b/apps/backend/internal/office/service/prompt_reason_contract_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	workflowcfg "github.com/kandev/kandev/config/workflows"
+	"github.com/kandev/kandev/internal/workflow/models"
+)
+
+// fallbackPromptPrefix is BuildPrompt's default-branch marker (prompt_builder.go).
+// A shipped workflow reason that produces this prefix has lost every bit of
+// task context BuildPrompt would otherwise template in.
+const fallbackPromptPrefix = "You have been woken for reason:"
+
+// reasonOccurrence names exactly where a `reason:` value was found so a
+// failing assertion can point straight at the offending YAML.
+type reasonOccurrence struct {
+	template string
+	step     string
+	trigger  string
+	reason   string
+}
+
+// collectReasonOccurrences walks every step of every shipped template and
+// every event trigger that can carry a `reason:` config key (the four
+// original triggers plus the seven Phase 2 event-driven ones), returning
+// every occurrence found. This is table-driven off the actual shipped
+// config rather than a hand-maintained list of known-bad reasons, so a new
+// bad reason added to any template tomorrow fails this test without anyone
+// updating it.
+func collectReasonOccurrences(templates []*models.WorkflowTemplate) []reasonOccurrence {
+	var out []reasonOccurrence
+	for _, tmpl := range templates {
+		for _, step := range tmpl.Steps {
+			for _, a := range step.Events.OnEnter {
+				if reason, ok := a.Config["reason"].(string); ok && reason != "" {
+					out = append(out, reasonOccurrence{tmpl.ID, step.ID, "on_enter", reason})
+				}
+			}
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_comment", step.Events.OnComment)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_blocker_resolved", step.Events.OnBlockerResolved)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_children_completed", step.Events.OnChildrenCompleted)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_approval_resolved", step.Events.OnApprovalResolved)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_heartbeat", step.Events.OnHeartbeat)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_budget_alert", step.Events.OnBudgetAlert)...)
+			out = append(out, collectGenericReasons(tmpl.ID, step.ID, "on_agent_error", step.Events.OnAgentError)...)
+		}
+	}
+	return out
+}
+
+func collectGenericReasons(templateID, stepID, trigger string, actions []models.GenericAction) []reasonOccurrence {
+	var out []reasonOccurrence
+	for _, a := range actions {
+		if reason, ok := a.Config["reason"].(string); ok && reason != "" {
+			out = append(out, reasonOccurrence{templateID, stepID, trigger, reason})
+		}
+	}
+	return out
+}
+
+// TestPromptReasonContract_AllShippedReasonsResolve asserts that every
+// `reason:` value emitted by a shipped workflow template resolves to a real
+// BuildPrompt case instead of falling through to the bare fallback string.
+// It must fail against the unmodified office-default.yml (4 of 7 reasons
+// fall through) and pass once the YAML is corrected.
+func TestPromptReasonContract_AllShippedReasonsResolve(t *testing.T) {
+	templates, err := workflowcfg.LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates: %v", err)
+	}
+
+	occurrences := collectReasonOccurrences(templates)
+	if len(occurrences) == 0 {
+		t.Fatal("no reason: occurrences found across shipped workflow templates — test setup is broken")
+	}
+
+	for _, occ := range occurrences {
+		got := BuildPrompt(&PromptContext{Reason: occ.reason})
+		if strings.HasPrefix(got, fallbackPromptPrefix) {
+			t.Errorf(
+				"template %q step %q trigger %q: reason %q falls through to the bare fallback prompt: %q",
+				occ.template, occ.step, occ.trigger, occ.reason, got,
+			)
+		}
+	}
+}
+
+// TestPromptReasonContract_ReviewAndApprovalStagesRouteToVerdictPrompt pins
+// the office-default review/approval fan-out contract: reason task_assigned
+// with payload stage_type "review" or "approval" must both produce the
+// reviewer verdict prompt, not the generic "start working" default prompt.
+// This guards the YAML's payload-based routing so it cannot silently rot.
+func TestPromptReasonContract_ReviewAndApprovalStagesRouteToVerdictPrompt(t *testing.T) {
+	for _, stage := range []string{"review", "approval"} {
+		pc := &PromptContext{
+			Reason:    RunReasonTaskAssigned,
+			StageType: stage,
+			TaskID:    "T-1",
+			TaskTitle: "Add auth",
+		}
+		got := BuildPrompt(pc)
+		if !strings.Contains(got, "Submit your verdict") {
+			t.Errorf("stage_type=%q: expected reviewer verdict prompt, got %q", stage, got)
+		}
+	}
+}

--- a/apps/backend/internal/office/service/prompt_reason_contract_test.go
+++ b/apps/backend/internal/office/service/prompt_reason_contract_test.go
@@ -23,8 +23,8 @@ type reasonOccurrence struct {
 }
 
 // collectReasonOccurrences walks every step of every shipped template and
-// every event trigger that can carry a `reason:` config key (the four
-// original triggers plus the seven Phase 2 event-driven ones), returning
+// every event trigger that can carry a `reason:` config key (the original
+// on_enter trigger plus the seven Phase 2 event-driven ones), returning
 // every occurrence found. This is table-driven off the actual shipped
 // config rather than a hand-maintained list of known-bad reasons, so a new
 // bad reason added to any template tomorrow fails this test without anyone
@@ -63,8 +63,7 @@ func collectGenericReasons(templateID, stepID, trigger string, actions []models.
 // TestPromptReasonContract_AllShippedReasonsResolve asserts that every
 // `reason:` value emitted by a shipped workflow template resolves to a real
 // BuildPrompt case instead of falling through to the bare fallback string.
-// It must fail against the unmodified office-default.yml (4 of 7 reasons
-// fall through) and pass once the YAML is corrected.
+// It fails when a shipped reason is not mapped to a structured prompt.
 func TestPromptReasonContract_AllShippedReasonsResolve(t *testing.T) {
 	templates, err := workflowcfg.LoadTemplates()
 	if err != nil {
@@ -96,10 +95,8 @@ func TestPromptReasonContract_AllShippedReasonsResolve(t *testing.T) {
 //
 // Round 1 review (R1) caught that asserting only "both contain 'Submit
 // your verdict'" is not enough: it let stage_type "approval" silently
-// reuse the reviewer's "You are reviewing" framing (and its
-// builder-comments block, which was dead by construction for approvers —
-// see scheduler_integration.go's enrichBuilderComments guard). Assert the
-// two stages are actually distinguishable, not just both non-default.
+// reuse the reviewer's "You are reviewing" framing. Assert the two stages
+// are actually distinguishable, not just both non-default.
 func TestPromptReasonContract_ReviewAndApprovalStagesRouteToVerdictPrompt(t *testing.T) {
 	buildFor := func(stage string) string {
 		return BuildPrompt(&PromptContext{

--- a/apps/backend/internal/office/service/run.go
+++ b/apps/backend/internal/office/service/run.go
@@ -29,6 +29,16 @@ const (
 	RunReasonAgentError            = "agent_error"
 )
 
+// These reasons were persisted by earlier workflow templates. Keep them
+// readable so existing materialized workflows continue to wake the correct
+// prompt after the built-in template changes.
+const (
+	legacyRunReasonBlockersResolved  = "blockers_resolved"
+	legacyRunReasonChildrenCompleted = "children_completed"
+	legacyRunReasonReviewStarted     = "review_started"
+	legacyRunReasonApprovalStarted   = "approval_started"
+)
+
 // Run status constants.
 const (
 	RunStatusQueued    = "queued"

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -823,7 +823,7 @@ func (si *SchedulerIntegration) buildPromptContext(
 		pc.StageType = parsed["stage_type"]
 		pc.ReviewFeedback = parsed["feedback"]
 
-		if pc.StageType == "review" && pc.TaskID != "" {
+		if (pc.StageType == "review" || pc.StageType == "approval") && pc.TaskID != "" {
 			si.enrichBuilderComments(ctx, pc)
 		}
 	}

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -814,16 +814,25 @@ func (si *SchedulerIntegration) buildPromptContext(
 		pc.ApprovalNote = parsed["decision_note"]
 	}
 
-	if reason == RunReasonTaskChildrenCompleted {
+	if reason == RunReasonTaskChildrenCompleted || reason == legacyRunReasonChildrenCompleted {
 		si.enrichChildrenContext(pc, payload)
 	}
 
-	if reason == RunReasonTaskAssigned {
+	if reason == RunReasonTaskAssigned || reason == legacyRunReasonReviewStarted || reason == legacyRunReasonApprovalStarted {
 		pc.StageID = parsed["stage_id"]
+		if pc.StageID == "" {
+			pc.StageID = parsed["workflow_step_id"]
+		}
 		pc.StageType = parsed["stage_type"]
 		pc.ReviewFeedback = parsed["feedback"]
+		switch reason {
+		case legacyRunReasonReviewStarted:
+			pc.StageType = stageTypeReview
+		case legacyRunReasonApprovalStarted:
+			pc.StageType = stageTypeApproval
+		}
 
-		if (pc.StageType == "review" || pc.StageType == "approval") && pc.TaskID != "" {
+		if (pc.StageType == stageTypeReview || pc.StageType == stageTypeApproval) && pc.TaskID != "" {
 			si.enrichBuilderComments(ctx, pc)
 		}
 	}
@@ -891,8 +900,8 @@ func (si *SchedulerIntegration) resolveCommentAuthor(
 	return "User"
 }
 
-// enrichBuilderComments fetches the most recent comments left by the task
-// assignee (builder) and appends them to pc.BuilderComments.
+// enrichBuilderComments fetches the most recent task comments and appends them
+// to pc.BuilderComments for review and approval prompts.
 func (si *SchedulerIntegration) enrichBuilderComments(ctx context.Context, pc *PromptContext) {
 	comments, err := si.svc.repo.ListRecentTaskComments(ctx, pc.TaskID, 5)
 	if err != nil {

--- a/apps/backend/internal/office/service/scheduler_integration_test.go
+++ b/apps/backend/internal/office/service/scheduler_integration_test.go
@@ -348,6 +348,54 @@ func TestSchedulerIntegration_BuildPromptContext_TaskComment(t *testing.T) {
 	}
 }
 
+func TestSchedulerIntegration_BuildPromptContext_ApprovalStageIncludesRecentComments(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	insertTaskForPrompt(t, svc, "task-approval", "ws-1", "Approve release", "Confirm the release is safe", 3)
+	svc.ExecSQL(t, `INSERT INTO task_comments (id, task_id, author_type, author_id, body, source, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		"cmt-approval", "task-approval", "user", "user-1", "Release notes are complete", "user")
+
+	payload := `{"task_id":"task-approval","stage_id":"step-approval","stage_type":"approval"}`
+	pc := service.BuildPromptContextForTest(svc, ctx, service.RunReasonTaskAssigned, payload)
+
+	if pc.StageType != "approval" {
+		t.Fatalf("StageType = %q, want approval", pc.StageType)
+	}
+	if len(pc.BuilderComments) != 1 || pc.BuilderComments[0] != "Release notes are complete" {
+		t.Fatalf("recent task comments = %#v, want the inserted comment", pc.BuilderComments)
+	}
+	prompt := service.BuildPrompt(pc)
+	if !containsIgnoreCase(prompt, "Recent task comments:") {
+		t.Errorf("approval prompt should label comments as recent task comments, got: %s", prompt)
+	}
+}
+
+func TestSchedulerIntegration_BuildPromptContext_LegacyApprovalStageIncludesRecentComments(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	insertTaskForPrompt(t, svc, "task-legacy-approval", "ws-1", "Approve release", "Confirm the release is safe", 3)
+	svc.ExecSQL(t, `INSERT INTO task_comments (id, task_id, author_type, author_id, body, source, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		"cmt-legacy-approval", "task-legacy-approval", "agent", "builder-1", "Builder finished the release", "agent")
+
+	pc := service.BuildPromptContextForTest(
+		svc,
+		ctx,
+		"approval_started",
+		`{"task_id":"task-legacy-approval","workflow_step_id":"step-approval"}`,
+	)
+
+	if pc.StageType != "approval" {
+		t.Fatalf("legacy StageType = %q, want approval", pc.StageType)
+	}
+	if len(pc.BuilderComments) != 1 || pc.BuilderComments[0] != "Builder finished the release" {
+		t.Fatalf("legacy recent task comments = %#v, want the inserted comment", pc.BuilderComments)
+	}
+}
+
 func TestSchedulerIntegration_BuildPromptContext_TaskComment_AgentAuthor(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/service/task_assignee.go
+++ b/apps/backend/internal/office/service/task_assignee.go
@@ -23,8 +23,10 @@ import (
 // them when rendering reviewer/ship-stage prompts. The engine emits
 // the same string values from workflow_steps.stage_type.
 const (
-	stageTypeWork = "work"
-	stageTypeShip = "ship"
+	stageTypeWork     = "work"
+	stageTypeReview   = "review"
+	stageTypeApproval = "approval"
+	stageTypeShip     = "ship"
 )
 
 // participantTypeAgent identifies an agent (vs user) actor in event

--- a/apps/backend/internal/workflow/engine/office_default_smoke_test.go
+++ b/apps/backend/internal/workflow/engine/office_default_smoke_test.go
@@ -77,8 +77,8 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Review.on_enter: %v", err)
 	}
-	if got := countCallsByReason(queue, "review_started"); got != 2 {
-		t.Errorf("review_started fan-out calls = %d, want 2", got)
+	if got := countCallsByReasonAndStep(queue, "task_assigned", steps["review"].ID); got != 2 {
+		t.Errorf("task_assigned fan-out calls for review step = %d, want 2", got)
 	}
 
 	// Reviewers approve.
@@ -113,8 +113,8 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Approval.on_enter: %v", err)
 	}
-	if got := countCallsByReason(queue, "approval_started"); got != 1 {
-		t.Errorf("approval_started fan-out calls = %d, want 1", got)
+	if got := countCallsByReasonAndStep(queue, "task_assigned", steps["approval"].ID); got != 1 {
+		t.Errorf("task_assigned fan-out calls for approval step = %d, want 1", got)
 	}
 
 	// Approver approves.
@@ -363,6 +363,20 @@ func countCallsByReason(q *fakeRunQueue, reason string) int {
 	count := 0
 	for _, c := range q.calls {
 		if c.Reason == reason {
+			count++
+		}
+	}
+	return count
+}
+
+// countCallsByReasonAndStep counts queued runs matching both reason and
+// WorkflowStepID. Needed once review and approval fan-out share the reason
+// "task_assigned" (distinguished only by payload stage_type) — a bare
+// reason count can no longer tell the two fan-outs apart.
+func countCallsByReasonAndStep(q *fakeRunQueue, reason, stepID string) int {
+	count := 0
+	for _, c := range q.calls {
+		if c.Reason == reason && c.WorkflowStepID == stepID {
 			count++
 		}
 	}

--- a/apps/backend/internal/workflow/engine/office_default_smoke_test.go
+++ b/apps/backend/internal/workflow/engine/office_default_smoke_test.go
@@ -80,6 +80,7 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 	if got := countCallsByReasonAndStep(queue, "task_assigned", steps["review"].ID); got != 2 {
 		t.Errorf("task_assigned fan-out calls for review step = %d, want 2", got)
 	}
+	assertPayloadStageType(t, queue, steps["review"].ID, "review")
 
 	// Reviewers approve.
 	for _, pID := range []string{"reviewer-1", "reviewer-2"} {
@@ -116,6 +117,7 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 	if got := countCallsByReasonAndStep(queue, "task_assigned", steps["approval"].ID); got != 1 {
 		t.Errorf("task_assigned fan-out calls for approval step = %d, want 1", got)
 	}
+	assertPayloadStageType(t, queue, steps["approval"].ID, "approval")
 
 	// Approver approves.
 	if err := decisions.RecordStepDecision(ctx, DecisionInfo{
@@ -359,16 +361,6 @@ func (noOpCallback) Execute(_ context.Context, _ ActionInput) (ActionResult, err
 	return ActionResult{}, nil
 }
 
-func countCallsByReason(q *fakeRunQueue, reason string) int {
-	count := 0
-	for _, c := range q.calls {
-		if c.Reason == reason {
-			count++
-		}
-	}
-	return count
-}
-
 // countCallsByReasonAndStep counts queued runs matching both reason and
 // WorkflowStepID. Needed once review and approval fan-out share the reason
 // "task_assigned" (distinguished only by payload stage_type) — a bare
@@ -381,4 +373,27 @@ func countCallsByReasonAndStep(q *fakeRunQueue, reason, stepID string) int {
 		}
 	}
 	return count
+}
+
+// assertPayloadStageType fails the test if any queued call for stepID does
+// not carry the expected Payload["stage_type"]. Deleting the YAML's
+// `payload: {stage_type: ...}` block would still pass countCallsByReasonAndStep
+// (reason + step are unaffected) — this closes that gap by checking the one
+// field BuildPrompt actually branches on to tell review and approval apart.
+func assertPayloadStageType(t *testing.T, q *fakeRunQueue, stepID, wantStageType string) {
+	t.Helper()
+	found := false
+	for _, c := range q.calls {
+		if c.WorkflowStepID != stepID {
+			continue
+		}
+		found = true
+		got, _ := c.Payload["stage_type"].(string)
+		if got != wantStageType {
+			t.Errorf("step %s: Payload[\"stage_type\"] = %q, want %q", stepID, got, wantStageType)
+		}
+	}
+	if !found {
+		t.Fatalf("no queued calls found for step %s", stepID)
+	}
 }

--- a/docs/workflow-import-export.md
+++ b/docs/workflow-import-export.md
@@ -250,7 +250,7 @@ events:
       config:
         target: primary
         task_id: this
-        reason: children_completed
+        reason: task_children_completed
 ```
 
 > [!WARNING]


### PR DESCRIPTION
**Today:** When an office agent is woken because a blocker was resolved, a subtask finished, review started, or approval started, four of the seven wake reasons in the shipped `office-default` workflow did not match the Go prompt builder's switch. The agent got the bare fallback string ("You have been woken for reason: X.") instead of a prompt telling it what changed or what to do. Separately, an approval participant that did wake correctly was handed the reviewer's own prompt verbatim ("You are reviewing task...") with no way to see the builder's comments, since the enrichment guard only fired for reviewers.

**After this:** All seven shipped wake reasons resolve to a real templated prompt. Review and approval participants each get role-correct framing, and approvers now see the same builder context reviewers do.

**Who hits this:** Every office task that reaches Review or Approval, or that resumes after a blocker-resolved or subtask-completed event, i.e. nearly every task run through the office-default workflow.

**Scope:** Standalone. One workflow YAML template plus the Go prompt-routing switch it drives.

**Not here:** Restructuring the prompt builder itself. Also out of scope: a same-task review/approval run-coalescing edge case surfaced during review (`CoalesceRun` in `internal/runs/repository/sqlite/runs.go` does not key on `stage_type`); it is a pre-existing, unreachable-in-practice residual unrelated to this fix and is not addressed here.

Fixed reasons in `apps/backend/config/workflows/office-default.yml`:

| Step | Trigger | Before | After |
|---|---|---|---|
| `work` | blocker resolved | `reason: blockers_resolved` | `reason: task_blockers_resolved` |
| `work` | subtask completed | `reason: children_completed` | `reason: task_children_completed` |
| `review` | review started | `reason: review_started` | `reason: task_assigned` + `payload: {stage_type: review}` |
| `approval` | approval started | `reason: approval_started` | `reason: task_assigned` + `payload: {stage_type: approval}` |

## Validation

- `go test ./internal/office/service/ ./internal/workflow/engine/ ./config/workflows/`: all packages green, including a new contract test (`TestPromptReasonContract_AllShippedReasonsResolve`) that fails on any shipped `reason:` value that doesn't resolve to a real prompt, and a strengthened test that asserts review and approval produce distinguishable prompts.
- `make -C apps/backend lint`: `0 issues.`
- `gofmt -l` on every changed `.go` file: clean.
- `make lint-format`: Prettier clean.
- `cd apps/web && pnpm run i18n:ratchet`: no-op (this diff touches zero `apps/web/` files).
- Scoped Playwright run: this diff is under `apps/backend/**`, so CI's `e2e-tests.yml` pattern match runs the full E2E gate. Ran the two specs whose surface it actually exercises ahead of that: `pnpm exec playwright test tests/office/workflow-quorum-transitions.spec.ts tests/office/scheduler-events.spec.ts` produced **4 passed (7.0s)**.
- Independently reproduced RED then GREEN for both fixes by hand (revert source, confirm the new/strengthened test fails with the exact pre-fix symptom, restore, confirm green) rather than trusting a single pass.
- Rebased onto current `origin/main`; re-ran the scoped Go tests, `gofmt`, and lint after rebase, all green.
- `make test` has 9 pre-existing failures across 6 unrelated packages (`internal/agent/managedruntime`, `internal/agent/settings/controller`, `internal/agentctl/server/config`, `internal/common/config`, `internal/launcher`, `internal/system/storage/workspaces`): macOS tmpdir/symlink resolution and ambient `KANDEV_HEALTH_TIMEOUT_MS` env leakage, reproduced identically against the merge base in a scratch worktree. None overlap this diff.

## Possible Improvements

Low risk: behavior-only change to prompt text/routing and one guard condition, with new/strengthened regression tests covering the exact defects found in review.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. (N/A: no `apps/web/` files touched)
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Fixed a stale example in `docs/workflow-import-export.md`; no `docs/public/**` impact.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->