### PR TITLE
fix(office): stop reviews stranding tasks with no recorded decision

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -51,6 +51,29 @@ func (r *Repository) GetTaskWorkflowStepID(ctx context.Context, taskID string) (
 	return r.stepIDForTask(ctx, taskID)
 }
 
+// GetWorkflowStepStageType returns the persisted stage type for a workflow
+// step. It returns an empty string when the step does not exist so callers
+// can apply compatibility fallbacks for older run payloads.
+func (r *Repository) GetWorkflowStepStageType(ctx context.Context, stepID string) (string, error) {
+	if stepID == "" {
+		return "", nil
+	}
+	var stageType sql.NullString
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(
+		`SELECT stage_type FROM workflow_steps WHERE id = ?`,
+	), stepID).Scan(&stageType)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !stageType.Valid {
+		return "", nil
+	}
+	return stageType.String, nil
+}
+
 // AddTaskParticipant inserts a (task, agent, role) row idempotently into
 // workflow_step_participants under the task's current workflow step. A
 // second call with the same natural key is a no-op. Returns nil silently

--- a/apps/backend/internal/office/repository/sqlite/step_decisions.go
+++ b/apps/backend/internal/office/repository/sqlite/step_decisions.go
@@ -1,0 +1,27 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// HasActiveStepDecision reports whether an active (non-superseded) row exists
+// in workflow_step_decisions for the given task, step, and decider. It backs
+// the review/approval completion check that flags a reviewer or approver
+// turn that ended without recording a verdict via record_step_decision_kandev.
+func (r *Repository) HasActiveStepDecision(ctx context.Context, taskID, stepID, deciderID string) (bool, error) {
+	var exists int
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT 1 FROM workflow_step_decisions
+		WHERE task_id = ? AND step_id = ? AND decider_id = ? AND superseded_at IS NULL
+		LIMIT 1
+	`), taskID, stepID, deciderID).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/apps/backend/internal/office/repository/sqlite/step_decisions_test.go
+++ b/apps/backend/internal/office/repository/sqlite/step_decisions_test.go
@@ -1,0 +1,45 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHasActiveStepDecisionDistinguishesSupersededRows(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `CREATE TABLE workflow_step_decisions (
+		id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL,
+		step_id TEXT NOT NULL,
+		decider_id TEXT NOT NULL,
+		decision TEXT NOT NULL,
+		superseded_at DATETIME
+	)`); err != nil {
+		t.Fatalf("create workflow_step_decisions: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `INSERT INTO workflow_step_decisions
+		(id, task_id, step_id, decider_id, decision, superseded_at)
+		VALUES
+		('active', 'task-1', 'step-1', 'agent-1', 'approved', NULL),
+		('superseded', 'task-1', 'step-2', 'agent-1', 'rejected', CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("insert decisions: %v", err)
+	}
+
+	active, err := repo.HasActiveStepDecision(ctx, "task-1", "step-1", "agent-1")
+	if err != nil {
+		t.Fatalf("active decision lookup: %v", err)
+	}
+	if !active {
+		t.Fatal("active decision lookup = false, want true")
+	}
+
+	superseded, err := repo.HasActiveStepDecision(ctx, "task-1", "step-2", "agent-1")
+	if err != nil {
+		t.Fatalf("superseded decision lookup: %v", err)
+	}
+	if superseded {
+		t.Fatal("superseded decision lookup = true, want false")
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/workflow_steps_test.go
+++ b/apps/backend/internal/office/repository/sqlite/workflow_steps_test.go
@@ -1,0 +1,39 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetWorkflowStepStageType(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `CREATE TABLE workflow_steps (
+		id TEXT PRIMARY KEY,
+		stage_type TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create workflow_steps: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx,
+		`INSERT INTO workflow_steps (id, stage_type) VALUES (?, ?)`,
+		"step-approval", "approval"); err != nil {
+		t.Fatalf("insert workflow step: %v", err)
+	}
+
+	got, err := repo.GetWorkflowStepStageType(ctx, "step-approval")
+	if err != nil {
+		t.Fatalf("stage type lookup: %v", err)
+	}
+	if got != "approval" {
+		t.Fatalf("stage type = %q, want approval", got)
+	}
+
+	missing, err := repo.GetWorkflowStepStageType(ctx, "step-missing")
+	if err != nil {
+		t.Fatalf("missing stage type lookup: %v", err)
+	}
+	if missing != "" {
+		t.Fatalf("missing stage type = %q, want empty", missing)
+	}
+}

--- a/apps/backend/internal/office/service/base_test.go
+++ b/apps/backend/internal/office/service/base_test.go
@@ -82,7 +82,8 @@ func newTestService(t *testing.T, overrides ...service.ServiceOptions) *service.
 	}
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS workflow_steps (
 		id TEXT PRIMARY KEY,
-		agent_profile_id TEXT NOT NULL DEFAULT ''
+		agent_profile_id TEXT NOT NULL DEFAULT '',
+		stage_type TEXT NOT NULL DEFAULT 'custom'
 	)`); err != nil {
 		t.Fatalf("create workflow_steps: %v", err)
 	}

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -377,22 +377,9 @@ func (s *Service) warnIfReviewDecisionMissing(ctx context.Context, run *models.R
 		return
 	}
 	parsed := ParseRunPayload(run.Payload)
-	stageType := parsed["stage_type"]
-	if stageType == "" {
-		switch run.Reason {
-		case legacyRunReasonReviewStarted:
-			stageType = stageTypeReview
-		case legacyRunReasonApprovalStarted:
-			stageType = stageTypeApproval
-		}
-	}
-	if stageType != stageTypeReview && stageType != stageTypeApproval {
+	taskID, stepID, stageType := s.resolveReviewStage(ctx, run.Reason, parsed)
+	if !isReviewOrApprovalStage(stageType) {
 		return
-	}
-	taskID := parsed["task_id"]
-	stepID := parsed["stage_id"]
-	if stepID == "" {
-		stepID = parsed["workflow_step_id"]
 	}
 	if taskID == "" || stepID == "" {
 		return

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -347,6 +347,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 	})
 	s.markRoutingSuccess(ctx, run)
 	s.recordRunOutputSummary(ctx, run, *data)
+	s.warnIfReviewDecisionMissing(ctx, run)
 	// resolveLifecycleRun prefers the immutable run ID from the event and
 	// falls back to task plus agent only for legacy events. Releasing here
 	// (rather than unconditionally inside transitionRunTerminal) is safe —
@@ -362,6 +363,54 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 	s.releaseTaskCheckoutForRun(ctx, run)
 	s.stampRunFinished(ctx, run)
 	return nil
+}
+
+// warnIfReviewDecisionMissing flags a review or approval run that finished
+// without the agent ever calling record_step_decision_kandev. A reviewer can
+// post a full critique and reject the work in a comment, but if that comment
+// never becomes a recorded decision the workflow engine has nothing to act
+// on and the task strands in its current step forever. This does not fix
+// the missing decision — it only surfaces it as a warn-level run event so
+// the stall is visible instead of silent.
+func (s *Service) warnIfReviewDecisionMissing(ctx context.Context, run *models.Run) {
+	if run == nil {
+		return
+	}
+	parsed := ParseRunPayload(run.Payload)
+	stageType := parsed["stage_type"]
+	if stageType != stageTypeReview && stageType != stageTypeApproval {
+		return
+	}
+	taskID := parsed["task_id"]
+	stepID := parsed["stage_id"]
+	if stepID == "" {
+		stepID = parsed["workflow_step_id"]
+	}
+	if taskID == "" || stepID == "" {
+		return
+	}
+	has, err := s.repo.HasActiveStepDecision(ctx, taskID, stepID, run.AgentProfileID)
+	if err != nil {
+		s.logger.Warn("failed to check step decision presence",
+			zap.String("task_id", taskID),
+			zap.String("run_id", run.ID),
+			zap.Error(err))
+		return
+	}
+	if has {
+		return
+	}
+	s.logger.Warn("review/approval run finished without a recorded step decision",
+		zap.String("task_id", taskID),
+		zap.String("run_id", run.ID),
+		zap.String("stage_type", stageType),
+		zap.String("step_id", stepID),
+		zap.String("agent_profile_id", run.AgentProfileID))
+	s.AppendRunEvent(ctx, run.ID, "decision.missing", string(models.RunEventLevelWarn), map[string]interface{}{
+		"task_id":    taskID,
+		"stage_type": stageType,
+		"step_id":    stepID,
+	})
 }
 
 // markRoutingSuccess delegates to the routing dispatcher (when wired)

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -378,6 +378,14 @@ func (s *Service) warnIfReviewDecisionMissing(ctx context.Context, run *models.R
 	}
 	parsed := ParseRunPayload(run.Payload)
 	stageType := parsed["stage_type"]
+	if stageType == "" {
+		switch run.Reason {
+		case legacyRunReasonReviewStarted:
+			stageType = stageTypeReview
+		case legacyRunReasonApprovalStarted:
+			stageType = stageTypeApproval
+		}
+	}
 	if stageType != stageTypeReview && stageType != stageTypeApproval {
 		return
 	}

--- a/apps/backend/internal/office/service/event_subscribers_decision_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_decision_test.go
@@ -171,6 +171,123 @@ func TestHandleAgentCompleted_WarnsOnStageIDKeyedPayload(t *testing.T) {
 	}
 }
 
