### PR TITLE
docs(agentctl): correct comments that describe adapters and protocols that don't exist

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -50,7 +50,7 @@ type AgentExecution struct {
 	WorkspaceSourceRoots []string             // Canonical durable source roots permitted by agentctl file operations
 	ACPSessionID         string               // ACP session ID to resume, if available
 	AgentCommand         string               // Command to start the agent subprocess
-	ContinueCommand      string               // Command for follow-up prompts (one-shot agents like Amp)
+	ContinueCommand      string               // Command for follow-up prompts (one-shot agents)
 	AgentArgs            []string             // Structured argv for AgentCommand
 	ContinueArgs         []string             // Structured argv for ContinueCommand
 	RuntimeName          agentruntime.Runtime // Name of the runtime used (e.g., "docker", "standalone")

--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -167,15 +167,13 @@ type AgentInfo struct {
 //  8. Call Close() when done
 type AgentAdapter interface {
 	// PrepareEnvironment performs protocol-specific setup before the agent process starts.
-	// For ACP, this is a no-op (MCP servers are passed through the protocol).
-	// For OpenCode, this returns environment variables for server authentication.
+	// The ACP adapter is a no-op (MCP servers are passed through the protocol).
 	// Must be called before the agent subprocess is started.
 	// Returns a map of environment variables to add to the subprocess environment.
 	PrepareEnvironment() (map[string]string, error)
 
 	// PrepareCommandArgs returns extra command-line arguments for the agent process.
-	// For Codex, this returns -c flags for MCP servers and sandbox config.
-	// For other protocols, this returns nil (no extra args needed).
+	// The ACP adapter returns nil (no extra args needed).
 	// Must be called after PrepareEnvironment and before starting the subprocess.
 	PrepareCommandArgs() []string
 
@@ -184,8 +182,7 @@ type AgentAdapter interface {
 	Connect(stdin io.Writer, stdout io.Reader) error
 
 	// Initialize establishes the connection with the agent and exchanges capabilities.
-	// For subprocess-based agents (ACP), this sends the initialize request.
-	// For HTTP-based agents (REST), this might do a health check.
+	// Sends the ACP initialize request over the subprocess's stdin/stdout.
 	Initialize(ctx context.Context) error
 
 	// GetAgentInfo returns information about the connected agent.
@@ -217,8 +214,8 @@ type AgentAdapter interface {
 	GetSessionID() string
 
 	// GetOperationID returns the current operation/turn ID.
-	// Returns empty string if no operation is in progress or not supported by the protocol.
-	// For Codex this is the turn ID, for ACP this may be empty.
+	// Returns empty string if no operation is in progress, or if the connected
+	// ACP agent does not report a turn ID.
 	GetOperationID() string
 
 	// SetPermissionHandler sets the handler for permission requests.
@@ -228,10 +225,11 @@ type AgentAdapter interface {
 	Close() error
 
 	// RequiresProcessKill returns true if the adapter's subprocess needs to be
-	// explicitly killed during shutdown. Adapters that communicate via stdin/stdout
-	// (ACP, Codex, Claude Code) return false because closing stdin causes the
-	// subprocess to exit. HTTP-server-based adapters (OpenCode) return true because
-	// they don't exit on stdin close.
+	// explicitly killed during shutdown. Most ACP agents return false because
+	// closing stdin causes the subprocess to exit. Some agents (e.g. opencode
+	// acp) keep an internal HTTP server and MCP child processes alive after
+	// stdin closes, so their config sets this true to force an immediate
+	// process-group kill instead of waiting on a graceful stdin close.
 	RequiresProcessKill() bool
 }
 
@@ -277,7 +275,9 @@ type Config struct {
 	// Used for display purposes.
 	AgentName string
 
-	// For HTTP-based adapters (REST)
+	// BaseURL, AuthHeader, AuthValue, and Headers are unused by any adapter
+	// today (no HTTP-based transport exists); no production code sets or
+	// reads them.
 	BaseURL    string            // Base URL of the agent's HTTP API
 	AuthHeader string            // Optional auth header name
 	AuthValue  string            // Optional auth header value

--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -276,8 +276,8 @@ type Config struct {
 	AgentName string
 
 	// BaseURL, AuthHeader, AuthValue, and Headers are unused by any adapter
-	// today (no HTTP-based transport exists); no production code sets or
-	// reads them.
+	// today (no HTTP-based transport exists). Config.ToSharedConfig still
+	// propagates them to shared.Config, but no transport reads them.
 	BaseURL    string            // Base URL of the agent's HTTP API
 	AuthHeader string            // Optional auth header name
 	AuthValue  string            // Optional auth header value

--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -1,9 +1,9 @@
-// Package adapter provides protocol adapters for different agent communication protocols.
-// This abstraction allows agentctl to work with agents using ACP, REST, MCP, or custom protocols.
+// Package adapter provides protocol adapters for agent communication.
+// Only ACP is supported; non-ACP variants were removed in the ACP-first migration.
 //
 // Architecture:
-//   - Transport layer (transport/*): Handles protocol-level communication (ACP, stream-json, codex, opencode)
-//   - Factory: Creates the appropriate transport adapter based on agent's protocol
+//   - Transport layer (transport/*): Handles protocol-level communication (ACP is the only transport)
+//   - Factory: Creates the ACP transport adapter
 //
 // Agent configuration (commands, discovery, models) is handled by the agent/registry package
 // using agents.json as the source of truth. This package only handles protocol communication.
@@ -52,9 +52,10 @@ const (
 )
 
 // OneShotAdapter is an optional interface implemented by adapters that spawn
-// a new process per prompt (e.g., Amp). When an adapter is one-shot, the
-// process manager skips subprocess creation and the adapter manages its own
-// subprocess lifecycle internally.
+// a new process per prompt. When an adapter is one-shot, the process manager
+// skips subprocess creation and the adapter manages its own subprocess
+// lifecycle internally. No production adapter implements this today; Amp is
+// now an ACP agent and goes through the standard subprocess path.
 type OneShotAdapter interface {
 	IsOneShot() bool
 }
@@ -152,7 +153,7 @@ type AgentInfo struct {
 }
 
 // AgentAdapter defines the interface for protocol adapters.
-// Each adapter translates a specific protocol (ACP, REST, MCP, etc.) into the
+// Each adapter translates ACP, the only supported protocol, into the
 // normalized AgentEvent format that agentctl exposes via its HTTP API.
 //
 // Lifecycle:

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -265,7 +265,6 @@ func (a *Adapter) sendPrompt(
 	}
 
 	// Emit complete event via the stream, including the StopReason from the agent.
-	// This normalizes ACP behavior to match other adapters (stream-json, amp, copilot, opencode).
 	a.logger.Debug("emitting complete event after prompt",
 		zap.String("session_id", sessionID),
 		zap.String("stop_reason", stopReason))

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
@@ -38,7 +38,9 @@ type Config struct {
 	// Used for display purposes.
 	AgentName string
 
-	// For HTTP-based adapters (REST)
+	// BaseURL, AuthHeader, AuthValue, and Headers are unused by any adapter
+	// today (no HTTP-based transport exists); no production code sets or
+	// reads them.
 	BaseURL    string            // Base URL of the agent's HTTP API
 	AuthHeader string            // Optional auth header name
 	AuthValue  string            // Optional auth header value

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
@@ -39,8 +39,8 @@ type Config struct {
 	AgentName string
 
 	// BaseURL, AuthHeader, AuthValue, and Headers are unused by any adapter
-	// today (no HTTP-based transport exists); no production code sets or
-	// reads them.
+	// today (no HTTP-based transport exists). Populated by
+	// adapter.Config.ToSharedConfig but never read by a transport.
 	BaseURL    string            // Base URL of the agent's HTTP API
 	AuthHeader string            // Optional auth header name
 	AuthValue  string            // Optional auth header value

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/debug.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/debug.go
@@ -18,15 +18,9 @@ var debugMode = os.Getenv(envDebugMessages) == "true"
 // debugMode is true.
 var acpLog = newACPLogManager(acpLogConfigFromEnv())
 
-// Protocol constants for debug file naming
-const (
-	ProtocolACP        = "acp"
-	ProtocolStreamJSON = "streamjson"
-	ProtocolCodex      = "codex"
-	ProtocolOpenCode   = "opencode"
-	ProtocolAmp        = "amp"
-	ProtocolCopilot    = "copilot"
-)
+// ProtocolACP names the ACP transport in debug file naming (raw-acp-*.jsonl,
+// normalized-acp-*.jsonl). It is the only supported protocol.
+const ProtocolACP = "acp"
 
 // ACPDebugEnabled reports whether agent-message debug logging is on.
 func ACPDebugEnabled() bool { return debugMode }

--- a/apps/backend/internal/agentctl/server/api/server.go
+++ b/apps/backend/internal/agentctl/server/api/server.go
@@ -428,10 +428,10 @@ func (s *Server) handleStart(c *gin.Context) {
 type AgentConfigureRequest struct {
 	Command         string            `json:"command"`
 	AgentArgs       optionalArgs      `json:"agent_args"`
-	ContinueCommand string            `json:"continue_command,omitempty"` // For one-shot agents (Amp): command for follow-up prompts
+	ContinueCommand string            `json:"continue_command,omitempty"` // For one-shot agents: command for follow-up prompts
 	ContinueArgs    optionalArgs      `json:"continue_args"`
 	Env             map[string]string `json:"env,omitempty"`
-	ApprovalPolicy  string            `json:"approval_policy,omitempty"` // For Codex: "untrusted", "on-failure", "on-request", "never"
+	ApprovalPolicy  string            `json:"approval_policy,omitempty"` // "untrusted", "on-failure", "on-request", or "never"
 }
 
 type optionalArgs struct {

--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -223,7 +223,8 @@ type InstanceConfig struct {
 
 	// ContinueCommand is the command template for follow-up prompts in one-shot agents.
 	// When set, the adapter spawns a new process per prompt using this command for
-	// continuation (thread ID appended at runtime). Only used by Amp.
+	// continuation (thread ID appended at runtime). No production adapter is
+	// one-shot today; see OneShotAdapter in adapter/adapter.go.
 	ContinueCommand string
 
 	// ContinueArgs is the structured argv for ContinueCommand.

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -1295,7 +1295,7 @@ func (m *Manager) buildAdapterConfig() error {
 	}
 
 	// Configure one-shot mode when a continue command is provided.
-	// One-shot adapters (e.g., Amp) spawn a new subprocess per prompt.
+	// One-shot adapters spawn a new subprocess per prompt.
 	continueArgs := m.cfg.ContinueArgs
 	if continueArgs == nil && m.cfg.ContinueCommand != "" {
 		continueArgs = config.ParseCommand(m.cfg.ContinueCommand)
@@ -1589,7 +1589,7 @@ func (m *Manager) Configure(command string, agentArgs []string, agentArgsPresent
 		m.cfg.ApprovalPolicy = approvalPolicy
 	}
 
-	// Store continue command for one-shot adapters (e.g., Amp)
+	// Store continue command for one-shot adapters
 	if continueArgsPresent {
 		m.cfg.ContinueCommand = continueCommand
 		m.cfg.ContinueArgs = continueArgs


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3012/7862b22ebf6a.html)
<!-- kandev-pr-walkthrough-end -->

Backend Go comments across the adapter layer still described Codex, OpenCode, Copilot, and stream-json adapters and transports as if they were live, and claimed a set of HTTP-only config fields were never read by production code. None of that is true today: only ACP is supported (`factory.go` rejects every other protocol), and the "unused" config fields are in fact propagated by `Config.ToSharedConfig`. This corrects every comment in that falsehood class to match the real single-protocol implementation and removes five provably dead protocol constants.

**Today:** Anyone reading `adapter.go`, `manager.go`, `config.go`, `api/server.go`, or `lifecycle/types.go` sees doc comments describing a Codex adapter, an OpenCode protocol, Copilot/stream-json transports, and Amp-specific one-shot behavior — none of which exist. A contributor (or an agent) navigating the adapter layer before adding a feature would be chasing adapters that were never built.
**After this:** Every comment in that class matches `factory.go`'s actual single-protocol (ACP) implementation. `transport/shared/debug.go`'s five dead `Protocol*` constants (`StreamJSON`, `Codex`, `OpenCode`, `Amp`, `Copilot`) — zero references anywhere outside their own declaration — are removed; `ProtocolACP` (genuinely referenced) is kept.
**Who hits this:** Any contributor or coding agent reading `internal/agentctl/server/adapter/**` (or its API/config/lifecycle call sites) before touching agent-transport code — these comments are the map they navigate the layer with.
**Scope:** Follow-up slice of #3001 (`docs: correct three false claims in backend architecture docs`), which fixed the same falsehood class in Markdown docs only and deliberately deferred the Go source comments to this card. Standalone otherwise — comment/dead-constant edits only, no behavior change.
**Not here:** `docs/add-agent-cli.md`'s stale six-protocol table — tracked separately, #3010 (open). The `//go:build e2e` adapter tests that reference removed `agent.Protocol*` symbols and don't compile — pre-existing on `main`, tracked separately as a follow-up card; not caused by or fixed in this PR.

## Validation

Backend Go, comment-only plus a 5-constant dead-code deletion — no `apps/web/` files touched, so no E2E required.

- `gofmt -l` on all 8 changed files → clean
- `go build ./...` → clean (proves no dangling reference to the deleted constants)
- `go vet ./...` (default tags) → clean
- `make -C apps/backend lint` → `golangci-lint run ./...` / `0 issues.`
- `go vet -tags e2e ./internal/agentctl/server/adapter/e2e/` → still fails (`undefined: agent.ProtocolAmp`), reproduced identically before and after this change; pre-existing on `main`, tracked as a separate follow-up, not fixed here
- Targeted package tests for every changed package (`adapter`, `transport/acp`, `transport/shared`, `api`, `config`, `process`, `lifecycle`) — all pass except a fixed set of pre-existing/environmental failures (npm registry access, GitHub CLI shim dependency, SQLite lock contention, macOS unix-socket path limits), proven pre-existing against the merge-base commit in a scratch worktree
- `make fmt`, `make typecheck`, `make lint`, `make lint-format` (repo-wide) → clean
- `pnpm run i18n:ratchet` (apps/web) → clean (no-op — no UI source touched)
- Full `make test` (backend, all packages) re-run against this branch: same pre-existing failure set as above; a few additional failures seen under full-suite concurrent load (LSP bridge timing test, port-detection tests, git-admission timeout test) were re-run in isolation and passed 3/3 — confirmed resource-contention flakes, not regressions

## Possible Improvements

Low risk: comment-only changes plus removal of five constants with zero references anywhere in the repo (confirmed via repo-wide grep and a green `go build`, which would fail loudly on any missed reference).


## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
