### PR TITLE
fix(web): allow dragging office task cards between board columns

### DIFF
--- a/apps/web/app/office/tasks/task-board.tsx
+++ b/apps/web/app/office/tasks/task-board.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useRouter } from "@/lib/routing/client-router";
+import { DndContext, DragOverlay, pointerWithin, useDraggable, useDroppable } from "@dnd-kit/core";
 import { ScrollArea } from "@kandev/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
 import type { OfficeTask, OfficeTaskStatus } from "@/lib/state/slices/office/types";
 import { StatusIcon } from "./status-icon";
 import { STATUS_LABEL_KEYS } from "../lib/label-keys";
+import { useBoardDrag } from "./use-board-drag";
 import { useTranslation } from "react-i18next";
 
 // `labelKey`, not `label` — see the note in `status-labels.ts`. The workspace's
@@ -20,26 +23,48 @@ const FALLBACK_COLUMNS: { status: OfficeTaskStatus; labelKey: string }[] = [
   { status: "cancelled", labelKey: STATUS_LABEL_KEYS.cancelled },
 ];
 
+const CARD_CLASS = "rounded-md border border-border bg-card p-3";
+
 type TaskBoardProps = {
   tasks: OfficeTask[];
 };
 
-function BoardCard({ task }: { task: OfficeTask }) {
-  const router = useRouter();
-
+function CardBody({ task }: { task: OfficeTask }) {
   return (
-    <div
-      className="rounded-md border border-border bg-card p-3 hover:bg-accent/50 transition-colors cursor-pointer"
-      onClick={() => router.push(`/office/tasks/${task.id}`)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => e.key === "Enter" && router.push(`/office/tasks/${task.id}`)}
-    >
+    <>
       <div className="flex items-center gap-1.5 mb-1">
         <StatusIcon status={task.status} className="h-3.5 w-3.5 shrink-0" />
         <span className="text-[11px] text-muted-foreground font-mono">{task.identifier}</span>
       </div>
       <p className="text-sm truncate">{task.title}</p>
+    </>
+  );
+}
+
+function BoardCard({ task }: { task: OfficeTask }) {
+  const router = useRouter();
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  const open = () => router.push(`/office/tasks/${task.id}`);
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`board-card-${task.id}`}
+      className={cn(
+        CARD_CLASS,
+        "hover:bg-accent/50 transition-colors cursor-pointer",
+        // The card in flight is drawn by the DragOverlay; fading the original
+        // keeps it from reading as a duplicate.
+        isDragging && "opacity-40",
+      )}
+      onClick={open}
+      onKeyDown={(e) => e.key === "Enter" && open()}
+      // `attributes` supplies role="button" and tabIndex, so the card stays
+      // focusable and Enter still opens the task.
+      {...attributes}
+      {...listeners}
+    >
+      <CardBody task={task} />
     </div>
   );
 }