+func TestHandleAgentCompleted_WarnsOnLegacyApprovalStartedReason(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "approver-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "approver-1")
+	payload := `{"task_id":"` + taskID + `","workflow_step_id":"step-approval","agent_profile_id":"approver-1"}`
+	if err := svc.QueueRun(ctx, "approver-1", "approval_started", payload, "approval-started-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-approval-1",
+		"agent_profile_id": "approver-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want a decision.missing event for legacy approval_started reason", rowEvents)
+}
+
+func TestHandleAgentCompleted_WarnsOnTaskReviewRequested(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "approver-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "approver-1")
+	svc.ExecSQL(t, `UPDATE tasks SET workflow_step_id = ? WHERE id = ?`, "step-review-requested", taskID)
+	svc.ExecSQL(t, `INSERT INTO workflow_steps (id, stage_type) VALUES (?, ?)`, "step-review-requested", "approval")
+
+	payload := `{"task_id":"` + taskID + `","role":"approver"}`
+	if err := svc.QueueRun(ctx, "approver-1", service.RunReasonTaskReviewRequested, payload, "task-review-requested-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-review-requested",
+		"agent_profile_id": "approver-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want a decision.missing event for task_review_requested", rowEvents)
+}
+
+func TestHandleAgentCompleted_UsesAuthoritativeStageTypeWhenPayloadOmitsIt(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "approver-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "approver-1")
+	svc.ExecSQL(t, `UPDATE tasks SET workflow_step_id = ? WHERE id = ?`, "step-authoritative-decision", taskID)
+	svc.ExecSQL(t, `INSERT INTO workflow_steps (id, stage_type) VALUES (?, ?)`, "step-authoritative-decision", "approval")
+
+	payload := `{"task_id":"` + taskID + `","workflow_step_id":"step-authoritative-decision"}`
+	if err := svc.QueueRun(ctx, "approver-1", service.RunReasonTaskAssigned, payload, "authoritative-decision-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-authoritative-decision",
+		"agent_profile_id": "approver-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want a decision.missing event for authoritative approval stage", rowEvents)
+}
+
 // TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded is the
 // counterpart green path: when the reviewer's decision was recorded via
 // record_step_decision_kandev before the run finished, no decision.missing

