### PR TITLE
fix(ci): preserve walkthrough HTML bytes

### DIFF
--- a/.github/scripts/pr-walkthrough-workflow-contract_test.py
+++ b/.github/scripts/pr-walkthrough-workflow-contract_test.py
@@ -297,7 +297,7 @@ class PRWalkthroughWorkflowContractTest(unittest.TestCase):
             'OBJECT_KEY="pr/${PR_NUMBER}/${SHORT_HEAD_SHA}.html"',
             "aws s3 cp",
             '--content-type "text/html; charset=utf-8"',
-            '--cache-control "public, max-age=300"',
+            '--cache-control "public, max-age=300, no-transform"',
             "aws s3api head-object",
             'test "$content_type" = "text/html; charset=utf-8"',
             'test "$content_length" -gt 0',

--- a/.github/workflows/pr-walkthrough.yml
+++ b/.github/workflows/pr-walkthrough.yml
@@ -310,7 +310,7 @@ jobs:
           aws s3 cp "$HTML_PATH" "s3://${CLOUDFLARE_R2_BUCKET}/${OBJECT_KEY}" \
             --endpoint-url "$CLOUDFLARE_R2_ENDPOINT" \
             --content-type "text/html; charset=utf-8" \
-            --cache-control "public, max-age=300" \
+            --cache-control "public, max-age=300, no-transform" \
             --only-show-errors
 
           content_type="$(aws s3api head-object \

--- a/docs/plans/pr-walkthrough/task-04-r2-html-publication.md
+++ b/docs/plans/pr-walkthrough/task-04-r2-html-publication.md
@@ -81,3 +81,14 @@ Verification: workflow contract tests passed; the publication job has no
 checkout step, and R2 secrets are scoped only to the upload step. Operator
 provisioning is complete; a live upload remains pending the first eligible PR
 workflow run.
+
+Follow-up remediation: added `Cache-Control: no-transform` to the R2 upload so
+Cloudflare cannot rewrite the HTML before the public byte comparison. Updated
+the workflow contract regression to require the cache directive.
+
+Follow-up verification: `python3 .github/scripts/pr-walkthrough-workflow-contract_test.py`
+(22 tests passed), `python3 .github/scripts/lint-action-pinning_test.py` (9 tests
+passed), `python3 .github/scripts/lint-action-pinning.py` (20 workflows passed),
+and `git diff --check` passed. `zizmor` 1.25.2 retained the existing
+`dangerous-triggers` finding for the intentional `pull_request_target` workflow;
+the finding is outside this diff. `actionlint` was unavailable locally.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/2994/90319f5b28d1.html)
<!-- kandev-pr-walkthrough-end -->

Cloudflare Email Address Obfuscation rewrote published walkthrough HTML before the workflow's byte comparison, causing valid R2 uploads to fail. Add `no-transform` to the R2 cache policy and cover it in the publication contract test so the public response remains byte-identical.

## Validation

- `python3 .github/scripts/pr-walkthrough-workflow-contract_test.py` (22 tests passed)
- `python3 .github/scripts/lint-action-pinning_test.py` (9 tests passed)
- `python3 .github/scripts/lint-action-pinning.py` (20 workflows passed)
- `git diff --check`
- `zizmor .github/workflows/pr-walkthrough.yml` retains the existing intentional `pull_request_target` finding; it is outside this diff.
- `actionlint` was unavailable locally.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->