### PR TITLE
fix(backend): use the session auth token for non-Docker launch and resume

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_auth_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_auth_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/secrets"
+	"github.com/kandev/kandev/internal/task/models"
 )
 
 // inMemorySecretStore implements secrets.SecretStore for testing.
@@ -293,6 +294,100 @@ func TestRevealContainerControlAuthToken(t *testing.T) {
 		}
 		if got != "" {
 			t.Fatalf("revealContainerControlAuthToken() token = %q, want empty", got)
+		}
+	})
+}
+
+// TestResolveLaunchAuthToken is the regression test for the SSH resume
+// preflight failing with "missing agentctl auth token": #2843 made every
+// launch/resume consume the Docker-only container control token, so a
+// non-Docker executor (SSH) with a real session auth secret got "" instead.
+func TestResolveLaunchAuthToken(t *testing.T) {
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+
+	t.Run("ssh with a session auth secret returns that token", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		store.store["session-auth"] = &secrets.SecretWithValue{Value: "the-ssh-token"}
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeSSH)}
+		metadata := map[string]interface{}{MetadataKeyAuthTokenSecret: "session-auth"}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, metadata)
+		if err != nil {
+			t.Fatalf("resolveLaunchAuthToken() error = %v", err)
+		}
+		if got != "the-ssh-token" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want %q", got, "the-ssh-token")
+		}
+	})
+
+	t.Run("ssh with no secret anywhere returns empty and resume still rejects it", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeSSH)}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("resolveLaunchAuthToken() error = %v", err)
+		}
+		if got != "" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want empty", got)
+		}
+		if err := requireSSHAgentctlAuthToken(got); err == nil {
+			t.Fatal("requireSSHAgentctlAuthToken() accepted an empty token")
+		}
+	})
+
+	t.Run("docker with workspace reuse still prefers the container control token", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		store.store["control-secret"] = &secrets.SecretWithValue{Value: "environment-control-token"}
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeLocalDocker), WorkspaceReuseRequired: true}
+		metadata := map[string]interface{}{MetadataKeyContainerControlAuthSecret: "control-secret"}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, metadata)
+		if err != nil {
+			t.Fatalf("resolveLaunchAuthToken() error = %v", err)
+		}
+		if got != "environment-control-token" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want %q", got, "environment-control-token")
+		}
+	})
+
+	t.Run("docker with workspace reuse falls back to the session token when no control handle exists", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		store.store["session-auth"] = &secrets.SecretWithValue{Value: "legacy-session-token"}
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeRemoteDocker), WorkspaceReuseRequired: true}
+		metadata := map[string]interface{}{MetadataKeyAuthTokenSecret: "session-auth"}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, metadata)
+		if err != nil {
+			t.Fatalf("resolveLaunchAuthToken() error = %v", err)
+		}
+		if got != "legacy-session-token" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want %q", got, "legacy-session-token")
+		}
+	})
+
+	t.Run("docker without workspace reuse returns empty when no control handle exists", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		store.store["session-auth"] = &secrets.SecretWithValue{Value: "legacy-session-token"}
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeLocalDocker), WorkspaceReuseRequired: false}
+		metadata := map[string]interface{}{MetadataKeyAuthTokenSecret: "session-auth"}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, metadata)
+		if err != nil {
+			t.Fatalf("resolveLaunchAuthToken() error = %v", err)
+		}
+		if got != "" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want empty", got)
 		}
 	})
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_auth_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_auth_test.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -319,6 +320,25 @@ func TestResolveLaunchAuthToken(t *testing.T) {
 		}
 		if got != "the-ssh-token" {
 			t.Fatalf("resolveLaunchAuthToken() = %q, want %q", got, "the-ssh-token")
+		}
+	})
+
+	t.Run("ssh reports a session secret reveal failure", func(t *testing.T) {
+		store := newInMemorySecretStore()
+		revealErr := errors.New("secret backend unavailable")
+		store.revealErr = revealErr
+		store.store["session-auth"] = &secrets.SecretWithValue{Value: "the-ssh-token"}
+		m := &Manager{logger: log, secretStore: store}
+
+		req := &LaunchRequest{ExecutorType: string(models.ExecutorTypeSSH)}
+		metadata := map[string]interface{}{MetadataKeyAuthTokenSecret: "session-auth"}
+
+		got, err := m.resolveLaunchAuthToken(context.Background(), req, metadata)
+		if !errors.Is(err, revealErr) {
+			t.Fatalf("resolveLaunchAuthToken() error = %v, want %v", err, revealErr)
+		}
+		if got != "" {
+			t.Fatalf("resolveLaunchAuthToken() = %q, want empty", got)
 		}
 	})
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -732,7 +732,7 @@ func (m *Manager) prepareExecutionCreateRequest(
 		autoApproveOverride = boolPtr(profileInfo.AutoApprove)
 	}
 	authToken := m.revealRuntimeSecret(ctx, info.Metadata, MetadataKeyAuthTokenSecret)