--- a/apps/backend/internal/office/service/event_subscribers_decision_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_decision_test.go
@@ -123,6 +123,54 @@ func TestHandleAgentCompleted_WarnsOnLegacyReviewStartedReason(t *testing.T) {
 	}
 }
 
+// TestHandleAgentCompleted_WarnsOnStageIDKeyedPayload pins the primary
+// (non-fallback) branch of the stepID extraction: the scheduler's own
+// RunContext struct (internal/office/scheduler/run.go) carries a "stage_id"
+// JSON key, and buildPromptContext already extracts it first before falling
+// back to "workflow_step_id" (scheduler_integration.go). The detector must
+// take the same primary branch, not only the workflow_step_id fallback the
+// other tests in this file exercise.
+func TestHandleAgentCompleted_WarnsOnStageIDKeyedPayload(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "reviewer-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
+
+	payload := `{"task_id":"` + taskID + `","stage_type":"approval","stage_id":"step-1"}`
+	if err := svc.QueueRun(ctx, "reviewer-1", service.RunReasonTaskAssigned, payload, "approval-stage-id-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "reviewer-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	found := false
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want a decision.missing warn event for stage_id-keyed payload", rowEvents)
+	}
+}
+
 // TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded is the
 // counterpart green path: when the reviewer's decision was recorded via
 // record_step_decision_kandev before the run finished, no decision.missing

--- a/apps/backend/internal/office/service/event_subscribers_decision_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_decision_test.go
@@ -1,0 +1,162 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/office/service"
+)
+
+// createStepDecisionsTable stubs the workflow_step_decisions table (owned
+// by internal/workflow/repository in production) so tests in this package
+// can exercise the office service's read of it without pulling in the
+// workflow package's full schema.
+func createStepDecisionsTable(t *testing.T, svc *service.Service) {
+	t.Helper()
+	svc.ExecSQL(t, `CREATE TABLE IF NOT EXISTS workflow_step_decisions (
+		id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL,
+		step_id TEXT NOT NULL,
+		decider_id TEXT NOT NULL DEFAULT '',
+		decision TEXT NOT NULL,
+		superseded_at DATETIME
+	)`)
+}
+
+// TestHandleAgentCompleted_WarnsWhenReviewDecisionMissing pins the fix for
+// the "reviewer rejects in a comment but the task strands in Review
+// forever" defect: a review-stage run that completes without an active
+// workflow_step_decisions row for the reviewer must emit a warn-level
+// "decision.missing" run event, so the stall is visible instead of silent.
+func TestHandleAgentCompleted_WarnsWhenReviewDecisionMissing(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "reviewer-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
+
+	payload := `{"task_id":"` + taskID + `","stage_type":"review","stage_id":"step-1"}`
+	if err := svc.QueueRun(ctx, "reviewer-1", service.RunReasonTaskAssigned, payload, "review-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "reviewer-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	found := false
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			found = true
+			if string(e.Level) != "warn" {
+				t.Errorf("decision.missing level = %q, want warn", e.Level)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want a decision.missing warn event", rowEvents)
+	}
+}
+
+// TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded is the
+// counterpart green path: when the reviewer's decision was recorded via
+// record_step_decision_kandev before the run finished, no decision.missing
+// event should be emitted.
+func TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "reviewer-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
+
+	payload := `{"task_id":"` + taskID + `","stage_type":"review","stage_id":"step-1"}`
+	if err := svc.QueueRun(ctx, "reviewer-1", service.RunReasonTaskAssigned, payload, "review-with-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	svc.ExecSQL(t,
+		`INSERT INTO workflow_step_decisions (id, task_id, step_id, decider_id, decision) VALUES (?, ?, ?, ?, ?)`,
+		"decision-1", taskID, "step-1", "reviewer-1", "rejected",
+	)
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "reviewer-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			t.Fatalf("unexpected decision.missing event: %+v", e)
+		}
+	}
+}
+
+// TestHandleAgentCompleted_NoWarnForWorkStage pins that the check is
+// scoped to review/approval stages only: a work-stage run finishing
+// without any workflow_step_decisions row is expected (builders don't
+// record decisions) and must not emit decision.missing.
+func TestHandleAgentCompleted_NoWarnForWorkStage(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "builder-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "builder-1")
+
+	payload := `{"task_id":"` + taskID + `","stage_type":"work","stage_id":"step-1"}`
+	if err := svc.QueueRun(ctx, "builder-1", service.RunReasonTaskAssigned, payload, "work-stage"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "builder-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			t.Fatalf("unexpected decision.missing event for work stage: %+v", e)
+		}
+	}
+}

