### PR TITLE
feat(mcp): add task-scoped inbox

### DIFF
--- a/apps/backend/internal/db/dialect/promptindex.go
+++ b/apps/backend/internal/db/dialect/promptindex.go
@@ -58,3 +58,20 @@ func PromptOrderIndexDDL(driver, indexName, table string) string {
 		indexName, table, NormalizedMicrosecond(driver, "created_at"),
 	)
 }
+
+// TaskInboxOrderIndexDDL returns the additive task/author/order index used by
+// the task-wide inbox projection. The ordering expression matches the query's
+// normalized timestamp expression exactly, and IF NOT EXISTS makes schema
+// initialization safe to replay on existing databases.
+func TaskInboxOrderIndexDDL(driver, indexName, table string) string {
+	if IsPostgres(driver) {
+		return fmt.Sprintf(
+			"CREATE INDEX IF NOT EXISTS %s ON %s(task_id, author_type, created_at, id)",
+			indexName, table,
+		)
+	}
+	return fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS %s ON %s(task_id, author_type, (%s), id)",
+		indexName, table, NormalizedMicrosecond(driver, "created_at"),
+	)
+}

--- a/apps/backend/internal/mcp/handlers/automation_authorization.go
+++ b/apps/backend/internal/mcp/handlers/automation_authorization.go
@@ -44,6 +44,7 @@ var automationSurfaceActions = map[string]struct{}{
 	ws.ActionMCPListRelatedTasks:            {},
 	ws.ActionMCPGetTaskConversation:         {},
 	ws.ActionMCPListTaskSessions:            {},
+	ws.ActionMCPListTaskInbox:               {},
 	ws.ActionMCPCreateTask:                  {},
 	ws.ActionMCPUpdateTask:                  {},
 	ws.ActionMCPMoveTask:                    {},

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -436,6 +436,7 @@ func (h *Handlers) registerTaskReadHandlers(d *guardedMCPDispatcher) {
 	d.RegisterFunc(ws.ActionMCPUpdateTaskMRAutomation, h.handleUpdateTaskMRAutomation)
 	d.RegisterFunc(ws.ActionMCPGetTaskConversation, h.handleGetTaskConversation)
 	d.RegisterFunc(ws.ActionMCPListTaskSessions, h.handleListTaskSessions)
+	d.RegisterFunc(ws.ActionMCPListTaskInbox, h.handleListTaskInbox)
 	d.RegisterFunc(ws.ActionMCPListPendingAgentPermissions, h.handleListPendingAgentPermissions)
 	d.RegisterFunc(ws.ActionMCPResolveAgentPermission, h.handleResolveAgentPermission)
 }

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 	ws "github.com/kandev/kandev/pkg/websocket"
@@ -57,6 +58,8 @@ type inboxAttachment struct {
 	Name         string `json:"name,omitempty"`
 	SizeBytes    int64  `json:"size_bytes,omitempty"`
 }
+
+const inboxTransitionIDKey = "inbox_transition_id"
 
 func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
 	req, cursor, errResp := h.parseTaskInboxRequest(ctx, msg)
@@ -136,14 +139,15 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 		}
 		items = append(items, inboxItem{
 			ID:           message.ID,
-			TransitionID: inboxMetadataString(message.Metadata, "queue_entry_id"),
+			TransitionID: inboxTransitionID(message.Metadata, inboxMetadataString(message.Metadata, "queue_entry_id")),
 			State:        "delivered",
 			SessionID:    session.ID,
 			SessionName:  session.Name,
 			IsPrimary:    session.IsPrimary,
 			IsCurrent:    session.ID == currentID,
 			Sender:       string(message.AuthorType),
-			Content:      message.Content,
+			Content:      sysprompt.StripSystemContent(message.Content),
+			Attachments:  safeInboxMessageAttachments(message.Metadata),
 			Timestamp:    message.CreatedAt,
 		})
 		counts[session.ID]++