-	if info.ExecutorType == string(models.ExecutorTypeLocalDocker) || info.ExecutorType == string(models.ExecutorTypeRemoteDocker) {
+	if isDockerExecutorType(info.ExecutorType) {
 		controlToken, err := m.revealContainerControlAuthToken(ctx, info.Metadata, getMetadataString(info.Metadata, MetadataKeyContainerID) != "")
 		if err != nil {
 			return nil, fmt.Errorf("resolve container control token: %w", err)
@@ -1022,20 +1022,29 @@ func (m *Manager) persistRuntimeSecret(
 		zap.String("metadata_key", metadataKey))
 }
 
-func (m *Manager) revealRuntimeSecret(ctx context.Context, metadata map[string]interface{}, metadataKey string) string {
-	if m.secretStore == nil {
-		return ""
-	}
+// revealRuntimeSecretValue reveals a configured runtime secret and preserves
+// storage errors for callers that need to report a failed launch.
+func (m *Manager) revealRuntimeSecretValue(ctx context.Context, metadata map[string]interface{}, metadataKey string) (string, error) {
 	secretID := getMetadataString(metadata, metadataKey)
 	if secretID == "" {
-		return ""
+		return "", nil
+	}
+	if m.secretStore == nil {
+		return "", errors.New("runtime secret store is unavailable")
 	}
 	value, err := revealGlobalSecret(ctx, m.secretStore, secretID)
+	if err != nil {
+		return "", fmt.Errorf("reveal runtime secret %q: %w", metadataKey, err)
+	}
+	return value, nil
+}
+
+func (m *Manager) revealRuntimeSecret(ctx context.Context, metadata map[string]interface{}, metadataKey string) string {
+	value, err := m.revealRuntimeSecretValue(ctx, metadata, metadataKey)
 	if err != nil {
 		m.logger.Warn("failed to reveal runtime secret",
 			zap.String("metadata_key", metadataKey),
 			zap.Error(err))
-		return ""
 	}
 	return value
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -858,11 +858,9 @@ func (m *Manager) launchBuildExecutorRequest(ctx context.Context, executionID st
 		metadata[MetadataKeyContributionDestinations] = contributionDestinations
 	}
 
-	allowLegacyContainerControlFallback := reqWithWorktree.WorkspaceReuseRequired &&
-		(reqWithWorktree.ExecutorType == string(models.ExecutorTypeLocalDocker) || reqWithWorktree.ExecutorType == string(models.ExecutorTypeRemoteDocker))
-	containerControlAuthToken, err := m.revealContainerControlAuthToken(ctx, metadata, allowLegacyContainerControlFallback)
+	launchAuthToken, err := m.resolveLaunchAuthToken(ctx, reqWithWorktree, metadata)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("resolve container control token: %w", err)
+		return nil, nil, nil, fmt.Errorf("resolve launch auth token: %w", err)
 	}
 
 	var autoApproveOverride *bool
@@ -893,7 +891,7 @@ func (m *Manager) launchBuildExecutorRequest(ctx context.Context, executionID st
 		McpMode:                        reqWithWorktree.McpMode,
 		McpProviders:                   reqWithWorktree.McpProviders,
 		McpProfile:                     reqWithWorktree.McpProfile,
-		AuthToken:                      containerControlAuthToken,
+		AuthToken:                      launchAuthToken,
 		BootstrapNonce:                 m.revealRuntimeSecret(ctx, metadata, MetadataKeyBootstrapNonceSecret),
 		AgentctlStartupConfig:          m.agentctlStartupConfig,
 		OnProgress:                     onProgress,
@@ -913,6 +911,23 @@ func (m *Manager) launchBuildExecutorRequest(ctx context.Context, executionID st
 		return nil, nil, nil, fmt.Errorf("failed to create execution: %w", err)
 	}
 	return execReq, execInstance, rt, nil
+}
+
+func isDockerExecutorType(executorType string) bool {
+	return executorType == string(models.ExecutorTypeLocalDocker) || executorType == string(models.ExecutorTypeRemoteDocker)
+}
+
+// resolveLaunchAuthToken returns the agentctl token a launch/resume hands the
+// backend. Docker uses the environment-scoped container control token (#2843)
+// so a sibling session can authenticate to a shared container, falling back
+// to the session token only when workspace reuse is required and no
+// container-control secret exists yet. Every other executor uses its own
+// session handshake token directly, which SSH resume requires.
+func (m *Manager) resolveLaunchAuthToken(ctx context.Context, req *LaunchRequest, metadata map[string]interface{}) (string, error) {
+	if isDockerExecutorType(req.ExecutorType) {
+		return m.revealContainerControlAuthToken(ctx, metadata, req.WorkspaceReuseRequired)
+	}
+	return m.revealRuntimeSecret(ctx, metadata, MetadataKeyAuthTokenSecret), nil
 }
 
 func resumeRemoteInstancePreflight(ctx context.Context, rt ExecutorBackend, req *ExecutorCreateRequest) error {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -927,7 +927,7 @@ func (m *Manager) resolveLaunchAuthToken(ctx context.Context, req *LaunchRequest
 	if isDockerExecutorType(req.ExecutorType) {
 		return m.revealContainerControlAuthToken(ctx, metadata, req.WorkspaceReuseRequired)
 	}
-	return m.revealRuntimeSecret(ctx, metadata, MetadataKeyAuthTokenSecret), nil
+	return m.revealRuntimeSecretValue(ctx, metadata, MetadataKeyAuthTokenSecret)
 }
 
 func resumeRemoteInstancePreflight(ctx context.Context, rt ExecutorBackend, req *ExecutorCreateRequest) error {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3007/12a1a6207cb1.html)
<!-- kandev-pr-walkthrough-end -->

An SSH-executor task dies at the first workflow step that resets agent context:

```
failed to resume session: failed remote resume preflight: ssh resume: missing agentctl auth token
```

Reproduced on a real macOS arm64 SSH host on 2026-08-24, walking Triage → Build → Verify fine and
then dying on entry to Review. The same error appears after a backend restart, when startup recovery
tries to resume.

## Root cause

There are two paths that build the executor request, and they disagreed about which token to send.

`prepareWorkspaceExecution` (`internal/agent/runtime/lifecycle/manager_execution.go` ~line 734)
already gets it right — it reads the session's own handshake token and only *overrides* it with the
container-control token for the two Docker executor types:

```go
authToken := m.revealRuntimeSecret(ctx, info.Metadata, MetadataKeyAuthTokenSecret)
if info.ExecutorType == string(models.ExecutorTypeLocalDocker) || ... {
    // override with container control token
}
```

`launchBuildExecutorRequest` (`manager_launch.go` ~line 858) did not. Since #2843 it consumed the
container-control token *unconditionally*:

```go
allowLegacyContainerControlFallback := reqWithWorktree.WorkspaceReuseRequired &&
    (executorType == LocalDocker || executorType == RemoteDocker)
containerControlAuthToken, err := m.revealContainerControlAuthToken(ctx, metadata, allowLegacyContainerControlFallback)
...
AuthToken: containerControlAuthToken,
```

For SSH both branches of `revealContainerControlAuthToken` fall away: there is no
`MetadataKeyContainerControlAuthSecret` (that secret is only minted for containers), and
`allowLegacyFallback` is false because the executor is not Docker. So it returns `"", nil` and the
launch hands agentctl an empty token — every time, not intermittently.

SSH is the only executor whose resume *requires* the token (`requireSSHAgentctlAuthToken`,
`executor_ssh.go` ~line 760), which is why Local and Worktree cards are unaffected and this reads as
"SSH is broken".

The metadata plumbing was never the problem — the key is present the whole time, and only the reader
ignored it. On a resume it reaches the launch request from the session's own `executors_running` row:
`applyRunningRecordToResumeRequest` (`internal/orchestrator/executor/executor_resume.go` ~line 1074)
reads `GetExecutorRunningBySessionID` and copies every key passing `ShouldPersistMetadataKey`, and
`env_secret_id_` is in `persistentMetadataPrefixes` (`executor_backend.go` ~line 288). It survives
`buildLaunchMetadata` unfiltered. Confirmed against the database: the four `executors_running` rows
belonging to SSH sessions all carry `env_secret_id_AGENTCTL_AUTH_TOKEN`. (Zero `task_sessions` rows
do, which is correct — `session.Metadata` is deliberately never merged into the workspace info.)

## Fix

Extract `resolveLaunchAuthToken` and give `manager_launch.go` the same per-executor split
`manager_execution.go` already had: Docker keeps the container-control token (including the existing
workspace-reuse fallback), every other executor uses its own session handshake token.

The Docker behaviour is unchanged — for a Docker executor the new call is exactly the old one, since
`allowLegacyContainerControlFallback` reduced to `WorkspaceReuseRequired` once the type check was
already satisfied.

## Tests

`TestResolveLaunchAuthToken` in `manager_auth_test.go`, five cases: SSH with a session secret returns
it; SSH with nothing anywhere returns empty *and* `requireSSHAgentctlAuthToken` still rejects it (so
the fix cannot silently launch unauthenticated); and three Docker cases pinning the container-control
precedence, the legacy fallback, and the no-reuse case.

Verified RED against the previous resolver — `ssh with a session auth secret returns that token`
fails without this change and passes with it. The four Docker cases pass either way, which is the
point: they are there to pin behaviour this PR must not move.

`go build ./...`, `golangci-lint run ./...` (0 issues), and
`go test ./internal/agent/runtime/... ./internal/backendapp/...` are clean. One unrelated
pre-existing failure, `TestBuildAuthMethodsIdentityAgentOverridesEnvironment`, reproduces
identically on an unmodified `main` checkout — it binds a unix socket under `t.TempDir()` and blows
macOS's ~104-byte `sun_path` limit. It is a macOS-only local-run papercut, not a regression here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->