--- a/apps/backend/internal/office/service/event_subscribers_decision_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_decision_test.go
@@ -38,7 +38,7 @@ func TestHandleAgentCompleted_WarnsWhenReviewDecisionMissing(t *testing.T) {
 	createTestAgent(t, svc, "ws-1", "reviewer-1")
 	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
 
-	payload := `{"task_id":"` + taskID + `","stage_type":"review","stage_id":"step-1"}`
+	payload := `{"task_id":"` + taskID + `","stage_type":"review","workflow_step_id":"step-1"}`
 	if err := svc.QueueRun(ctx, "reviewer-1", service.RunReasonTaskAssigned, payload, "review-no-decision"); err != nil {
 		t.Fatalf("queue run: %v", err)
 	}
@@ -74,6 +74,55 @@ func TestHandleAgentCompleted_WarnsWhenReviewDecisionMissing(t *testing.T) {
 	}
 }
 
+// TestHandleAgentCompleted_WarnsOnLegacyReviewStartedReason pins Review
+// round 1 finding 1: a run woken with the legacy "review_started" reason
+// (the exact reason on the incident's run f05a6f89) carries no stage_type
+// in its payload — production payload shape is {task_id, workflow_step_id,
+// agent_profile_id}, mirroring what runPayload persists. The detector must
+// derive stage_type from run.Reason the same way buildPromptContext already
+// does for the prompt, or a decisionless review_started/approval_started
+// turn goes undetected.
+func TestHandleAgentCompleted_WarnsOnLegacyReviewStartedReason(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	createStepDecisionsTable(t, svc)
+
+	createTestAgent(t, svc, "ws-1", "reviewer-1")
+	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
+
+	payload := `{"task_id":"` + taskID + `","workflow_step_id":"step-1","agent_profile_id":"reviewer-1"}`
+	if err := svc.QueueRun(ctx, "reviewer-1", "review_started", payload, "review-started-no-decision"); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	run, err := svc.ClaimNextRun(ctx)
+	if err != nil || run == nil {
+		t.Fatalf("claim run: %v (run=%v)", err, run)
+	}
+
+	completed := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "sess-1",
+		"agent_profile_id": "reviewer-1",
+	})
+	if pErr := eb.Publish(ctx, events.AgentCompleted, completed); pErr != nil {
+		t.Fatalf("publish completed: %v", pErr)
+	}
+
+	rowEvents, err := listRunEvents(t, svc, run.ID)
+	if err != nil {
+		t.Fatalf("list run events: %v", err)
+	}
+	found := false
+	for _, e := range rowEvents {
+		if string(e.EventType) == "decision.missing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want a decision.missing warn event for legacy review_started reason", rowEvents)
+	}
+}
+
 // TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded is the
 // counterpart green path: when the reviewer's decision was recorded via
 // record_step_decision_kandev before the run finished, no decision.missing