@@ -157,7 +161,7 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 		}
 		items = append(items, inboxItem{
 			ID:           entry.ID,
-			TransitionID: entry.ID,
+			TransitionID: inboxTransitionID(entry.Metadata, entry.ID),
 			State:        "queued",
 			SessionID:    session.ID,
 			SessionName:  session.Name,
@@ -177,6 +181,12 @@ func inboxMetadataString(metadata map[string]interface{}, key string) string {
 	value, _ := metadata[key].(string)
 	return value
 }
+func inboxTransitionID(metadata map[string]interface{}, fallback string) string {
+	if id := inboxMetadataString(metadata, inboxTransitionIDKey); id != "" {
+		return id
+	}
+	return fallback
+}
 func inboxLimit(requested int) int {
 	if requested <= 0 {
 		return inboxDefaultLimit
@@ -192,6 +202,22 @@ func safeInboxAttachments(entries []messagequeue.MessageAttachment) []inboxAttac
 		out = append(out, inboxAttachment{AttachmentID: entry.AttachmentID, Type: entry.Type, MimeType: entry.MimeType, Name: entry.Name, SizeBytes: entry.SizeBytes})
 	}
 	return out
+}
+
+func safeInboxMessageAttachments(metadata map[string]interface{}) []inboxAttachment {
+	attachments, ok := metadata["attachments"]
+	if !ok {
+		return nil
+	}
+	encoded, err := json.Marshal(attachments)
+	if err != nil {
+		return nil
+	}
+	var queued []messagequeue.MessageAttachment
+	if err := json.Unmarshal(encoded, &queued); err != nil {
+		return nil
+	}
+	return safeInboxAttachments(queued)
 }
 func inboxBefore(a, b inboxItem) bool {
 	if !a.Timestamp.Equal(b.Timestamp) {

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	mcpscope "github.com/kandev/kandev/internal/mcp/scope"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
@@ -22,11 +23,12 @@ const (
 )
 
 type taskInboxRequest struct {
-	TaskID           string `json:"task_id"`
-	CallerTaskID     string `json:"caller_task_id"`
-	CurrentSessionID string `json:"current_session_id"`
-	Cursor           string `json:"cursor"`
-	Limit            int    `json:"limit"`
+	TaskID string `json:"task_id"`
+	Cursor string `json:"cursor"`
+	Limit  int    `json:"limit"`
+	// CurrentSessionID is filled from the trusted MCP principal, never from
+	// the request payload.
+	CurrentSessionID string `json:"-"`
 }
 
 type taskInboxCursor struct {
@@ -163,9 +165,11 @@ func (h *Handlers) parseTaskInboxRequest(ctx context.Context, msg *ws.Message) (
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error())
 	}
-	if req.TaskID == "" || req.CallerTaskID == "" || req.TaskID != req.CallerTaskID {
+	principal, ok := mcpscope.PrincipalFromContext(ctx)
+	if !ok || req.TaskID == "" || req.TaskID != principal.CallerTaskID {
 		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "task not found")
 	}
+	req.CurrentSessionID = principal.CallerSessionID
 	if req.Limit < 0 {
 		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeValidation, "limit must be non-negative")
 	}

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	ws "github.com/kandev/kandev/pkg/websocket"
+	"go.uber.org/zap"
+)
+
+const inboxDefaultLimit = 100
+
+type taskInboxRequest struct {
+	TaskID           string `json:"task_id"`
+	CallerTaskID     string `json:"caller_task_id"`
+	CurrentSessionID string `json:"current_session_id"`
+	Cursor           string `json:"cursor"`
+	Limit            int    `json:"limit"`
+}
+
+type taskInboxCursor struct {
+	Timestamp time.Time `json:"t"`
+	ID        string    `json:"id"`
+}
+
+// inboxItem is deliberately a safe projection. In particular it does not
+// return message metadata or attachment bytes, both of which can contain
+// internal context that a polling coordinator does not need.
+type inboxItem struct {
+	ID           string            `json:"id"`
+	TransitionID string            `json:"transition_id,omitempty"`
+	State        string            `json:"state"`
+	SessionID    string            `json:"session_id"`
+	SessionName  string            `json:"session_name,omitempty"`
+	IsPrimary    bool              `json:"is_primary"`
+	IsCurrent    bool              `json:"is_current"`
+	Sender       string            `json:"sender"`
+	Content      string            `json:"content"`
+	Attachments  []inboxAttachment `json:"attachments,omitempty"`
+	Timestamp    time.Time         `json:"timestamp"`
+}
+
+type inboxAttachment struct {
+	AttachmentID string `json:"attachment_id,omitempty"`
+	Type         string `json:"type"`
+	MimeType     string `json:"mime_type,omitempty"`
+	Name         string `json:"name,omitempty"`
+	SizeBytes    int64  `json:"size_bytes,omitempty"`
+}
+
+func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	req, cursor, errResp := h.parseTaskInboxRequest(ctx, msg)
+	if errResp != nil {
+		return errResp, nil
+	}
+	sessions, err := h.taskSvc.ListTaskSessions(ctx, req.TaskID)
+	if err != nil {
+		h.logger.Error("failed to list inbox sessions", zap.Error(err))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
+	}
+	items := make([]inboxItem, 0)
+	perSession := make(map[string]int, len(sessions))
+	for _, session := range sessions {
+		items, err = h.appendSessionInbox(ctx, items, perSession, session, req.CurrentSessionID)
+		if err != nil {
+			h.logger.Error("failed to list session inbox", zap.String("session_id", session.ID), zap.Error(err))
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return inboxBefore(items[i], items[j]) })
+	start := 0
+	if cursor != nil {
+		for start < len(items) && !inboxAfter(items[start], *cursor) {
+			start++
+		}
+	}
+	limit := req.Limit
+	if limit == 0 {
+		limit = inboxDefaultLimit
+	}
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	page := items[start:end]
+	next := ""
+	if end < len(items) && len(page) > 0 {
+		next = encodeInboxCursor(page[len(page)-1])
+	}
+	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+		"task_id": req.TaskID, "items": page, "total": len(items), "returned": len(page),
+		"has_more": end < len(items), "cursor": next, "per_session_counts": perSession,
+	})
+}
+
+func (h *Handlers) parseTaskInboxRequest(ctx context.Context, msg *ws.Message) (*taskInboxRequest, *taskInboxCursor, *ws.Message) {
+	var req taskInboxRequest
+	if err := json.Unmarshal(msg.Payload, &req); err != nil {
+		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error())
+	}
+	if req.TaskID == "" || req.CallerTaskID == "" || req.TaskID != req.CallerTaskID {
+		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "task not found")
+	}
+	if req.Limit < 0 {
+		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeValidation, "limit must be non-negative")
+	}
+	cursor, err := decodeInboxCursor(req.Cursor)
+	if err != nil {
+		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeValidation, "invalid cursor")
+	}
+	if _, err = h.taskSvc.GetTask(ctx, req.TaskID); err != nil {
+		if errors.Is(err, repoerrors.ErrTaskNotFound) || errors.Is(err, repoerrors.ErrWorkspaceNotFound) {
+			return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "task not found")
+		}
+		h.logger.Error("failed to look up inbox task", zap.Error(err))
+		return nil, nil, wsError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox")
+	}
+	return &req, cursor, nil
+}
+
+func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, counts map[string]int, session *models.TaskSession, currentID string) ([]inboxItem, error) {
+	messages, err := h.taskSvc.ListMessages(ctx, session.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, message := range messages {
+		if message.AuthorType != models.MessageAuthorUser {
+			continue
+		}
+		items = append(items, inboxItem{ID: message.ID, TransitionID: inboxMetadataString(message.Metadata, "queue_entry_id"), State: "delivered", SessionID: session.ID, SessionName: session.Name, IsPrimary: session.IsPrimary, IsCurrent: session.ID == currentID, Sender: string(message.AuthorType), Content: message.Content, Timestamp: message.CreatedAt})
+		counts[session.ID]++
+	}
+	if h.sessionLauncher == nil || h.sessionLauncher.GetMessageQueue() == nil {
+		return items, nil
+	}
+	for _, entry := range h.sessionLauncher.GetMessageQueue().GetStatus(ctx, session.ID).Entries {
+		if entry.IsReservedInFlight() {
+			continue
+		}
+		items = append(items, inboxItem{ID: entry.ID, TransitionID: entry.ID, State: "queued", SessionID: session.ID, SessionName: session.Name, IsPrimary: session.IsPrimary, IsCurrent: session.ID == currentID, Sender: entry.QueuedBy, Content: entry.Content, Attachments: safeInboxAttachments(entry.Attachments), Timestamp: entry.QueuedAt})
+		counts[session.ID]++
+	}
+	return items, nil
+}
+
+func inboxMetadataString(metadata map[string]interface{}, key string) string {
+	value, _ := metadata[key].(string)
+	return value
+}
+func safeInboxAttachments(entries []messagequeue.MessageAttachment) []inboxAttachment {
+	out := make([]inboxAttachment, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, inboxAttachment{AttachmentID: entry.AttachmentID, Type: entry.Type, MimeType: entry.MimeType, Name: entry.Name, SizeBytes: entry.SizeBytes})
+	}
+	return out
+}
+func inboxBefore(a, b inboxItem) bool {
+	if !a.Timestamp.Equal(b.Timestamp) {
+		return a.Timestamp.Before(b.Timestamp)
+	}
+	return a.ID < b.ID
+}
+func inboxAfter(item inboxItem, cursor taskInboxCursor) bool {
+	return item.Timestamp.After(cursor.Timestamp) || (item.Timestamp.Equal(cursor.Timestamp) && item.ID > cursor.ID)
+}
+func encodeInboxCursor(item inboxItem) string {
+	raw, _ := json.Marshal(taskInboxCursor{Timestamp: item.Timestamp, ID: item.ID})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+func decodeInboxCursor(encoded string) (*taskInboxCursor, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	var cursor taskInboxCursor
+	if err = json.Unmarshal(raw, &cursor); err != nil || cursor.ID == "" || cursor.Timestamp.IsZero() {
+		return nil, errors.New("invalid inbox cursor")
+	}
+	return &cursor, nil
+}

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -32,8 +32,9 @@ type taskInboxRequest struct {
 }
 
 type taskInboxCursor struct {
-	Timestamp time.Time `json:"t"`
-	ID        string    `json:"id"`
+	Timestamp time.Time      `json:"t"`
+	ID        string         `json:"id"`
+	Counts    map[string]int `json:"c,omitempty"`
 }
 
 // inboxItem is deliberately a safe projection. In particular it does not
@@ -79,7 +80,7 @@ func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*w
 		h.logger.Error("failed to build task inbox", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
 	}
-	page, hasMore, next := paginateTaskInbox(items, cursor, limit, messagesHasMore)
+	page, hasMore, next := paginateTaskInbox(items, cursor, limit, messagesHasMore, perSession)
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 		"task_id": req.TaskID, "items": page, "total": inboxCountTotal(perSession), "returned": len(page),
 		"has_more": hasMore, "cursor": next, "per_session_counts": perSession,
@@ -93,7 +94,7 @@ func (h *Handlers) buildTaskInboxItems(
 	sessions []*models.TaskSession,
 	limit int,
 ) ([]inboxItem, map[string]int, bool, error) {
-	messageOptions := models.TaskInboxMessagesOptions{Limit: limit}
+	messageOptions := models.TaskInboxMessagesOptions{Limit: limit, SkipCounts: cursor != nil}
 	if cursor != nil {
 		messageOptions.AfterCreatedAt = cursor.Timestamp
 		messageOptions.AfterID = cursor.ID
@@ -108,6 +109,11 @@ func (h *Handlers) buildTaskInboxItems(
 	}
 	items := make([]inboxItem, 0)
 	perSession := make(map[string]int, len(messageCounts)+len(sessions))
+	if cursor != nil {
+		for sessionID, count := range cursor.Counts {
+			perSession[sessionID] = count
+		}
+	}
 	for sessionID, count := range messageCounts {
 		perSession[sessionID] = count
 	}
@@ -124,22 +130,25 @@ func (h *Handlers) buildTaskInboxItems(
 			SessionName:  session.Name,
 			IsPrimary:    session.IsPrimary,
 			IsCurrent:    session.ID == req.CurrentSessionID,
-			Sender:       string(message.AuthorType),
+			Sender:       inboxSender(message.Metadata, string(message.AuthorType)),
 			Content:      sysprompt.StripSystemContent(message.Content),
 			Attachments:  safeInboxMessageAttachments(message.Metadata),
 			Timestamp:    message.CreatedAt,
 		})
 	}
-	for _, session := range sessions {
-		items, err = h.appendSessionQueueInbox(ctx, items, perSession, session, req.CurrentSessionID)
+	if h.sessionLauncher != nil && h.sessionLauncher.GetMessageQueue() != nil {
+		queued, err := h.sessionLauncher.GetMessageQueue().ListPendingByTask(ctx, req.TaskID)
 		if err != nil {
 			return nil, nil, false, err
+		}
+		for _, session := range sessions {
+			items = appendQueueInbox(items, perSession, session, req.CurrentSessionID, queued[session.ID], cursor == nil)
 		}
 	}
 	return items, perSession, messagesHasMore, nil
 }
 
-func paginateTaskInbox(items []inboxItem, cursor *taskInboxCursor, limit int, messagesHasMore bool) ([]inboxItem, bool, string) {
+func paginateTaskInbox(items []inboxItem, cursor *taskInboxCursor, limit int, messagesHasMore bool, counts map[string]int) ([]inboxItem, bool, string) {
 	sort.Slice(items, func(i, j int) bool { return inboxBefore(items[i], items[j]) })
 	start := 0
 	if cursor != nil {
@@ -155,7 +164,7 @@ func paginateTaskInbox(items []inboxItem, cursor *taskInboxCursor, limit int, me
 	hasMore := messagesHasMore || end < len(items)
 	next := ""
 	if hasMore && len(page) > 0 {
-		next = encodeInboxCursor(page[len(page)-1])
+		next = encodeInboxCursorWithCounts(page[len(page)-1], counts)
 	}
 	return page, hasMore, next
 }
@@ -187,14 +196,8 @@ func (h *Handlers) parseTaskInboxRequest(ctx context.Context, msg *ws.Message) (
 	return &req, cursor, nil
 }
 
-func (h *Handlers) appendSessionQueueInbox(ctx context.Context, items []inboxItem, counts map[string]int, session *models.TaskSession, currentID string) ([]inboxItem, error) {
-	if h.sessionLauncher == nil || h.sessionLauncher.GetMessageQueue() == nil {
-		return items, nil
-	}
-	for _, entry := range h.sessionLauncher.GetMessageQueue().GetStatus(ctx, session.ID).Entries {
-		if entry.IsReservedInFlight() {
-			continue
-		}
+func appendQueueInbox(items []inboxItem, counts map[string]int, session *models.TaskSession, currentID string, entries []messagequeue.QueuedMessage, countEntries bool) []inboxItem {
+	for _, entry := range entries {
 		items = append(items, inboxItem{
 			ID:           entry.ID,
 			TransitionID: inboxTransitionID(entry.Metadata, entry.ID),
@@ -203,14 +206,23 @@ func (h *Handlers) appendSessionQueueInbox(ctx context.Context, items []inboxIte
 			SessionName:  session.Name,
 			IsPrimary:    session.IsPrimary,
 			IsCurrent:    session.ID == currentID,
-			Sender:       entry.QueuedBy,
-			Content:      entry.Content,
+			Sender:       inboxSender(entry.Metadata, entry.QueuedBy),
+			Content:      sysprompt.StripSystemContent(entry.Content),
 			Attachments:  safeInboxAttachments(entry.Attachments),
 			Timestamp:    entry.QueuedAt,
 		})
-		counts[session.ID]++
+		if countEntries {
+			counts[session.ID]++
+		}
 	}
-	return items, nil
+	return items
+}
+
+func inboxSender(metadata map[string]interface{}, fallback string) string {
+	if sender := inboxMetadataString(metadata, messagequeue.MetadataSenderTaskID); sender != "" {
+		return sender
+	}
+	return fallback
 }
 
 func inboxCountTotal(counts map[string]int) int {
@@ -277,7 +289,10 @@ func inboxAfter(item inboxItem, cursor taskInboxCursor) bool {
 	return itemTimestamp.After(cursorTimestamp) || (itemTimestamp.Equal(cursorTimestamp) && item.ID > cursor.ID)
 }
 func encodeInboxCursor(item inboxItem) string {
-	raw, _ := json.Marshal(taskInboxCursor{Timestamp: inboxOrderTime(item.Timestamp), ID: item.ID})
+	return encodeInboxCursorWithCounts(item, nil)
+}
+func encodeInboxCursorWithCounts(item inboxItem, counts map[string]int) string {
+	raw, _ := json.Marshal(taskInboxCursor{Timestamp: inboxOrderTime(item.Timestamp), ID: item.ID, Counts: counts})
 	return base64.RawURLEncoding.EncodeToString(raw)
 }
 func inboxOrderTime(timestamp time.Time) time.Time {

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -59,7 +59,7 @@ type inboxAttachment struct {
 	SizeBytes    int64  `json:"size_bytes,omitempty"`
 }
 
-const inboxTransitionIDKey = "inbox_transition_id"
+const inboxTransitionIDKey = messagequeue.MetadataInboxTransitionID
 
 func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
 	req, cursor, errResp := h.parseTaskInboxRequest(ctx, msg)
@@ -71,15 +71,73 @@ func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*w
 		h.logger.Error("failed to list inbox sessions", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
 	}
-	items := make([]inboxItem, 0)
-	perSession := make(map[string]int, len(sessions))
+	limit := inboxLimit(req.Limit)
+	items, perSession, messagesHasMore, err := h.buildTaskInboxItems(ctx, req, cursor, sessions, limit)
+	if err != nil {
+		h.logger.Error("failed to build task inbox", zap.Error(err))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
+	}
+	page, hasMore, next := paginateTaskInbox(items, cursor, limit, messagesHasMore)
+	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+		"task_id": req.TaskID, "items": page, "total": inboxCountTotal(perSession), "returned": len(page),
+		"has_more": hasMore, "cursor": next, "per_session_counts": perSession,
+	})
+}
+
+func (h *Handlers) buildTaskInboxItems(
+	ctx context.Context,
+	req *taskInboxRequest,
+	cursor *taskInboxCursor,
+	sessions []*models.TaskSession,
+	limit int,
+) ([]inboxItem, map[string]int, bool, error) {
+	messageOptions := models.TaskInboxMessagesOptions{Limit: limit}
+	if cursor != nil {
+		messageOptions.AfterCreatedAt = cursor.Timestamp
+		messageOptions.AfterID = cursor.ID
+	}
+	messages, messagesHasMore, messageCounts, err := h.taskSvc.ListTaskInboxMessages(ctx, req.TaskID, messageOptions)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	sessionsByID := make(map[string]*models.TaskSession, len(sessions))
 	for _, session := range sessions {
-		items, err = h.appendSessionInbox(ctx, items, perSession, session, req.CurrentSessionID)
+		sessionsByID[session.ID] = session
+	}
+	items := make([]inboxItem, 0)
+	perSession := make(map[string]int, len(messageCounts)+len(sessions))
+	for sessionID, count := range messageCounts {
+		perSession[sessionID] = count
+	}
+	for _, message := range messages {
+		session := sessionsByID[message.TaskSessionID]
+		if session == nil {
+			continue
+		}
+		items = append(items, inboxItem{
+			ID:           message.ID,
+			TransitionID: inboxTransitionID(message.Metadata, inboxMetadataString(message.Metadata, "queue_entry_id")),
+			State:        "delivered",
+			SessionID:    session.ID,
+			SessionName:  session.Name,
+			IsPrimary:    session.IsPrimary,
+			IsCurrent:    session.ID == req.CurrentSessionID,
+			Sender:       string(message.AuthorType),
+			Content:      sysprompt.StripSystemContent(message.Content),
+			Attachments:  safeInboxMessageAttachments(message.Metadata),
+			Timestamp:    message.CreatedAt,
+		})
+	}
+	for _, session := range sessions {
+		items, err = h.appendSessionQueueInbox(ctx, items, perSession, session, req.CurrentSessionID)
 		if err != nil {
-			h.logger.Error("failed to list session inbox", zap.String("session_id", session.ID), zap.Error(err))
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task inbox", nil)
+			return nil, nil, false, err
 		}
 	}
+	return items, perSession, messagesHasMore, nil
+}
+
+func paginateTaskInbox(items []inboxItem, cursor *taskInboxCursor, limit int, messagesHasMore bool) ([]inboxItem, bool, string) {
 	sort.Slice(items, func(i, j int) bool { return inboxBefore(items[i], items[j]) })
 	start := 0
 	if cursor != nil {
@@ -87,20 +145,17 @@ func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*w
 			start++
 		}
 	}
-	limit := inboxLimit(req.Limit)
 	end := start + limit
 	if end > len(items) {
 		end = len(items)
 	}
 	page := items[start:end]
+	hasMore := messagesHasMore || end < len(items)
 	next := ""
-	if end < len(items) && len(page) > 0 {
+	if hasMore && len(page) > 0 {
 		next = encodeInboxCursor(page[len(page)-1])
 	}
-	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-		"task_id": req.TaskID, "items": page, "total": len(items), "returned": len(page),
-		"has_more": end < len(items), "cursor": next, "per_session_counts": perSession,
-	})
+	return page, hasMore, next
 }
 
 func (h *Handlers) parseTaskInboxRequest(ctx context.Context, msg *ws.Message) (*taskInboxRequest, *taskInboxCursor, *ws.Message) {
@@ -128,30 +183,7 @@ func (h *Handlers) parseTaskInboxRequest(ctx context.Context, msg *ws.Message) (
 	return &req, cursor, nil
 }
 
-func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, counts map[string]int, session *models.TaskSession, currentID string) ([]inboxItem, error) {
-	messages, err := h.taskSvc.ListMessages(ctx, session.ID)
-	if err != nil {
-		return nil, err
-	}
-	for _, message := range messages {
-		if message.AuthorType != models.MessageAuthorUser {
-			continue
-		}
-		items = append(items, inboxItem{
-			ID:           message.ID,
-			TransitionID: inboxTransitionID(message.Metadata, inboxMetadataString(message.Metadata, "queue_entry_id")),
-			State:        "delivered",
-			SessionID:    session.ID,
-			SessionName:  session.Name,
-			IsPrimary:    session.IsPrimary,
-			IsCurrent:    session.ID == currentID,
-			Sender:       string(message.AuthorType),
-			Content:      sysprompt.StripSystemContent(message.Content),
-			Attachments:  safeInboxMessageAttachments(message.Metadata),
-			Timestamp:    message.CreatedAt,
-		})
-		counts[session.ID]++
-	}
+func (h *Handlers) appendSessionQueueInbox(ctx context.Context, items []inboxItem, counts map[string]int, session *models.TaskSession, currentID string) ([]inboxItem, error) {
 	if h.sessionLauncher == nil || h.sessionLauncher.GetMessageQueue() == nil {
 		return items, nil
 	}
@@ -175,6 +207,14 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 		counts[session.ID]++
 	}
 	return items, nil
+}
+
+func inboxCountTotal(counts map[string]int) int {
+	total := 0
+	for _, count := range counts {
+		total += count
+	}
+	return total
 }
 
 func inboxMetadataString(metadata map[string]interface{}, key string) string {
@@ -220,17 +260,24 @@ func safeInboxMessageAttachments(metadata map[string]interface{}) []inboxAttachm
 	return safeInboxAttachments(queued)
 }
 func inboxBefore(a, b inboxItem) bool {
-	if !a.Timestamp.Equal(b.Timestamp) {
-		return a.Timestamp.Before(b.Timestamp)
+	aTimestamp := inboxOrderTime(a.Timestamp)
+	bTimestamp := inboxOrderTime(b.Timestamp)
+	if !aTimestamp.Equal(bTimestamp) {
+		return aTimestamp.Before(bTimestamp)
 	}
 	return a.ID < b.ID
 }
 func inboxAfter(item inboxItem, cursor taskInboxCursor) bool {
-	return item.Timestamp.After(cursor.Timestamp) || (item.Timestamp.Equal(cursor.Timestamp) && item.ID > cursor.ID)
+	itemTimestamp := inboxOrderTime(item.Timestamp)
+	cursorTimestamp := inboxOrderTime(cursor.Timestamp)
+	return itemTimestamp.After(cursorTimestamp) || (itemTimestamp.Equal(cursorTimestamp) && item.ID > cursor.ID)
 }
 func encodeInboxCursor(item inboxItem) string {
-	raw, _ := json.Marshal(taskInboxCursor{Timestamp: item.Timestamp, ID: item.ID})
+	raw, _ := json.Marshal(taskInboxCursor{Timestamp: inboxOrderTime(item.Timestamp), ID: item.ID})
 	return base64.RawURLEncoding.EncodeToString(raw)
+}
+func inboxOrderTime(timestamp time.Time) time.Time {
+	return timestamp.UTC().Truncate(time.Microsecond)
 }
 func decodeInboxCursor(encoded string) (*taskInboxCursor, error) {
 	if encoded == "" {

--- a/apps/backend/internal/mcp/handlers/list_task_inbox.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox.go
@@ -15,7 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const inboxDefaultLimit = 100
+const (
+	inboxDefaultLimit = 100
+	inboxMaxLimit     = 500
+)
 
 type taskInboxRequest struct {
 	TaskID           string `json:"task_id"`
@@ -81,10 +84,7 @@ func (h *Handlers) handleListTaskInbox(ctx context.Context, msg *ws.Message) (*w
 			start++
 		}
 	}
-	limit := req.Limit
-	if limit == 0 {
-		limit = inboxDefaultLimit
-	}
+	limit := inboxLimit(req.Limit)
 	end := start + limit
 	if end > len(items) {
 		end = len(items)
@@ -134,7 +134,18 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 		if message.AuthorType != models.MessageAuthorUser {
 			continue
 		}
-		items = append(items, inboxItem{ID: message.ID, TransitionID: inboxMetadataString(message.Metadata, "queue_entry_id"), State: "delivered", SessionID: session.ID, SessionName: session.Name, IsPrimary: session.IsPrimary, IsCurrent: session.ID == currentID, Sender: string(message.AuthorType), Content: message.Content, Timestamp: message.CreatedAt})
+		items = append(items, inboxItem{
+			ID:           message.ID,
+			TransitionID: inboxMetadataString(message.Metadata, "queue_entry_id"),
+			State:        "delivered",
+			SessionID:    session.ID,
+			SessionName:  session.Name,
+			IsPrimary:    session.IsPrimary,
+			IsCurrent:    session.ID == currentID,
+			Sender:       string(message.AuthorType),
+			Content:      message.Content,
+			Timestamp:    message.CreatedAt,
+		})
 		counts[session.ID]++
 	}
 	if h.sessionLauncher == nil || h.sessionLauncher.GetMessageQueue() == nil {
@@ -144,7 +155,19 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 		if entry.IsReservedInFlight() {
 			continue
 		}
-		items = append(items, inboxItem{ID: entry.ID, TransitionID: entry.ID, State: "queued", SessionID: session.ID, SessionName: session.Name, IsPrimary: session.IsPrimary, IsCurrent: session.ID == currentID, Sender: entry.QueuedBy, Content: entry.Content, Attachments: safeInboxAttachments(entry.Attachments), Timestamp: entry.QueuedAt})
+		items = append(items, inboxItem{
+			ID:           entry.ID,
+			TransitionID: entry.ID,
+			State:        "queued",
+			SessionID:    session.ID,
+			SessionName:  session.Name,
+			IsPrimary:    session.IsPrimary,
+			IsCurrent:    session.ID == currentID,
+			Sender:       entry.QueuedBy,
+			Content:      entry.Content,
+			Attachments:  safeInboxAttachments(entry.Attachments),
+			Timestamp:    entry.QueuedAt,
+		})
 		counts[session.ID]++
 	}
 	return items, nil
@@ -153,6 +176,15 @@ func (h *Handlers) appendSessionInbox(ctx context.Context, items []inboxItem, co
 func inboxMetadataString(metadata map[string]interface{}, key string) string {
 	value, _ := metadata[key].(string)
 	return value
+}
+func inboxLimit(requested int) int {
+	if requested <= 0 {
+		return inboxDefaultLimit
+	}
+	if requested > inboxMaxLimit {
+		return inboxMaxLimit
+	}
+	return requested
 }
 func safeInboxAttachments(entries []messagequeue.MessageAttachment) []inboxAttachment {
 	out := make([]inboxAttachment, 0, len(entries))

--- a/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// @covers AC-1, AC-4: inbox aggregation is task-bound and includes all of
+// the task's delivered inbound prompts without exposing another task.
+func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	_, task, primary := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	sibling := &models.TaskSession{ID: "inbox-sibling", TaskID: task.ID, IsPrimary: false, State: models.TaskSessionStateWaitingForInput}
+	require.NoError(t, repo.CreateTaskSession(context.Background(), sibling))
+	for _, session := range []*models.TaskSession{primary, sibling} {
+		_, err := svc.CreateMessage(context.Background(), &service.CreateMessageRequest{TaskSessionID: session.ID, TaskID: task.ID, AuthorType: "user", Content: session.ID})
+		require.NoError(t, err)
+	}
+	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
+	resp, err := h.handleListTaskInbox(context.Background(), makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": task.ID}))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	var payload struct {
+		Items []inboxItem `json:"items"`
+		Total int         `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Len(t, payload.Items, 2)
+	assert.Equal(t, 2, payload.Total)
+}
+
+func TestHandleListTaskInbox_RejectsForeignTarget(t *testing.T) {
+	h := &Handlers{}
+	resp, err := h.handleListTaskInbox(context.Background(), makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": "foreign", "caller_task_id": "own"}))
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeNotFound)
+}
+
+// @covers AC-2, AC-7, AC-9: queue visibility is a non-mutating snapshot and
+// never includes a lifecycle row already reserved for delivery.
+func TestHandleListTaskInbox_ListsSafeQueuedPromptsWithoutMutatingQueue(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	_, task, session := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	h, orch := newMessageTaskHandler(t, svc)
+	require.NoError(t, orch.queue.SetAutoRun(ctx, session.ID, false))
+	orch.queue.SetPendingMove(ctx, session.ID, &messagequeue.PendingMove{MoveID: "move-1", TaskID: task.ID})
+	queued, err := orch.queue.QueueMessage(ctx, session.ID, task.ID, "queued prompt", "", "peer", false, []messagequeue.MessageAttachment{{AttachmentID: "att-1", Type: "image", Data: "secret-bytes", MimeType: "image/png", Name: "diagram.png", SizeBytes: 42}})
+	require.NoError(t, err)
+
+	resp, err := h.handleListTaskInbox(ctx, makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": task.ID}))
+	require.NoError(t, err)
+	var payload struct {
+		Items []inboxItem `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	require.Len(t, payload.Items, 1)
+	assert.Equal(t, queued.ID, payload.Items[0].ID)
+	assert.Equal(t, queued.ID, payload.Items[0].TransitionID)
+	require.Len(t, payload.Items[0].Attachments, 1)
+	assert.Equal(t, "diagram.png", payload.Items[0].Attachments[0].Name)
+	assert.NotContains(t, string(resp.Payload), "secret-bytes")
+	status := orch.queue.GetStatus(ctx, session.ID)
+	assert.False(t, status.AutoRun)
+	require.Len(t, status.Entries, 1)
+	assert.Equal(t, queued.ID, status.Entries[0].ID)
+	move, ok := orch.queue.GetPendingMove(ctx, session.ID)
+	require.True(t, ok)
+	assert.Equal(t, "move-1", move.MoveID)
+}
+
+// @covers AC-3, AC-6: transition identity lets a caller recognize a queue
+// drain as the same work, while the cursor orders equal timestamps by ID.
+func TestTaskInboxCursorAndTransitionIdentity(t *testing.T) {
+	stamp := time.Now().UTC()
+	first := inboxItem{ID: "a", TransitionID: "queue-a", Timestamp: stamp}
+	second := inboxItem{ID: "b", TransitionID: "queue-a", Timestamp: stamp}
+	assert.True(t, inboxBefore(first, second))
+	cursor, err := decodeInboxCursor(encodeInboxCursor(first))
+	require.NoError(t, err)
+	assert.True(t, inboxAfter(second, *cursor))
+	assert.False(t, inboxAfter(first, *cursor))
+}

--- a/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	mcpprofile "github.com/kandev/kandev/internal/mcp/profile"
+	mcpscope "github.com/kandev/kandev/internal/mcp/scope"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
@@ -13,6 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func taskInboxContext(taskID, sessionID string) context.Context {
+	return mcpscope.WithPrincipal(context.Background(), mcpscope.Principal{
+		CallerTaskID:    taskID,
+		CallerSessionID: sessionID,
+	})
+}
 
 // @covers AC-1, AC-4: inbox aggregation is task-bound and includes all of
 // the task's delivered inbound prompts without exposing another task.
@@ -36,7 +45,8 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 		require.NoError(t, err)
 	}
 	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
-	resp, err := h.handleListTaskInbox(context.Background(), makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": task.ID}))
+	ctx := taskInboxContext(task.ID, primary.ID)
+	resp, err := h.handleListTaskInbox(ctx, makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": "spoofed"}))
 	require.NoError(t, err)
 	require.Equal(t, ws.MessageTypeResponse, resp.Type)
 	var payload struct {
@@ -47,6 +57,7 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	assert.Len(t, payload.Items, 2)
 	assert.Equal(t, 2, payload.Total)
 	assert.Equal(t, "transition-primary", payload.Items[0].TransitionID)
+	assert.True(t, payload.Items[0].IsCurrent)
 	assert.Equal(t, "visible", payload.Items[0].Content)
 	require.Len(t, payload.Items[0].Attachments, 1)
 	assert.Equal(t, "delivered.png", payload.Items[0].Attachments[0].Name)
@@ -89,7 +100,7 @@ func TestHandleListTaskInbox_PaginatesDeliveredMessagesWithCursor(t *testing.T) 
 		Cursor  string      `json:"cursor"`
 		HasMore bool        `json:"has_more"`
 	}
-	resp, err := h.handleListTaskInbox(ctx, request(""))
+	resp, err := h.handleListTaskInbox(taskInboxContext(task.ID, primary.ID), request(""))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(resp.Payload, &firstPayload))
 	require.Len(t, firstPayload.Items, 1)
@@ -104,7 +115,7 @@ func TestHandleListTaskInbox_PaginatesDeliveredMessagesWithCursor(t *testing.T) 
 		Cursor  string      `json:"cursor"`
 		HasMore bool        `json:"has_more"`
 	}
-	resp, err = h.handleListTaskInbox(ctx, request(firstPayload.Cursor))
+	resp, err = h.handleListTaskInbox(taskInboxContext(task.ID, primary.ID), request(firstPayload.Cursor))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(resp.Payload, &secondPayload))
 	require.Len(t, secondPayload.Items, 1)
@@ -133,7 +144,7 @@ func TestHandleListTaskInbox_ListsSafeQueuedPromptsWithoutMutatingQueue(t *testi
 	queued, err := orch.queue.QueueMessage(ctx, session.ID, task.ID, "queued prompt", "", "peer", false, []messagequeue.MessageAttachment{{AttachmentID: "att-1", Type: "image", Data: "secret-bytes", MimeType: "image/png", Name: "diagram.png", SizeBytes: 42}})
 	require.NoError(t, err)
 
-	resp, err := h.handleListTaskInbox(ctx, makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": task.ID}))
+	resp, err := h.handleListTaskInbox(taskInboxContext(task.ID, session.ID), makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID, "caller_task_id": task.ID, "current_session_id": "spoofed"}))
 	require.NoError(t, err)
 	var payload struct {
 		Items []inboxItem `json:"items"`
@@ -171,4 +182,23 @@ func TestInboxLimitCapsOversizedPages(t *testing.T) {
 	assert.Equal(t, inboxDefaultLimit, inboxLimit(0))
 	assert.Equal(t, 7, inboxLimit(7))
 	assert.Equal(t, inboxMaxLimit, inboxLimit(inboxMaxLimit+1))
+}
+
+func TestHandleListTaskInbox_AllowsAutomationDispatch(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	_, task, session := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
+	dispatcher := ws.NewDispatcher()
+	h.RegisterHandlers(dispatcher)
+	ctx := mcpscope.WithPrincipal(context.Background(), mcpscope.Principal{
+		AutomationID:    "automation-1",
+		WorkspaceID:     task.WorkspaceID,
+		CallerTaskID:    task.ID,
+		CallerSessionID: session.ID,
+		Surface:         mcpprofile.SurfaceAutomation,
+	})
+	resp, err := dispatcher.Dispatch(ctx, makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": task.ID}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
 }

--- a/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
@@ -23,10 +23,16 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	require.NoError(t, repo.CreateTaskSession(context.Background(), sibling))
 	for _, session := range []*models.TaskSession{primary, sibling} {
 		metadata := map[string]interface{}(nil)
+		content := session.ID
 		if session.ID == primary.ID {
-			metadata = map[string]interface{}{"queue_entry_id": "queue-primary"}
+			metadata = map[string]interface{}{
+				"queue_entry_id":     "queue-primary",
+				inboxTransitionIDKey: "transition-primary",
+				"attachments":        []messagequeue.MessageAttachment{{Type: "image", Data: "secret", MimeType: "image/png", Name: "delivered.png", SizeBytes: 12}},
+			}
+			content = "visible\n\n<kandev-system>hidden</kandev-system>"
 		}
-		_, err := svc.CreateMessage(context.Background(), &service.CreateMessageRequest{TaskSessionID: session.ID, TaskID: task.ID, AuthorType: "user", Content: session.ID, Metadata: metadata})
+		_, err := svc.CreateMessage(context.Background(), &service.CreateMessageRequest{TaskSessionID: session.ID, TaskID: task.ID, AuthorType: "user", Content: content, Metadata: metadata})
 		require.NoError(t, err)
 	}
 	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
@@ -40,7 +46,11 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
 	assert.Len(t, payload.Items, 2)
 	assert.Equal(t, 2, payload.Total)
-	assert.Equal(t, "queue-primary", payload.Items[0].TransitionID)
+	assert.Equal(t, "transition-primary", payload.Items[0].TransitionID)
+	assert.Equal(t, "visible", payload.Items[0].Content)
+	require.Len(t, payload.Items[0].Attachments, 1)
+	assert.Equal(t, "delivered.png", payload.Items[0].Attachments[0].Name)
+	assert.NotContains(t, string(resp.Payload), "secret")
 }
 
 func TestHandleListTaskInbox_RejectsForeignTarget(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
@@ -22,7 +22,11 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	sibling := &models.TaskSession{ID: "inbox-sibling", TaskID: task.ID, IsPrimary: false, State: models.TaskSessionStateWaitingForInput}
 	require.NoError(t, repo.CreateTaskSession(context.Background(), sibling))
 	for _, session := range []*models.TaskSession{primary, sibling} {
-		_, err := svc.CreateMessage(context.Background(), &service.CreateMessageRequest{TaskSessionID: session.ID, TaskID: task.ID, AuthorType: "user", Content: session.ID})
+		metadata := map[string]interface{}(nil)
+		if session.ID == primary.ID {
+			metadata = map[string]interface{}{"queue_entry_id": "queue-primary"}
+		}
+		_, err := svc.CreateMessage(context.Background(), &service.CreateMessageRequest{TaskSessionID: session.ID, TaskID: task.ID, AuthorType: "user", Content: session.ID, Metadata: metadata})
 		require.NoError(t, err)
 	}
 	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
@@ -36,6 +40,7 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
 	assert.Len(t, payload.Items, 2)
 	assert.Equal(t, 2, payload.Total)
+	assert.Equal(t, "queue-primary", payload.Items[0].TransitionID)
 }
 
 func TestHandleListTaskInbox_RejectsForeignTarget(t *testing.T) {
@@ -89,4 +94,10 @@ func TestTaskInboxCursorAndTransitionIdentity(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, inboxAfter(second, *cursor))
 	assert.False(t, inboxAfter(first, *cursor))
+}
+
+func TestInboxLimitCapsOversizedPages(t *testing.T) {
+	assert.Equal(t, inboxDefaultLimit, inboxLimit(0))
+	assert.Equal(t, 7, inboxLimit(7))
+	assert.Equal(t, inboxMaxLimit, inboxLimit(inboxMaxLimit+1))
 }

--- a/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
+++ b/apps/backend/internal/mcp/handlers/list_task_inbox_test.go
@@ -53,6 +53,67 @@ func TestHandleListTaskInbox_AggregatesDeliveredMessagesForOwnTask(t *testing.T)
 	assert.NotContains(t, string(resp.Payload), "secret")
 }
 
+func TestHandleListTaskInbox_PaginatesDeliveredMessagesWithCursor(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	_, task, primary := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	sibling := &models.TaskSession{ID: "inbox-page-sibling", TaskID: task.ID, State: models.TaskSessionStateWaitingForInput}
+	require.NoError(t, repo.CreateTaskSession(ctx, sibling))
+	first, err := svc.CreateMessage(ctx, &service.CreateMessageRequest{
+		TaskSessionID: primary.ID,
+		TaskID:        task.ID,
+		AuthorType:    "user",
+		Content:       "first",
+	})
+	require.NoError(t, err)
+	second, err := svc.CreateMessage(ctx, &service.CreateMessageRequest{
+		TaskSessionID: sibling.ID,
+		TaskID:        task.ID,
+		AuthorType:    "user",
+		Content:       "second",
+	})
+	require.NoError(t, err)
+
+	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
+	request := func(cursor string) *ws.Message {
+		return makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{
+			"task_id":        task.ID,
+			"caller_task_id": task.ID,
+			"limit":          1,
+			"cursor":         cursor,
+		})
+	}
+	var firstPayload struct {
+		Items   []inboxItem `json:"items"`
+		Total   int         `json:"total"`
+		Cursor  string      `json:"cursor"`
+		HasMore bool        `json:"has_more"`
+	}
+	resp, err := h.handleListTaskInbox(ctx, request(""))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Payload, &firstPayload))
+	require.Len(t, firstPayload.Items, 1)
+	assert.Equal(t, first.ID, firstPayload.Items[0].ID)
+	assert.Equal(t, 2, firstPayload.Total)
+	assert.True(t, firstPayload.HasMore)
+	assert.NotEmpty(t, firstPayload.Cursor)
+
+	var secondPayload struct {
+		Items   []inboxItem `json:"items"`
+		Total   int         `json:"total"`
+		Cursor  string      `json:"cursor"`
+		HasMore bool        `json:"has_more"`
+	}
+	resp, err = h.handleListTaskInbox(ctx, request(firstPayload.Cursor))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Payload, &secondPayload))
+	require.Len(t, secondPayload.Items, 1)
+	assert.Equal(t, second.ID, secondPayload.Items[0].ID)
+	assert.Equal(t, 2, secondPayload.Total)
+	assert.False(t, secondPayload.HasMore)
+	assert.Empty(t, secondPayload.Cursor)
+}
+
 func TestHandleListTaskInbox_RejectsForeignTarget(t *testing.T) {
 	h := &Handlers{}
 	resp, err := h.handleListTaskInbox(context.Background(), makeWSMessage(t, ws.ActionMCPListTaskInbox, map[string]interface{}{"task_id": "foreign", "caller_task_id": "own"}))

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -556,6 +556,23 @@ func (s *Server) listTaskSessionsHandler() server.ToolHandlerFunc {
 	}
 }
 
+func (s *Server) listTaskInboxHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if s.taskID == "" {
+			return mcp.NewToolResultError("list_task_inbox_kandev is available only from a task session"), nil
+		}
+		payload := map[string]interface{}{"task_id": s.taskID, "caller_task_id": s.taskID, "current_session_id": s.sessionID}
+		copyOptionalStringArg(payload, req, "cursor")
+		copyOptionalLimitArg(payload, req)
+		var result map[string]interface{}
+		if err := s.backend.RequestPayload(ctx, ws.ActionMCPListTaskInbox, payload, &result); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		data, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(data)), nil
+	}
+}
+
 func (s *Server) listPendingAgentPermissionsHandler() server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		taskID, err := req.RequireString(mcpKeyTaskID)

