### PR TITLE
fix(workflow): stop a task getting stuck when the agent's turn fails right after it finishes

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1699,6 +1699,21 @@ func (s *Service) handleRecoverableFailureLocked(ctx context.Context, data watch
 	// Ensure task is in REVIEW state unless another session is still working.
 	s.writeTaskReviewState(ctx, data.TaskID, data.SessionID)
 
+	// Give the ADR 0015 reconciler a second chance: a step_complete_kandev
+	// call that landed mid-turn (session still RUNNING) is never picked up
+	// by processOnTurnCompleteViaEngine when the turn fails instead of
+	// completing successfully, so the signal would otherwise sit inert in
+	// the session's metadata bag until it's silently cleared on resume.
+	// Office sessions go FAILED, not WAITING_FOR_INPUT, and must not
+	// advance the step here.
+	if nextState == models.TaskSessionStateWaitingForInput {
+		if session, err := s.repo.GetTaskSession(ctx, data.SessionID); err == nil {
+			if signal, ok := models.LoadPendingStepSignal(session.Metadata); ok {
+				s.reconcileStepCompletionSignalLocked(ctx, data.TaskID, data.SessionID, signal.StepID)
+			}
+		}
+	}
+
 	// Clean up the agent execution.
 	go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
 }

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1706,11 +1706,16 @@ func (s *Service) handleRecoverableFailureLocked(ctx context.Context, data watch
 	// the session's metadata bag until it's silently cleared on resume.
 	// Office sessions go FAILED, not WAITING_FOR_INPUT, and must not
 	// advance the step here.
-	if nextState == models.TaskSessionStateWaitingForInput {
-		if session, err := s.repo.GetTaskSession(ctx, data.SessionID); err == nil {
-			if signal, ok := models.LoadPendingStepSignal(session.Metadata); ok {
-				s.reconcileStepCompletionSignalLocked(ctx, data.TaskID, data.SessionID, signal.StepID)
-			}
+	if nextState == models.TaskSessionStateWaitingForInput && data.SessionID != "" {
+		session, err := s.repo.GetTaskSession(ctx, data.SessionID)
+		if err != nil {
+			s.logger.Warn("failed to reload session for step-completion reconciliation; "+
+				"a pending signal may be dropped",
+				zap.String("task_id", data.TaskID),
+				zap.String("session_id", data.SessionID),
+				zap.Error(err))
+		} else if signal, ok := models.LoadPendingStepSignal(session.Metadata); ok {
+			s.reconcileStepCompletionSignalLocked(ctx, data.TaskID, data.SessionID, signal.StepID)
 		}
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1697,6 +1697,12 @@ func (s *Service) handleRecoverableFailureLocked(ctx context.Context, data watch
 	s.updateTaskSessionState(ctx, data.TaskID, data.SessionID, nextState, data.ErrorMessage, false)
 
 	// Ensure task is in REVIEW state unless another session is still working.
+	// Unlike the success path (processOnTurnCompleteViaEngine runs first and
+	// skips this write entirely on a transition), REVIEW is written before the
+	// reconciliation below runs. A pending signal that reconciles into a
+	// transition here is a transient REVIEW flash a watching client could
+	// observe; that's accepted as the price of keeping this failure path
+	// simple, since the agent genuinely did fail.
 	s.writeTaskReviewState(ctx, data.TaskID, data.SessionID)
 
 	// Give the ADR 0015 reconciler a second chance: a step_complete_kandev

--- a/apps/backend/internal/orchestrator/event_handlers_step_completion.go
+++ b/apps/backend/internal/orchestrator/event_handlers_step_completion.go
@@ -167,9 +167,20 @@ func (s *Service) onStepCompletionSignaled(ctx context.Context, event *bus.Event
 		return
 	}
 
+	s.reconcileStepCompletionSignalLocked(ctx, taskID, sessionID, stepID)
+}
+
+// reconcileStepCompletionSignalLocked re-checks a pending step-completion
+// signal against the task's current state and, if still valid, drives the
+// transition. Callers must already hold sessionID's cancelInFlight guard —
+// this is the case for onStepCompletionSignaled's bus subscriber, and for
+// the turn-failure settle point in handleRecoverableFailureLocked, which
+// gives the ADR 0015 reconciler a second chance when the turn never reached
+// a successful processOnTurnCompleteViaEngine call.
+func (s *Service) reconcileStepCompletionSignalLocked(ctx context.Context, taskID, sessionID, stepID string) {
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
-		s.logger.Warn("onStepCompletionSignaled: failed to load session",
+		s.logger.Warn("reconcileStepCompletionSignalLocked: failed to load session",
 			zap.String("session_id", sessionID), zap.Error(err))
 		return
 	}
@@ -182,12 +193,12 @@ func (s *Service) onStepCompletionSignaled(ctx context.Context, event *bus.Event
 
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
-		s.logger.Warn("onStepCompletionSignaled: failed to load task",
+		s.logger.Warn("reconcileStepCompletionSignalLocked: failed to load task",
 			zap.String("task_id", taskID), zap.Error(err))
 		return
 	}
 	if task.WorkflowStepID != stepID {
-		s.logger.Debug("onStepCompletionSignaled: signal stale (step changed)",
+		s.logger.Debug("reconcileStepCompletionSignalLocked: signal stale (step changed)",
 			zap.String("signal_step", stepID), zap.String("current_step", task.WorkflowStepID))
 		// Only clear the bag when its current contents are themselves
 		// stale (matching THIS subscriber's stepID). Re-load the session

--- a/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
@@ -666,6 +666,9 @@ func TestStepCompletionSignalSurvivesTurnFailure(t *testing.T) {
 		if session.State != models.TaskSessionStateWaitingForInput {
 			t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
 		}
+		if _, hasBag := models.LoadPendingStepSignal(session.Metadata); hasBag {
+			t.Error("expected the stale signal to be cleared by the reconciler")
+		}
 
 		task, err := repo.GetTask(ctx, "t1")
 		if err != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
@@ -535,147 +535,167 @@ func TestOnStepCompletionSignaled(t *testing.T) {
 	})
 }
 
+// newGatedStepFailureService creates the workflow used by the turn-failure
+// signal tests below. The first step advances only when a matching signal is
+// present.
+func newGatedStepFailureService(t *testing.T) (*Service, *sqliterepo.Repository) {
+	t.Helper()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1") // seedSession leaves the session RUNNING.
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+		AutoAdvanceRequiresSignal: true,
+		Events: wfmodels.StepEvents{
+			OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+				{Type: wfmodels.OnTurnCompleteMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
+	}
+
+	taskRepo := newMockTaskRepo()
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	return createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr), repo
+}
+
+func seedPendingStepCompletionSignal(t *testing.T, repo *sqliterepo.Repository, stepID, summary string) {
+	t.Helper()
+	signal := models.PendingStepCompletionSignal{
+		StepID:     stepID,
+		Source:     models.StepCompletionSourceAgent,
+		Summary:    summary,
+		SignaledAt: time.Now().UTC(),
+	}
+	if err := repo.SetSessionMetadataKey(context.Background(), "s1", models.SessionMetaKeyPendingStepCompletion, signal); err != nil {
+		t.Fatalf("seed pending signal: %v", err)
+	}
+}
+
+func stepCompletionSignalEvent(taskID, sessionID, stepID string) *bus.Event {
+	return bus.NewEvent("workflow.step_completion_signaled", "test", map[string]interface{}{
+		"task_id":    taskID,
+		"session_id": sessionID,
+		"step_id":    stepID,
+	})
+}
+
 // TestStepCompletionSignalSurvivesTurnFailure is the regression test for the
-// dropped-signal bug: a step_complete_kandev call lands mid-turn (session
-// still RUNNING), so onStepCompletionSignaled's bus subscriber correctly
-// no-ops (the inline turn-end check was expected to pick it up). But the
-// turn then FAILS instead of completing successfully, so
-// processOnTurnCompleteViaEngine never runs. Before the fix,
-// handleRecoverableFailureLocked settled the session into
-// WAITING_FOR_INPUT without ever re-checking the bag, and the signal sat
-// inert until it was silently cleared on resume — the task stayed stuck on
-// step1 forever. The fix gives the reconciler a second chance right where
-// the session settles into WAITING_FOR_INPUT.
+// dropped-signal bug. A signal written during a running turn must be applied
+// when that turn fails and settles the session into WAITING_FOR_INPUT.
 func TestStepCompletionSignalSurvivesTurnFailure(t *testing.T) {
 	ctx := context.Background()
+	svc, repo := newGatedStepFailureService(t)
+	seedPendingStepCompletionSignal(t, repo, "step1", "all done")
 
-	buildEvent := func(taskID, sessionID, stepID string) *bus.Event {
-		return bus.NewEvent("workflow.step_completion_signaled", "test", map[string]interface{}{
-			"task_id":    taskID,
-			"session_id": sessionID,
-			"step_id":    stepID,
-		})
+	// The subscriber sees a running session and correctly defers to the
+	// turn-end path.
+	svc.onStepCompletionSignaled(ctx, stepCompletionSignalEvent("t1", "s1", "step1"))
+	if session, err := repo.GetTaskSession(ctx, "s1"); err != nil || session.State != models.TaskSessionStateRunning {
+		t.Fatalf("expected session to remain RUNNING after subscriber no-op, got %+v (err=%v)", session, err)
+	}
+	if task, err := repo.GetTask(ctx, "t1"); err != nil || task.WorkflowStepID != "step1" {
+		t.Fatalf("expected no transition yet, got %+v (err=%v)", task, err)
 	}
 
-	newGatedService := func(t *testing.T) (svc *Service, repo *sqliterepo.Repository) {
-		t.Helper()
-		repo = setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1") // seedSession leaves the session RUNNING.
+	svc.handleAgentFailed(ctx, watcher.AgentEventData{
+		TaskID:           "t1",
+		SessionID:        "s1",
+		AgentExecutionID: "exec-1",
+		ErrorMessage:     "agent crashed",
+	})
 
-		stepGetter := newMockStepGetter()
-		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
-			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
-			AutoAdvanceRequiresSignal: true,
-			Events: wfmodels.StepEvents{
-				OnTurnComplete: []wfmodels.OnTurnCompleteAction{
-					{Type: wfmodels.OnTurnCompleteMoveToNext},
-				},
-			},
-		}
-		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
-			ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
-		}
-
-		taskRepo := newMockTaskRepo()
-		agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
-		svc = createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
-		return svc, repo
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
+	}
+	if _, hasSignal := models.LoadPendingStepSignal(session.Metadata); hasSignal {
+		t.Error("expected the pending signal to be consumed by the transition")
 	}
 
-	t.Run("signal survives turn failure and applies once WAITING_FOR_INPUT", func(t *testing.T) {
-		svc, repo := newGatedService(t)
+	task, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task.WorkflowStepID != "step2" {
+		t.Fatalf("expected task to advance to step2 after the failed turn, got %q", task.WorkflowStepID)
+	}
+}
 
-		// Step 1: mid-turn step_complete_kandev — writes the bag entry
-		// while the session is still RUNNING.
-		signal := models.PendingStepCompletionSignal{
-			StepID:     "step1",
-			Source:     models.StepCompletionSourceAgent,
-			Summary:    "all done",
-			SignaledAt: time.Now().UTC(),
-		}
-		if err := repo.SetSessionMetadataKey(ctx, "s1", models.SessionMetaKeyPendingStepCompletion, signal); err != nil {
-			t.Fatalf("seed pending signal: %v", err)
-		}
+func TestStaleStepCompletionSignalDoesNotTransitionAfterTurnFailure(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newGatedStepFailureService(t)
+	seedPendingStepCompletionSignal(t, repo, "step_old", "stale")
 
-		// Step 2: the ADR 0015 bus subscriber fires synchronously off the
-		// signal write. Session is still RUNNING, so it must no-op.
-		svc.onStepCompletionSignaled(ctx, buildEvent("t1", "s1", "step1"))
-		if session, err := repo.GetTaskSession(ctx, "s1"); err != nil || session.State != models.TaskSessionStateRunning {
-			t.Fatalf("expected session to remain RUNNING after subscriber no-op, got %+v (err=%v)", session, err)
-		}
-		if task, err := repo.GetTask(ctx, "t1"); err != nil || task.WorkflowStepID != "step1" {
-			t.Fatalf("expected no transition yet, got %+v (err=%v)", task, err)
-		}
-
-		// Step 3: the turn fails (not completes) with a non-transient
-		// error. handleAgentFailed -> handleRecoverableFailureLocked
-		// settles the session into WAITING_FOR_INPUT.
-		svc.handleAgentFailed(ctx, watcher.AgentEventData{
-			TaskID:           "t1",
-			SessionID:        "s1",
-			AgentExecutionID: "exec-1",
-			ErrorMessage:     "agent crashed",
-		})
-
-		session, err := repo.GetTaskSession(ctx, "s1")
-		if err != nil {
-			t.Fatalf("get session: %v", err)
-		}
-		if session.State != models.TaskSessionStateWaitingForInput {
-			t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
-		}
-		if _, hasBag := models.LoadPendingStepSignal(session.Metadata); hasBag {
-			t.Error("expected the pending signal to be consumed by the transition")
-		}
-
-		task, err := repo.GetTask(ctx, "t1")
-		if err != nil {
-			t.Fatalf("get task: %v", err)
-		}
-		if task.WorkflowStepID != "step2" {
-			t.Fatalf("expected task to advance to step2 after the failed turn, got %q", task.WorkflowStepID)
-		}
+	svc.handleAgentFailed(ctx, watcher.AgentEventData{
+		TaskID:           "t1",
+		SessionID:        "s1",
+		AgentExecutionID: "exec-1",
+		ErrorMessage:     "agent crashed",
 	})
 
-	t.Run("stale signal (step changed) does not transition on failure", func(t *testing.T) {
-		svc, repo := newGatedService(t)
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
+	}
+	if _, hasSignal := models.LoadPendingStepSignal(session.Metadata); hasSignal {
+		t.Error("expected the stale signal to be cleared by the reconciler")
+	}
 
-		// Bag holds a signal for a step the task is no longer on — must
-		// not fire the transition just because a turn failed.
-		signal := models.PendingStepCompletionSignal{
-			StepID:     "step_old",
-			Source:     models.StepCompletionSourceAgent,
-			Summary:    "stale",
-			SignaledAt: time.Now().UTC(),
-		}
-		if err := repo.SetSessionMetadataKey(ctx, "s1", models.SessionMetaKeyPendingStepCompletion, signal); err != nil {
-			t.Fatalf("seed stale signal: %v", err)
-		}
+	task, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task.WorkflowStepID != "step1" {
+		t.Fatalf("expected task to stay on step1 (stale signal must not transition), got %q", task.WorkflowStepID)
+	}
+}
 
-		svc.handleAgentFailed(ctx, watcher.AgentEventData{
-			TaskID:           "t1",
-			SessionID:        "s1",
-			AgentExecutionID: "exec-1",
-			ErrorMessage:     "agent crashed",
-		})
+// TestOfficeStepCompletionSignalDoesNotAdvanceAfterTurnFailure covers the
+// Office-session exclusion. Office failures are terminal for the session and
+// must not advance the workflow from a matching pending signal.
+func TestOfficeStepCompletionSignalDoesNotAdvanceAfterTurnFailure(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newGatedStepFailureService(t)
+	task, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	task.ProjectID = "office-project"
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("mark task as Office-owned: %v", err)
+	}
+	seedPendingStepCompletionSignal(t, repo, "step1", "all done")
 
-		session, err := repo.GetTaskSession(ctx, "s1")
-		if err != nil {
-			t.Fatalf("get session: %v", err)
-		}
-		if session.State != models.TaskSessionStateWaitingForInput {
-			t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
-		}
-		if _, hasBag := models.LoadPendingStepSignal(session.Metadata); hasBag {
-			t.Error("expected the stale signal to be cleared by the reconciler")
-		}
-
-		task, err := repo.GetTask(ctx, "t1")
-		if err != nil {
-			t.Fatalf("get task: %v", err)
-		}
-		if task.WorkflowStepID != "step1" {
-			t.Fatalf("expected task to stay on step1 (stale signal must not transition), got %q", task.WorkflowStepID)
-		}
+	svc.handleAgentFailed(ctx, watcher.AgentEventData{
+		TaskID:           "t1",
+		SessionID:        "s1",
+		AgentExecutionID: "exec-1",
+		ErrorMessage:     "agent crashed",
 	})
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if session.State != models.TaskSessionStateFailed {
+		t.Fatalf("expected Office session FAILED after failure, got %q", session.State)
+	}
+
+	task, err = repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task.WorkflowStepID != "step1" {
+		t.Fatalf("expected Office task to stay on step1, got %q", task.WorkflowStepID)
+	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_step_completion_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
@@ -528,6 +531,148 @@ func TestOnStepCompletionSignaled(t *testing.T) {
 		}
 		if _, hasSignal := models.LoadPendingStepSignal(updatedSession.Metadata); !hasSignal {
 			t.Fatal("stop-winning subscriber consumed the queued completion signal")
+		}
+	})
+}
+
+// TestStepCompletionSignalSurvivesTurnFailure is the regression test for the
+// dropped-signal bug: a step_complete_kandev call lands mid-turn (session
+// still RUNNING), so onStepCompletionSignaled's bus subscriber correctly
+// no-ops (the inline turn-end check was expected to pick it up). But the
+// turn then FAILS instead of completing successfully, so
+// processOnTurnCompleteViaEngine never runs. Before the fix,
+// handleRecoverableFailureLocked settled the session into
+// WAITING_FOR_INPUT without ever re-checking the bag, and the signal sat
+// inert until it was silently cleared on resume — the task stayed stuck on
+// step1 forever. The fix gives the reconciler a second chance right where
+// the session settles into WAITING_FOR_INPUT.
+func TestStepCompletionSignalSurvivesTurnFailure(t *testing.T) {
+	ctx := context.Background()
+
+	buildEvent := func(taskID, sessionID, stepID string) *bus.Event {
+		return bus.NewEvent("workflow.step_completion_signaled", "test", map[string]interface{}{
+			"task_id":    taskID,
+			"session_id": sessionID,
+			"step_id":    stepID,
+		})
+	}
+
+	newGatedService := func(t *testing.T) (svc *Service, repo *sqliterepo.Repository) {
+		t.Helper()
+		repo = setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1") // seedSession leaves the session RUNNING.
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+			AutoAdvanceRequiresSignal: true,
+			Events: wfmodels.StepEvents{
+				OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+					{Type: wfmodels.OnTurnCompleteMoveToNext},
+				},
+			},
+		}
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
+		}
+
+		taskRepo := newMockTaskRepo()
+		agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+		svc = createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+		return svc, repo
+	}
+
+	t.Run("signal survives turn failure and applies once WAITING_FOR_INPUT", func(t *testing.T) {
+		svc, repo := newGatedService(t)
+
+		// Step 1: mid-turn step_complete_kandev — writes the bag entry
+		// while the session is still RUNNING.
+		signal := models.PendingStepCompletionSignal{
+			StepID:     "step1",
+			Source:     models.StepCompletionSourceAgent,
+			Summary:    "all done",
+			SignaledAt: time.Now().UTC(),
+		}
+		if err := repo.SetSessionMetadataKey(ctx, "s1", models.SessionMetaKeyPendingStepCompletion, signal); err != nil {
+			t.Fatalf("seed pending signal: %v", err)
+		}
+
+		// Step 2: the ADR 0015 bus subscriber fires synchronously off the
+		// signal write. Session is still RUNNING, so it must no-op.
+		svc.onStepCompletionSignaled(ctx, buildEvent("t1", "s1", "step1"))
+		if session, err := repo.GetTaskSession(ctx, "s1"); err != nil || session.State != models.TaskSessionStateRunning {
+			t.Fatalf("expected session to remain RUNNING after subscriber no-op, got %+v (err=%v)", session, err)
+		}
+		if task, err := repo.GetTask(ctx, "t1"); err != nil || task.WorkflowStepID != "step1" {
+			t.Fatalf("expected no transition yet, got %+v (err=%v)", task, err)
+		}
+
+		// Step 3: the turn fails (not completes) with a non-transient
+		// error. handleAgentFailed -> handleRecoverableFailureLocked
+		// settles the session into WAITING_FOR_INPUT.
+		svc.handleAgentFailed(ctx, watcher.AgentEventData{
+			TaskID:           "t1",
+			SessionID:        "s1",
+			AgentExecutionID: "exec-1",
+			ErrorMessage:     "agent crashed",
+		})
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		if session.State != models.TaskSessionStateWaitingForInput {
+			t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
+		}
+		if _, hasBag := models.LoadPendingStepSignal(session.Metadata); hasBag {
+			t.Error("expected the pending signal to be consumed by the transition")
+		}
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step2" {
+			t.Fatalf("expected task to advance to step2 after the failed turn, got %q", task.WorkflowStepID)
+		}
+	})
+
+	t.Run("stale signal (step changed) does not transition on failure", func(t *testing.T) {
+		svc, repo := newGatedService(t)
+
+		// Bag holds a signal for a step the task is no longer on — must
+		// not fire the transition just because a turn failed.
+		signal := models.PendingStepCompletionSignal{
+			StepID:     "step_old",
+			Source:     models.StepCompletionSourceAgent,
+			Summary:    "stale",
+			SignaledAt: time.Now().UTC(),
+		}
+		if err := repo.SetSessionMetadataKey(ctx, "s1", models.SessionMetaKeyPendingStepCompletion, signal); err != nil {
+			t.Fatalf("seed stale signal: %v", err)
+		}
+
+		svc.handleAgentFailed(ctx, watcher.AgentEventData{
+			TaskID:           "t1",
+			SessionID:        "s1",
+			AgentExecutionID: "exec-1",
+			ErrorMessage:     "agent crashed",
+		})
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		if session.State != models.TaskSessionStateWaitingForInput {
+			t.Fatalf("expected session WAITING_FOR_INPUT after failure, got %q", session.State)
+		}
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step1" {
+			t.Fatalf("expected task to stay on step1 (stale signal must not transition), got %q", task.WorkflowStepID)
 		}
 	})
 }


### PR DESCRIPTION
**Today:** if an agent finishes a workflow step and its turn then errors out afterward — most commonly a rate limit that exhausts its retries — before the platform gets a chance to act on that completion, the task is stuck on that step forever. Nothing is logged, no error is surfaced; it just looks like an ordinary unsignalled park, so a human has to notice and move the card by hand.
**After this:** the queued step completion is reconciled once the session settles into a waiting state via the failure path too, so the task advances to the next step exactly as it would after a normal successful turn.
**Who hits this:** any workflow step configured to auto-advance on an explicit completion signal, whenever the agent's turn errors out after it already reported the step done. Silent and easy to miss until a card just stops moving.
**Scope:** standalone bugfix, not part of a larger feature slice.
**Not here:** a related but distinct bug, where the signal *is* consumed by a normal successful turn-completion but then fails a WIP-limit-blocked transition, is filed and handled separately — not touched here.

A workflow step's completion signal was silently dropped whenever the agent's turn failed before the platform could act on it, leaving the task stuck on that step with no visible error anywhere. This reconciles the pending signal once the session settles after a failed turn, so the task advances exactly as it would have after a successful one.

## Important Changes

- Extracted the existing signal-reconciliation logic into a standalone `reconcileStepCompletionSignalLocked` so both the original success-path subscriber and the new failure path can call it, with no behaviour change to the existing path.
- The turn-failure handler now calls that reconciliation when the session lands in a waiting state and still holds a pending completion signal for the task's current step. A stale signal (task already moved on) is left alone, matching the existing staleness check on the success path.
- A session-reload error on that new path is now logged instead of silently discarded, so a transient read error can't quietly reintroduce the same silent-drop symptom this PR fixes.

## Validation

- `go test ./internal/orchestrator/... -run 'TestStepCompletionSignalSurvivesTurnFailure|TestOnStepCompletionSignaled' -race -count=1` — new regression test (signals mid-turn, then fails the turn instead of completing it, and asserts the transition still applies once the session reaches the waiting state; a second subtest asserts a stale signal is cleared but does not transition) plus every pre-existing subtest, race-clean.
- Proved test rigor by running the new test file against the unmodified pre-fix production code in a scratch worktree: both subtests fail at the exact assertions the fix addresses (signal not consumed, step not advanced, stale bag not cleared); with the fix, both pass.
- `make -C apps/backend lint` — 0 issues. `make -C apps/backend test` (full suite) and `make test-web`/`make test-cli`/`make test-scripts` (repo root) — no failures attributable to this change; a fixed set of 6 backend packages and 2 web/script tests fail identically with this change reverted (macOS tmp-dir symlink and CI-only environment assumptions, plus known-flaky async/timeout tests that pass cleanly on retry) — all pre-existing and unrelated to `internal/orchestrator`.
- `make lint-format`, `pnpm run i18n:ratchet` — clean; this change touches no `apps/web/` files, so no E2E was required or run.
- Two independent review passes (in-repo review skill plus a cross-vendor outside-voice pass at high reasoning effort) traced lock ownership, ordering against the existing success path, idempotency, and re-entrancy across every call site of the touched function; no blocking issue survived adjudication.

## Possible Improvements

Low risk: confined to `internal/orchestrator`, no API/schema/contract change, and the new code path is defensively gated to only ever apply a signal targeting the task's current step.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->