### PR TITLE
ci: add macOS launch guidance to releases

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -731,12 +731,20 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
 
         self.assertIn("macos_unsigned=false", warning)
         self.assertIn("macos_unsigned=true", warning)
-        self.assertIn('if [ "$macos_unsigned" = "true" ]; then', warning)
+        branch_if = 'if [ "$macos_unsigned" = "true" ]; then'
+        command = "xattr -d com.apple.quarantine /Applications/Kandev.app"
+
+        self.assertIn(branch_if, warning)
         self.assertIn("verify the checksum", warning)
-        self.assertIn(
-            "xattr -d com.apple.quarantine /Applications/Kandev.app",
-            warning,
+        self.assertIn(command, warning)
+        self.assertLess(
+            warning.index("verify the checksum"),
+            warning.index(command),
         )
+        branch_start = warning.index(branch_if)
+        branch_end = warning.index("\n            fi", branch_start)
+        branch_body = warning[branch_start:branch_end]
+        self.assertIn(command, branch_body)
 
     def test_release_asset_globs_are_disjoint_and_upload_sequentially(self) -> None:
         publish = step_block("Publish release")

--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -726,6 +726,18 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn('"${UPDATER_SIGNING_ENABLED:-false}" = "true"', collect)
         self.assertIn('"$DESKTOP_ASSET_VERIFIER" --require-updaters', collect)
 
+    def test_unsigned_macos_warning_includes_launch_recovery_command(self) -> None:
+        warning = step_block("Add unsigned desktop warning to release notes")
+
+        self.assertIn("macos_unsigned=false", warning)
+        self.assertIn("macos_unsigned=true", warning)
+        self.assertIn('if [ "$macos_unsigned" = "true" ]; then', warning)
+        self.assertIn("verify the checksum", warning)
+        self.assertIn(
+            "xattr -d com.apple.quarantine /Applications/Kandev.app",
+            warning,
+        )
+
     def test_release_asset_globs_are_disjoint_and_upload_sequentially(self) -> None:
         publish = step_block("Publish release")
         files = re.search(r"\n          files: \|\n((?:            \S+\n)+)", publish)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1975,8 +1975,10 @@ jobs:
           set -euo pipefail
 
           unsigned=()
+          macos_unsigned=false
           if ! bash scripts/release/desktop-signing-ready.sh macos >/dev/null 2>&1; then
             unsigned+=("macOS")
+            macos_unsigned=true
           fi
           if ! bash scripts/release/desktop-signing-ready.sh windows >/dev/null 2>&1; then
             unsigned+=("Windows")
@@ -1994,6 +1996,14 @@ jobs:
             echo "> [!WARNING]"
             echo "> $platforms desktop installers in this release are unsigned development builds."
             echo "> They may require manual OS security bypasses and are not trusted downloads."
+            if [ "$macos_unsigned" = "true" ]; then
+              echo ">"
+              echo "> If macOS blocks Kandev after you verify the checksum, run:"
+              echo ">"
+              echo '> ```bash'
+              echo "> xattr -d com.apple.quarantine /Applications/Kandev.app"
+              echo '> ```'
+            fi
             echo
             cat RELEASE_NOTES.md
           } > "$tmp"


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2991/5134aa5c0cee.html)
<!-- kandev-pr-walkthrough-end -->

The unsigned desktop warning did not explain how macOS users can open a verified development build after Gatekeeper blocks it. This adds a checksum-first recovery command to the warning when macOS signing is unavailable.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py`
- `bash scripts/release-desktop.test.sh`
- `make test-cli`
- `bash -n scripts/release-desktop.test.sh`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->