### PR TITLE
fix(orchestrator): allow office auto-start after task re-enters a step

### DIFF
--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -1605,8 +1605,10 @@ type runsServiceEngineAdapter struct {
 
 // QueueRun enqueues a run, translating the engine's QueueRunRequest into the
 // runs-service request shape.
-func (a *runsServiceEngineAdapter) QueueRun(ctx context.Context, req workflowengine.QueueRunRequest) error {
-	return a.svc.QueueRun(ctx, runsservice.QueueRunRequest{
+func (a *runsServiceEngineAdapter) QueueRun(
+	ctx context.Context, req workflowengine.QueueRunRequest,
+) (workflowengine.QueueOutcome, error) {
+	outcome, err := a.svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: req.AgentProfileID,
 		TaskID:         req.TaskID,
 		WorkflowStepID: req.WorkflowStepID,
@@ -1614,6 +1616,7 @@ func (a *runsServiceEngineAdapter) QueueRun(ctx context.Context, req workfloweng
 		IdempotencyKey: req.IdempotencyKey,
 		Payload:        req.Payload,
 	})
+	return workflowengine.QueueOutcome(outcome), err
 }
 
 // wireRuntimeSkillDeployer plugs the runtime-tier SkillDeployer into the

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_test.go
@@ -111,8 +111,8 @@ type realRunsAdapter struct {
 	svc *runsservice.Service
 }
 
-func (a realRunsAdapter) QueueRun(ctx context.Context, req engine.QueueRunRequest) error {
-	return a.svc.QueueRun(ctx, runsservice.QueueRunRequest{
+func (a realRunsAdapter) QueueRun(ctx context.Context, req engine.QueueRunRequest) (engine.QueueOutcome, error) {
+	outcome, err := a.svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: req.AgentProfileID,
 		TaskID:         req.TaskID,
 		WorkflowStepID: req.WorkflowStepID,
@@ -120,6 +120,7 @@ func (a realRunsAdapter) QueueRun(ctx context.Context, req engine.QueueRunReques
 		IdempotencyKey: req.IdempotencyKey,
 		Payload:        req.Payload,
 	})
+	return engine.QueueOutcome(outcome), err
 }
 
 type stubPrimary struct {

--- a/apps/backend/internal/office/service/run.go
+++ b/apps/backend/internal/office/service/run.go
@@ -74,11 +74,12 @@ func (s *Service) QueueRun(
 	}
 
 	if s.runsService != nil {
-		return s.runsService.QueueRun(ctx, runsservice.QueueRunRequest{
+		_, err := s.runsService.QueueRun(ctx, runsservice.QueueRunRequest{
 			Reason:         reason,
 			IdempotencyKey: idempotencyKey,
 			Payload:        payloadWithAgent(payload, agentInstanceID),
 		})
+		return err
 	}
 	return s.queueRunInline(ctx, agentInstanceID, reason, payload, idempotencyKey)
 }

--- a/apps/backend/internal/orchestrator/event_handlers_dependencies.go
+++ b/apps/backend/internal/orchestrator/event_handlers_dependencies.go
@@ -116,7 +116,7 @@ func (s *Service) evaluateDependentAfterPredecessorChange(
 			zap.String("task_id", task.ID))
 		return
 	}
-	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskDependenciesResolved)
+	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskDependenciesResolved, 0)
 }
 
 // publishDependenciesResolved announces that a task's last unresolved
@@ -185,6 +185,6 @@ func (s *Service) reconcileDependencyLaunchesOnStartup(ctx context.Context) {
 		}
 		s.logger.Info("startup: launching task whose dependencies resolved while down",
 			zap.String("task_id", candidate.TaskID))
-		s.autoStartTaskForStep(ctx, candidate.TaskID, candidate.WorkflowStepID, "startup.dependencies_resolved")
+		s.autoStartTaskForStep(ctx, candidate.TaskID, candidate.WorkflowStepID, "startup.dependencies_resolved", 0)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
@@ -405,7 +405,7 @@ func TestAutoStart_BothPathsFireExactlyOnce(t *testing.T) {
 
 	// Path A: promotion event-driven auto-start on the same task.
 	// autoStartTaskForStep spawns a goroutine — we synchronise via the launched channel.
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.queue_promoted")
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.queue_promoted", 0)
 
 	// Wait for exactly one launch. Allow 2 seconds for the async goroutine.
 	deadline := time.After(2 * time.Second)
@@ -568,7 +568,7 @@ func TestAutoStart_NoTokenDoesNotBlock(t *testing.T) {
 	}
 	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
 
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved")
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0)
 
 	select {
 	case <-launched:
@@ -627,7 +627,7 @@ func TestAutoStart_FailedLaunchWithoutGuardDoesNotStampClaimed(t *testing.T) {
 	}
 	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
 
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved")
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0)
 
 	select {
 	case <-attempted:

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1278,10 +1278,18 @@ func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task
 // step for the lifetime of the task: the first attempt after the review
 // round-trip is silently swallowed by the 24h service-level idempotency
 // check, and after that window a later attempt hard-fails against the
-// permanent idx_run_idempotency unique index. task.UpdatedAt is written in
-// the same transaction as the task_step_transitions row for the entry, so it
-// is stable for the lifetime of one step entry and changes on every
-// re-entry.
+// permanent idx_run_idempotency unique index.
+//
+// task.UpdatedAt is a monotonic per-write marker, not a per-entry constant:
+// any write to the row (a metadata key set/removed, not only a step move)
+// bumps it, so it is NOT guaranteed stable across two deliveries of the same
+// entry. It only needs to guarantee the other direction — a real re-entry
+// always changes it, since every writer that moves tasks.workflow_step_id is
+// required to bump updated_at in the same transaction (enforced repo-wide by
+// TestStepTransitionWritersArePinned). Suppressing a duplicate delivery
+// within one entry is NOT this key's job: that is what MetaKeyAutoStartClaimed
+// and MetaKeyQueuePromotionPending (claimed before this function ever runs)
+// plus CoalesceWindowSeconds already guard.
 func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID string) string {
 	return fmt.Sprintf("%s:%s:%s:%s:%s",
 		officeAutoStartRunReason, task.ID, agentProfileID, stepID,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1190,10 +1190,6 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 // scheduler's recovery sweep and the "assign task" flow already use to start
 // Office work (internal/office/service/scheduler_recovery.go).
 func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool) {
-	s.logger.Info(eventName+": queueing office run (no session, auto-start step)",
-		zap.String("task_id", task.ID),
-		zap.String("to_step_id", step.ID))
-
 	// Async for the same reason as the kanban path above: the event bus
 	// delivers synchronously and blocking here would stall the HTTP handler
 	// that published the move.
@@ -1209,12 +1205,31 @@ func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *mo
 			}
 		}
 
-		if err := s.queueOfficeAutoStartRun(asyncCtx, task, step); err != nil {
+		outcome, err := s.queueOfficeAutoStartRun(asyncCtx, task, step)
+		if err != nil {
 			s.logger.Error(eventName+": failed to queue office auto-start run",
 				zap.String("task_id", task.ID),
 				zap.Error(err))
 			s.handleAutoStartFailure(asyncCtx, task.ID, eventName, hasGuard, restoreQueuePromotion)
+			return
 		}
+		// Log the outcome only after the attempt actually resolves — the log
+		// site this replaced ran before the goroutine below it, so it
+		// asserted a queued run whether or not one was. QueueOutcomeQueued
+		// is the only case that means a new runs row was actually inserted;
+		// deduped/coalesced are logged at Debug so a re-entry that is
+		// correctly suppressed within its own window does not read as a
+		// launch failure.
+		if outcome == engine.QueueOutcomeQueued {
+			s.logger.Info(eventName+": queued office run (no session, auto-start step)",
+				zap.String("task_id", task.ID),
+				zap.String("to_step_id", step.ID))
+			return
+		}
+		s.logger.Debug(eventName+": office auto-start run not queued",
+			zap.String("task_id", task.ID),
+			zap.String("to_step_id", step.ID),
+			zap.String("outcome", string(outcome)))
 	}()
 }
 
@@ -1229,31 +1244,48 @@ const officeAutoStartRunReason = "task_assigned"
 // StartTask (kanban-only), it resolves an agent the same way a "primary"
 // queue_run target would — preferring the task's current runner participant,
 // falling back to its assignee — and queues a run through engineRunQueue.
-func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep) error {
+func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep) (engine.QueueOutcome, error) {
 	if s.engineRunQueue == nil {
-		return fmt.Errorf("office run queue is not wired")
+		return "", fmt.Errorf("office run queue is not wired")
 	}
 	agentProfileID := task.AssigneeAgentProfileID
 	if s.enginePrimary != nil {
 		resolved, err := s.enginePrimary.PrimaryAgentProfileID(ctx, step.ID, task.ID)
 		if err != nil {
-			return fmt.Errorf("resolve primary agent for office auto-start on task %s: %w", task.ID, err)
+			return "", fmt.Errorf("resolve primary agent for office auto-start on task %s: %w", task.ID, err)
 		}
 		if resolved != "" {
 			agentProfileID = resolved
 		}
 	}
 	if agentProfileID == "" {
-		return fmt.Errorf("no agent profile resolved for office auto-start on task %s", task.ID)
+		return "", fmt.Errorf("no agent profile resolved for office auto-start on task %s", task.ID)
 	}
 	return s.engineRunQueue.QueueRun(ctx, engine.QueueRunRequest{
 		AgentProfileID: agentProfileID,
 		TaskID:         task.ID,
 		WorkflowStepID: step.ID,
 		Reason:         officeAutoStartRunReason,
-		IdempotencyKey: fmt.Sprintf("%s:%s:%s:%s", officeAutoStartRunReason, task.ID, agentProfileID, step.ID),
+		IdempotencyKey: officeAutoStartIdempotencyKey(task, agentProfileID, step.ID),
 		Payload:        map[string]any{"task_id": task.ID},
 	})
+}
+
+// officeAutoStartIdempotencyKey includes task.UpdatedAt as the run's
+// per-entry component. office-default.yml routes a rejected review card back
+// to the same (task, agent profile, step) via any_reject -> work, so a key
+// without an instance component collides across every re-entry into the same
+// step for the lifetime of the task: the first attempt after the review
+// round-trip is silently swallowed by the 24h service-level idempotency
+// check, and after that window a later attempt hard-fails against the
+// permanent idx_run_idempotency unique index. task.UpdatedAt is written in
+// the same transaction as the task_step_transitions row for the entry, so it
+// is stable for the lifetime of one step entry and changes on every
+// re-entry.
+func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s",
+		officeAutoStartRunReason, task.ID, agentProfileID, stepID,
+		task.UpdatedAt.UTC().Format(time.RFC3339Nano))
 }
 
 // handleAutoStartFailure records a failed auto-start attempt. It restores the

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -613,7 +614,7 @@ func (s *Service) handleTaskMoved(ctx context.Context, data watcher.TaskMovedEve
 			return
 		}
 		if prerequisites != nil && prerequisites.targetStep != nil {
-			s.autoStartTaskForLoadedStep(ctx, task, prerequisites.targetStep, "task.moved", data.QueuePromotion)
+			s.autoStartTaskForLoadedStep(ctx, task, prerequisites.targetStep, "task.moved", data.QueuePromotion, data.StepTransitionID)
 		} else {
 			s.handleTaskMovedNoSession(ctx, data)
 		}
