### PR TITLE
fix: stop a flaky test hang from failing CI on unrelated PRs

### DIFF
--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -656,17 +656,31 @@ func TestRequestGate_ReleaseAllIsIdempotentAndUnblocksParkedHandlers(t *testing.
 		HTTPClient: gate.server.Client(),
 	}, logger.Default())
 
-	refreshDone := make(chan error, 1)
-	go func() { refreshDone <- c.Refresh(context.Background()) }()
+	var refreshErr error
+	refreshDone := make(chan struct{})
+	go func() {
+		refreshErr = c.Refresh(context.Background())
+		close(refreshDone)
+	}()
+	// Same self-contained release-then-join shape as
+	// TestClient_ConcurrentRefreshCallsShareOneFetch: if waitForFirstRequest
+	// below times out, this Cleanup still drains the goroutine before
+	// t.TempDir() removes the directory it may be writing into. refreshDone
+	// is closed (not a single-value send) so both this Cleanup and the
+	// select below can receive from it without racing over who drains it.
+	t.Cleanup(func() {
+		gate.releaseAll()
+		<-refreshDone
+	})
 	gate.waitForFirstRequest(t)
 
 	gate.releaseAll()
 	gate.releaseAll()
 
 	select {
-	case err := <-refreshDone:
-		if err != nil {
-			t.Fatalf("Refresh: %v", err)
+	case <-refreshDone:
+		if refreshErr != nil {
+			t.Fatalf("Refresh: %v", refreshErr)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Refresh did not complete after releaseAll")

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -519,6 +519,20 @@ func TestClient_ConcurrentRefreshCallsShareOneFetch(t *testing.T) {
 			}
 		}()
 	}
+	// If waitForFirstRequest below times out, its t.Fatal runs
+	// runtime.Goexit and skips the explicit releaseAll+wg.Wait() that
+	// follows, leaving these 8 goroutines parked in the gate. This
+	// Cleanup performs release-then-join as one atomic unit so it is
+	// safe regardless of its LIFO position relative to newRequestGate's
+	// own release Cleanup: without it, the parked goroutines complete
+	// only once the deferred release fires, after the test has already
+	// been marked done, and their t.Errorf call above then panics with
+	// "Log in goroutine after Test has completed" instead of failing
+	// cleanly.
+	t.Cleanup(func() {
+		gate.releaseAll()
+		wg.Wait()
+	})
 	close(start)
 	gate.waitForFirstRequest(t)
 	gate.releaseAll()

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -668,11 +668,19 @@ func TestRequestGate_ReleaseAllIsIdempotentAndUnblocksParkedHandlers(t *testing.
 // the inner t.Run and the outer test both hang until the package's -timeout
 // fires; post-fix it returns in milliseconds because the cleanup-registered
 // gate.releaseAll unblocks the handler so httptest.Server.Close can proceed.
+//
+// dir and refreshDone are hoisted to the outer t so the Refresh goroutine is
+// explicitly joined before this function returns: httptest.Server.Close only
+// waits for the handler goroutine, not for the client goroutine to finish
+// writeCacheAtomic, so leaving it unjoined races the inner t.TempDir cleanup
+// against files the goroutine is still writing into that same directory.
 func TestRequestGate_ParkedHandlerDoesNotBlockTestTeardown(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	refreshDone := make(chan struct{})
+
 	start := time.Now()
 	t.Run("park-without-release", func(t *testing.T) {
-		dir := t.TempDir()
-		cachePath := filepath.Join(dir, "models-dev.json")
 		gate := newRequestGate(t, sampleDataset)
 		c := modelsdev.New(modelsdev.Config{
 			CachePath:  cachePath,
@@ -681,13 +689,22 @@ func TestRequestGate_ParkedHandlerDoesNotBlockTestTeardown(t *testing.T) {
 			HTTPClient: gate.server.Client(),
 		}, logger.Default())
 
-		go func() { _ = c.Refresh(context.Background()) }()
+		go func() {
+			defer close(refreshDone)
+			_ = c.Refresh(context.Background())
+		}()
 		gate.waitForFirstRequest(t)
 		// Intentionally return without releasing the gate — the subtest's
 		// t.Cleanup chain must release it during teardown.
 	})
 	if elapsed := time.Since(start); elapsed > 10*time.Second {
 		t.Fatalf("parked handler blocked teardown for %v, want well under 10s", elapsed)
+	}
+
+	select {
+	case <-refreshDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Refresh goroutine did not finish after the subtest released the gate")
 	}
 }
 

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -449,10 +449,11 @@ func TestClient_FirstBootMissesGracefully(t *testing.T) {
 }
 
 type requestGate struct {
-	server   *httptest.Server
-	started  chan struct{}
-	release  chan struct{}
-	requests atomic.Int32
+	server      *httptest.Server
+	started     chan struct{}
+	release     chan struct{}
+	releaseOnce sync.Once
+	requests    atomic.Int32
 }
 
 func newRequestGate(t *testing.T, body string) *requestGate {
@@ -473,8 +474,17 @@ func newRequestGate(t *testing.T, body string) *requestGate {
 		}
 		_, _ = w.Write([]byte(body))
 	}))
+	// Cleanup runs LIFO: registering releaseAll after server.Close means it
+	// runs first, so a t.Fatal (which skips the explicit release below via
+	// runtime.Goexit) still unblocks any parked handler before Close waits
+	// on it.
 	t.Cleanup(gate.server.Close)
+	t.Cleanup(gate.releaseAll)
 	return gate
+}
+
+func (g *requestGate) releaseAll() {
+	g.releaseOnce.Do(func() { close(g.release) })
 }
 
 func (g *requestGate) waitForFirstRequest(t *testing.T) {
@@ -511,7 +521,7 @@ func TestClient_ConcurrentRefreshCallsShareOneFetch(t *testing.T) {
 	}
 	close(start)
 	gate.waitForFirstRequest(t)
-	close(gate.release)
+	gate.releaseAll()
 	wg.Wait()
 
 	if got := gate.requests.Load(); got != 1 {
@@ -559,7 +569,7 @@ func TestClient_ConcurrentLookupsShareOneBackgroundFetch(t *testing.T) {
 	}
 	refreshDone := make(chan error, 1)
 	go func() { refreshDone <- c.Refresh(context.Background()) }()
-	close(gate.release)
+	gate.releaseAll()
 	select {
 	case err := <-refreshDone:
 		if err != nil {
@@ -604,7 +614,7 @@ func TestClient_CanceledStaleLookupDoesNotCancelJoinedRefresh(t *testing.T) {
 	case <-time.After(25 * time.Millisecond):
 	}
 
-	close(gate.release)
+	gate.releaseAll()
 	select {
 	case err := <-refreshDone:
 		if err != nil {
@@ -615,6 +625,69 @@ func TestClient_CanceledStaleLookupDoesNotCancelJoinedRefresh(t *testing.T) {
 	}
 	if got := gate.requests.Load(); got != 1 {
 		t.Fatalf("models.dev request count after canceled lookup = %d, want 1", got)
+	}
+}
+
+// releaseAll must be safe to call more than once (the happy-path release
+// races the t.Cleanup-registered release on the same gate) and must unblock
+// a handler already parked in the select inside newRequestGate.
+func TestRequestGate_ReleaseAllIsIdempotentAndUnblocksParkedHandlers(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	gate := newRequestGate(t, sampleDataset)
+	c := modelsdev.New(modelsdev.Config{
+		CachePath:  cachePath,
+		URL:        gate.server.URL,
+		TTL:        time.Hour,
+		HTTPClient: gate.server.Client(),
+	}, logger.Default())
+
+	refreshDone := make(chan error, 1)
+	go func() { refreshDone <- c.Refresh(context.Background()) }()
+	gate.waitForFirstRequest(t)
+
+	gate.releaseAll()
+	gate.releaseAll()
+
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("Refresh: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Refresh did not complete after releaseAll")
+	}
+	// t.Cleanup(gate.releaseAll) fires a third call on the same gate below.
+}
+
+// A parked requestGate handler must not block test teardown when the calling
+// t.Run returns without releasing it — the same shape as waitForFirstRequest
+// timing out and running t.Fatal (runtime.Goexit skips the explicit release
+// that follows it), minus the induced failure so the assertion below is
+// meaningful. Pre-fix (raw close(gate.release) only, no t.Cleanup release),
+// the inner t.Run and the outer test both hang until the package's -timeout
+// fires; post-fix it returns in milliseconds because the cleanup-registered
+// gate.releaseAll unblocks the handler so httptest.Server.Close can proceed.
+func TestRequestGate_ParkedHandlerDoesNotBlockTestTeardown(t *testing.T) {
+	start := time.Now()
+	t.Run("park-without-release", func(t *testing.T) {
+		dir := t.TempDir()
+		cachePath := filepath.Join(dir, "models-dev.json")
+		gate := newRequestGate(t, sampleDataset)
+		c := modelsdev.New(modelsdev.Config{
+			CachePath:  cachePath,
+			URL:        gate.server.URL,
+			TTL:        time.Hour,
+			HTTPClient: gate.server.Client(),
+		}, logger.Default())
+
+		go func() { _ = c.Refresh(context.Background()) }()
+		gate.waitForFirstRequest(t)
+		// Intentionally return without releasing the gate — the subtest's
+		// t.Cleanup chain must release it during teardown.
+	})
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("parked handler blocked teardown for %v, want well under 10s", elapsed)
 	}
 }
 


### PR DESCRIPTION
**Today:** Any PR to this repo — even one that touches zero files in this package — can fail CI when `TestClient_ConcurrentRefreshCallsShareOneFetch`'s helper hits a timing hiccup: its 1-second wait times out and calls `t.Fatal`, which runs `runtime.Goexit()` and skips the goroutine release the test depended on. The 8 parked handler goroutines then block forever, `t.Cleanup(gate.server.Close)` waits on them, and the package burns its full 600-second CI timeout instead of failing. PR #2975 hit this twice with zero files changed in this package, and needed an admin-only CI rerun both times.
**After this:** The release now fires unconditionally via `t.Cleanup`, guarded by `sync.Once` so the happy path's explicit release can't double-close it. A failed wait can no longer strand the handlers — the package completes in ~2-3 seconds, including under `-race`.
**Who hits this:** Anyone opening a PR against this repo, regardless of whether they touch `internal/office/costs/modelsdev`.
**Scope:** standalone — one of three unrelated flaky-CI failures found in a five-hour window; the other two are separate cards.
**Not here:** `client.go` itself is untouched, to stay conflict-free with #2964, which is mid-review on that same file.

A single timing hiccup in a test helper could deadlock the whole `modelsdev` package and burn its entire 600-second CI timeout — on PRs that never touch this code — because the helper's `t.Fatal` skipped a goroutine release it depended on. Closing the release unconditionally via `t.Cleanup`, guarded by `sync.Once`, makes a failed wait fail fast instead of hanging.

## Important Changes

- `newRequestGate` now closes `gate.release` via `t.Cleanup` (once, via `sync.Once`) instead of relying on each test to close it explicitly at the end of a successful run — so every exit path, including a `t.Fatal` mid-test, releases parked handlers.
- Added `TestRequestGate_ReleaseAllIsIdempotentAndUnblocksParkedHandlers` and `TestRequestGate_ParkedHandlerDoesNotBlockTestTeardown` to cover the release-idempotency and teardown-unblocking properties directly.

## Validation

Package-level, fresh runs against this branch:
```
$ go test -tags fts5 ./internal/office/costs/modelsdev/... -v -count=1 -timeout 60s
... (all 20 tests) PASS
ok  	github.com/kandev/kandev/internal/office/costs/modelsdev	1.778s

$ go test -race ./internal/office/costs/modelsdev/... -v -count=1 -timeout 60s
ok  	github.com/kandev/kandev/internal/office/costs/modelsdev	2.893s
```
Stress runs to confirm the flake is actually gone, not just quiet this time:
```
$ go test ./internal/office/costs/modelsdev/ -run TestRequestGate -count=500 -timeout 300s
ok  	github.com/kandev/kandev/internal/office/costs/modelsdev	6.344s     (500/500; was 11/500 failing before the fix)

$ go test -race ./internal/office/costs/modelsdev/ -run TestRequestGate -count=100 -timeout 300s
ok  	github.com/kandev/kandev/internal/office/costs/modelsdev	2.636s     (100/100 under -race; was 4/100 failing)

$ go test ./internal/office/costs/modelsdev/ -count=30 -timeout 300s
ok  	github.com/kandev/kandev/internal/office/costs/modelsdev	39.826s    (30/30 full-package CI-shape; was 1/30 failing)
```
Regression-test teeth verified empirically in a scratch worktree (reverted the `t.Cleanup(gate.releaseAll)` line and reran the new test alone — it reproduces the exact original signature, `httptest.Server blocked in Close`, running to the 30s test timeout with no `--- FAIL`; restoring the line brings the whole package back to ~3s).

Repo-wide gauntlet, all green:
```
make fmt
make typecheck        # exit 0
make lint              # 0 issues (backend + web + harness + spec + architecture)
make lint-format        # All matched files use Prettier code style!
cd apps/web && pnpm run i18n:ratchet   # no UI source added or modified; guard allowlist intact
```
`make test` (full backend suite) shows the same 4 pre-existing failing packages as at the merge-base with zero branch changes present (`internal/agent/managedruntime`, `internal/agent/settings/controller`, `internal/agentctl/server/config`, `internal/system/storage/workspaces` — host npm-cache-symlink and login-shell-PATH environment issues, unrelated to this change and reproduced identically in a scratch worktree at the merge-base). `internal/repoclone` flaked once under full-suite parallel load and passed 3/3 in isolation — a known timing-sensitive package, untouched by this diff.

Scope check: `git diff --name-only origin/main...HEAD` is exactly one file, `apps/backend/internal/office/costs/modelsdev/client_test.go` — nothing under `apps/web/`, so no E2E run is required.

## Possible Improvements

Low risk. One test-rigor note from review: the new `TestRequestGate_ParkedHandlerDoesNotBlockTestTeardown`'s `elapsed > 10s` assertion is not reachable under the exact pre-fix code — with the fix reverted, the test instead hangs to the outer test timeout (the original bug's own signature) rather than failing that specific assertion. The regression is still caught (proven above), just via a timeout rather than a fast, targeted failure. Not addressed here: a watchdog goroutine to make it fail fast would itself add another source of test flakiness, which is the exact class of problem this PR removes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Test-only change; no public docs affected.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->