--- a/apps/backend/internal/mcp/server/list_task_sessions_test.go
+++ b/apps/backend/internal/mcp/server/list_task_sessions_test.go
@@ -30,6 +30,11 @@ func TestListTaskSessions_RegisteredWhereverConversationIs(t *testing.T) {
 			require.Contains(t, tools, "get_task_conversation_kandev")
 			assert.Contains(t, tools, "list_task_sessions_kandev",
 				"session discovery must ship with the tools that consume a session_id")
+			if tc.name == "task" {
+				assert.Contains(t, tools, "list_task_inbox_kandev")
+			} else {
+				assert.NotContains(t, tools, "list_task_inbox_kandev")
+			}
 		})
 	}
 }
@@ -42,6 +47,20 @@ func TestListTaskSessions_NotRegisteredInOfficeMode(t *testing.T) {
 	tools := getRegisteredToolNames(s)
 	require.NotContains(t, tools, "get_task_conversation_kandev")
 	assert.NotContains(t, tools, "list_task_sessions_kandev")
+	assert.NotContains(t, tools, "list_task_inbox_kandev")
+}
+
+func TestListTaskInbox_IsBoundToCurrentTask(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"total": 0}}
+	s := newTaskModeServer(t, backend, "task-current")
+	result := callTool(t, s, "list_task_inbox_kandev", map[string]interface{}{})
+	require.False(t, result.IsError)
+	assert.Equal(t, ws.ActionMCPListTaskInbox, backend.lastAction)
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "task-current", payload["task_id"])
+	assert.Equal(t, "task-current", payload["caller_task_id"])
+	assert.Equal(t, "test-session", payload["current_session_id"])
 }
 
 func TestListTaskSessions_ToolSchemaIsTaskIDOnly(t *testing.T) {

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -1161,6 +1161,25 @@ func (s *Server) registerKanbanTools() {
 		s.wrapHandler("get_task_conversation_kandev", s.getTaskConversationHandler()),
 	)
 	s.registerListTaskSessionsTool()
+	s.registerListTaskInboxTool()
+}
+
+func (s *Server) registerListTaskInboxTool() {
+	if s.taskID == "" {
+		return
+	}
+	s.mcpServer.AddTool(
+		mcp.NewTool("list_task_inbox_kandev",
+			mcp.WithDescription("List inbound delivered and queued prompts across the current task's sessions. This read-only polling view is bound to this task and never marks messages read or drains the queue."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(false),
+			mcp.WithString("cursor", mcp.Description("Opaque continuation cursor returned by a previous call")),
+			mcp.WithNumber("limit", mcp.Description("Optional page size")),
+		),
+		s.wrapHandler("list_task_inbox_kandev", s.listTaskInboxHandler()),
+	)
 }
 
 func (s *Server) registerPRAutomationTools() {

--- a/apps/backend/internal/mcp/server/server_test.go
+++ b/apps/backend/internal/mcp/server/server_test.go
@@ -533,6 +533,7 @@ func TestServerSurfaceAutomationHasFixedCoordinatorCatalog(t *testing.T) {
 		"add_task_dependency_kandev", "remove_task_dependency_kandev", "message_task_kandev",
 		"stop_task_kandev", "spawn_session_kandev", "list_pending_questions_kandev",
 		"answer_question_kandev", "list_pending_agent_permissions_kandev", "resolve_agent_permission_kandev",
+		"list_task_inbox_kandev",
 	}
 	assert.ElementsMatch(t, want, getRegisteredToolNames(s))
 }

--- a/apps/backend/internal/mcp/server/server_test.go
+++ b/apps/backend/internal/mcp/server/server_test.go
@@ -729,7 +729,7 @@ drained:
 	// as in TestServerModeTask_ToolCount and
 	// TestRegisterTools_LoggedCountMatchesRegisteredTools (list_task_sessions_test.go),
 	// which pin the per-mode registration rather than this SetProviders rebuild.
-	require.Len(t, tools, 36, "final registry should contain the complete GitLab-only task tool set")
+	require.Len(t, tools, 37, "final registry should contain the complete GitLab-only task tool set")
 	assert.Contains(t, tools, "get_task_mr_automation_kandev")
 	assert.NotContains(t, tools, "get_task_pr_automation_kandev")
 }