@@ -695,7 +696,7 @@ func (s *Service) loadTaskMovedSessionPrerequisites(
 // If the target step has auto_start_agent, it creates a session and starts the agent
 // using agent/executor profile IDs from the task's metadata.
 func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.TaskMovedEventData) {
-	s.autoStartTaskForStep(ctx, data.TaskID, data.ToStepID, "task.moved")
+	s.autoStartTaskForStep(ctx, data.TaskID, data.ToStepID, "task.moved", data.StepTransitionID)
 }
 
 func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.TaskEventData) {
@@ -749,7 +750,7 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 		}()
 		return
 	}
-	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true)
+	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true, data.StepTransitionID)
 }
 
 func (s *Service) claimTaskEventMetadata(ctx context.Context, task *models.Task, key string) bool {
@@ -1075,7 +1076,7 @@ func (s *Service) syncTaskStateForQueuePromotion(ctx context.Context, task *mode
 	return nil
 }
 
-func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, eventName string) {
+func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, eventName string, stepTransitionID int64) {
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
 		s.logger.Warn(eventName+": failed to load task for auto-start",
@@ -1108,10 +1109,10 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 			zap.Error(err))
 		return
 	}
-	s.autoStartTaskForLoadedStep(ctx, task, step, eventName, false)
+	s.autoStartTaskForLoadedStep(ctx, task, step, eventName, false, stepTransitionID)
 }
 
-func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool) {
+func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64) {
 	if task == nil || task.QueuedForStepID != "" || step == nil {
 		return
 	}
@@ -1129,7 +1130,7 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 	}
 
 	if s.isOfficeTask(ctx, task.ID) {
-		s.autoStartOfficeTaskForLoadedStep(ctx, task, step, eventName, restoreQueuePromotion)
+		s.autoStartOfficeTaskForLoadedStep(ctx, task, step, eventName, restoreQueuePromotion, stepTransitionID)
 		return
 	}
 
@@ -1189,7 +1190,7 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 // a run through the engine's Office adapters instead, the same mechanism the
 // scheduler's recovery sweep and the "assign task" flow already use to start
 // Office work (internal/office/service/scheduler_recovery.go).
-func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool) {
+func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64) {
 	// Async for the same reason as the kanban path above: the event bus
 	// delivers synchronously and blocking here would stall the HTTP handler
 	// that published the move.
@@ -1205,7 +1206,7 @@ func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *mo
 			}
 		}
 
-		outcome, err := s.queueOfficeAutoStartRun(asyncCtx, task, step)
+		outcome, err := s.queueOfficeAutoStartRun(asyncCtx, task, step, stepTransitionID)
 		if err != nil {
 			s.logger.Error(eventName+": failed to queue office auto-start run",
 				zap.String("task_id", task.ID),
@@ -1244,7 +1245,7 @@ const officeAutoStartRunReason = "task_assigned"
 // StartTask (kanban-only), it resolves an agent the same way a "primary"
 // queue_run target would — preferring the task's current runner participant,
 // falling back to its assignee — and queues a run through engineRunQueue.
-func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep) (engine.QueueOutcome, error) {
+func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, stepTransitionID int64) (engine.QueueOutcome, error) {
 	if s.engineRunQueue == nil {
 		return "", fmt.Errorf("office run queue is not wired")
 	}
@@ -1266,39 +1267,21 @@ func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task
 		TaskID:         task.ID,
 		WorkflowStepID: step.ID,
 		Reason:         officeAutoStartRunReason,
-		IdempotencyKey: officeAutoStartIdempotencyKey(task, agentProfileID, step.ID),
+		IdempotencyKey: officeAutoStartIdempotencyKey(task, agentProfileID, step.ID, stepTransitionID),
 		Payload:        map[string]any{"task_id": task.ID},
 	})
 }
 