@@ -86,7 +135,7 @@ func TestHandleAgentCompleted_NoWarnWhenReviewDecisionRecorded(t *testing.T) {
 	createTestAgent(t, svc, "ws-1", "reviewer-1")
 	taskID := createOfficeTask(t, svc, "ws-1", "reviewer-1")
 
-	payload := `{"task_id":"` + taskID + `","stage_type":"review","stage_id":"step-1"}`
+	payload := `{"task_id":"` + taskID + `","stage_type":"review","workflow_step_id":"step-1"}`
 	if err := svc.QueueRun(ctx, "reviewer-1", service.RunReasonTaskAssigned, payload, "review-with-decision"); err != nil {
 		t.Fatalf("queue run: %v", err)
 	}
@@ -132,7 +181,7 @@ func TestHandleAgentCompleted_NoWarnForWorkStage(t *testing.T) {
 	createTestAgent(t, svc, "ws-1", "builder-1")
 	taskID := createOfficeTask(t, svc, "ws-1", "builder-1")
 
-	payload := `{"task_id":"` + taskID + `","stage_type":"work","stage_id":"step-1"}`
+	payload := `{"task_id":"` + taskID + `","stage_type":"work","workflow_step_id":"step-1"}`
 	if err := svc.QueueRun(ctx, "builder-1", service.RunReasonTaskAssigned, payload, "work-stage"); err != nil {
 		t.Fatalf("queue run: %v", err)
 	}

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -80,6 +80,8 @@ func BuildPrompt(pc *PromptContext) string {
 		prompt = buildLegacyStagePrompt(pc, stageTypeReview)
 	case legacyRunReasonApprovalStarted:
 		prompt = buildLegacyStagePrompt(pc, stageTypeApproval)
+	case RunReasonTaskReviewRequested:
+		prompt = buildTaskAssignedPrompt(pc)
 	case RunReasonTaskComment:
 		prompt = buildTaskCommentPrompt(pc)
 	case RunReasonTaskBlockersResolved:

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -298,10 +298,13 @@ func buildApprovalStagePrompt(pc *PromptContext) string {
 }
 
 // writeDecisionContract appends the explicit record_step_decision_kandev contract shared by the
-// review and approval stage prompts: a verdict must be recorded via the tool call to end the turn,
-// since posting a comment alone is not a decision and leaves the task stranded in review.
+// review and approval stage prompts: a verdict must be recorded via the tool call, which the agent
+// must treat as its final action for the turn, since posting a comment alone is not a decision and
+// leaves the task stranded in review. The tool call itself does not halt the agent mid-turn (it
+// returns an ordinary result), so the prompt must not claim otherwise — it instructs the agent to
+// stop on its own after calling it.
 func writeDecisionContract(b *strings.Builder) {
-	b.WriteString("\n\nYou must call the record_step_decision_kandev tool with decision (\"approved\" or \"rejected\") and reason to record your verdict; this call ends your turn.")
+	b.WriteString("\n\nYou must call the record_step_decision_kandev tool with decision (\"approved\" or \"rejected\") and reason to record your verdict. Make this your final tool call for the turn, then stop.")
 	b.WriteString(" Posting a comment alone is not a decision and will not advance the task.")
 }
 

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -278,6 +278,7 @@ func buildReviewStagePrompt(pc *PromptContext) string {
 	}
 	b.WriteString("\nReview the implementation carefully. Check for correctness, edge cases, and code quality.\n")
 	b.WriteString("Submit your verdict: approve if the work is satisfactory, or reject with specific feedback on what needs to change.")
+	writeDecisionContract(&b)
 	return b.String()
 }
 
@@ -292,7 +293,16 @@ func buildApprovalStagePrompt(pc *PromptContext) string {
 	}
 	b.WriteString("\nConfirm that the approval requirements are met for this workflow.\n")
 	b.WriteString("Submit your verdict: approve if the requirements are met, or reject with specific feedback on what needs to change.")
+	writeDecisionContract(&b)
 	return b.String()
+}
+
+// writeDecisionContract appends the explicit record_step_decision_kandev contract shared by the
+// review and approval stage prompts: a verdict must be recorded via the tool call to end the turn,
+// since posting a comment alone is not a decision and leaves the task stranded in review.
+func writeDecisionContract(b *strings.Builder) {
+	b.WriteString("\n\nYou must call the record_step_decision_kandev tool with decision (\"approved\" or \"rejected\") and reason to record your verdict; this call ends your turn.")
+	b.WriteString(" Posting a comment alone is not a decision and will not advance the task.")
 }
 
 func buildShipStagePrompt(pc *PromptContext) string {

--- a/apps/backend/internal/office/service/prompt_builder_test.go
+++ b/apps/backend/internal/office/service/prompt_builder_test.go
@@ -79,12 +79,22 @@ func TestBuildPrompt_LegacyRunReasonsRemainCompatible(t *testing.T) {
 	tests := []struct {
 		name     string
 		reason   string
-		contains string
+		contains []string
 	}{
-		{name: "blockers resolved", reason: "blockers_resolved", contains: "All blockers"},
-		{name: "children completed", reason: "children_completed", contains: "All child tasks"},
-		{name: "review started", reason: "review_started", contains: "You are reviewing"},
-		{name: "approval started", reason: "approval_started", contains: "You are approving"},
+		{name: "blockers resolved", reason: "blockers_resolved", contains: []string{"All blockers"}},
+		{name: "children completed", reason: "children_completed", contains: []string{"All child tasks"}},
+		{name: "review started", reason: "review_started", contains: []string{
+			"You are reviewing",
+			"Legacy workflow task",
+			"record_step_decision_kandev",
+			"Posting a comment alone is not a decision",
+		}},
+		{name: "approval started", reason: "approval_started", contains: []string{
+			"You are approving",
+			"Legacy workflow task",
+			"record_step_decision_kandev",
+			"Posting a comment alone is not a decision",
+		}},
 	}
 
 	for _, tt := range tests {
@@ -94,8 +104,10 @@ func TestBuildPrompt_LegacyRunReasonsRemainCompatible(t *testing.T) {
 				TaskIdentifier: "KAN-legacy",
 				TaskTitle:      "Legacy workflow task",
 			})
-			if !strings.Contains(prompt, tt.contains) {
-				t.Errorf("legacy reason %q should use its existing prompt, got:\n%s", tt.reason, prompt)
+			for _, c := range tt.contains {
+				if !strings.Contains(prompt, c) {
+					t.Errorf("legacy reason %q missing %q, got:\n%s", tt.reason, c, prompt)
+				}
 			}
 		})
 	}

--- a/apps/backend/internal/office/service/prompt_builder_test.go
+++ b/apps/backend/internal/office/service/prompt_builder_test.go
@@ -113,6 +113,22 @@ func TestBuildPrompt_LegacyRunReasonsRemainCompatible(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_TaskReviewRequestedUsesStageType(t *testing.T) {
+	prompt := service.BuildPrompt(&service.PromptContext{
+		Reason:         service.RunReasonTaskReviewRequested,
+		StageType:      "approval",
+		TaskIdentifier: "KAN-review",
+		TaskTitle:      "Approve release",
+	})
+
+	if !strings.HasPrefix(prompt, "You are approving") {
+		t.Errorf("task_review_requested approver prompt = %q, want approver framing", prompt)
+	}
+	if !strings.Contains(prompt, "record_step_decision_kandev") {
+		t.Errorf("task_review_requested prompt missing decision tool contract: %q", prompt)
+	}
+}
+
 func TestBuildPrompt_ApprovalResolved(t *testing.T) {
 	pc := &service.PromptContext{
 		Reason:         service.RunReasonApprovalResolved,

--- a/apps/backend/internal/office/service/review_stage.go
+++ b/apps/backend/internal/office/service/review_stage.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// resolveReviewStage returns the task, workflow step, and stage type for a
+// review-capable run. The persisted workflow step is authoritative for the
+// task_assigned path. Role remains authoritative for task_review_requested,
+// because that wake is explicitly fanned out per reviewer or approver.
+func (s *Service) resolveReviewStage(
+	ctx context.Context, reason string, parsed map[string]string,
+) (string, string, string) {
+	taskID := parsed["task_id"]
+	stepID := parsed["stage_id"]
+	if stepID == "" {
+		stepID = parsed["workflow_step_id"]
+	}
+	stepID = s.resolveMissingReviewStepID(ctx, reason, taskID, stepID)
+
+	roleStageType := reviewStageTypeForRole(parsed["role"])
+	stageType := reviewStageTypeFallback(reason, parsed["stage_type"], roleStageType)
+	if shouldResolveAuthoritativeStage(reason, roleStageType) {
+		stageType = s.resolveAuthoritativeStageType(ctx, reason, stepID, stageType)
+	}
+
+	return taskID, stepID, stageType
+}
+
+func (s *Service) resolveMissingReviewStepID(
+	ctx context.Context, reason, taskID, stepID string,
+) string {
+	if stepID != "" || taskID == "" {
+		return stepID
+	}
+	currentStepID, err := s.repo.GetTaskWorkflowStepID(ctx, taskID)
+	if err == nil {
+		return currentStepID
+	}
+	s.logger.Debug("resolve current workflow step for review run failed",
+		zap.String("task_id", taskID), zap.String("reason", reason), zap.Error(err))
+	return ""
+}
+
+func reviewStageTypeFallback(reason, payloadStageType, roleStageType string) string {
+	if reason == RunReasonTaskReviewRequested && roleStageType != "" {
+		return roleStageType
+	}
+	if payloadStageType != "" {
+		return payloadStageType
+	}
+	switch reason {
+	case legacyRunReasonReviewStarted:
+		return stageTypeReview
+	case legacyRunReasonApprovalStarted:
+		return stageTypeApproval
+	default:
+		return ""
+	}
+}
+
+func shouldResolveAuthoritativeStage(reason, roleStageType string) bool {
+	return reason == RunReasonTaskAssigned ||
+		(reason == RunReasonTaskReviewRequested && roleStageType == "")
+}
+
+func (s *Service) resolveAuthoritativeStageType(
+	ctx context.Context, reason, stepID, fallback string,
+) string {
+	if stepID == "" {
+		return fallback
+	}
+	authoritative, err := s.repo.GetWorkflowStepStageType(ctx, stepID)
+	if err != nil {
+		s.logger.Debug("resolve workflow step stage type for review run failed",
+			zap.String("step_id", stepID), zap.String("reason", reason), zap.Error(err))
+		return fallback
+	}
+	if authoritative == "" {
+		return fallback
+	}
+	return authoritative
+}
+
+func reviewStageTypeForRole(role string) string {
+	switch role {
+	case models.ParticipantRoleReviewer:
+		return stageTypeReview
+	case models.ParticipantRoleApprover:
+		return stageTypeApproval
+	default:
+		return ""
+	}
+}
+
+func isReviewOrApprovalStage(stageType string) bool {
+	return stageType == stageTypeReview || stageType == stageTypeApproval
+}

--- a/apps/backend/internal/office/service/run.go
+++ b/apps/backend/internal/office/service/run.go
@@ -24,6 +24,7 @@ const (
 	RunReasonTaskBlockersResolved  = "task_blockers_resolved"
 	RunReasonTaskChildrenCompleted = "task_children_completed"
 	RunReasonApprovalResolved      = "approval_resolved"
+	RunReasonTaskReviewRequested   = "task_review_requested"
 	RunReasonRoutineTrigger        = "routine_trigger"
 	// RunReasonHeartbeat aliases shared.RunReasonHeartbeat so this package's
 	// local constant and the shared idle-skip classifier cannot drift apart

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -827,19 +827,10 @@ func (si *SchedulerIntegration) buildPromptContext(
 		si.enrichChildrenContext(pc, payload)
 	}
 
-	if reason == RunReasonTaskAssigned || reason == legacyRunReasonReviewStarted || reason == legacyRunReasonApprovalStarted {
-		pc.StageID = parsed["stage_id"]
-		if pc.StageID == "" {
-			pc.StageID = parsed["workflow_step_id"]
-		}
-		pc.StageType = parsed["stage_type"]
+	if reason == RunReasonTaskAssigned || reason == RunReasonTaskReviewRequested ||
+		reason == legacyRunReasonReviewStarted || reason == legacyRunReasonApprovalStarted {
+		_, pc.StageID, pc.StageType = si.svc.resolveReviewStage(ctx, reason, parsed)
 		pc.ReviewFeedback = parsed["feedback"]
-		switch reason {
-		case legacyRunReasonReviewStarted:
-			pc.StageType = stageTypeReview
-		case legacyRunReasonApprovalStarted:
-			pc.StageType = stageTypeApproval
-		}
 
 		if (pc.StageType == stageTypeReview || pc.StageType == stageTypeApproval) && pc.TaskID != "" {
 			si.enrichBuilderComments(ctx, pc)

--- a/apps/backend/internal/office/service/scheduler_integration_test.go
+++ b/apps/backend/internal/office/service/scheduler_integration_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -369,6 +370,55 @@ func TestSchedulerIntegration_BuildPromptContext_ApprovalStageIncludesRecentComm
 	prompt := service.BuildPrompt(pc)
 	if !containsIgnoreCase(prompt, "Recent task comments:") {
 		t.Errorf("approval prompt should label comments as recent task comments, got: %s", prompt)
+	}
+}
+
+func TestSchedulerIntegration_BuildPromptContext_UsesAuthoritativeStageType(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	insertTaskForPrompt(t, svc, "task-authoritative-stage", "ws-1", "Approve release", "Confirm the release is safe", 3)
+	svc.ExecSQL(t, `UPDATE tasks SET workflow_step_id = ? WHERE id = ?`, "step-authoritative", "task-authoritative-stage")
+	svc.ExecSQL(t, `INSERT INTO workflow_steps (id, stage_type) VALUES (?, ?)`, "step-authoritative", "approval")
+
+	pc := service.BuildPromptContextForTest(
+		svc,
+		ctx,
+		service.RunReasonTaskAssigned,
+		`{"task_id":"task-authoritative-stage","workflow_step_id":"step-authoritative","stage_type":"work"}`,
+	)
+
+	if pc.StageType != "approval" {
+		t.Fatalf("StageType = %q, want authoritative approval stage", pc.StageType)
+	}
+	if prompt := service.BuildPrompt(pc); !strings.HasPrefix(prompt, "You are approving") {
+		t.Fatalf("prompt = %q, want approver framing", prompt)
+	}
+}
+
+func TestSchedulerIntegration_BuildPromptContext_TaskReviewRequestedUsesRole(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	insertTaskForPrompt(t, svc, "task-review-requested", "ws-1", "Review release", "Check the release", 3)
+	svc.ExecSQL(t, `UPDATE tasks SET workflow_step_id = ? WHERE id = ?`, "step-review-requested", "task-review-requested")
+	svc.ExecSQL(t, `INSERT INTO workflow_steps (id, stage_type) VALUES (?, ?)`, "step-review-requested", "custom")
+
+	pc := service.BuildPromptContextForTest(
+		svc,
+		ctx,
+		service.RunReasonTaskReviewRequested,
+		`{"task_id":"task-review-requested","role":"approver"}`,
+	)
+
+	if pc.StageID != "step-review-requested" {
+		t.Fatalf("StageID = %q, want current task workflow step", pc.StageID)
+	}
+	if pc.StageType != "approval" {
+		t.Fatalf("StageType = %q, want approval from participant role", pc.StageType)
+	}
+	if prompt := service.BuildPrompt(pc); !strings.HasPrefix(prompt, "You are approving") {
+		t.Fatalf("prompt = %q, want approver framing", prompt)
 	}
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3009/2701084b22a4.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** A woken reviewer can do a full, correct review — even independently
re-run the author's work and reject it with real reasons in a comment — and the
task still never moves. Nothing tells the reviewer that posting a comment isn't
enough; only calling the decision tool ends its turn. With zero decision rows,
neither the "reject → back to Work" nor "approve → advance" quorum guard can
fire, so the card sits in Review forever.
**After this:** The review/approval prompt now explicitly names
`record_step_decision_kandev`, states its required `decision`/`reason`
arguments, and says plainly that a comment alone is not a decision and will
leave the task stranded. If a reviewer's turn still ends with no decision
recorded — including the legacy `review_started`/`approval_started` wake
reasons, which carry no `stage_type` in their payload and are the exact shape
of the incident that surfaced this — the run now logs a warning and appends a
`decision.missing` run event, so the omission is visible instead of silent.
**Who hits this:** Any Office workspace review or approval step. Observed live
on task `751e7144`: the reviewer's rejection was correct and complete, but
`workflow_step_decisions` held zero rows for it.
**Scope:** Standalone fix, no siblings.
**Not here:** Quorum thresholds and the closed AC-23 reason-code set are
untouched — a missing decision is the bug, not the quorum. A reviewer whose
process *crashes* mid-turn is a separate, pre-existing gap (the review/approval
steps have no `on_agent_error` handler, unlike the work step) — not this bug,
and not touched here.

A reviewer that finishes its turn without calling the decision tool leaves
`workflow_step_decisions` empty for that task/step, so the workflow engine's
guarded transitions (`any_reject`, `all_approve`) can't satisfy either branch
and the task never leaves Review. The prompt reworded the ask ("submit your
verdict") in a way a reviewer could satisfy with a plain comment, so nothing
in the loop ever surfaced the miss.

## Important Changes

- `prompt_builder.go`: `buildReviewStagePrompt`/`buildApprovalStagePrompt` now
  append a shared closing paragraph naming the decision tool, its required
  arguments, and stating that a comment alone does not end the turn.
- `event_subscribers.go`: `handleAgentCompleted` now calls
  `warnIfReviewDecisionMissing`, which checks `workflow_step_decisions` for an
  active decision by the finishing agent and logs + records a `decision.missing`
  run event when none exists. Derives `stage_type` from the run's legacy
  `review_started`/`approval_started` reason when the payload doesn't carry one,
  mirroring the existing derivation in `buildPromptContext`.
- `internal/office/repository/sqlite/step_decisions.go` (new): read-only
  `HasActiveStepDecision` against the existing `workflow_step_decisions` table.
  No new interface threaded through service construction.

## Validation

Backend-only diff (`apps/backend/internal/office/...`), zero paths under
`apps/web/` — no E2E or i18n surface.

```
$ go test ./internal/office/service/... -count=1
ok  	github.com/kandev/kandev/internal/office/service	11.642s

$ go test ./internal/workflow/engine/... -count=1
ok  	github.com/kandev/kandev/internal/workflow/engine	2.380s

$ go test -tags fts5 ./internal/office/... ./internal/workflow/... -count=1
ok for every non-empty package (32 office + 8 workflow packages)

$ make lint
Running linter...
golangci-lint run ./...
0 issues.

$ make typecheck test lint
(green — typecheck, backend/web lint, harness lint, architecture lint all pass)

$ make lint-format
All matched files use Prettier code style!

$ pnpm run i18n:ratchet
✓ i18n new-code ratchet — no UI source added or modified
✓ guard allowlist intact — 644 entr(ies)
```

`make test` surfaces 8 pre-existing failing packages
(`internal/agent/managedruntime`, `internal/agent/runtime/lifecycle`,
`internal/agentctl/server/{api,config,process}`,
`internal/agent/settings/controller`, `internal/common/config`,
`internal/system/storage/workspaces`) — all environment-path issues (`open ...
not a directory` under this sandbox's temp/npm-cache roots), unrelated to this
diff. Confirmed identical, test-for-test, against a fresh scratch worktree at
this branch's merge base (`6c76ed84c`) before submitting.

Went through two review rounds on this card: round 1 found the missing-decision
detector didn't derive `stage_type` from the legacy reason codes (so it would
have missed the exact incident it's meant to catch) and that the new tests used
a payload key (`stage_id`) no production code path emits. Both fixed and
re-verified with a red→green TDD proof against the actual incident payload
shape.

## Possible Improvements

Low risk: additive changes to a prompt string and a warn-only observability
check on an existing read-only table; no change to quorum evaluation or
workflow transitions.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->