@@ -909,7 +909,7 @@ func TestServerModeTask_ToolCount(t *testing.T) {
 	assert.Contains(t, tools, "add_task_dependency_kandev", "dependency edges must be manageable in task mode")
 	assert.Contains(t, tools, "remove_task_dependency_kandev")
 	assert.Contains(t, tools, "show_rich_output_kandev", "native rich output must be registered in task mode")
-	assert.Equal(t, 38, len(tools))
+	assert.Equal(t, 39, len(tools))
 }
 
 func TestServerStepCompleteTool_TaskAndOfficeOnlyAndDiscoverable(t *testing.T) {

--- a/apps/backend/internal/mcp/server/tool_metadata_test.go
+++ b/apps/backend/internal/mcp/server/tool_metadata_test.go
@@ -66,6 +66,7 @@ func TestCoreToolRiskAnnotations(t *testing.T) {
 		openWorld   bool
 	}{
 		{name: "list_task_sessions_kandev", readOnly: true, destructive: false, idempotent: true, openWorld: false},
+		{name: "list_task_inbox_kandev", readOnly: true, destructive: false, idempotent: true, openWorld: false},
 		{name: "archive_task_kandev", readOnly: false, destructive: false, idempotent: true, openWorld: false},
 		{name: "delete_task_kandev", readOnly: false, destructive: true, idempotent: false, openWorld: false},
 		{name: "stop_task_kandev", readOnly: false, destructive: true, idempotent: true, openWorld: false},

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -769,13 +769,19 @@ func (s *Service) recordQueuedUserMessage(ctx context.Context, queuedMsg *messag
 	if metaMap == nil {
 		metaMap = make(map[string]interface{})
 	}
+	if queuedMsg.Metadata == nil {
+		queuedMsg.Metadata = make(map[string]interface{})
+	}
+	transitionID, _ := queuedMsg.Metadata[messagequeue.MetadataInboxTransitionID].(string)
+	if transitionID == "" {
+		transitionID = queuedMsg.ID
+		queuedMsg.Metadata[messagequeue.MetadataInboxTransitionID] = transitionID
+	}
+	metaMap[messagequeue.MetadataInboxTransitionID] = transitionID
 	metaMap["queue_entry_id"] = queuedMsg.ID
 	if err := s.messageCreator.CreateUserMessage(ctx, queuedMsg.TaskID, promptContent, queuedMsg.SessionID, turnID, metaMap); err != nil {
 		s.logger.Error("failed to create user message for queued message", zap.String("session_id", queuedMsg.SessionID), zap.Error(err))
 		return err
-	}
-	if queuedMsg.Metadata == nil {
-		queuedMsg.Metadata = map[string]interface{}{}
 	}
 	queuedMsg.Metadata[metaKeyUserMessageRecorded] = true
 	return nil

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -763,6 +763,13 @@ func (s *Service) recordQueuedUserMessage(ctx context.Context, queuedMsg *messag
 		WithAttachments(attachments).
 		WithEntityReferences(references)
 	metaMap := mergeMetadata(meta.ToMap(), metadataWithoutEntityReferences(queuedMsg.Metadata))
+	// Preserve the durable queue identity on the transcript row. Consumers that
+	// poll while a queue drains can collapse queued and delivered observations
+	// of the same prompt without relying on content or timestamps.
+	if metaMap == nil {
+		metaMap = make(map[string]interface{})
+	}
+	metaMap["queue_entry_id"] = queuedMsg.ID
 	if err := s.messageCreator.CreateUserMessage(ctx, queuedMsg.TaskID, promptContent, queuedMsg.SessionID, turnID, metaMap); err != nil {
 		s.logger.Error("failed to create user message for queued message", zap.String("session_id", queuedMsg.SessionID), zap.Error(err))
 		return err

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -200,13 +200,21 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 		t.Errorf("queued metadata workflow_step_name = %q, want Merge", name)
 	}
 	mergeUserMsgs := 0
+	var recordedTransitionID string
 	for _, m := range msgCreator.userMessages {
 		if name, _ := m.metadata["workflow_step_name"].(string); name == "Merge" {
 			mergeUserMsgs++
+			recordedTransitionID, _ = m.metadata[inboxTransitionMetadataKey].(string)
 		}
 	}
 	if mergeUserMsgs != 1 {
 		t.Errorf("expected exactly 1 Merge user_message (from recordAutoStartMessage before PromptTask failed), got %d", mergeUserMsgs)
+	}
+	if recordedTransitionID == "" {
+		t.Fatal("recorded workflow message is missing inbox transition identity")
+	}
+	if queuedTransitionID, _ := queued.Metadata[inboxTransitionMetadataKey].(string); queuedTransitionID != recordedTransitionID {
+		t.Errorf("queued transition identity = %q, want recorded message identity %q", queuedTransitionID, recordedTransitionID)
 	}
 
 	// --- Phase 2: user resumes the session — boot_ready must drain the queue ---

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -604,13 +604,21 @@ func TestAutoStartCreatedLaunch_QueuesPromptWhenAgentAlreadyRunning(t *testing.T
 
 	// The recorded prompt must survive as a queued message the boot-ready
 	// drain can deliver, not only as an undeliverable chat row.
-	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 1 {
-		t.Fatalf("expected the prompt to be queued for redelivery, queue count = %d", got)
+	status := svc.messageQueue.GetStatus(ctx, sessionID)
+	if status.Count != 1 {
+		t.Fatalf("expected the prompt to be queued for redelivery, queue count = %d", status.Count)
 	}
 
 	// The chat row was already written, so the drain must not write a second.
 	if len(msgCreator.userMessages) != 1 {
 		t.Fatalf("expected exactly 1 recorded user message, got %d", len(msgCreator.userMessages))
+	}
+	transitionID, _ := msgCreator.userMessages[0].metadata[inboxTransitionMetadataKey].(string)
+	if transitionID == "" {
+		t.Fatalf("expected recorded user message to have a transition ID, got %#v", msgCreator.userMessages[0].metadata)
+	}
+	if got := status.Entries[0].Metadata[inboxTransitionMetadataKey]; got != transitionID {
+		t.Fatalf("queued transition ID = %#v, want recorded transition ID %q", got, transitionID)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -1526,6 +1526,9 @@ func TestExecuteQueuedMessage_RequeuesTransientPromptFailure(t *testing.T) {
 	if len(messages.userMessages) != 1 {
 		t.Fatalf("expected boot-ready drain to reuse the existing user message, got %d", len(messages.userMessages))
 	}
+	if messages.userMessages[0].metadata["queue_entry_id"] != "q1" {
+		t.Fatalf("expected delivered user message to retain queue transition id, got %#v", messages.userMessages[0].metadata)
+	}
 }
 
 func TestExecuteQueuedMessage_RequeuesCoalescedMessageWithOriginalSender(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -1554,6 +1554,8 @@ func TestExecuteQueuedMessage_RequeuesCoalescedMessageWithOriginalSender(t *test
 	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
 	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
 
 	queuedMsg := &messagequeue.QueuedMessage{
 		ID:        "q1",
@@ -1582,6 +1584,16 @@ func TestExecuteQueuedMessage_RequeuesCoalescedMessageWithOriginalSender(t *test
 	}
 	if status.Entries[0].Metadata[messagequeue.MetadataCoalesceKey] != "ci-key" {
 		t.Fatalf("expected coalesce metadata to be preserved, got %+v", status.Entries[0].Metadata)
+	}
+	if len(messages.userMessages) != 1 {
+		t.Fatalf("expected one delivered user message, got %d", len(messages.userMessages))
+	}
+	transitionID, _ := messages.userMessages[0].metadata[inboxTransitionMetadataKey].(string)
+	if transitionID == "" {
+		t.Fatalf("expected delivered user message to have a transition ID, got %#v", messages.userMessages[0].metadata)
+	}
+	if got := status.Entries[0].Metadata[inboxTransitionMetadataKey]; got != transitionID {
+		t.Fatalf("queued transition ID = %#v, want delivered transition ID %q", got, transitionID)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2886,7 +2886,7 @@ func (s *Service) autoStartPassthroughPrompt(
 // failed transiently and the queue was later drained via boot_ready.
 const (
 	metaKeyUserMessageRecorded = "user_message_recorded"
-	inboxTransitionMetadataKey = "inbox_transition_id"
+	inboxTransitionMetadataKey = messagequeue.MetadataInboxTransitionID
 )
 
 type workflowMessageOrigin struct {
@@ -2965,6 +2965,7 @@ func (s *Service) handleCreatedAutoStartLaunchFailure(
 	attachments []v1.MessageAttachment,
 	origin workflowMessageOrigin,
 	references []v1.EntityReference,
+	inboxTransitionID string,
 	takenMsg *messagequeue.QueuedMessage,
 ) {
 	promptQueued := false
@@ -2973,7 +2974,7 @@ func (s *Service) handleCreatedAutoStartLaunchFailure(
 		if queueErr := s.queueAutoStartPrompt(
 			ctx, taskID, sessionID, prompt, planMode,
 			attachments, origin, userMessageRecorded, references,
-			"",
+			inboxTransitionID,
 		); queueErr != nil {
 			s.logger.Warn("failed to queue auto-start prompt after launch failure",
 				zap.String("task_id", taskID),
@@ -3099,7 +3100,7 @@ func (s *Service) autoStartStepPrompt(
 			s.handleCreatedAutoStartLaunchFailure(
 				ctx, taskID, sessionID, stepName, prompt, err,
 				planMode, shouldQueueIfBusy, userMsgRecorded,
-				attachments, origin, references, takenMsg,
+				attachments, origin, references, inboxTransitionID, takenMsg,
 			)
 		}
 		return err

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/agents"
@@ -2883,7 +2884,10 @@ func (s *Service) autoStartPassthroughPrompt(
 // before the prompt was queued. executeQueuedMessage reads this flag to skip
 // its own CreateUserMessage and avoid the duplicate observed when PromptTask
 // failed transiently and the queue was later drained via boot_ready.
-const metaKeyUserMessageRecorded = "user_message_recorded"
+const (
+	metaKeyUserMessageRecorded = "user_message_recorded"
+	inboxTransitionMetadataKey = "inbox_transition_id"
+)
 
 type workflowMessageOrigin struct {
 	StepID    string
@@ -2969,6 +2973,7 @@ func (s *Service) handleCreatedAutoStartLaunchFailure(
 		if queueErr := s.queueAutoStartPrompt(
 			ctx, taskID, sessionID, prompt, planMode,
 			attachments, origin, userMessageRecorded, references,
+			"",
 		); queueErr != nil {
 			s.logger.Warn("failed to queue auto-start prompt after launch failure",
 				zap.String("task_id", taskID),
@@ -3075,7 +3080,7 @@ func (s *Service) autoStartStepPrompt(
 			}, referenceContext, pullRequestTargetContext)
 		}
 	}
-	userMsgRecorded := s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin, references)
+	userMsgRecorded, inboxTransitionID := s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin, references)
 
 	// If the session is in CREATED state, the agent was never started (e.g. workspace-only
 	// preparation from a blocked auto-start). PromptTask will reject CREATED sessions,
@@ -3130,7 +3135,7 @@ func (s *Service) autoStartStepPrompt(
 		// chat row was successfully inserted above; a failed write passes false,
 		// letting the drain re-attempt insertion.
 		if isAgentAlreadyRunningError(err) && shouldQueueIfBusy {
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded, references); queueErr != nil {
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded, references, inboxTransitionID); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -3145,7 +3150,7 @@ func (s *Service) autoStartStepPrompt(
 		if shouldQueueIfBusy {
 			// Pass userMsgRecorded so the drain skips CreateUserMessage only when
 			// the chat row was successfully inserted above by recordAutoStartMessage.
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded, references); queueErr != nil {
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded, references, inboxTransitionID); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -3317,9 +3322,9 @@ func (s *Service) recordAutoStartMessage(
 	planMode bool,
 	origin workflowMessageOrigin,
 	references []v1.EntityReference,
-) bool {
+) (bool, string) {
 	if s.messageCreator == nil || prompt == "" {
-		return false
+		return false, ""
 	}
 	turnID := s.getActiveTurnID(sessionID)
 	if turnID == "" {
@@ -3334,14 +3339,16 @@ func (s *Service) recordAutoStartMessage(
 	// workflow_auto_start is the original tag this function set; preserved
 	// for any consumer reading it directly.
 	metaMap := workflowMessageMetadata(planMode, origin, references)
+	transitionID := uuid.NewString()
+	metaMap[inboxTransitionMetadataKey] = transitionID
 	if err := s.messageCreator.CreateUserMessage(ctx, taskID, prompt, sessionID, turnID, metaMap); err != nil {
 		s.logger.Error("failed to create auto-start user message",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
-		return false
+		return false, ""
 	}
-	return true
+	return true, transitionID
 }
 
 // queueAutoStartPromptIfRunning queues the workflow auto-start prompt only
@@ -3362,7 +3369,7 @@ func (s *Service) queueAutoStartPromptIfRunning(
 	if session.State != models.TaskSessionStateRunning && session.State != models.TaskSessionStateStarting {
 		return false, nil
 	}
-	if err := s.queueAutoStartPrompt(ctx, taskID, session.ID, prompt, planMode, attachments, origin, userMessageRecorded, references); err != nil {
+	if err := s.queueAutoStartPrompt(ctx, taskID, session.ID, prompt, planMode, attachments, origin, userMessageRecorded, references, ""); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -3406,6 +3413,7 @@ func (s *Service) queueAutoStartPrompt(
 	origin workflowMessageOrigin,
 	userMessageRecorded bool,
 	references []v1.EntityReference,
+	inboxTransitionID string,
 ) error {
 	if s.messageQueue == nil {
 		return fmt.Errorf("message queue is not configured")
@@ -3413,6 +3421,9 @@ func (s *Service) queueAutoStartPrompt(
 	meta := workflowMessageMetadata(planMode, origin, references)
 	if userMessageRecorded {
 		meta[metaKeyUserMessageRecorded] = true
+	}
+	if inboxTransitionID != "" {
+		meta[inboxTransitionMetadataKey] = inboxTransitionID
 	}
 	_, err := s.messageQueue.QueueMessageWithMetadata(
 		ctx,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -3081,7 +3081,7 @@ func (s *Service) autoStartStepPrompt(
 			}, referenceContext, pullRequestTargetContext)
 		}
 	}
-	userMsgRecorded, inboxTransitionID := s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin, references)
+	userMsgRecorded, inboxTransitionID := s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin, references, attachments)
 
 	// If the session is in CREATED state, the agent was never started (e.g. workspace-only
 	// preparation from a blocked auto-start). PromptTask will reject CREATED sessions,
@@ -3323,6 +3323,7 @@ func (s *Service) recordAutoStartMessage(
 	planMode bool,
 	origin workflowMessageOrigin,
 	references []v1.EntityReference,
+	attachments []v1.MessageAttachment,
 ) (bool, string) {
 	if s.messageCreator == nil || prompt == "" {
 		return false, ""
@@ -3340,6 +3341,9 @@ func (s *Service) recordAutoStartMessage(
 	// workflow_auto_start is the original tag this function set; preserved
 	// for any consumer reading it directly.
 	metaMap := workflowMessageMetadata(planMode, origin, references)
+	if len(attachments) > 0 {
+		metaMap["attachments"] = toQueuedAttachments(attachments)
+	}
 	transitionID := uuid.NewString()
 	metaMap[inboxTransitionMetadataKey] = transitionID
 	if err := s.messageCreator.CreateUserMessage(ctx, taskID, prompt, sessionID, turnID, metaMap); err != nil {

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -60,6 +60,8 @@ type Repository interface {
 
 	// ListBySession returns all entries for a session ordered by position ascending.
 	ListBySession(ctx context.Context, sessionID string) ([]QueuedMessage, error)
+	// ListByTask returns all queued entries belonging to live sessions of a task.
+	ListByTask(ctx context.Context, taskID string) (map[string][]QueuedMessage, error)
 
 	// CountBySession returns the number of entries for a session.
 	CountBySession(ctx context.Context, sessionID string) (int, error)

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -352,6 +352,24 @@ func (r *memoryRepository) ListBySession(_ context.Context, sessionID string) ([
 	return out, nil
 }
 
+func (r *memoryRepository) ListByTask(_ context.Context, taskID string) (map[string][]QueuedMessage, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string][]QueuedMessage)
+	for sessionID, list := range r.entries {
+		for _, msg := range list {
+			if msg.TaskID != taskID || msg.IsReservedInFlight() {
+				continue
+			}
+			out[sessionID] = append(out[sessionID], *msg)
+		}
+	}
+	for _, entries := range out {
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Position < entries[j].Position })
+	}
+	return out, nil
+}
+
 // CountBySession returns the number of entries for a session.
 func (r *memoryRepository) CountBySession(_ context.Context, sessionID string) (int, error) {
 	r.mu.Lock()

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -910,6 +910,33 @@ func (r *sqliteRepository) ListBySession(ctx context.Context, sessionID string) 
 	return out, rows.Err()
 }
 
+func (r *sqliteRepository) ListByTask(ctx context.Context, taskID string) (map[string][]QueuedMessage, error) {
+	rows, err := r.ro.QueryxContext(ctx, r.ro.Rebind(`
+		SELECT q.id, q.session_id, q.task_id, q.position, q.content, q.model, q.plan_mode,
+		       q.attachments_json, q.metadata_json, q.queued_at, q.queued_by
+		FROM queued_messages q
+		INNER JOIN task_sessions s ON s.id = q.session_id
+		WHERE q.task_id = ?
+		ORDER BY q.session_id ASC, q.position ASC
+	`), taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list queued by task: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string][]QueuedMessage)
+	for rows.Next() {
+		msg, err := scanQueuedRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		if msg.IsReservedInFlight() {
+			continue
+		}
+		out[msg.SessionID] = append(out[msg.SessionID], *msg)
+	}
+	return out, rows.Err()
+}
+
 // CountBySession returns the number of entries for a session.
 func (r *sqliteRepository) CountBySession(ctx context.Context, sessionID string) (int, error) {
 	var n int

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -958,6 +958,15 @@ func (s *Service) CountPendingByTaskIDs(ctx context.Context, taskIDs []string) (
 	return counts, nil
 }
 
+// ListPendingByTask returns one fail-closed snapshot of visible queue entries.
+func (s *Service) ListPendingByTask(ctx context.Context, taskID string) (map[string][]QueuedMessage, error) {
+	entries, err := s.repo.ListByTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list pending by task: %w", err)
+	}
+	return entries, nil
+}
+
 // CountPendingByTask returns the pending prompt count for one task.
 func (s *Service) CountPendingByTask(ctx context.Context, taskID string) (int, error) {
 	counts, err := s.CountPendingByTaskIDs(ctx, []string{taskID})

--- a/apps/backend/internal/orchestrator/messagequeue/types.go
+++ b/apps/backend/internal/orchestrator/messagequeue/types.go
@@ -42,6 +42,10 @@ func IsReservedQueuedBy(queuedBy string) bool {
 // than appended when a newer pending message supersedes an older one.
 const MetadataCoalesceKey = "coalesce_key"
 
+// MetadataInboxTransitionID identifies one logical inbox delivery across
+// queued, retried, and delivered observations.
+const MetadataInboxTransitionID = "inbox_transition_id"
+
 // MetadataEntityReferences carries persisted entity-reference context for a
 // queued message.
 const MetadataEntityReferences = "entity_references"

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
@@ -18,6 +19,7 @@ import (
 	"github.com/kandev/kandev/internal/entityrefs"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
@@ -414,6 +416,11 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		WithAttachments(req.Attachments).
 		WithContextFiles(req.ContextFiles).
 		WithEntityReferences(req.EntityReferences)
+	metadata := meta.ToMap()
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata[messagequeue.MetadataInboxTransitionID] = uuid.NewString()
 
 	// First message on a CREATED session is the kanban "type in chat to start
 	// the agent" path. Wrap with the Kandev MCP system block before persisting
@@ -476,7 +483,7 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		Content:       storedContent,
 		AuthorType:    "user",
 		AuthorID:      req.AuthorID,
-		Metadata:      meta.ToMap(),
+		Metadata:      metadata,
 	}
 	var message *models.Message
 	var err error
@@ -490,6 +497,10 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create message", nil)
 	}
 	if turnStartResult.Queued {
+		queueMetadata := message.Metadata
+		if queueMetadata == nil {
+			queueMetadata = metadata
+		}
 		if err := h.orchestrator.QueueUserPrompt(
 			ctx,
 			req.TaskID,
@@ -498,7 +509,7 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 			req.Model,
 			req.PlanMode,
 			req.Attachments,
-			meta.ToMap(),
+			queueMetadata,
 			true,
 		); err != nil {
 			h.logger.Warn("failed to queue prompt until workflow promotion",

--- a/apps/backend/internal/task/handlers/message_handlers_blocked_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_blocked_test.go
@@ -116,6 +116,7 @@ type firstTurnCaptureOrchestrator struct {
 
 type queuedPromptCall struct {
 	taskID, sessionID, prompt string
+	metadata                  map[string]interface{}
 	userMessageRecorded       bool
 }
 
@@ -147,8 +148,11 @@ func (o *firstTurnCaptureOrchestrator) ProcessOnTurnStart(context.Context, strin
 	return o.turnStartResult, nil
 }
 
-func (o *firstTurnCaptureOrchestrator) QueueUserPrompt(_ context.Context, taskID, sessionID, prompt, _ string, _ bool, _ []v1.MessageAttachment, _ map[string]interface{}, userMessageRecorded bool) error {
-	o.queuedPromptCall = &queuedPromptCall{taskID: taskID, sessionID: sessionID, prompt: prompt, userMessageRecorded: userMessageRecorded}
+func (o *firstTurnCaptureOrchestrator) QueueUserPrompt(_ context.Context, taskID, sessionID, prompt, _ string, _ bool, _ []v1.MessageAttachment, metadata map[string]interface{}, userMessageRecorded bool) error {
+	o.queuedPromptCall = &queuedPromptCall{
+		taskID: taskID, sessionID: sessionID, prompt: prompt,
+		metadata: metadata, userMessageRecorded: userMessageRecorded,
+	}
 	return nil
 }
 

--- a/apps/backend/internal/task/handlers/message_handlers_inbox_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_inbox_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/orchestrator"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWSAddMessageWIPQueuePreservesInboxTransitionID(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &messageAddSwitchRepo{
+		tasks: map[string]*models.Task{
+			"t1": {ID: "t1", State: v1.TaskStateInProgress, UpdatedAt: now},
+		},
+		sessions: map[string]*models.TaskSession{
+			"s1": {ID: "s1", TaskID: "t1", State: models.TaskSessionStateWaitingForInput, UpdatedAt: now},
+		},
+		primaryID: "s1",
+	}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	orch := &firstTurnCaptureOrchestrator{
+		turnStartResult: orchestrator.ProcessOnTurnStartResult{Queued: true},
+	}
+	h := NewMessageHandlers(svc, orch, log)
+
+	req, err := ws.NewRequest("req-inbox-transition", ws.ActionMessageAdd, map[string]interface{}{
+		"task_id":    "t1",
+		"session_id": "s1",
+		"content":    "wait for admission",
+	})
+	require.NoError(t, err)
+	resp, err := h.wsAddMessage(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	require.Len(t, repo.messages, 1)
+	require.NotNil(t, orch.queuedPromptCall)
+
+	deliveredID, ok := repo.messages[0].Metadata[messagequeue.MetadataInboxTransitionID].(string)
+	require.True(t, ok)
+	queuedID, ok := orch.queuedPromptCall.metadata[messagequeue.MetadataInboxTransitionID].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, deliveredID)
+	require.Equal(t, deliveredID, queuedID)
+}

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -65,6 +65,15 @@ type ListMessagesOptions struct {
 	Sort   string
 }
 
+// TaskInboxMessagesOptions defines task-wide keyset pagination for delivered
+// user messages. The cursor uses the same created_at and ID ordering as the
+// task inbox projection.
+type TaskInboxMessagesOptions struct {
+	Limit          int
+	AfterCreatedAt time.Time
+	AfterID        string
+}
+
 // SearchMessagesOptions defines options for searching a session's messages.
 type SearchMessagesOptions struct {
 	Query string

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -72,6 +72,7 @@ type TaskInboxMessagesOptions struct {
 	Limit          int
 	AfterCreatedAt time.Time
 	AfterID        string
+	SkipCounts     bool
 }
 
 // SearchMessagesOptions defines options for searching a session's messages.

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -241,6 +241,13 @@ type MessageRepository interface {
 	DeleteMessage(ctx context.Context, id string) error
 }
 
+// TaskInboxMessageRepository is the optional task-wide message query used by
+// the task inbox. It stays separate from MessageRepository so test doubles and
+// lightweight repository adapters do not need to implement an unrelated read.
+type TaskInboxMessageRepository interface {
+	ListTaskInboxMessages(ctx context.Context, taskID string, opts models.TaskInboxMessagesOptions) ([]*models.Message, bool, map[string]int, error)
+}
+
 // AttachmentRepository stores file-backed prompt attachment descriptors.
 // Implementations must keep ownership and aggregate-claim checks in the same
 // transaction as state transitions so a retry cannot partially claim a batch.

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -45,6 +45,7 @@ func (r *Repository) initSchema() error {
 		r.ensureWorkspaceIndexes,
 		r.ensureMessageMetadataIndexes,
 		r.ensurePromptOrderIndex,
+		r.ensureTaskInboxOrderIndex,
 	}
 	for _, step := range steps {
 		if err := step(); err != nil {
@@ -173,6 +174,16 @@ func (r *Repository) ensurePromptOrderIndex() error {
 	ddl := dialect.PromptOrderIndexDDL(r.db.DriverName(), "idx_messages_prompt_order", "task_session_messages")
 	if _, err := r.db.Exec(ddl); err != nil {
 		return fmt.Errorf("create prompt-order index: %w", err)
+	}
+	return nil
+}
+
+// ensureTaskInboxOrderIndex creates the additive task/author/order index used
+// by the bounded task-wide inbox projection.
+func (r *Repository) ensureTaskInboxOrderIndex() error {
+	ddl := dialect.TaskInboxOrderIndexDDL(r.db.DriverName(), "idx_messages_task_inbox_order", "task_session_messages")
+	if _, err := r.db.Exec(ddl); err != nil {
+		return fmt.Errorf("create task inbox order index: %w", err)
 	}
 	return nil
 }

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -146,6 +146,78 @@ func (r *Repository) ListMessages(ctx context.Context, sessionID string) ([]*mod
 	return msgs, err
 }
 
+// ListTaskInboxMessages returns a bounded, task-wide view of delivered user
+// messages. The cursor is a keyset over normalized created_at and message ID,
+// so callers do not need to load every session transcript before pagination.
+func (r *Repository) ListTaskInboxMessages(
+	ctx context.Context,
+	taskID string,
+	opts models.TaskInboxMessagesOptions,
+) ([]*models.Message, bool, map[string]int, error) {
+	counts := make(map[string]int)
+	countRows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+		SELECT task_session_id, COUNT(*)
+		FROM task_session_messages
+		WHERE task_id = ? AND author_type = ?
+		GROUP BY task_session_id
+	`), taskID, string(models.MessageAuthorUser))
+	if err != nil {
+		return nil, false, nil, err
+	}
+	for countRows.Next() {
+		var sessionID string
+		var count int
+		if err := countRows.Scan(&sessionID, &count); err != nil {
+			_ = countRows.Close()
+			return nil, false, nil, err
+		}
+		counts[sessionID] = count
+	}
+	if err := countRows.Err(); err != nil {
+		_ = countRows.Close()
+		return nil, false, nil, err
+	}
+	if err := countRows.Close(); err != nil {
+		return nil, false, nil, err
+	}
+
+	limit := opts.Limit
+	if limit < 0 {
+		limit = 0
+	}
+	nm := dialect.NormalizedMicrosecond(r.ro.DriverName(), "created_at")
+	query := `
+		SELECT id, task_session_id, task_id, turn_id, author_type, author_id,
+		       content, requests_input, type, metadata, created_at, updated_at
+		FROM task_session_messages
+		WHERE task_id = ? AND author_type = ?`
+	args := []interface{}{taskID, string(models.MessageAuthorUser)}
+	if !opts.AfterCreatedAt.IsZero() {
+		bound := "?"
+		if dialect.IsPostgres(r.ro.DriverName()) {
+			bound = "CAST(? AS timestamp)"
+		}
+		query += fmt.Sprintf(" AND (%s > %s OR (%s = %s AND id > ?))", nm, bound, nm, bound)
+		cursorKey := formatPromptKey(opts.AfterCreatedAt)
+		args = append(args, cursorKey, cursorKey, opts.AfterID)
+	}
+	query += fmt.Sprintf(" ORDER BY %s ASC, id ASC", nm)
+	if limit > 0 {
+		query += sqlLimitClause
+		args = append(args, limit+1)
+	}
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(query), args...)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	messages, hasMore, err := scanMessageRows(rows, limit)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	return messages, hasMore, counts, nil
+}
+
 // ListMessagesByTurnID returns all messages for a single turn ordered by
 // creation time. Backed by idx_messages_turn_id, so it reads only the turn's
 // own rows rather than the whole session's history.

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -155,30 +155,32 @@ func (r *Repository) ListTaskInboxMessages(
 	opts models.TaskInboxMessagesOptions,
 ) ([]*models.Message, bool, map[string]int, error) {
 	counts := make(map[string]int)
-	countRows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+	if !opts.SkipCounts {
+		countRows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
 		SELECT task_session_id, COUNT(*)
 		FROM task_session_messages
 		WHERE task_id = ? AND author_type = ?
 		GROUP BY task_session_id
 	`), taskID, string(models.MessageAuthorUser))
-	if err != nil {
-		return nil, false, nil, err
-	}
-	for countRows.Next() {
-		var sessionID string
-		var count int
-		if err := countRows.Scan(&sessionID, &count); err != nil {
+		if err != nil {
+			return nil, false, nil, err
+		}
+		for countRows.Next() {
+			var sessionID string
+			var count int
+			if err := countRows.Scan(&sessionID, &count); err != nil {
+				_ = countRows.Close()
+				return nil, false, nil, err
+			}
+			counts[sessionID] = count
+		}
+		if err := countRows.Err(); err != nil {
 			_ = countRows.Close()
 			return nil, false, nil, err
 		}
-		counts[sessionID] = count
-	}
-	if err := countRows.Err(); err != nil {
-		_ = countRows.Close()
-		return nil, false, nil, err
-	}
-	if err := countRows.Close(); err != nil {
-		return nil, false, nil, err
+		if err := countRows.Close(); err != nil {
+			return nil, false, nil, err
+		}
 	}
 
 	limit := opts.Limit

--- a/apps/backend/internal/task/repository/sqlite/message_inbox_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_inbox_postgres_test.go
@@ -1,0 +1,45 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresTaskInboxOrderIndexAndPagination(t *testing.T) {
+	repo := openPostgresRepo(t)
+	ctx := context.Background()
+	base := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	seedPostgresSession(t, repo, "task-inbox-pg", "session-inbox-pg", "turn-inbox-pg", base)
+
+	createInboxMessage(t, repo, "pg-m1", "task-inbox-pg", "session-inbox-pg", "turn-inbox-pg", models.MessageAuthorUser, base)
+	createInboxMessage(t, repo, "pg-m2", "task-inbox-pg", "session-inbox-pg", "turn-inbox-pg", models.MessageAuthorUser, base.Add(time.Microsecond))
+
+	var indexExists bool
+	require.NoError(t, repo.ro.Get(&indexExists, `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_indexes
+			WHERE schemaname = current_schema()
+			  AND indexname = 'idx_messages_task_inbox_order'
+		)
+	`))
+	require.True(t, indexExists)
+
+	page, hasMore, counts, err := repo.ListTaskInboxMessages(ctx, "task-inbox-pg", models.TaskInboxMessagesOptions{Limit: 1})
+	require.NoError(t, err)
+	require.True(t, hasMore)
+	require.Equal(t, []string{"pg-m1"}, inboxMessageIDs(page))
+	require.Equal(t, map[string]int{"session-inbox-pg": 2}, counts)
+
+	page, hasMore, _, err = repo.ListTaskInboxMessages(ctx, "task-inbox-pg", models.TaskInboxMessagesOptions{
+		Limit:          1,
+		AfterCreatedAt: page[0].CreatedAt,
+		AfterID:        page[0].ID,
+	})
+	require.NoError(t, err)
+	require.False(t, hasMore)
+	require.Equal(t, []string{"pg-m2"}, inboxMessageIDs(page))
+}

--- a/apps/backend/internal/task/repository/sqlite/message_inbox_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_inbox_test.go
@@ -2,9 +2,11 @@ package sqlite
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/db/dialect"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +40,44 @@ func TestListTaskInboxMessagesScopesAuthorsAndPaginatesByTask(t *testing.T) {
 	require.False(t, hasMore)
 	require.Equal(t, []string{"m3"}, inboxMessageIDs(page))
 	require.Equal(t, map[string]int{"session-a": 2, "session-b": 1}, counts)
+}
+
+func TestListTaskInboxMessagesUsesTaskScopedOrderingIndex(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	normalizedCreatedAt := dialect.NormalizedMicrosecond(dialect.SQLite3, "created_at")
+	rows, err := repo.ro.QueryxContext(context.Background(), repo.ro.Rebind(`
+		EXPLAIN QUERY PLAN
+		SELECT id
+		FROM task_session_messages
+		WHERE task_id = ? AND author_type = ?
+		ORDER BY `+normalizedCreatedAt+` ASC, id ASC
+		LIMIT ?
+	`), "task-inbox", string(models.MessageAuthorUser), 1)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, details)
+	require.True(t, slicesContain(details, "idx_messages_task_inbox_order"), "query plan: %v", details)
+	for _, detail := range details {
+		require.False(t, strings.Contains(detail, "USE TEMP B-TREE FOR ORDER BY"), "query plan: %v", details)
+	}
+}
+
+func slicesContain(values []string, wanted string) bool {
+	for _, value := range values {
+		if strings.Contains(value, wanted) {
+			return true
+		}
+	}
+	return false
 }
 
 func createInboxMessage(t *testing.T, repo *Repository, id, taskID, sessionID, turnID string, author models.MessageAuthorType, createdAt time.Time) {

--- a/apps/backend/internal/task/repository/sqlite/message_inbox_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_inbox_test.go
@@ -1,0 +1,63 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTaskInboxMessagesScopesAuthorsAndPaginatesByTask(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedForMsgTest(t, repo, "task-inbox", "session-a", "turn-a")
+	seedForMsgTest(t, repo, "task-inbox", "session-b", "turn-b")
+	seedForMsgTest(t, repo, "task-other", "session-other", "turn-other")
+
+	base := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	createInboxMessage(t, repo, "m1", "task-inbox", "session-a", "turn-a", models.MessageAuthorUser, base)
+	createInboxMessage(t, repo, "agent", "task-inbox", "session-a", "turn-a", models.MessageAuthorAgent, base.Add(time.Microsecond))
+	createInboxMessage(t, repo, "m2", "task-inbox", "session-b", "turn-b", models.MessageAuthorUser, base.Add(2*time.Microsecond))
+	createInboxMessage(t, repo, "m3", "task-inbox", "session-a", "turn-a", models.MessageAuthorUser, base.Add(3*time.Microsecond))
+	createInboxMessage(t, repo, "foreign", "task-other", "session-other", "turn-other", models.MessageAuthorUser, base.Add(4*time.Microsecond))
+
+	page, hasMore, counts, err := repo.ListTaskInboxMessages(ctx, "task-inbox", models.TaskInboxMessagesOptions{Limit: 2})
+	require.NoError(t, err)
+	require.True(t, hasMore)
+	require.Equal(t, []string{"m1", "m2"}, inboxMessageIDs(page))
+	require.Equal(t, map[string]int{"session-a": 2, "session-b": 1}, counts)
+
+	page, hasMore, counts, err = repo.ListTaskInboxMessages(ctx, "task-inbox", models.TaskInboxMessagesOptions{
+		Limit:          2,
+		AfterCreatedAt: page[len(page)-1].CreatedAt,
+		AfterID:        page[len(page)-1].ID,
+	})
+	require.NoError(t, err)
+	require.False(t, hasMore)
+	require.Equal(t, []string{"m3"}, inboxMessageIDs(page))
+	require.Equal(t, map[string]int{"session-a": 2, "session-b": 1}, counts)
+}
+
+func createInboxMessage(t *testing.T, repo *Repository, id, taskID, sessionID, turnID string, author models.MessageAuthorType, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, repo.CreateMessage(context.Background(), &models.Message{
+		ID:            id,
+		TaskID:        taskID,
+		TaskSessionID: sessionID,
+		TurnID:        turnID,
+		AuthorType:    author,
+		Content:       id,
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}))
+}
+
+func inboxMessageIDs(messages []*models.Message) []string {
+	ids := make([]string, 0, len(messages))
+	for _, message := range messages {
+		ids = append(ids, message.ID)
+	}
+	return ids
+}

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
 )
 
 const (
@@ -344,6 +345,19 @@ func (s *Service) ListMessages(ctx context.Context, sessionID string) ([]*models
 		return nil, err
 	}
 	return s.messages.ListMessages(ctx, sessionID)
+}
+
+// ListTaskInboxMessages returns a bounded task-wide view of delivered user
+// messages for the task inbox projection.
+func (s *Service) ListTaskInboxMessages(ctx context.Context, taskID string, opts models.TaskInboxMessagesOptions) ([]*models.Message, bool, map[string]int, error) {
+	if err := s.authorizeTaskID(ctx, taskID); err != nil {
+		return nil, false, nil, err
+	}
+	repo, ok := s.messages.(repository.TaskInboxMessageRepository)
+	if !ok {
+		return nil, false, nil, fmt.Errorf("message repository does not support task inbox queries")
+	}
+	return repo.ListTaskInboxMessages(ctx, taskID, opts)
 }
 
 // ListMessagesPaginated returns messages for a session with pagination options.

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -489,6 +489,7 @@ const (
 	ActionMCPSpawnSession                = "mcp.spawn_session"
 	ActionMCPGetTaskConversation         = "mcp.get_task_conversation"
 	ActionMCPListTaskSessions            = "mcp.list_task_sessions"
+	ActionMCPListTaskInbox               = "mcp.list_task_inbox"
 	ActionMCPListPendingAgentPermissions = "mcp.list_pending_agent_permissions"
 	ActionMCPResolveAgentPermission      = "mcp.resolve_agent_permission"
 )


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2974/b542ba3a580b.html)
<!-- kandev-pr-walkthrough-end -->

A provider-neutral agent or plugin needs one read-only inbox for its own task that sees delivered prompts and pending queue work across sibling sessions without consuming UI state. The new MCP tool is task-bound, paginated with an opaque cursor, and carries queue transition identity so queue drain observations can be collapsed safely.

## Important Changes

- Adds `list_task_inbox_kandev` for only the MCP server's bound task, with fail-closed backend forwarding.
- Aggregates inbound transcript prompts and visible queue entries with session provenance, deterministic ordering, reserved-row exclusion, visible-content projection, and safe attachment descriptors.
- Preserves a stable transition identity across normal queue drain and the workflow auto-start pre-record/fallback-queue path, so a poller can recognize the same work while it moves from queued to delivered.
- Deliberately provides only this generic core primitive. Coordinator-specific inbox policy, follow-up ledgers, escalation rules, and reconciliation cycles belong in `kandev-plugin-coordinator`.

## Validation

- `GOCACHE=/tmp/kandev-go-cache go test ./internal/mcp/handlers`
- `GOCACHE=/tmp/kandev-go-cache go test ./internal/orchestrator -run 'TestAutoStartTransientError_BootReadyDrainsOrphanedQueue|TestExecuteQueuedMessage_RequeuesTransientPromptFailure|TestExecuteQueuedMessage_RequeuesCoalescedMessageWithOriginalSender'`
- `GOCACHE=/tmp/kandev-go-cache go test ./internal/mcp/server -run 'Test(ListTask|CoreToolRiskAnnotations|RegisterTools_LoggedCountMatchesRegisteredTools)'`
- Commit hooks: architecture lint, gofmt, changed-code Go lint, commitlint, and repository guards.
- The complete `internal/mcp/server` suite could not run in this sandbox because an existing test requires a loopback listener, which the sandbox denies. Focused server tests passed.
- Current review-fix head: `e8dbdc8a9b40134cc2d536e49c4ff9cb3fcd7f4b`; fresh exact-head CI is required before readiness.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. This backend-only MCP surface has no public-doc impact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2974-bwo7.sprites.app |
| **Commit** | `b542ba3` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->