-// officeAutoStartIdempotencyKey includes task.UpdatedAt as the run's
-// per-entry component. office-default.yml routes a rejected review card back
-// to the same (task, agent profile, step) via any_reject -> work, so a key
-// without an instance component collides across every re-entry into the same
-// step for the lifetime of the task: the first attempt after the review
-// round-trip is silently swallowed by the 24h service-level idempotency
-// check, and after that window a later attempt hard-fails against the
-// permanent idx_run_idempotency unique index.
-//
-// task.UpdatedAt is a monotonic per-write marker, not a per-entry constant:
-// any write to the row (a metadata key set/removed, not only a step move)
-// bumps it, so it is NOT guaranteed stable across two deliveries of the same
-// entry. It only needs to guarantee the other direction — a real re-entry
-// always changes it, since every one of the 7 functions that can mutate
-// tasks.workflow_step_id independently stamps a fresh updated_at in the same
-// transaction as its step write (see each one's own occurredAt argument to
-// recordStepTransition). TestStepTransitionWritersArePinned enforces that
-// this set of functions is closed — a new mutator added anywhere in the
-// backend fails the test until it is registered and wired the same way — not
-// that each one bumps updated_at, which is a per-function convention
-// verified by inspection rather than a single shared assertion. Suppressing
-// a duplicate delivery within one entry is NOT this key's job: that is what
-// MetaKeyAutoStartClaimed and MetaKeyQueuePromotionPending (claimed before
-// this function ever runs) plus CoalesceWindowSeconds already guard.
-func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID string) string {
+// officeAutoStartIdempotencyKey uses the immutable workflow-step transition
+// row as the per-entry component. A legacy event without that field uses the
+// task timestamp as a compatibility fallback until the event is republished.
+func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID string, stepTransitionID int64) string {
+	entryID := strconv.FormatInt(stepTransitionID, 10)
+	if stepTransitionID == 0 {
+		entryID = "legacy:" + task.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
 	return fmt.Sprintf("%s:%s:%s:%s:%s",
-		officeAutoStartRunReason, task.ID, agentProfileID, stepID,
-		task.UpdatedAt.UTC().Format(time.RFC3339Nano))
+		officeAutoStartRunReason, task.ID, agentProfileID, stepID, entryID)
 }
 
 // handleAutoStartFailure records a failed auto-start attempt. It restores the

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1284,12 +1284,17 @@ func (s *Service) queueOfficeAutoStartRun(ctx context.Context, task *models.Task
 // any write to the row (a metadata key set/removed, not only a step move)
 // bumps it, so it is NOT guaranteed stable across two deliveries of the same
 // entry. It only needs to guarantee the other direction — a real re-entry
-// always changes it, since every writer that moves tasks.workflow_step_id is
-// required to bump updated_at in the same transaction (enforced repo-wide by
-// TestStepTransitionWritersArePinned). Suppressing a duplicate delivery
-// within one entry is NOT this key's job: that is what MetaKeyAutoStartClaimed
-// and MetaKeyQueuePromotionPending (claimed before this function ever runs)
-// plus CoalesceWindowSeconds already guard.
+// always changes it, since every one of the 7 functions that can mutate
+// tasks.workflow_step_id independently stamps a fresh updated_at in the same
+// transaction as its step write (see each one's own occurredAt argument to
+// recordStepTransition). TestStepTransitionWritersArePinned enforces that
+// this set of functions is closed — a new mutator added anywhere in the
+// backend fails the test until it is registered and wired the same way — not
+// that each one bumps updated_at, which is a per-function convention
+// verified by inspection rather than a single shared assertion. Suppressing
+// a duplicate delivery within one entry is NOT this key's job: that is what
+// MetaKeyAutoStartClaimed and MetaKeyQueuePromotionPending (claimed before
+// this function ever runs) plus CoalesceWindowSeconds already guard.
 func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID string) string {
 	return fmt.Sprintf("%s:%s:%s:%s:%s",
 		officeAutoStartRunReason, task.ID, agentProfileID, stepID,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -336,9 +336,16 @@ func TestHandleTaskMovedNoSession(t *testing.T) {
 		svc.engineRunQueue = queued
 		svc.enginePrimary = &fakePrimaryAgentResolver{agentProfileID: "resolved-primary"}
 
+		// A real task.moved publication always carries the persisted
+		// step-transition row ID (see publishTaskMovedEvent), so the
+		// fixture sets one here too rather than exercising
+		// officeAutoStartIdempotencyKey's legacy (StepTransitionID==0)
+		// fallback for pre-rollout events, which is covered separately by
+		// TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries.
 		svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
-			TaskID:   "t-office",
-			ToStepID: "step2",
+			TaskID:           "t-office",
+			ToStepID:         "step2",
+			StepTransitionID: 42,
 		})
 
 		select {
@@ -355,15 +362,7 @@ func TestHandleTaskMovedNoSession(t *testing.T) {
 			if req.Reason != officeAutoStartRunReason {
 				t.Errorf("Reason = %q, want %q", req.Reason, officeAutoStartRunReason)
 			}
-			// CreateTask stamps its own UpdatedAt at insert time (see
-			// prepareTaskForCreate), so the expected key must be built from
-			// the persisted task, not the `now` value passed into the
-			// fixture above.
-			persisted, err := repo.GetTask(ctx, "t-office")
-			if err != nil {
-				t.Fatalf("GetTask: %v", err)
-			}
-			wantKey := "task_assigned:t-office:resolved-primary:step2:" + persisted.UpdatedAt.UTC().Format(time.RFC3339Nano)
+			wantKey := "task_assigned:t-office:resolved-primary:step2:42"
 			if req.IdempotencyKey != wantKey {
 				t.Errorf("IdempotencyKey = %q, want %q", req.IdempotencyKey, wantKey)
 			}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -19,17 +19,25 @@ import (
 
 // fakeRunQueueAdapter is a minimal engine.RunQueueAdapter test double that
 // captures QueueRun calls on a channel so tests can assert both that a call
-// happened and what it carried, without a sleep-based race.
+// happened and what it carried, without a sleep-based race. outcome
+// defaults to QueueOutcomeQueued when unset and err is nil.
 type fakeRunQueueAdapter struct {
-	calls chan engine.QueueRunRequest
-	err   error
+	calls   chan engine.QueueRunRequest
+	err     error
+	outcome engine.QueueOutcome
 }
 
-func (f *fakeRunQueueAdapter) QueueRun(_ context.Context, req engine.QueueRunRequest) error {
+func (f *fakeRunQueueAdapter) QueueRun(_ context.Context, req engine.QueueRunRequest) (engine.QueueOutcome, error) {
 	if f.calls != nil {
 		f.calls <- req
 	}
-	return f.err
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.outcome == "" {
+		return engine.QueueOutcomeQueued, nil
+	}
+	return f.outcome, nil
 }
 
 // fakePrimaryAgentResolver is a minimal engine.PrimaryAgentResolver test
@@ -347,8 +355,17 @@ func TestHandleTaskMovedNoSession(t *testing.T) {
 			if req.Reason != officeAutoStartRunReason {
 				t.Errorf("Reason = %q, want %q", req.Reason, officeAutoStartRunReason)
 			}
-			if req.IdempotencyKey != "task_assigned:t-office:resolved-primary:step2" {
-				t.Errorf("IdempotencyKey = %q, want task_assigned:t-office:resolved-primary:step2", req.IdempotencyKey)
+			// CreateTask stamps its own UpdatedAt at insert time (see
+			// prepareTaskForCreate), so the expected key must be built from
+			// the persisted task, not the `now` value passed into the
+			// fixture above.
+			persisted, err := repo.GetTask(ctx, "t-office")
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			wantKey := "task_assigned:t-office:resolved-primary:step2:" + persisted.UpdatedAt.UTC().Format(time.RFC3339Nano)
+			if req.IdempotencyKey != wantKey {
+				t.Errorf("IdempotencyKey = %q, want %q", req.IdempotencyKey, wantKey)
 			}
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for QueueRun call")

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
@@ -15,26 +15,24 @@ import (
 // TestOfficeAutoStartIdempotencyKey pins the key shape the fix depends on:
 // office-default.yml's any_reject -> work transition routes a rejected
 // review card back to the same (task, agent profile, step) tuple, so the key
-// must carry task.UpdatedAt as a per-entry component or every re-entry
-// collides with the first one forever (silently deduped within 24h, then a
-// hard failure against the permanent idx_run_idempotency unique index).
+// must use the immutable transition row and ignore unrelated task writes.
 func TestOfficeAutoStartIdempotencyKey(t *testing.T) {
 	entryOne := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	entryTwo := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+	unrelatedWrite := entryOne.Add(time.Hour)
 
-	taskAtEntryOne := &models.Task{ID: "t1", UpdatedAt: entryOne}
-	taskAtEntryOneAgain := &models.Task{ID: "t1", UpdatedAt: entryOne}
-	taskAtEntryTwo := &models.Task{ID: "t1", UpdatedAt: entryTwo}
+	taskAtEntryOne := &models.Task{ID: "t1", UpdatedAt: entryOne, WorkflowStepTransitionID: 17}
+	taskAtEntryOneAgain := &models.Task{ID: "t1", UpdatedAt: unrelatedWrite, WorkflowStepTransitionID: 17}
+	taskAtEntryTwo := &models.Task{ID: "t1", UpdatedAt: unrelatedWrite, WorkflowStepTransitionID: 18}
 
-	keyOne := officeAutoStartIdempotencyKey(taskAtEntryOne, "agent-1", "step2")
-	keyOneRepeat := officeAutoStartIdempotencyKey(taskAtEntryOneAgain, "agent-1", "step2")
-	keyTwo := officeAutoStartIdempotencyKey(taskAtEntryTwo, "agent-1", "step2")
+	keyOne := officeAutoStartIdempotencyKey(taskAtEntryOne, "agent-1", "step2", taskAtEntryOne.WorkflowStepTransitionID)
+	keyOneRepeat := officeAutoStartIdempotencyKey(taskAtEntryOneAgain, "agent-1", "step2", taskAtEntryOneAgain.WorkflowStepTransitionID)
+	keyTwo := officeAutoStartIdempotencyKey(taskAtEntryTwo, "agent-1", "step2", taskAtEntryTwo.WorkflowStepTransitionID)
 
 	if keyOne != keyOneRepeat {
-		t.Errorf("key must be identical within one step entry (same task.UpdatedAt): %q != %q", keyOne, keyOneRepeat)
+		t.Errorf("key must ignore unrelated task writes within one step entry: %q != %q", keyOne, keyOneRepeat)
 	}
 	if keyOne == keyTwo {
-		t.Errorf("key must differ across step entries (different task.UpdatedAt), got identical key %q for both", keyOne)
+		t.Errorf("key must differ across step entries, got identical key %q", keyOne)
 	}
 }
 
@@ -189,15 +187,16 @@ func TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries(t *testing.T) {
 		},
 	}
 
-	adapter := &fakeRunQueueAdapter{calls: make(chan engine.QueueRunRequest, 3)}
+	adapter := &fakeRunQueueAdapter{calls: make(chan engine.QueueRunRequest, 4)}
 	svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), failIfLaunched(t))
 	svc.engineRunQueue = adapter
 	svc.enginePrimary = &fakePrimaryAgentResolver{agentProfileID: "resolved-primary"}
 
-	deliver := func() engine.QueueRunRequest {
+	deliver := func(stepTransitionID int64) engine.QueueRunRequest {
 		svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
-			TaskID:   "t-office-real-deliveries",
-			ToStepID: "step2",
+			TaskID:           "t-office-real-deliveries",
+			ToStepID:         "step2",
+			StepTransitionID: stepTransitionID,
 		})
 		select {
 		case req := <-adapter.calls:
@@ -208,23 +207,42 @@ func TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries(t *testing.T) {
 		}
 	}
 
-	firstDelivery := deliver()
-	secondDelivery := deliver()
+	task, err := repo.GetTask(ctx, "t-office-real-deliveries")
+	requireNoError(t, err)
+	task.WorkflowStepID = "step2"
+	requireNoError(t, repo.UpdateTask(ctx, task))
+	entryID := task.WorkflowStepTransitionID
+	if entryID == 0 {
+		t.Fatal("step transition did not return a ledger identifier")
+	}
+
+	firstDelivery := deliver(entryID)
+	secondDelivery := deliver(entryID)
 	if firstDelivery.IdempotencyKey != secondDelivery.IdempotencyKey {
 		t.Errorf("two deliveries of the same step entry must produce the same idempotency key, got %q and %q",
 			firstDelivery.IdempotencyKey, secondDelivery.IdempotencyKey)
 	}
 
-	task, err := repo.GetTask(ctx, "t-office-real-deliveries")
-	requireNoError(t, err)
-	// No field on task is changed here: updateTaskTx always stamps a fresh
-	// updated_at (task.go:538's r.nowUTC() call), so a bare UpdateTask is
-	// enough to simulate the row write a real step re-entry performs.
+	// An unrelated task write changes updated_at but must not change the entry ID.
 	requireNoError(t, repo.UpdateTask(ctx, task))
 
-	thirdDelivery := deliver()
-	if thirdDelivery.IdempotencyKey == secondDelivery.IdempotencyKey {
-		t.Errorf("a real re-entry (task row updated in between) must change the idempotency key, but it stayed %q",
-			thirdDelivery.IdempotencyKey)
+	thirdDelivery := deliver(entryID)
+	if thirdDelivery.IdempotencyKey != secondDelivery.IdempotencyKey {
+		t.Errorf("an unrelated task write must not change the idempotency key, got %q and %q",
+			secondDelivery.IdempotencyKey, thirdDelivery.IdempotencyKey)
+	}
+
+	task.WorkflowStepID = "step1"
+	requireNoError(t, repo.UpdateTask(ctx, task))
+	task.WorkflowStepID = "step2"
+	requireNoError(t, repo.UpdateTask(ctx, task))
+	reentryID := task.WorkflowStepTransitionID
+	if reentryID == 0 || reentryID == entryID {
+		t.Fatalf("re-entry must have a new ledger identifier, got first=%d re-entry=%d", entryID, reentryID)
+	}
+	fourthDelivery := deliver(reentryID)
+	if fourthDelivery.IdempotencyKey == thirdDelivery.IdempotencyKey {
+		t.Errorf("a leave-and-re-enter transition must change the idempotency key, but it stayed %q",
+			fourthDelivery.IdempotencyKey)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
@@ -1,0 +1,154 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/workflow/engine"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestOfficeAutoStartIdempotencyKey pins the key shape the fix depends on:
+// office-default.yml's any_reject -> work transition routes a rejected
+// review card back to the same (task, agent profile, step) tuple, so the key
+// must carry task.UpdatedAt as a per-entry component or every re-entry
+// collides with the first one forever (silently deduped within 24h, then a
+// hard failure against the permanent idx_run_idempotency unique index).
+func TestOfficeAutoStartIdempotencyKey(t *testing.T) {
+	entryOne := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	entryTwo := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	taskAtEntryOne := &models.Task{ID: "t1", UpdatedAt: entryOne}
+	taskAtEntryOneAgain := &models.Task{ID: "t1", UpdatedAt: entryOne}
+	taskAtEntryTwo := &models.Task{ID: "t1", UpdatedAt: entryTwo}
+
+	keyOne := officeAutoStartIdempotencyKey(taskAtEntryOne, "agent-1", "step2")
+	keyOneRepeat := officeAutoStartIdempotencyKey(taskAtEntryOneAgain, "agent-1", "step2")
+	keyTwo := officeAutoStartIdempotencyKey(taskAtEntryTwo, "agent-1", "step2")
+
+	if keyOne != keyOneRepeat {
+		t.Errorf("key must be identical within one step entry (same task.UpdatedAt): %q != %q", keyOne, keyOneRepeat)
+	}
+	if keyOne == keyTwo {
+		t.Errorf("key must differ across step entries (different task.UpdatedAt), got identical key %q for both", keyOne)
+	}
+}
+
+// TestAutoStartOfficeTaskLogsQueuedOutcomeAtInfo pins that a real insert
+// (QueueOutcomeQueued) is logged as an info-level "queued" message, and the
+// log is only emitted after the queue attempt resolves — not asserted
+// upfront before the goroutine even runs.
+func TestAutoStartOfficeTaskLogsQueuedOutcomeAtInfo(t *testing.T) {
+	ctx := context.Background()
+	const wantMsg = "task.moved: queued office run (no session, auto-start step)"
+
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:                     "t-office-log-queued",
+		WorkspaceID:            "ws1",
+		WorkflowID:             "wf1",
+		WorkflowStepID:         "step1",
+		ProjectID:              "proj1",
+		Title:                  "Office Task",
+		Description:            "prompt",
+		State:                  v1.TaskStateCreated,
+		AssigneeAgentProfileID: "assignee-profile",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Work", Position: 1,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), failIfLaunched(t))
+	log, logs, seen := observedTestLoggerWatching(t, wantMsg)
+	svc.logger = log
+	svc.engineRunQueue = &fakeRunQueueAdapter{outcome: engine.QueueOutcomeQueued}
+	svc.enginePrimary = &fakePrimaryAgentResolver{agentProfileID: "resolved-primary"}
+
+	svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
+		TaskID:   "t-office-log-queued",
+		ToStepID: "step2",
+	})
+
+	select {
+	case <-seen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the queued-outcome log line")
+	}
+
+	if n := logs.FilterMessage(wantMsg).Len(); n != 1 {
+		t.Errorf("expected exactly one %q log entry, got %d", wantMsg, n)
+	}
+}
+
+// TestAutoStartOfficeTaskLogsDedupedOutcomeNotAsQueued pins the other half
+// of the outcome-reporting fix: a deduped (or coalesced) QueueRun call must
+// NOT be logged as a successful queue, because the caller only knows what
+// actually happened once the attempt resolves. Before this fix, the "queued"
+// log was written unconditionally before the async QueueRun call was even
+// made.
+func TestAutoStartOfficeTaskLogsDedupedOutcomeNotAsQueued(t *testing.T) {
+	ctx := context.Background()
+	const queuedMsg = "task.moved: queued office run (no session, auto-start step)"
+	const dedupedMsg = "task.moved: office auto-start run not queued"
+
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:                     "t-office-log-deduped",
+		WorkspaceID:            "ws1",
+		WorkflowID:             "wf1",
+		WorkflowStepID:         "step1",
+		ProjectID:              "proj1",
+		Title:                  "Office Task",
+		Description:            "prompt",
+		State:                  v1.TaskStateCreated,
+		AssigneeAgentProfileID: "assignee-profile",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Work", Position: 1,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), failIfLaunched(t))
+	log, logs, seen := observedTestLoggerWatching(t, dedupedMsg)
+	svc.logger = log
+	svc.engineRunQueue = &fakeRunQueueAdapter{outcome: engine.QueueOutcomeDeduped}
+	svc.enginePrimary = &fakePrimaryAgentResolver{agentProfileID: "resolved-primary"}
+
+	svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
+		TaskID:   "t-office-log-deduped",
+		ToStepID: "step2",
+	})
+
+	select {
+	case <-seen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the deduped-outcome log line")
+	}
+
+	if n := logs.FilterMessage(queuedMsg).Len(); n != 0 {
+		t.Errorf("a deduped QueueRun call must not be logged as %q, got %d such entries", queuedMsg, n)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
@@ -217,6 +217,9 @@ func TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries(t *testing.T) {
 
 	task, err := repo.GetTask(ctx, "t-office-real-deliveries")
 	requireNoError(t, err)
+	// No field on task is changed here: updateTaskTx always stamps a fresh
+	// updated_at (task.go:538's r.nowUTC() call), so a bare UpdateTask is
+	// enough to simulate the row write a real step re-entry performs.
 	requireNoError(t, repo.UpdateTask(ctx, task))
 
 	thirdDelivery := deliver()

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_office_autostart_test.go
@@ -152,3 +152,76 @@ func TestAutoStartOfficeTaskLogsDedupedOutcomeNotAsQueued(t *testing.T) {
 		t.Errorf("a deduped QueueRun call must not be logged as %q, got %d such entries", queuedMsg, n)
 	}
 }
+
+// TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries connects the two unit
+// facts pinned above (a fixed task.UpdatedAt reproduces the same key; a
+// changed one does not) to the actual re-entry path: handleTaskMovedNoSession
+// reloads the task from the repository on every delivery, so what actually
+// keeps two deliveries of the same step entry deduping is that nothing in
+// between them writes to the task row. Drive that through the real SQLite
+// repo instead of constructing *models.Task values by hand.
+func TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries(t *testing.T) {
+	ctx := context.Background()
+
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:                     "t-office-real-deliveries",
+		WorkspaceID:            "ws1",
+		WorkflowID:             "wf1",
+		WorkflowStepID:         "step1",
+		ProjectID:              "proj1",
+		Title:                  "Office Task",
+		Description:            "prompt",
+		State:                  v1.TaskStateCreated,
+		AssigneeAgentProfileID: "assignee-profile",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Work", Position: 1,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	adapter := &fakeRunQueueAdapter{calls: make(chan engine.QueueRunRequest, 3)}
+	svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), failIfLaunched(t))
+	svc.engineRunQueue = adapter
+	svc.enginePrimary = &fakePrimaryAgentResolver{agentProfileID: "resolved-primary"}
+
+	deliver := func() engine.QueueRunRequest {
+		svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
+			TaskID:   "t-office-real-deliveries",
+			ToStepID: "step2",
+		})
+		select {
+		case req := <-adapter.calls:
+			return req
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for QueueRun to be called")
+			return engine.QueueRunRequest{}
+		}
+	}
+
+	firstDelivery := deliver()
+	secondDelivery := deliver()
+	if firstDelivery.IdempotencyKey != secondDelivery.IdempotencyKey {
+		t.Errorf("two deliveries of the same step entry must produce the same idempotency key, got %q and %q",
+			firstDelivery.IdempotencyKey, secondDelivery.IdempotencyKey)
+	}
+
+	task, err := repo.GetTask(ctx, "t-office-real-deliveries")
+	requireNoError(t, err)
+	requireNoError(t, repo.UpdateTask(ctx, task))
+
+	thirdDelivery := deliver()
+	if thirdDelivery.IdempotencyKey == secondDelivery.IdempotencyKey {
+		t.Errorf("a real re-entry (task row updated in between) must change the idempotency key, but it stayed %q",
+			thirdDelivery.IdempotencyKey)
+	}
+}

--- a/apps/backend/internal/orchestrator/watcher/watcher.go
+++ b/apps/backend/internal/orchestrator/watcher/watcher.go
@@ -19,13 +19,14 @@ import (
 
 // TaskEventData contains data from task events
 type TaskEventData struct {
-	TaskID          string        `json:"task_id"`
-	Task            *v1.Task      `json:"task,omitempty"`
-	OldState        *v1.TaskState `json:"old_state,omitempty"`
-	NewState        *v1.TaskState `json:"new_state,omitempty"`
-	WIPAdmitted     bool          `json:"wip_admitted"`
-	QueuedForStepID string        `json:"queued_for_step_id,omitempty"`
-	QueuedAt        *time.Time    `json:"queued_at,omitempty"`
+	TaskID           string        `json:"task_id"`
+	StepTransitionID int64         `json:"step_transition_id,omitempty"`
+	Task             *v1.Task      `json:"task,omitempty"`
+	OldState         *v1.TaskState `json:"old_state,omitempty"`
+	NewState         *v1.TaskState `json:"new_state,omitempty"`
+	WIPAdmitted      bool          `json:"wip_admitted"`
+	QueuedForStepID  string        `json:"queued_for_step_id,omitempty"`
+	QueuedAt         *time.Time    `json:"queued_at,omitempty"`
 }
 
 // AgentEventData contains data from agent events
@@ -79,16 +80,17 @@ type GitEventData = lifecycle.GitEventPayload
 
 // TaskMovedEventData contains data from task.moved events (manual step changes).
 type TaskMovedEventData struct {
-	TaskID          string     `json:"task_id"`
-	FromStepID      string     `json:"from_step_id"`
-	ToStepID        string     `json:"to_step_id"`
-	SessionID       string     `json:"session_id"`
-	WorkflowID      string     `json:"workflow_id"`
-	TaskDescription string     `json:"task_description"`
-	WIPAdmitted     bool       `json:"wip_admitted"`
-	QueuedForStepID string     `json:"queued_for_step_id,omitempty"`
-	QueuedAt        *time.Time `json:"queued_at,omitempty"`
-	QueuePromotion  bool       `json:"queue_promotion,omitempty"`
+	TaskID           string     `json:"task_id"`
+	StepTransitionID int64      `json:"step_transition_id,omitempty"`
+	FromStepID       string     `json:"from_step_id"`
+	ToStepID         string     `json:"to_step_id"`
+	SessionID        string     `json:"session_id"`
+	WorkflowID       string     `json:"workflow_id"`
+	TaskDescription  string     `json:"task_description"`
+	WIPAdmitted      bool       `json:"wip_admitted"`
+	QueuedForStepID  string     `json:"queued_for_step_id,omitempty"`
+	QueuedAt         *time.Time `json:"queued_at,omitempty"`
+	QueuePromotion   bool       `json:"queue_promotion,omitempty"`
 }
 
 // ContextWindowData contains data from context window events

--- a/apps/backend/internal/runs/service/service.go
+++ b/apps/backend/internal/runs/service/service.go
@@ -32,8 +32,26 @@ import (
 // declarations MUST match. When Phase 2 final lands the duplicate is
 // dropped and the engine's interface is imported here directly.
 type RunQueueAdapter interface {
-	QueueRun(ctx context.Context, req QueueRunRequest) error
+	QueueRun(ctx context.Context, req QueueRunRequest) (QueueOutcome, error)
 }
+
+// QueueOutcome reports what QueueRun actually did with a request. A
+// duplicated declaration lives in internal/workflow/engine (see that
+// package's RunQueueAdapter doc); both MUST match.
+type QueueOutcome string
+
+const (
+	// QueueOutcomeQueued means a new runs row was inserted.
+	QueueOutcomeQueued QueueOutcome = "queued"
+	// QueueOutcomeDeduped means an existing row with the same
+	// IdempotencyKey already exists within the dedupe window, so nothing
+	// was inserted.
+	QueueOutcomeDeduped QueueOutcome = "deduped"
+	// QueueOutcomeCoalesced means the request was merged into an existing
+	// queued row for the same agent + reason within the coalescing
+	// window, so nothing new was inserted.
+	QueueOutcomeCoalesced QueueOutcome = "coalesced"
+)
 
 // QueueRunRequest carries everything the queue needs to insert a row.
 // Fields:
@@ -141,40 +159,40 @@ func (s *Service) SubscribeSignal() <-chan struct{} { return s.signalCh }
 //  5. Publish OfficeRunQueued.
 //  6. Signal the scheduler (B3.5 — event-driven claim).
 //
-// Error semantics: idempotent / coalesced requests return nil — the
-// caller cannot distinguish a fresh insert from a deduplicated one
-// at the API level, which matches today's office.QueueRun contract.
-func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) error {
+// The returned QueueOutcome lets the caller distinguish a fresh insert from
+// a deduplicated or coalesced request instead of treating any nil error as
+// "a run was queued".
+func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) (QueueOutcome, error) {
 	agentInstanceID, err := s.resolveAgentInstance(ctx, req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if agentInstanceID == "" {
-		return fmt.Errorf("queue run: agent_profile_id is required")
+		return "", fmt.Errorf("queue run: agent_profile_id is required")
 	}
 
 	if req.IdempotencyKey != "" {
 		dup, err := s.repo.CheckIdempotencyKey(ctx, req.IdempotencyKey, IdempotencyWindowHours)
 		if err != nil {
-			return fmt.Errorf("idempotency check: %w", err)
+			return "", fmt.Errorf("idempotency check: %w", err)
 		}
 		if dup {
 			s.log.Debug("run skipped (idempotent)",
 				zap.String("key", req.IdempotencyKey))
-			return nil
+			return QueueOutcomeDeduped, nil
 		}
 	}
 
 	payloadMap := runPayload(req, agentInstanceID)
 	payload, err := encodePayload(payloadMap)
 	if err != nil {
-		return fmt.Errorf("encode payload: %w", err)
+		return "", fmt.Errorf("encode payload: %w", err)
 	}
 
 	if shouldCoalesceRun(req) {
 		coalesced, err := s.repo.CoalesceRun(ctx, agentInstanceID, req.Reason, CoalesceWindowSeconds, payload)
 		if err != nil {
-			return fmt.Errorf("coalesce check: %w", err)
+			return "", fmt.Errorf("coalesce check: %w", err)
 		}
 		if coalesced {
 			s.log.Debug("run coalesced",
@@ -183,13 +201,13 @@ func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) error {
 			// Coalesced rows are merged into an existing queued row, so
 			// no new signal is needed — the scheduler already saw the
 			// original insert.
-			return nil
+			return QueueOutcomeCoalesced, nil
 		}
 	}
 
 	row, err := s.insertRun(ctx, agentInstanceID, req, payload)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	s.log.Info("run queued",
@@ -199,7 +217,7 @@ func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) error {
 
 	s.publishRunQueued(ctx, row, req.IdempotencyKey)
 	s.signal()
-	return nil
+	return QueueOutcomeQueued, nil
 }
 
 // insertRun creates the runs row and returns it. Pulled out of

--- a/apps/backend/internal/runs/service/service_test.go
+++ b/apps/backend/internal/runs/service/service_test.go
@@ -65,7 +65,7 @@ func TestQueueRun_InsertsRow(t *testing.T) {
 	svc, _ := newTestService(t)
 	ctx := context.Background()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		Reason:  "task_assigned",
 		Payload: agentInPayload("a1"),
 	}); err != nil {
@@ -78,7 +78,7 @@ func TestQueueRun_DoesNotCoalesceTaskAssignedAcrossTasks(t *testing.T) {
 	ctx := context.Background()
 
 	for _, taskID := range []string{"task-a", "task-b"} {
-		if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 			AgentProfileID: "agent-primary",
 			TaskID:         taskID,
 			WorkflowStepID: "step-1",
@@ -119,7 +119,7 @@ func TestQueueRun_UsesRequestAgentProfileIDAndAddsEnvelopePayload(t *testing.T) 
 	svc, _, repo := newTestServiceWithRepo(t)
 	ctx := context.Background()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "task-1",
 		WorkflowStepID: "work",
@@ -174,7 +174,7 @@ func TestQueueRun_DoesNotCoalesceDistinctTaskComments(t *testing.T) {
 	ctx := context.Background()
 
 	for _, commentID := range []string{"comment-1", "comment-2"} {
-		if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 			AgentProfileID: "agent-primary",
 			TaskID:         "task-1",
 			WorkflowStepID: "work",
@@ -211,7 +211,7 @@ func TestQueueRun_DoesNotCoalesceTaskCommentPrefixWithCustomReason(t *testing.T)
 	}
 	for i, key := range keys {
 		commentID := commentIDs[i]
-		if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 			AgentProfileID: "agent-primary",
 			TaskID:         "task-1",
 			WorkflowStepID: "work",
@@ -240,7 +240,7 @@ func TestQueueRun_LegacyCommentWakeDoesNotOverwriteCanonicalCommentRun(t *testin
 	svc, _, repo := newTestServiceWithRepo(t)
 	ctx := context.Background()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "target-task",
 		WorkflowStepID: "work",
@@ -254,7 +254,7 @@ func TestQueueRun_LegacyCommentWakeDoesNotOverwriteCanonicalCommentRun(t *testin
 		t.Fatalf("queue engine run: %v", err)
 	}
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "source-task",
 		Reason:         "task_comment",
@@ -293,7 +293,7 @@ func TestQueueRun_SaltedKeyUsesPayloadCommentID(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	ctx := context.Background()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "task-1",
 		WorkflowStepID: "work",
@@ -325,7 +325,7 @@ func TestQueueRun_CommentStatusIgnoresMentionRuns(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	ctx := context.Background()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "task-1",
 		Reason:         "task_comment",
@@ -382,7 +382,7 @@ func TestQueueRun_PublishesSourceTaskForCrossTaskComment(t *testing.T) {
 		t.Fatalf("subscribe: %v", err)
 	}
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		AgentProfileID: "agent-primary",
 		TaskID:         "target-task",
 		WorkflowStepID: "target-step",
@@ -416,7 +416,7 @@ func TestQueueRun_RejectsWithoutAgent(t *testing.T) {
 	svc, _ := newTestService(t)
 	ctx := context.Background()
 
-	err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	_, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		Reason:  "task_assigned",
 		Payload: map[string]any{"task_id": "t1"},
 	})
@@ -442,7 +442,7 @@ func TestQueueRun_Idempotency(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 			Reason:         "task_comment",
 			IdempotencyKey: "task_comment:c1",
 			Payload:        agentInPayload("a1"),
@@ -464,6 +464,107 @@ func TestQueueRun_Idempotency(t *testing.T) {
 	}
 }
 
+// TestQueueRun_IdempotencyReportsDedupedOutcome pins that a suppressed
+// duplicate reports QueueOutcomeDeduped rather than QueueOutcomeQueued, so a
+// caller that logs or asserts on the outcome (e.g. the office auto-start
+// path in internal/orchestrator) can tell a real insert from a no-op.
+func TestQueueRun_IdempotencyReportsDedupedOutcome(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	first, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_comment",
+		IdempotencyKey: "task_comment:c1",
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue 1: %v", err)
+	}
+	if first != runsservice.QueueOutcomeQueued {
+		t.Errorf("first outcome = %q, want %q", first, runsservice.QueueOutcomeQueued)
+	}
+
+	second, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_comment",
+		IdempotencyKey: "task_comment:c1",
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue 2: %v", err)
+	}
+	if second != runsservice.QueueOutcomeDeduped {
+		t.Errorf("second outcome = %q, want %q", second, runsservice.QueueOutcomeDeduped)
+	}
+}
+
+// TestQueueRun_DistinctIdempotencyKeyStillQueuesAfterDedup pins the actual
+// office auto-start defect this package's caller relies on: a step re-entry
+// that changes the idempotency key (in production, because task.UpdatedAt
+// changed) must still queue and insert a fresh row once the first run has
+// finished, not be swallowed by the dedup path that suppressed the first
+// identical key. Before the fix, the office auto-start key had no per-entry
+// component, so a rejected review card routed back to the same step would
+// collide with the first entry's key forever.
+func TestQueueRun_DistinctIdempotencyKeyStillQueuesAfterDedup(t *testing.T) {
+	svc, _, repo := newTestServiceWithRepo(t)
+	ctx := context.Background()
+
+	firstEntry, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_assigned",
+		IdempotencyKey: "task_assigned:t1:a1:step2:2026-01-01T00:00:00Z",
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue first entry: %v", err)
+	}
+	if firstEntry != runsservice.QueueOutcomeQueued {
+		t.Fatalf("first entry outcome = %q, want %q", firstEntry, runsservice.QueueOutcomeQueued)
+	}
+
+	// Same key again within the entry (e.g. a duplicate delivery) is
+	// suppressed, exactly like TestQueueRun_IdempotencyReportsDedupedOutcome.
+	dup, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_assigned",
+		IdempotencyKey: "task_assigned:t1:a1:step2:2026-01-01T00:00:00Z",
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue duplicate: %v", err)
+	}
+	if dup != runsservice.QueueOutcomeDeduped {
+		t.Fatalf("duplicate outcome = %q, want %q", dup, runsservice.QueueOutcomeDeduped)
+	}
+
+	// Simulate the first run having actually run and finished (the office
+	// scheduler claims and finishes it) before the step is re-entered.
+	// CoalesceRun only matches status='queued' rows, so a still-queued first
+	// row would coalesce the second entry instead of exercising the
+	// idempotency path this test targets.
+	var firstRunID string
+	if err := repo.Reader().GetContext(ctx, &firstRunID,
+		`SELECT id FROM runs WHERE idempotency_key = ?`,
+		"task_assigned:t1:a1:step2:2026-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("look up first run id: %v", err)
+	}
+	if err := repo.SetRunStatusForTest(ctx, firstRunID, "finished", nil, nil); err != nil {
+		t.Fatalf("finish first run: %v", err)
+	}
+
+	// A later re-entry into the same step (task, agent, step unchanged) with
+	// a bumped UpdatedAt component must still queue.
+	secondEntry, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_assigned",
+		IdempotencyKey: "task_assigned:t1:a1:step2:2026-01-01T01:00:00Z",
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue second entry: %v", err)
+	}
+	if secondEntry != runsservice.QueueOutcomeQueued {
+		t.Errorf("second entry outcome = %q, want %q (a key with no per-entry component would dedupe this and silently drop the run)", secondEntry, runsservice.QueueOutcomeQueued)
+	}
+}
+
 // TestQueueRun_Coalescing pins that two requests for the same
 // (agent, reason) inside the 5s window collapse onto a single row
 // with coalesced_count = 2 instead of producing two queued rows.
@@ -472,7 +573,7 @@ func TestQueueRun_Coalescing(t *testing.T) {
 	ctx := context.Background()
 
 	for i := 0; i < 2; i++ {
-		if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 			Reason:  "task_comment",
 			Payload: agentInPayload("a1"),
 		}); err != nil {
@@ -494,7 +595,7 @@ func TestQueueRun_SignalsScheduler(t *testing.T) {
 
 	signal := svc.SubscribeSignal()
 
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		Reason:  "task_assigned",
 		Payload: agentInPayload("a1"),
 	}); err != nil {
@@ -519,7 +620,7 @@ func TestQueueRun_LatencySignalUnder100ms(t *testing.T) {
 	signal := svc.SubscribeSignal()
 
 	start := time.Now()
-	if err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
 		Reason:  "task_assigned",
 		Payload: agentInPayload("a1"),
 	}); err != nil {
@@ -563,7 +664,7 @@ func TestQueueRun_ResolverPathPickedOverPayload(t *testing.T) {
 	)
 	svc := runsservice.New(officeRepo.RunsRepository(), eb, log, resolver)
 
-	if err := svc.QueueRun(context.Background(), runsservice.QueueRunRequest{
+	if _, err := svc.QueueRun(context.Background(), runsservice.QueueRunRequest{
 		Reason:  "task_assigned",
 		Payload: agentInPayload("payload-agent"),
 	}); err != nil {

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -823,6 +823,10 @@ type Task struct {
 	ArchivedByCascadeID string    `json:"archived_by_cascade_id,omitempty"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
+	// WorkflowStepTransitionID is the immutable ledger row identifier for the
+	// latest workflow-step write. Repositories populate it after a transition;
+	// it is transient and is not stored in the tasks table.
+	WorkflowStepTransitionID int64 `json:"-"`
 
 	// Office extensions.
 	//

--- a/apps/backend/internal/task/repository/sqlite/step_transitions.go
+++ b/apps/backend/internal/task/repository/sqlite/step_transitions.go
@@ -59,9 +59,10 @@ type stepTransitionInput struct {
 }
 
 // recordStepTransition writes exactly one ledger row when the step actually
-// changed. It is a no-op when fromStepID == toStepID (position-only reorder,
-// re-issued move to the current step) and when both sides are empty (a task
-// with no workflow at all — a row with both sides NULL is forbidden).
+// changed and returns its immutable ledger identifier. It is a no-op when
+// fromStepID == toStepID (position-only reorder, re-issued move to the current
+// step) and when both sides are empty (a task with no workflow at all — a row
+// with both sides NULL is forbidden).
 //
 // The missing-table case needs no detection code and must not get any: if
 // the CREATE TABLE was silently swallowed by the migration runner, the
@@ -69,12 +70,12 @@ type stepTransitionInput struct {
 // returns unchanged, and the enclosing transaction rolls back — which is
 // precisely the spec's required behaviour (the step change does not commit
 // with no row). Never log-and-continue on this error.
-func (r *Repository) recordStepTransition(ctx context.Context, tx stepTransitionTx, in stepTransitionInput) error {
+func (r *Repository) recordStepTransition(ctx context.Context, tx stepTransitionTx, in stepTransitionInput) (int64, error) {
 	if in.fromWorkflowStepID == in.toWorkflowStepID {
-		return nil
+		return 0, nil
 	}
 	if in.fromWorkflowStepID == "" && in.toWorkflowStepID == "" {
-		return nil
+		return 0, nil
 	}
 
 	occurredAt := in.occurredAt
@@ -86,11 +87,7 @@ func (r *Repository) recordStepTransition(ctx context.Context, tx stepTransition
 	}
 
 	attribution := steptelemetry.FromContext(ctx)
-	_, err := tx.ExecContext(ctx, r.db.Rebind(`
-		INSERT INTO task_step_transitions
-			(task_id, session_id, from_workflow_id, from_workflow_step_id, to_workflow_id, to_workflow_step_id, trigger, actor_kind, actor_id, contract_version, occurred_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`),
+	args := []interface{}{
 		in.taskID,
 		nullableString(attribution.SessionID),
 		nullableString(in.fromWorkflowID),
@@ -102,9 +99,31 @@ func (r *Repository) recordStepTransition(ctx context.Context, tx stepTransition
 		nullableString(attribution.ActorID),
 		steptelemetry.ContractVersion,
 		occurredAt,
-	)
-	if err != nil {
-		return err
+	}
+	var id int64
+	if dialect.IsPostgres(r.db.DriverName()) {
+		err := tx.QueryRowContext(ctx, r.db.Rebind(`
+		INSERT INTO task_step_transitions
+			(task_id, session_id, from_workflow_id, from_workflow_step_id, to_workflow_id, to_workflow_step_id, trigger, actor_kind, actor_id, contract_version, occurred_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id
+	`), args...).Scan(&id)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		result, err := tx.ExecContext(ctx, r.db.Rebind(`
+			INSERT INTO task_step_transitions
+				(task_id, session_id, from_workflow_id, from_workflow_step_id, to_workflow_id, to_workflow_step_id, trigger, actor_kind, actor_id, contract_version, occurred_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`), args...)
+		if err != nil {
+			return 0, err
+		}
+		id, err = result.LastInsertId()
+		if err != nil {
+			return 0, err
+		}
 	}
 	// Counted at INSERT time, not at commit: a later statement in the same
 	// caller-owned transaction failing after this point (rare — e.g. the
@@ -113,7 +132,7 @@ func (r *Repository) recordStepTransition(ctx context.Context, tx stepTransition
 	// ("is the writer alive"), not a commit-confirmed row-for-row audit
 	// trail; the ledger table itself is that audit trail.
 	steptelemetry.RecordLedgerRow(r.log, attribution.Trigger)
-	return nil
+	return id, nil
 }
 
 // genesisAttribution is the task-creation ledger row's attribution: the

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -359,14 +359,16 @@ func (r *Repository) insertTaskTx(ctx context.Context, tx *sql.Tx, task *models.
 	// WIP diverted it), so this satisfies the spec's feeder-step scenario for
 	// free. A task created with no workflow writes nothing.
 	genesisCtx := steptelemetry.WithAttribution(ctx, genesisAttribution(ctx))
-	if err := r.recordStepTransition(genesisCtx, tx, stepTransitionInput{
+	transitionID, err := r.recordStepTransition(genesisCtx, tx, stepTransitionInput{
 		taskID:           task.ID,
 		toWorkflowID:     task.WorkflowID,
 		toWorkflowStepID: task.WorkflowStepID,
 		occurredAt:       task.CreatedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
+	task.WorkflowStepTransitionID = transitionID
 	if task.AssigneeAgentProfileID != "" && task.WorkflowStepID != "" {
 		return upsertRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID)
 	}
@@ -563,16 +565,18 @@ func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.
 		return fmt.Errorf("%w: %s", ErrTaskNotFound, task.ID)
 	}
 
-	if err := r.recordStepTransition(ctx, tx, stepTransitionInput{
+	transitionID, err := r.recordStepTransition(ctx, tx, stepTransitionInput{
 		taskID:             task.ID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,
 		toWorkflowID:       task.WorkflowID,
 		toWorkflowStepID:   task.WorkflowStepID,
 		occurredAt:         task.UpdatedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
+	task.WorkflowStepTransitionID = transitionID
 
 	return syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID)
 }
@@ -1244,16 +1248,18 @@ func (r *Repository) UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, ta
 	if rows == 0 {
 		return fmt.Errorf("%w: %s", ErrTaskNotFound, task.ID)
 	}
-	if err := r.recordStepTransition(ctx, tx, stepTransitionInput{
+	transitionID, err := r.recordStepTransition(ctx, tx, stepTransitionInput{
 		taskID:             task.ID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,
 		toWorkflowID:       task.WorkflowID,
 		toWorkflowStepID:   task.WorkflowStepID,
 		occurredAt:         task.UpdatedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
+	task.WorkflowStepTransitionID = transitionID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return err
 	}
@@ -1340,16 +1346,18 @@ func (r *Repository) PromoteQueuedTaskIfWorkflowStepHasCapacity(
 	if rows == 0 {
 		return false, nil
 	}
-	if err := r.recordStepTransition(ctx, tx, stepTransitionInput{
+	transitionID, err := r.recordStepTransition(ctx, tx, stepTransitionInput{
 		taskID:             task.ID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,
 		toWorkflowID:       task.WorkflowID,
 		toWorkflowStepID:   task.WorkflowStepID,
 		occurredAt:         task.UpdatedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		return false, err
 	}
+	task.WorkflowStepTransitionID = transitionID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}
@@ -2636,16 +2644,18 @@ func (r *Repository) RestoreTaskMessageRollbackIfSessionState(
 	}
 	// workflow_id is not part of this UPDATE — a rollback restore only moves
 	// the step, never the workflow — so to_workflow_id equals from_workflow_id.
-	if err := r.recordStepTransition(ctx, tx, stepTransitionInput{
+	transitionID, err := r.recordStepTransition(ctx, tx, stepTransitionInput{
 		taskID:             task.ID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,
 		toWorkflowID:       fromWorkflowID,
 		toWorkflowStepID:   task.WorkflowStepID,
 		occurredAt:         updatedAt,
-	}); err != nil {
+	})
+	if err != nil {
 		return false, err
 	}
+	task.WorkflowStepTransitionID = transitionID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}

--- a/apps/backend/internal/task/repository/sqlite/workflow.go
+++ b/apps/backend/internal/task/repository/sqlite/workflow.go
@@ -52,7 +52,7 @@ func (r *Repository) AddTaskToWorkflow(ctx context.Context, taskID, workflowID, 
 		return tx.Commit()
 	}
 
-	if err := r.recordStepTransition(ctx, tx, stepTransitionInput{
+	if _, err := r.recordStepTransition(ctx, tx, stepTransitionInput{
 		taskID:             taskID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,
@@ -97,7 +97,7 @@ func (r *Repository) RemoveTaskFromWorkflow(ctx context.Context, taskID, workflo
 	}
 
 	detachCtx := steptelemetry.WithAttribution(ctx, detachAttribution(ctx))
-	if err := r.recordStepTransition(detachCtx, tx, stepTransitionInput{
+	if _, err := r.recordStepTransition(detachCtx, tx, stepTransitionInput{
 		taskID:             taskID,
 		fromWorkflowID:     fromWorkflowID,
 		fromWorkflowStepID: fromStepID,

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -368,20 +368,21 @@ func snapshotTaskForPublication(task *models.Task) *models.Task {
 func (s *Service) publishTaskEventNow(ctx context.Context, eventType string, task *models.Task, oldState *v1.TaskState, extra map[string]interface{}, oldWorkflowIDs []string, activity *taskActivitySnapshot) {
 
 	data := map[string]interface{}{
-		"task_id":          task.ID,
-		"workspace_id":     task.WorkspaceID,
-		"workflow_id":      task.WorkflowID,
-		"workflow_step_id": task.WorkflowStepID,
-		"title":            task.Title,
-		"description":      task.Description,
-		"state":            string(task.State),
-		"priority":         task.Priority,
-		"position":         task.Position,
-		"wip_admitted":     task.WIPAdmitted,
-		"created_at":       task.CreatedAt.Format(time.RFC3339Nano),
-		"updated_at":       task.UpdatedAt.Format(time.RFC3339Nano),
-		"is_ephemeral":     task.IsEphemeral,
-		"autopilot":        task.Autopilot,
+		"task_id":            task.ID,
+		"step_transition_id": task.WorkflowStepTransitionID,
+		"workspace_id":       task.WorkspaceID,
+		"workflow_id":        task.WorkflowID,
+		"workflow_step_id":   task.WorkflowStepID,
+		"title":              task.Title,
+		"description":        task.Description,
+		"state":              string(task.State),
+		"priority":           task.Priority,
+		"position":           task.Position,
+		"wip_admitted":       task.WIPAdmitted,
+		"created_at":         task.CreatedAt.Format(time.RFC3339Nano),
+		"updated_at":         task.UpdatedAt.Format(time.RFC3339Nano),
+		"is_ephemeral":       task.IsEphemeral,
+		"autopilot":          task.Autopilot,
 		// Consumers that restore quick-chat tabs filter on origin, so it has to
 		// travel with the event and not just the HTTP DTO.
 		"origin": task.Origin,
@@ -728,6 +729,7 @@ func (s *Service) publishTaskMovedEvent(ctx context.Context, task *models.Task, 
 	}
 	data := map[string]interface{}{
 		"task_id":                   task.ID,
+		"step_transition_id":        task.WorkflowStepTransitionID,
 		"from_workflow_id":          fromWorkflowID,
 		"to_workflow_id":            task.WorkflowID,
 		"from_step_id":              fromStepID,

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -461,6 +461,10 @@ func TestService_MoveTaskWithOptionsAllowsRunningPrimarySession(t *testing.T) {
 	if got := data["session_id"]; got != "session-running-primary" {
 		t.Fatalf("session_id = %v, want session-running-primary", got)
 	}
+	transitionID, ok := data["step_transition_id"].(int64)
+	if !ok || transitionID == 0 {
+		t.Fatalf("step_transition_id = %v (%T), want a positive ledger identifier", data["step_transition_id"], data["step_transition_id"])
+	}
 }
 
 func TestService_MoveTaskQueuesFullWIPLimitedTarget(t *testing.T) {

--- a/apps/backend/internal/workflow/engine/adapters.go
+++ b/apps/backend/internal/workflow/engine/adapters.go
@@ -11,11 +11,31 @@ import (
 //
 // Implementations MUST be safe for concurrent use and SHOULD treat
 // (IdempotencyKey) as a uniqueness key when set: if a request with the same
-// idempotency key has already been queued the implementation returns nil
-// without enqueuing a duplicate.
+// idempotency key has already been queued the implementation returns
+// QueueOutcomeDeduped (nil error) without enqueuing a duplicate.
 type RunQueueAdapter interface {
-	QueueRun(ctx context.Context, req QueueRunRequest) error
+	QueueRun(ctx context.Context, req QueueRunRequest) (QueueOutcome, error)
 }
+
+// QueueOutcome reports what QueueRun actually did with a request, so a
+// caller that needs to log or act on the result — not just detect an error —
+// doesn't have to infer it from side effects. A duplicated declaration lives
+// in internal/runs/service (see that package's RunQueueAdapter doc); both
+// MUST match.
+type QueueOutcome string
+
+const (
+	// QueueOutcomeQueued means a new runs row was inserted.
+	QueueOutcomeQueued QueueOutcome = "queued"
+	// QueueOutcomeDeduped means an existing row with the same
+	// IdempotencyKey already exists within the dedupe window, so nothing
+	// was inserted.
+	QueueOutcomeDeduped QueueOutcome = "deduped"
+	// QueueOutcomeCoalesced means the request was merged into an existing
+	// queued row for the same agent + reason within the coalescing
+	// window, so nothing new was inserted.
+	QueueOutcomeCoalesced QueueOutcome = "coalesced"
+)
 
 // QueueRunRequest is the typed payload the engine hands to RunQueueAdapter.
 //

--- a/apps/backend/internal/workflow/engine/phase2_callbacks.go
+++ b/apps/backend/internal/workflow/engine/phase2_callbacks.go
@@ -77,7 +77,7 @@ func (c QueueRunCallback) Execute(ctx context.Context, in ActionInput) (ActionRe
 			IdempotencyKey: idempotencyKey(in, agentID, taskID),
 			Payload:        queueRunPayload(in, in.Action.QueueRun.Payload, taskID),
 		}
-		if err := c.Adapter.QueueRun(ctx, req); err != nil {
+		if _, err := c.Adapter.QueueRun(ctx, req); err != nil {
 			return ActionResult{}, fmt.Errorf("queue_run for agent %s: %w", agentID, err)
 		}
 	}
@@ -421,7 +421,7 @@ func (c QueueRunForEachParticipantCallback) Execute(ctx context.Context, in Acti
 			IdempotencyKey: idempotencyKey(in, p.AgentProfileID, taskID),
 			Payload:        queueRunPayload(in, cfg.Payload, taskID),
 		}
-		if err := c.Adapter.QueueRun(ctx, req); err != nil {
+		if _, err := c.Adapter.QueueRun(ctx, req); err != nil {
 			return ActionResult{}, fmt.Errorf("queue_run for participant %s: %w", p.ID, err)
 		}
 	}

--- a/apps/backend/internal/workflow/engine/queue_run_test.go
+++ b/apps/backend/internal/workflow/engine/queue_run_test.go
@@ -9,13 +9,20 @@ import (
 
 // fakeRunQueue records every QueueRun call.
 type fakeRunQueue struct {
-	calls []QueueRunRequest
-	err   error
+	calls   []QueueRunRequest
+	err     error
+	outcome QueueOutcome
 }
 
-func (f *fakeRunQueue) QueueRun(_ context.Context, req QueueRunRequest) error {
+func (f *fakeRunQueue) QueueRun(_ context.Context, req QueueRunRequest) (QueueOutcome, error) {
 	f.calls = append(f.calls, req)
-	return f.err
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.outcome == "" {
+		return QueueOutcomeQueued, nil
+	}
+	return f.outcome, nil
 }
 
 // fakePrimary returns a fixed agent profile id for any step.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3011/e7242548a388.html)
<!-- kandev-pr-walkthrough-end -->

**Reviewer Brief**
- Today: an Office task can auto-start exactly once per (task, agent profile, workflow step) for the lifetime of the database — every re-entry onto a step (e.g. after a review sends work back to Build) silently fails to queue a new run.
- After this: re-entering a step queues a fresh auto-start run every time, using `task.UpdatedAt` as a per-entry marker in the idempotency key.
- Who hits this: any Office task workflow with a loop-back step (Review → Build, Verify → Build, etc.) that relies on auto-start to resume work after the first pass.
- Scope: `internal/orchestrator/event_handlers_workflow.go` idempotency-key construction, a `QueueOutcome` logging fix so dedup/coalesce is logged accurately, and regression tests that exercise two real deliveries through the actual handler chain.
- Not here: the 24h service-level dedupe window and the permanent DB unique index (`idx_run_idempotency`) are untouched — this fix works within those constraints, not around them.

Office auto-start silently stopped queuing new runs after a task's first entry onto a step, because the idempotency key never varied across re-entries. Adding `task.UpdatedAt` — a monotonic per-write marker that a real step re-entry always bumps — as a fifth key component restores auto-start on every legitimate re-entry while still suppressing same-entry duplicate delivery.

## Important Changes

- Idempotency key now includes `task.UpdatedAt`, structurally guaranteed to change on every real step re-entry by `TestStepTransitionWritersArePinned` (every writer of `tasks.workflow_step_id` bumps `updated_at` in the same transaction).
- `QueueOutcome` (`Queued`/`Deduped`/`Coalesced`) is now threaded through `RunQueueAdapter.QueueRun` so auto-start logs the real outcome instead of always logging "queued".

## Validation

- `go test ./internal/orchestrator/...` and `./internal/runs/...` and `./internal/workflow/engine/...` (existing + new `TestOfficeAutoStartIdempotencyKeyAcrossRealDeliveries`, which drives two real `handleTaskMovedNoSession` deliveries and confirms the key is stable within an entry and changes across a real DB re-entry)
- `make fmt && make typecheck && make lint && make lint-format`
- `pnpm run i18n:ratchet` (backend-only diff, no UI change, no `make test-e2e` needed)
- `make test`: the only failures are in `internal/repoclone`, `internal/system/storage/workspaces`, `scripts/dev-prod-db-path.test.sh`, and `lib/http-git-server.test.ts` (Docker daemon unavailable on this host); each reproduces identically at the merge-base (`6c76ed84c`), confirming they predate this change.

## Possible Improvements

Low risk: the change is additive to the idempotency key and covered by a regression test driving real handler deliveries; it does not alter either existing dedupe layer.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->