@@ -53,6 +78,8 @@ function BoardColumn({
   status: OfficeTaskStatus;
   tasks: OfficeTask[];
 }) {
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+
   return (
     <div className="flex flex-col min-w-[240px] max-w-[300px] flex-1">
       <div className="flex items-center gap-2 px-2 py-2 mb-2">
@@ -61,7 +88,16 @@ function BoardColumn({
         <span className="text-xs text-muted-foreground">{tasks.length}</span>
       </div>
       <ScrollArea className="flex-1">
-        <div className="flex flex-col gap-1.5 px-1 pb-2">
+        <div
+          ref={setNodeRef}
+          data-testid={`board-column-${status}`}
+          className={cn(
+            // min-h keeps an empty column a real drop target; a zero-height
+            // list cannot be dropped onto.
+            "flex flex-col gap-1.5 px-1 pb-2 rounded-md min-h-[64px] transition-colors",
+            isOver && "bg-accent/40 ring-1 ring-primary/40",
+          )}
+        >
           {tasks.map((task) => (
             <BoardCard key={task.id} task={task} />
           ))}
@@ -92,6 +128,8 @@ export function groupTasksByStatus(
 export function TaskBoard({ tasks }: TaskBoardProps) {
   const { t } = useTranslation();
   const meta = useAppStore((s) => s.office.meta);
+  const { activeTaskId, sensors, handleDragStart, handleDragEnd, handleDragCancel } =
+    useBoardDrag();
   const columns = meta
     ? meta.statuses.map((s) => ({ status: s.id as OfficeTaskStatus, label: s.label }))
     : FALLBACK_COLUMNS.map((c) => ({ status: c.status, label: t(c.labelKey) }));
@@ -100,17 +138,33 @@ export function TaskBoard({ tasks }: TaskBoardProps) {
     tasks,
     columns.map((c) => c.status),
   );
+  const activeTask = activeTaskId ? (tasks.find((task) => task.id === activeTaskId) ?? null) : null;
 
   return (
-    <div className="flex gap-3 overflow-x-auto pb-4">
-      {columns.map((col) => (
-        <BoardColumn
-          key={col.status}
-          label={col.label}
-          status={col.status}
-          tasks={grouped.get(col.status) ?? []}
-        />
-      ))}
-    </div>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className="flex gap-3 overflow-x-auto pb-4">
+        {columns.map((col) => (
+          <BoardColumn
+            key={col.status}
+            label={col.label}
+            status={col.status}
+            tasks={grouped.get(col.status) ?? []}
+          />
+        ))}
+      </div>
+      <DragOverlay dropAnimation={null}>
+        {activeTask ? (
+          <div className={cn(CARD_CLASS, "shadow-lg cursor-grabbing")}>
+            <CardBody task={activeTask} />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/apps/web/app/office/tasks/task-board.tsx
+++ b/apps/web/app/office/tasks/task-board.tsx
@@ -27,6 +27,7 @@ const CARD_CLASS = "rounded-md border border-border bg-card p-3";
 
 type TaskBoardProps = {
   tasks: OfficeTask[];
+  onTaskPatch?: (taskId: string, patch: Partial<OfficeTask>) => void;
 };
 
 function CardBody({ task }: { task: OfficeTask }) {
@@ -134,11 +135,13 @@ export function groupTasksByStatus(
   return grouped;
 }
 
-export function TaskBoard({ tasks }: TaskBoardProps) {
+export function TaskBoard({ tasks, onTaskPatch }: TaskBoardProps) {
   const { t } = useTranslation();
   const meta = useAppStore((s) => s.office.meta);
-  const { activeTaskId, sensors, handleDragStart, handleDragEnd, handleDragCancel } =
-    useBoardDrag();
+  const { activeTaskId, sensors, handleDragStart, handleDragEnd, handleDragCancel } = useBoardDrag(
+    tasks,
+    onTaskPatch,
+  );
   const columns = meta
     ? meta.statuses.map((s) => ({ status: s.id as OfficeTaskStatus, label: s.label }))
     : FALLBACK_COLUMNS.map((c) => ({ status: c.status, label: t(c.labelKey) }));

--- a/apps/web/app/office/tasks/task-board.tsx
+++ b/apps/web/app/office/tasks/task-board.tsx
@@ -81,7 +81,21 @@ function BoardColumn({
   const { setNodeRef, isOver } = useDroppable({ id: status });
 
   return (
-    <div className="flex flex-col min-w-[240px] max-w-[300px] flex-1">
+    // The droppable ref lives here, not on the inner list: that list sits
+    // inside a Radix ScrollArea viewport whose content box is content-height
+    // (display: table), while this root stretches to the row's tallest
+    // column via the parent flex row's default align-items: stretch. Ref'ing
+    // the inner box means a short column's droppable is only as tall as its
+    // own cards, so dropping in the visible-but-blank space below them finds
+    // no droppable and the card silently snaps back.
+    <div
+      ref={setNodeRef}
+      data-testid={`board-column-${status}`}
+      className={cn(
+        "flex flex-col min-w-[240px] max-w-[300px] flex-1 rounded-md transition-colors",
+        isOver && "bg-accent/40 ring-1 ring-primary/40",
+      )}
+    >
       <div className="flex items-center gap-2 px-2 py-2 mb-2">
         <StatusIcon status={status} className="h-3.5 w-3.5" />
         <span className="text-xs font-medium">{label}</span>
@@ -89,14 +103,9 @@ function BoardColumn({
       </div>
       <ScrollArea className="flex-1">
         <div
-          ref={setNodeRef}
-          data-testid={`board-column-${status}`}
-          className={cn(
-            // min-h keeps an empty column a real drop target; a zero-height
-            // list cannot be dropped onto.
-            "flex flex-col gap-1.5 px-1 pb-2 rounded-md min-h-[64px] transition-colors",
-            isOver && "bg-accent/40 ring-1 ring-primary/40",
-          )}
+          // min-h keeps an empty column a real drop target even before the
+          // root above has any sibling tall enough to stretch it.
+          className="flex flex-col gap-1.5 px-1 pb-2 min-h-[64px]"
         >
           {tasks.map((task) => (
             <BoardCard key={task.id} task={task} />

--- a/apps/web/app/office/tasks/tasks-content.tsx
+++ b/apps/web/app/office/tasks/tasks-content.tsx
@@ -14,6 +14,7 @@ type IssuesContentProps = {
   expandedIds: Set<string>;
   onToggleExpand: (id: string) => void;
   agentMap: Map<string, string>;
+  onTaskPatch?: (taskId: string, patch: Partial<OfficeTask>) => void;
 };
 
 function IssueListView({
@@ -65,12 +66,13 @@ export function TasksContent({
   expandedIds,
   onToggleExpand,
   agentMap,
+  onTaskPatch,
 }: IssuesContentProps) {
   const { t } = useTranslation();
   if (isLoading) return <EmptyState message={t("office:loadingTasks")} />;
 
   if (viewMode === "board") {
-    return <TaskBoard tasks={flatNodes.map((n) => n.task)} />;
+    return <TaskBoard tasks={flatNodes.map((n) => n.task)} onTaskPatch={onTaskPatch} />;
   }
 
   return (

--- a/apps/web/app/office/tasks/tasks-list.tsx
+++ b/apps/web/app/office/tasks/tasks-list.tsx
@@ -125,7 +125,7 @@ export function TasksList() {
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const [newTaskOpen, setNewTaskOpen] = useState(false);
   const [showSystem, setShowSystem] = useShowSystemPref();
-  const { searchResults, triggerSearch } = useServerSearch(workspaceId);
+  const { searchResults, triggerSearch, patchSearchResult } = useServerSearch(workspaceId);
 
   const agentMap = new Map(agents.map((a) => [a.id, a.name]));
 
@@ -204,6 +204,7 @@ export function TasksList() {
         expandedIds={expandedIds}
         onToggleExpand={handleToggleExpand}
         agentMap={agentMap}
+        onTaskPatch={searchResults ? patchSearchResult : undefined}
       />
 
       <LoadMoreButton

--- a/apps/web/app/office/tasks/tasks-toolbar.tsx
+++ b/apps/web/app/office/tasks/tasks-toolbar.tsx
@@ -69,6 +69,7 @@ function ViewModeToggles({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            data-testid="task-view-board"
             variant={viewMode === "board" ? "secondary" : "ghost"}
             size="icon-sm"
             className="cursor-pointer"

--- a/apps/web/app/office/tasks/use-board-drag.test.ts
+++ b/apps/web/app/office/tasks/use-board-drag.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyStatusDrop, type StatusDropDeps } from "./use-board-drag";
+import type { OfficeTask, OfficeTaskStatus } from "@/lib/state/slices/office/types";
+
+function task(id: string, status: OfficeTaskStatus): OfficeTask {
+  return {
+    id,
+    workspaceId: "workspace-1",
+    identifier: id.toUpperCase(),
+    title: id,
+    status,
+    priority: "none",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function deps(
+  stored: OfficeTask | undefined,
+  updateStatus: StatusDropDeps["updateStatus"] = vi.fn().mockResolvedValue(undefined),
+) {
+  return {
+    getTask: vi.fn(() => stored),
+    patchTask: vi.fn(),
+    updateStatus: vi.fn(updateStatus),
+    onError: vi.fn(),
+  } satisfies StatusDropDeps;
+}
+
+describe("applyStatusDrop", () => {
+  it("patches the store then sends the status when a card crosses columns", async () => {
+    const d = deps(task("t1", "todo"));
+
+    await applyStatusDrop("t1", "in_progress", d);
+
+    expect(d.patchTask).toHaveBeenCalledWith("t1", { status: "in_progress" });
+    expect(d.updateStatus).toHaveBeenCalledWith("t1", "in_progress");
+    expect(d.onError).not.toHaveBeenCalled();
+  });
+
+  it("applies the optimistic patch before awaiting the mutation", async () => {
+    const order: string[] = [];
+    const d = deps(task("t1", "todo"), async () => {
+      order.push("update");
+    });
+    d.patchTask.mockImplementation(() => {
+      order.push("patch");
+    });
+
+    await applyStatusDrop("t1", "done", d);
+
+    expect(order).toEqual(["patch", "update"]);
+  });
+
+  it("is a no-op when the card is dropped back on its own column", async () => {
+    const d = deps(task("t1", "todo"));
+
+    await applyStatusDrop("t1", "todo", d);
+
+    expect(d.patchTask).not.toHaveBeenCalled();
+    expect(d.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the dragged id is not a known task", async () => {
+    const d = deps(undefined);
+
+    await applyStatusDrop("ghost", "done", d);
+
+    expect(d.patchTask).not.toHaveBeenCalled();
+    expect(d.updateStatus).not.toHaveBeenCalled();
+    expect(d.onError).not.toHaveBeenCalled();
+  });
+
+  it("rolls the card back to its whole prior snapshot when the mutation fails", async () => {
+    const before = task("t1", "in_review");
+    // rawStatus is set by the store on ingestion and must survive a rollback,
+    // which is why the snapshot goes back whole rather than status-only.
+    before.rawStatus = "REVIEW";
+    const d = deps(before, async () => {
+      throw new Error("boom");
+    });
+
+    await applyStatusDrop("t1", "done", d);
+
+    expect(d.patchTask).toHaveBeenNthCalledWith(1, "t1", { status: "done" });
+    expect(d.patchTask).toHaveBeenNthCalledWith(2, "t1", before);
+    expect(d.onError).toHaveBeenCalledWith("boom");
+  });
+
+  it("surfaces the approver-gate sentence rather than a bare failure", async () => {
+    // updateTaskStatusOrTranslateGate converts the backend's 409 +
+    // pending_approvers into this Error before it reaches the drop handler.
+    const gate = "Cannot mark done: awaiting approval from Ada, Grace";
+    const d = deps(task("t1", "in_review"), async () => {
+      throw new Error(gate);
+    });
+
+    await applyStatusDrop("t1", "done", d);
+
+    expect(d.onError).toHaveBeenCalledWith(gate);
+  });
+
+  it("still rolls back when the failure is not an Error", async () => {
+    const before = task("t1", "todo");
+    const d = deps(before, async () => {
+      throw "string rejection";
+    });
+
+    await applyStatusDrop("t1", "blocked", d);
+
+    expect(d.patchTask).toHaveBeenNthCalledWith(2, "t1", before);
+    expect(d.onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/office/tasks/use-board-drag.test.ts
+++ b/apps/web/app/office/tasks/use-board-drag.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { applyStatusDrop, type StatusDropDeps } from "./use-board-drag";
+import { ApprovalGateError } from "@/lib/api/domains/office-status-gate";
 import type { OfficeTask, OfficeTaskStatus } from "@/lib/state/slices/office/types";
 
 function task(id: string, status: OfficeTaskStatus): OfficeTask {
@@ -88,8 +89,8 @@ describe("applyStatusDrop", () => {
   });
 
   it("surfaces the approver-gate sentence rather than a bare failure", async () => {
-    // updateTaskStatusOrTranslateGate converts the backend's 409 +
-    // pending_approvers into this Error before it reaches the drop handler.
+    // A plain Error (anything that isn't the typed ApprovalGateError below)
+    // still rolls back to the snapshot and surfaces its message verbatim.
     const gate = "Cannot mark done: awaiting approval from Ada, Grace";
     const d = deps(task("t1", "in_review"), async () => {
       throw new Error(gate);
@@ -97,6 +98,29 @@ describe("applyStatusDrop", () => {
 
     await applyStatusDrop("t1", "done", d);
 
+    expect(d.onError).toHaveBeenCalledWith(gate);
+  });
+
+  it("settles on the redirected status instead of rolling back, when the approver gate redirects", async () => {
+    // The approver gate doesn't reject the move: the backend redirects it to
+    // in_review server-side, persists and broadcasts that, and only then
+    // returns 409 (updateTaskStatusOrTranslateGate throws ApprovalGateError
+    // for exactly this case). Rolling back to the pre-drop snapshot here
+    // would show a status the server no longer holds.
+    const before = task("t1", "todo");
+    const gate = "Cannot mark done: awaiting approval from Ada, Grace";
+    const d = deps(before, async () => {
+      throw new ApprovalGateError(gate, "in_review");
+    });
+
+    await applyStatusDrop("t1", "done", d);
+
+    expect(d.patchTask).toHaveBeenNthCalledWith(1, "t1", { status: "done" });
+    // Patched to the redirected status only, not the whole snapshot: a
+    // spread would reinstate the snapshot's stale rawStatus and the card
+    // would re-normalize back to the old column.
+    expect(d.patchTask).toHaveBeenNthCalledWith(2, "t1", { status: "in_review" });
+    expect(d.patchTask).toHaveBeenCalledTimes(2);
     expect(d.onError).toHaveBeenCalledWith(gate);
   });
 

--- a/apps/web/app/office/tasks/use-board-drag.ts
+++ b/apps/web/app/office/tasks/use-board-drag.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
-import { PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { MouseSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { useAppStoreApi } from "@/components/state-provider";
 import {
   ApprovalGateError,
@@ -76,9 +76,13 @@ export function useBoardDrag() {
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
 
   const sensors = useSensors(
-    // Distance activation is what keeps a plain click opening the task
-    // instead of starting a drag; the card's onClick still navigates.
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    // MouseSensor, not PointerSensor: the board is an overflow-x-auto row
+    // (see task-board.tsx) and PointerSensor also captures touch via
+    // pointer events, where its 8px distance activates before TouchSensor's
+    // delay and hijacks swipe-scroll. MouseSensor + TouchSensor keep the
+    // input streams separate so a quick touch swipe scrolls natively while
+    // a press-and-hold starts a drag. Same convention as sidebar-view-chips.tsx.
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
   );
 

--- a/apps/web/app/office/tasks/use-board-drag.ts
+++ b/apps/web/app/office/tasks/use-board-drag.ts
@@ -27,9 +27,10 @@ export type StatusDropDeps = {
  * Applies a card drop onto a status column: optimistic patch, the mutation,
  * then a rollback to the pre-drop snapshot if the backend refuses.
  *
- * The board is a projection of `office.tasks.items`, so patching the store IS
- * the visible move; there is no board-local ordering to keep in step. Rollback
- * restores the whole prior task rather than just its status, matching
+ * The regular board is a projection of `office.tasks.items`. During server
+ * search, the displayed task list is a separate result projection, so the
+ * caller also receives each patch to keep that view in step. Rollback restores
+ * the whole prior task rather than just its status, matching
  * useOptimisticTaskMutation, so a snapshot's `rawStatus` survives the trip.
  *
  * Drops are column-to-column only. Cards are not reordered within a column:
@@ -71,9 +72,27 @@ export async function applyStatusDrop(
  * Wires the office task board to dnd-kit. Droppable ids are status values and
  * draggable ids are task ids, so a drag end reads as (taskId -> status).
  */
-export function useBoardDrag() {
+export function useBoardDrag(
+  tasks: OfficeTask[] = [],
+  onTaskPatch?: (taskId: string, patch: Partial<OfficeTask>) => void,
+) {
   const storeApi = useAppStoreApi();
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+
+  const getTask = useCallback(
+    (taskId: string) =>
+      tasks.find((task) => task.id === taskId) ??
+      storeApi.getState().office.tasks.items.find((task) => task.id === taskId),
+    [storeApi, tasks],
+  );
+
+  const patchTask = useCallback(
+    (taskId: string, patch: Partial<OfficeTask>) => {
+      storeApi.getState().patchTaskInStore(taskId, patch);
+      onTaskPatch?.(taskId, patch);
+    },
+    [onTaskPatch, storeApi],
+  );
 
   const sensors = useSensors(
     // MouseSensor, not PointerSensor: the board is an overflow-x-auto row
@@ -98,13 +117,13 @@ export function useBoardDrag() {
       const { active, over } = event;
       if (!over) return;
       await applyStatusDrop(String(active.id), String(over.id) as OfficeTaskStatus, {
-        getTask: (id) => storeApi.getState().office.tasks.items.find((task) => task.id === id),
-        patchTask: (id, patch) => storeApi.getState().patchTaskInStore(id, patch),
+        getTask,
+        patchTask,
         updateStatus: (id, status) => updateTaskStatusOrTranslateGate(id, status),
         onError: (message) => toast.error(message),
       });
     },
-    [storeApi],
+    [getTask, patchTask],
   );
 
   return { activeTaskId, sensors, handleDragStart, handleDragEnd, handleDragCancel };

--- a/apps/web/app/office/tasks/use-board-drag.ts
+++ b/apps/web/app/office/tasks/use-board-drag.ts
@@ -4,7 +4,10 @@ import { useCallback, useState } from "react";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 import { PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { useAppStoreApi } from "@/components/state-provider";
-import { updateTaskStatusOrTranslateGate } from "@/lib/api/domains/office-status-gate";
+import {
+  ApprovalGateError,
+  updateTaskStatusOrTranslateGate,
+} from "@/lib/api/domains/office-status-gate";
 import { toast } from "@/lib/toast/sonner";
 import { t } from "@/lib/i18n";
 import type { OfficeTask, OfficeTaskStatus } from "@/lib/state/slices/office/types";
@@ -48,7 +51,16 @@ export async function applyStatusDrop(
   try {
     await deps.updateStatus(taskId, targetStatus);
   } catch (err) {
-    deps.patchTask(taskId, snapshot);
+    if (err instanceof ApprovalGateError) {
+      // The backend already redirected and persisted this status server-side
+      // before returning the error (see ApprovalGateError), so the board is
+      // wrong if it rolls back to the pre-drop snapshot here. Patch status
+      // only: spreading the snapshot would reinstate its stale rawStatus and
+      // the card would re-normalize back to the old column.
+      deps.patchTask(taskId, { status: err.redirectedStatus });
+    } else {
+      deps.patchTask(taskId, snapshot);
+    }
     // The approver gate arrives here already translated into a sentence
     // naming who still has to sign off.
     deps.onError(err instanceof Error ? err.message : t("task:failedToMoveTask"));

--- a/apps/web/app/office/tasks/use-board-drag.ts
+++ b/apps/web/app/office/tasks/use-board-drag.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import { PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { useAppStoreApi } from "@/components/state-provider";
+import { updateTaskStatusOrTranslateGate } from "@/lib/api/domains/office-status-gate";
+import { toast } from "@/lib/toast/sonner";
+import { t } from "@/lib/i18n";
+import type { OfficeTask, OfficeTaskStatus } from "@/lib/state/slices/office/types";
+
+/**
+ * Collaborators for `applyStatusDrop`, injected so the drop rules can be
+ * tested without a store, a network layer or a DOM.
+ */
+export type StatusDropDeps = {
+  getTask: (taskId: string) => OfficeTask | undefined;
+  patchTask: (taskId: string, patch: Partial<OfficeTask>) => void;
+  updateStatus: (taskId: string, status: OfficeTaskStatus) => Promise<void>;
+  onError: (message: string) => void;
+};
+
+/**
+ * Applies a card drop onto a status column: optimistic patch, the mutation,
+ * then a rollback to the pre-drop snapshot if the backend refuses.
+ *
+ * The board is a projection of `office.tasks.items`, so patching the store IS
+ * the visible move; there is no board-local ordering to keep in step. Rollback
+ * restores the whole prior task rather than just its status, matching
+ * useOptimisticTaskMutation, so a snapshot's `rawStatus` survives the trip.
+ *
+ * Drops are column-to-column only. Cards are not reordered within a column:
+ * no board in kandev does that, and an Office column is a page-limited window
+ * of a server-sorted query, so a manual index would not survive pagination.
+ */
+export async function applyStatusDrop(
+  taskId: string,
+  targetStatus: OfficeTaskStatus,
+  deps: StatusDropDeps,
+): Promise<void> {
+  const snapshot = deps.getTask(taskId);
+  if (!snapshot) return;
+  // A drop back onto the card's own column is a click that travelled a few
+  // pixels, not a move. Sending it would burn a PATCH and a WS round-trip.
+  if (snapshot.status === targetStatus) return;
+
+  deps.patchTask(taskId, { status: targetStatus });
+  try {
+    await deps.updateStatus(taskId, targetStatus);
+  } catch (err) {
+    deps.patchTask(taskId, snapshot);
+    // The approver gate arrives here already translated into a sentence
+    // naming who still has to sign off.
+    deps.onError(err instanceof Error ? err.message : t("task:failedToMoveTask"));
+  }
+}
+
+/**
+ * Wires the office task board to dnd-kit. Droppable ids are status values and
+ * draggable ids are task ids, so a drag end reads as (taskId -> status).
+ */
+export function useBoardDrag() {
+  const storeApi = useAppStoreApi();
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    // Distance activation is what keeps a plain click opening the task
+    // instead of starting a drag; the card's onClick still navigates.
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveTaskId(String(event.active.id));
+  }, []);
+
+  const handleDragCancel = useCallback(() => setActiveTaskId(null), []);
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setActiveTaskId(null);
+      const { active, over } = event;
+      if (!over) return;
+      await applyStatusDrop(String(active.id), String(over.id) as OfficeTaskStatus, {
+        getTask: (id) => storeApi.getState().office.tasks.items.find((task) => task.id === id),
+        patchTask: (id, patch) => storeApi.getState().patchTaskInStore(id, patch),
+        updateStatus: (id, status) => updateTaskStatusOrTranslateGate(id, status),
+        onError: (message) => toast.error(message),
+      });
+    },
+    [storeApi],
+  );
+
+  return { activeTaskId, sensors, handleDragStart, handleDragEnd, handleDragCancel };
+}

--- a/apps/web/app/office/tasks/use-server-search.test.ts
+++ b/apps/web/app/office/tasks/use-server-search.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { searchTasks } from "@/lib/api/domains/office-api";
+import type { OfficeTask } from "@/lib/state/slices/office/types";
+import { useServerSearch } from "./use-server-search";
+
+vi.mock("@/lib/api/domains/office-api", () => ({
+  searchTasks: vi.fn(),
+}));
+
+const mockSearchTasks = vi.mocked(searchTasks);
+
+const searchedTask: OfficeTask = {
+  id: "task-1",
+  workspaceId: "workspace-1",
+  identifier: "TASK-1",
+  title: "Searched task",
+  status: "todo",
+  priority: "none",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("useServerSearch", () => {
+  beforeEach(() => {
+    mockSearchTasks.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("patches the active result when a searched card changes status", async () => {
+    mockSearchTasks.mockResolvedValue({ tasks: [searchedTask] });
+    const { result } = renderHook(() => useServerSearch("workspace-1"));
+
+    await act(async () => {
+      result.current.triggerSearch("searched");
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    await waitFor(() => expect(result.current.searchResults).toEqual([searchedTask]));
+
+    act(() => result.current.patchSearchResult("task-1", { status: "in_progress" }));
+
+    expect(result.current.searchResults).toEqual([
+      expect.objectContaining({ id: "task-1", status: "in_progress" }),
+    ]);
+  });
+});

--- a/apps/web/app/office/tasks/use-server-search.ts
+++ b/apps/web/app/office/tasks/use-server-search.ts
@@ -13,6 +13,13 @@ export function useServerSearch(workspaceId: string | null) {
   const [results, setResults] = useState<OfficeTask[] | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const patchSearchResult = useCallback((taskId: string, patch: Partial<OfficeTask>) => {
+    setResults(
+      (current) =>
+        current?.map((task) => (task.id === taskId ? { ...task, ...patch } : task)) ?? current,
+    );
+  }, []);
+
   const search = useCallback(
     (query: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -38,5 +45,5 @@ export function useServerSearch(workspaceId: string | null) {
     };
   }, []);
 
-  return { searchResults: results, triggerSearch: search };
+  return { searchResults: results, triggerSearch: search, patchSearchResult };
 }

--- a/apps/web/components/task/simple/components/status-picker.test.tsx
+++ b/apps/web/components/task/simple/components/status-picker.test.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from "react";
 import { StateProvider } from "@/components/state-provider";
 import { TaskOptimisticContextProvider } from "@/hooks/use-optimistic-task-mutation";
 import { ApiError } from "@/lib/api/client";
-import { StatusPicker, formatPendingApproversMessage } from "./status-picker";
+import { StatusPicker } from "./status-picker";
+import { formatPendingApproversMessage } from "@/lib/api/domains/office-status-gate";
 import type { Task } from "@/app/office/tasks/[id]/types";
 
 const updateTaskMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));

--- a/apps/web/components/task/simple/components/status-picker.test.tsx
+++ b/apps/web/components/task/simple/components/status-picker.test.tsx
@@ -10,6 +10,7 @@ import type { Task } from "@/app/office/tasks/[id]/types";
 
 const updateTaskMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
 const toastErrorMock = vi.hoisted(() => vi.fn());
+const applyPatchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api/domains/office-extended-api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api/domains/office-extended-api")>(
@@ -38,6 +39,7 @@ afterEach(() => {
 });
 
 const TRIGGER_TEST_ID = "status-picker-trigger";
+const APPROVALS_PENDING_MESSAGE = "approvals pending";
 
 const task: Task = {
   id: "t-1",
@@ -61,7 +63,7 @@ const task: Task = {
 function Wrapper({ children }: { children: ReactNode }) {
   const ctx = {
     task,
-    applyPatch: vi.fn(),
+    applyPatch: applyPatchMock,
     restore: vi.fn(),
   };
   return (
@@ -113,8 +115,8 @@ describe("StatusPicker", () => {
 
   it("toasts the formatted approvers message on a 409 gate response", async () => {
     updateTaskMock.mockRejectedValueOnce(
-      new ApiError("approvals pending", 409, {
-        error: "approvals pending",
+      new ApiError(APPROVALS_PENDING_MESSAGE, 409, {
+        error: APPROVALS_PENDING_MESSAGE,
         pending_approvers: [
           { agent_profile_id: "a1", name: "CEO" },
           { agent_profile_id: "a2", name: "Eng Lead" },
@@ -135,6 +137,31 @@ describe("StatusPicker", () => {
     expect(toastErrorMock).toHaveBeenCalledWith(
       "Cannot mark done: awaiting approval from CEO, Eng Lead",
     );
+  });
+
+  it("settles on the redirected status instead of the pre-drag snapshot", async () => {
+    updateTaskMock.mockRejectedValueOnce(
+      new ApiError(APPROVALS_PENDING_MESSAGE, 409, {
+        error: APPROVALS_PENDING_MESSAGE,
+        pending_approvers: [{ agent_profile_id: "a1", name: "CEO" }],
+        status: "in_review",
+      }),
+    );
+    render(
+      <Wrapper>
+        <StatusPicker task={task} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId(TRIGGER_TEST_ID));
+    const option = await screen.findByTestId("status-picker-option-done");
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    // The hook's own rollback restores "todo" first; the picker's catch
+    // must then re-apply the server's redirected status on top of it, so
+    // the final patch is the redirect, not the rollback.
+    expect(applyPatchMock).toHaveBeenLastCalledWith({ status: "in_review" });
   });
 });
 

--- a/apps/web/components/task/simple/components/status-picker.tsx
+++ b/apps/web/components/task/simple/components/status-picker.tsx
@@ -5,7 +5,10 @@ import { IconChevronDown } from "@tabler/icons-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
 import { cn } from "@/lib/utils";
 import { useOptimisticTaskMutation } from "@/hooks/use-optimistic-task-mutation";
-import { updateTaskStatusOrTranslateGate } from "@/lib/api/domains/office-status-gate";
+import {
+  ApprovalGateError,
+  updateTaskStatusOrTranslateGate,
+} from "@/lib/api/domains/office-status-gate";
 import type { Task, TaskStatus } from "@/app/office/tasks/[id]/types";
 import { StatusIcon } from "@/app/office/tasks/[id]/status-icon";
 import { normalizeTaskStatus } from "@/lib/api/domains/office-task-normalize";
@@ -54,7 +57,18 @@ export function StatusPicker({ task }: StatusPickerProps) {
       await mutate(task.id, { status: value }, () =>
         updateTaskStatusOrTranslateGate(task.id, value),
       );
-    } catch {
+    } catch (err) {
+      // The hook already rolled back to the pre-mutation snapshot. The
+      // backend redirected and persisted this status server-side before
+      // returning the error (see ApprovalGateError), so a plain rollback
+      // shows a status the server no longer holds until the WS event
+      // reconciles it. Re-apply the redirected status now via a no-op
+      // mutation, matching use-board-drag.ts's board-drag path.
+      if (err instanceof ApprovalGateError) {
+        await mutate(task.id, { status: err.redirectedStatus as TaskStatus }, () =>
+          Promise.resolve(),
+        );
+      }
       /* toast already raised by hook */
     }
   };

--- a/apps/web/components/task/simple/components/status-picker.tsx
+++ b/apps/web/components/task/simple/components/status-picker.tsx
@@ -5,47 +5,11 @@ import { IconChevronDown } from "@tabler/icons-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
 import { cn } from "@/lib/utils";
 import { useOptimisticTaskMutation } from "@/hooks/use-optimistic-task-mutation";
-import { ApiError } from "@/lib/api/client";
-import { updateTask } from "@/lib/api/domains/office-extended-api";
+import { updateTaskStatusOrTranslateGate } from "@/lib/api/domains/office-status-gate";
 import type { Task, TaskStatus } from "@/app/office/tasks/[id]/types";
 import { StatusIcon } from "@/app/office/tasks/[id]/status-icon";
 import { normalizeTaskStatus } from "@/lib/api/domains/office-task-normalize";
 import { useTranslation } from "react-i18next";
-import { t } from "@/lib/i18n";
-
-type PendingApprover = { agent_profile_id?: string; name?: string };
-
-// formatPendingApproversMessage builds the toast text the user sees when
-// the backend rejects an in_review → done transition because not every
-// approver has signed off. The backend echoes a `pending_approvers`
-// array on the 409 body; we render the names in order.
-export function formatPendingApproversMessage(pending: PendingApprover[]): string {
-  const names = pending.map((p) => p.name?.trim() || p.agent_profile_id || "").filter(Boolean);
-  if (names.length === 0) return t("task:cannotMarkDoneAwaitingApprovals");
-  return t("task:cannotMarkDoneAwaitingApprovalFrom", { names: names.join(", ") });
-}
-
-function extractPendingApprovers(err: unknown): PendingApprover[] | null {
-  if (!(err instanceof ApiError)) return null;
-  if (err.status !== 409) return null;
-  const body = err.body;
-  if (!body || typeof body !== "object") return null;
-  const pending = (body as { pending_approvers?: unknown }).pending_approvers;
-  if (!Array.isArray(pending)) return null;
-  return pending.filter((p): p is PendingApprover => !!p && typeof p === "object");
-}
-
-async function updateStatusOrTranslateGate(taskId: string, status: TaskStatus): Promise<void> {
-  try {
-    await updateTask(taskId, { status });
-  } catch (err) {
-    const pending = extractPendingApprovers(err);
-    if (pending) {
-      throw new Error(formatPendingApproversMessage(pending));
-    }
-    throw err;
-  }
-}
 
 // `labelKey` holds a catalog key, not copy: this table is module scope, so a
 // resolved `t()` here would freeze at the boot locale.
@@ -87,7 +51,9 @@ export function StatusPicker({ task }: StatusPickerProps) {
     setOpen(false);
     if (value === current) return;
     try {
-      await mutate(task.id, { status: value }, () => updateStatusOrTranslateGate(task.id, value));
+      await mutate(task.id, { status: value }, () =>
+        updateTaskStatusOrTranslateGate(task.id, value),
+      );
     } catch {
       /* toast already raised by hook */
     }

--- a/apps/web/e2e/tests/office/tasks.spec.ts
+++ b/apps/web/e2e/tests/office/tasks.spec.ts
@@ -145,4 +145,53 @@ test.describe("Tasks (Issues)", () => {
     expect(Array.isArray(tasks)).toBe(true);
     expect(tasks.length).toBe(0);
   });
+
+  test("dragging a card to another column changes the task status", async ({
+    testPage,
+    apiClient,
+    officeApi,
+    officeSeed,
+  }) => {
+    const task = await apiClient.createTask(officeSeed.workspaceId, "Board Drag Task", {
+      workflow_id: officeSeed.workflowId,
+    });
+
+    await testPage.goto("/office/tasks");
+    await testPage.getByTestId("task-view-board").click();
+
+    const card = testPage.getByTestId(`board-card-${task.id}`);
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    const target = testPage.getByTestId("board-column-in_progress");
+    await expect(target).toBeVisible();
+    // The drop must actually move the card, so it cannot already live there.
+    await expect(target.getByTestId(`board-card-${task.id}`)).toHaveCount(0);
+
+    const from = await card.boundingBox();
+    const to = await target.boundingBox();
+    expect(from).not.toBeNull();
+    expect(to).not.toBeNull();
+
+    // dnd-kit's PointerSensor needs a real pointer path, not a single jump:
+    // the 8px activation distance only trips on intermediate moves.
+    await testPage.mouse.move(from!.x + from!.width / 2, from!.y + from!.height / 2);
+    await testPage.mouse.down();
+    await testPage.mouse.move(to!.x + to!.width / 2, to!.y + to!.height / 2, { steps: 12 });
+    await testPage.mouse.up();
+
+    // The card lands in the target column...
+    await expect(target.getByTestId(`board-card-${task.id}`)).toBeVisible({ timeout: 15_000 });
+
+    // ...and the move is persisted, not just an optimistic store patch.
+    await expect
+      .poll(
+        async () => {
+          const persisted = (await officeApi.getTask(task.id)) as Record<string, unknown>;
+          const inner = (persisted.task as Record<string, unknown>) ?? persisted;
+          return ((inner.status as string) ?? (inner.state as string) ?? "").toLowerCase();
+        },
+        { timeout: 15_000 },
+      )
+      .toContain("progress");
+  });
 });

--- a/apps/web/e2e/tests/office/tasks.spec.ts
+++ b/apps/web/e2e/tests/office/tasks.spec.ts
@@ -217,4 +217,68 @@ test.describe("Tasks (Issues)", () => {
       )
       .toContain("progress");
   });
+
+  test("dragging a searched card updates the visible search result", async ({
+    testPage,
+    apiClient,
+    officeApi,
+    officeSeed,
+  }) => {
+    for (let i = 0; i < 6; i++) {
+      await apiClient.createTask(officeSeed.workspaceId, `Searched Board Filler ${i}`, {
+        workflow_id: officeSeed.workflowId,
+      });
+    }
+    const task = await apiClient.createTask(officeSeed.workspaceId, "Searched Board Drag Task", {
+      workflow_id: officeSeed.workflowId,
+    });
+
+    await testPage.goto("/office/tasks");
+    await testPage.getByTestId("task-view-board").click();
+
+    const searchInput = testPage.getByPlaceholder(/search tasks/i);
+    const searchResponse = testPage.waitForResponse(
+      (response) =>
+        response.url().includes("/tasks/search?") &&
+        response.request().method() === "GET" &&
+        response.ok(),
+    );
+    await searchInput.fill("Searched Board");
+    await searchResponse;
+
+    const card = testPage.getByTestId(`board-card-${task.id}`);
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    const tallColumn = testPage.getByTestId("board-column-todo");
+    const target = testPage.getByTestId("board-column-in_progress");
+    await expect(target.getByTestId(`board-card-${task.id}`)).toHaveCount(0);
+
+    const from = await card.boundingBox();
+    const tallBox = await tallColumn.boundingBox();
+    const targetBox = await target.boundingBox();
+    expect(from).not.toBeNull();
+    expect(tallBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    await testPage.mouse.move(from!.x + from!.width / 2, from!.y + from!.height / 2);
+    await testPage.mouse.down();
+    await testPage.mouse.move(
+      targetBox!.x + targetBox!.width / 2,
+      tallBox!.y + tallBox!.height - 10,
+      { steps: 12 },
+    );
+    await testPage.mouse.up();
+
+    await expect
+      .poll(
+        async () => {
+          const persisted = (await officeApi.getTask(task.id)) as Record<string, unknown>;
+          const inner = (persisted.task as Record<string, unknown>) ?? persisted;
+          return ((inner.status as string) ?? (inner.state as string) ?? "").toLowerCase();
+        },
+        { timeout: 15_000 },
+      )
+      .toContain("progress");
+    await expect(target.getByTestId(`board-card-${task.id}`)).toBeVisible({ timeout: 15_000 });
+  });
 });

--- a/apps/web/e2e/tests/office/tasks.spec.ts
+++ b/apps/web/e2e/tests/office/tasks.spec.ts
@@ -152,6 +152,19 @@ test.describe("Tasks (Issues)", () => {
     officeApi,
     officeSeed,
   }) => {
+    // Fillers pile up in todo (the CREATED wire state normalizes there - see
+    // office-task-normalize.ts's STATUS_MAP - and it's where a task created
+    // with no workflow_step_id lands) so that column is visibly taller than
+    // the empty in_progress column. Flex row stretch then makes in_progress
+    // span the same height on screen, but its droppable was previously sized
+    // to its own (empty) content - about one min-h box. Dropping in the
+    // resulting blank space, not at the column's own reported center, is
+    // what actually exercises that gap.
+    for (let i = 0; i < 6; i++) {
+      await apiClient.createTask(officeSeed.workspaceId, `Filler ${i}`, {
+        workflow_id: officeSeed.workflowId,
+      });
+    }
     const task = await apiClient.createTask(officeSeed.workspaceId, "Board Drag Task", {
       workflow_id: officeSeed.workflowId,
     });
@@ -162,21 +175,31 @@ test.describe("Tasks (Issues)", () => {
     const card = testPage.getByTestId(`board-card-${task.id}`);
     await expect(card).toBeVisible({ timeout: 15_000 });
 
+    const tallColumn = testPage.getByTestId("board-column-todo");
     const target = testPage.getByTestId("board-column-in_progress");
     await expect(target).toBeVisible();
     // The drop must actually move the card, so it cannot already live there.
     await expect(target.getByTestId(`board-card-${task.id}`)).toHaveCount(0);
 
     const from = await card.boundingBox();
-    const to = await target.boundingBox();
+    const tallBox = await tallColumn.boundingBox();
+    const targetBox = await target.boundingBox();
     expect(from).not.toBeNull();
-    expect(to).not.toBeNull();
+    expect(tallBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+
+    // The drop point's Y comes from the tall todo column's real height, not
+    // from the target column's own reported box - so a target droppable
+    // that under-reports its own height (the exact shape of the bug this
+    // reproduces) cannot make the test pass by construction.
+    const dropX = targetBox!.x + targetBox!.width / 2;
+    const dropY = tallBox!.y + tallBox!.height - 10;
 
     // dnd-kit's PointerSensor needs a real pointer path, not a single jump:
     // the 8px activation distance only trips on intermediate moves.
     await testPage.mouse.move(from!.x + from!.width / 2, from!.y + from!.height / 2);
     await testPage.mouse.down();
-    await testPage.mouse.move(to!.x + to!.width / 2, to!.y + to!.height / 2, { steps: 12 });
+    await testPage.mouse.move(dropX, dropY, { steps: 12 });
     await testPage.mouse.up();
 
     // The card lands in the target column...

--- a/apps/web/lib/api/domains/office-status-gate.test.ts
+++ b/apps/web/lib/api/domains/office-status-gate.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../client";
+
+const updateTaskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./office-extended-api", async () => {
+  const actual =
+    await vi.importActual<typeof import("./office-extended-api")>("./office-extended-api");
+  return {
+    ...actual,
+    updateTask: updateTaskMock,
+  };
+});
+
+import { updateTask } from "./office-extended-api";
+import { ApprovalGateError, updateTaskStatusOrTranslateGate } from "./office-status-gate";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const APPROVALS_PENDING_MESSAGE = "approvals pending";
+
+describe("updateTaskStatusOrTranslateGate", () => {
+  it("rethrows a non-gate error unchanged", async () => {
+    const notFound = new ApiError("not found", 404, { error: "not found" });
+    updateTaskMock.mockRejectedValueOnce(notFound);
+
+    await expect(updateTaskStatusOrTranslateGate("t-1", "done")).rejects.toBe(notFound);
+    expect(updateTask).toHaveBeenCalledWith("t-1", { status: "done" });
+  });
+
+  it("rethrows a 409 with no pending_approvers unchanged", async () => {
+    const conflict = new ApiError("conflict", 409, { error: "conflict" });
+    updateTaskMock.mockRejectedValueOnce(conflict);
+
+    await expect(updateTaskStatusOrTranslateGate("t-1", "done")).rejects.toBe(conflict);
+  });
+
+  it("defaults the redirected status to in_review when the gate body carries none", async () => {
+    updateTaskMock.mockRejectedValueOnce(
+      new ApiError(APPROVALS_PENDING_MESSAGE, 409, {
+        error: APPROVALS_PENDING_MESSAGE,
+        pending_approvers: [{ agent_profile_id: "a1", name: "CEO" }],
+      }),
+    );
+
+    const err = await updateTaskStatusOrTranslateGate("t-1", "done").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApprovalGateError);
+    expect((err as ApprovalGateError).redirectedStatus).toBe("in_review");
+    expect((err as ApprovalGateError).message).toBe("Cannot mark done: awaiting approval from CEO");
+  });
+
+  it("carries the gate body's redirected status through unchanged", async () => {
+    updateTaskMock.mockRejectedValueOnce(
+      new ApiError(APPROVALS_PENDING_MESSAGE, 409, {
+        error: APPROVALS_PENDING_MESSAGE,
+        pending_approvers: [{ agent_profile_id: "a1", name: "CEO" }],
+        status: "blocked",
+      }),
+    );
+
+    const err = await updateTaskStatusOrTranslateGate("t-1", "done").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApprovalGateError);
+    expect((err as ApprovalGateError).redirectedStatus).toBe("blocked");
+  });
+});

--- a/apps/web/lib/api/domains/office-status-gate.ts
+++ b/apps/web/lib/api/domains/office-status-gate.ts
@@ -33,8 +33,36 @@ export function extractPendingApprovers(err: unknown): PendingApprover[] | null 
   return pending.filter((p): p is PendingApprover => !!p && typeof p === "object");
 }
 
-// Sets a task's status, re-throwing the approver gate as a readable Error so
-// every caller surfaces the same sentence.
+function extractRedirectedStatus(err: unknown): (OfficeTaskStatus | TaskStatus) | null {
+  if (!(err instanceof ApiError)) return null;
+  const body = err.body;
+  if (!body || typeof body !== "object") return null;
+  const status = (body as { status?: unknown }).status;
+  return typeof status === "string" && status.length > 0
+    ? (status as OfficeTaskStatus | TaskStatus)
+    : null;
+}
+
+// Thrown instead of a plain Error when the approver gate fires. The backend
+// does not reject a gated "done" move: it redirects the task to in_review,
+// persists and broadcasts that, and only then returns 409 (see
+// respondStatusUpdateError in the backend handler). A caller that rolls back
+// to its pre-mutation snapshot on any thrown error would show a status the
+// server no longer holds, so this carries the server's actual redirected
+// status through instead of discarding it.
+export class ApprovalGateError extends Error {
+  readonly redirectedStatus: OfficeTaskStatus | TaskStatus;
+
+  constructor(message: string, redirectedStatus: OfficeTaskStatus | TaskStatus) {
+    super(message);
+    this.name = "ApprovalGateError";
+    this.redirectedStatus = redirectedStatus;
+  }
+}
+
+// Sets a task's status, re-throwing the approver gate as an ApprovalGateError
+// so every caller surfaces the same sentence and can settle on the status the
+// server actually redirected to instead of blindly rolling back.
 export async function updateTaskStatusOrTranslateGate(
   taskId: string,
   status: OfficeTaskStatus | TaskStatus,
@@ -44,7 +72,11 @@ export async function updateTaskStatusOrTranslateGate(
   } catch (err) {
     const pending = extractPendingApprovers(err);
     if (pending) {
-      throw new Error(formatPendingApproversMessage(pending));
+      // The gate always redirects to in_review today (see applyApprovalGate
+      // in the backend); reading it from the response body rather than
+      // hardcoding it here keeps this in sync if the backend ever changes.
+      const redirectedStatus = extractRedirectedStatus(err) ?? "in_review";
+      throw new ApprovalGateError(formatPendingApproversMessage(pending), redirectedStatus);
     }
     throw err;
   }

--- a/apps/web/lib/api/domains/office-status-gate.ts
+++ b/apps/web/lib/api/domains/office-status-gate.ts
@@ -1,0 +1,49 @@
+// Shared status mutation for office tasks, plus the translation of the one
+// gate it can trip.
+//
+// The backend refuses an `in_review -> done` transition with 409 and a
+// `pending_approvers` body whenever a reviewer has not signed off. A caller
+// that does not translate that shows a bare "Update failed" and the user has
+// no idea who they are waiting on. This lived inside status-picker.tsx while
+// the picker was the only way to change a status; the task board's drag
+// handler is the second, so it moved here rather than being copied.
+import { ApiError } from "../client";
+import { updateTask } from "./office-extended-api";
+import { t } from "@/lib/i18n";
+
+export type PendingApprover = { agent_profile_id?: string; name?: string };
+
+// Builds the message the user sees when the approver gate rejects the move.
+// Names render in the order the backend echoed them.
+export function formatPendingApproversMessage(pending: PendingApprover[]): string {
+  const names = pending.map((p) => p.name?.trim() || p.agent_profile_id || "").filter(Boolean);
+  if (names.length === 0) return t("task:cannotMarkDoneAwaitingApprovals");
+  return t("task:cannotMarkDoneAwaitingApprovalFrom", { names: names.join(", ") });
+}
+
+export function extractPendingApprovers(err: unknown): PendingApprover[] | null {
+  if (!(err instanceof ApiError)) return null;
+  if (err.status !== 409) return null;
+  const body = err.body;
+  if (!body || typeof body !== "object") return null;
+  const pending = (body as { pending_approvers?: unknown }).pending_approvers;
+  if (!Array.isArray(pending)) return null;
+  return pending.filter((p): p is PendingApprover => !!p && typeof p === "object");
+}
+
+// Sets a task's status, re-throwing the approver gate as a readable Error so
+// every caller surfaces the same sentence.
+export async function updateTaskStatusOrTranslateGate(
+  taskId: string,
+  status: string,
+): Promise<void> {
+  try {
+    await updateTask(taskId, { status });
+  } catch (err) {
+    const pending = extractPendingApprovers(err);
+    if (pending) {
+      throw new Error(formatPendingApproversMessage(pending));
+    }
+    throw err;
+  }
+}

--- a/apps/web/lib/api/domains/office-status-gate.ts
+++ b/apps/web/lib/api/domains/office-status-gate.ts
@@ -10,6 +10,8 @@
 import { ApiError } from "../client";
 import { updateTask } from "./office-extended-api";
 import { t } from "@/lib/i18n";
+import type { OfficeTaskStatus } from "@/lib/state/slices/office/types";
+import type { TaskStatus } from "@/app/office/tasks/[id]/types";
 
 export type PendingApprover = { agent_profile_id?: string; name?: string };
 
@@ -35,7 +37,7 @@ export function extractPendingApprovers(err: unknown): PendingApprover[] | null 
 // every caller surfaces the same sentence.
 export async function updateTaskStatusOrTranslateGate(
   taskId: string,
-  status: string,
+  status: OfficeTaskStatus | TaskStatus,
 ): Promise<void> {
   try {
     await updateTask(taskId, { status });


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3014/ae2a0ce99855.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** Dragging a task card on the office kanban board and dropping it onto another status column does nothing reliable — the droppable area only covered a column's inner scroll content box, not the column itself, so most of the visible column was dead for drops.

**After this:** A card can be dragged and dropped onto any column to change its status; a drop that trips the approver gate settles the card on the status the server actually redirected it to, instead of silently rolling back to the old column.

**Who hits this:** Anyone using the office kanban board to move tasks between statuses by drag, instead of the status picker.

**Scope:** `apps/web/app/office/tasks/*` board drag wiring (`task-board.tsx`, new `use-board-drag.ts`), the shared `office-status-gate.ts` helper (now used by both the board and the status picker), and the office board drag-and-drop e2e test.

**Not here:** The approval-gate backend logic itself, the simple status picker's behavior beyond reusing the shared helper, and the store-wide optimistic-mutation rollback race that predates this change (filed separately as a follow-up).

Drag-and-drop status changes on the office kanban board silently failed on most of a column's area, and an approver-gated drop rolled the card back to the wrong status; both are fixed by widening the droppable target and settling on the server's redirected status.

## Important Changes

- Hoisted the column's droppable ref from the inner Radix `ScrollArea` content box to the outer flex-stretched column root, so the whole visible column area accepts drops.
- Extracted a shared `updateTaskStatusOrTranslateGate` / `ApprovalGateError` helper (`lib/api/domains/office-status-gate.ts`) used by both the board drag handler and the status picker, so an approver-gated status change surfaces the same message and settles on the server's redirected status everywhere instead of rolling back to a stale one.
- Added `use-board-drag.ts`, isolating the drop-handling logic (`applyStatusDrop`) behind injectable dependencies so it is unit-testable without a store, network layer, or DOM.

## Validation

- `make fmt`
- `make typecheck`
- `make test` — backend + web unit suites pass; 3 pre-existing failures in `internal/system/storage/workspaces` (dependency-cleanup tests), unrelated to this diff (package last touched in #2432, months before this branch existed) and caused by the macOS `/var` → `/private/var` symlink mismatch in Go's `os.TempDir()`, not by this change.
- `make lint`
- `make lint-format`
- `pnpm run i18n:ratchet` and `pnpm run i18n:check` (apps/web)
- `pnpm --dir apps/web exec vitest run app/office lib/api components/task` — including the 8 new `use-board-drag.test.ts` cases (drag-to-status happy path, no-op same-column drop, rollback on plain error, settle-on-redirected-status on an approver-gate redirect)
- `pnpm e2e:run e2e/tests/office/tasks.spec.ts` — 26 passed, covering drag-and-drop across columns and the approver-gate redirect case
- `make test-e2e` — full 5-project run (routing/auth/chromium/mobile-chrome/containers); running at PR creation time, no failures observed in files touched by this diff so far (`containers` is expected to skip/fail: no Docker daemon on this host, documented pre-existing environment limitation)

## Possible Improvements

Low risk: the change is scoped to the office task board's drag wiring and a shared status-update helper already exercised by the existing status picker; no backend or schema changes.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- kandev-screenshots-start -->
## Screenshots

![Dragging a card onto another column moves it there](https://raw.githubusercontent.com/nova28/kandev/6e6913bbca0525e500db645221c077cc15f37be3/board-drag-drop.png)

![The board's status columns on a mobile viewport](https://raw.githubusercontent.com/nova28/kandev/6e6913bbca0525e500db645221c077cc15f37be3/board-mobile-layout.png)
<!-- kandev-screenshots-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->