### PR TITLE
fix(task): preserve feeder promotion session routing (#3016)

### DIFF
--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -733,9 +733,16 @@ func (s *Service) promoteNextQueuedTask(ctx context.Context, targetStep *wfmodel
 	}
 	fromStepID := candidate.WorkflowStepID
 	oldWorkflowID := candidate.WorkflowID
-	if fromStepID != targetStep.ID && s.feederCandidateBlocked(ctx, candidate.ID) {
-		skipped[candidate.ID] = struct{}{}
-		return s.promoteNextQueuedTask(ctx, targetStep, position, skipped)
+	promotionSessionID := ""
+	if fromStepID != targetStep.ID {
+		promotionSession, blocked := s.feederCandidateSession(ctx, candidate.ID)
+		if blocked {
+			skipped[candidate.ID] = struct{}{}
+			return s.promoteNextQueuedTask(ctx, targetStep, position, skipped)
+		}
+		if promotionSession != nil {
+			promotionSessionID = promotionSession.ID
+		}
 	}
 	if moveLifecyclePending(candidate) {
 		skipped[candidate.ID] = struct{}{}
@@ -744,7 +751,7 @@ func (s *Service) promoteNextQueuedTask(ctx context.Context, targetStep *wfmodel
 	if candidate.WorkflowStepID == targetStep.ID {
 		return s.promoteSameStepQueuedTask(ctx, candidate, fromStepID, targetStep, position, skipped)
 	}
-	return s.promoteFeederQueuedTask(ctx, candidate, fromStepID, oldWorkflowID, targetStep, position, skipped)
+	return s.promoteFeederQueuedTask(ctx, candidate, fromStepID, oldWorkflowID, targetStep, position, skipped, promotionSessionID)
 }
 
 func queuedMoveExitPending(task *models.Task) bool {
@@ -840,7 +847,7 @@ func promoteQueuedTaskAtomically(ctx context.Context, tasks interface{}, task *m
 	return true, claimed, err
 }
 
-func (s *Service) promoteFeederQueuedTask(ctx context.Context, candidate *models.Task, fromStepID, oldWorkflowID string, targetStep *wfmodels.WorkflowStep, position int, skipped map[string]struct{}) bool {
+func (s *Service) promoteFeederQueuedTask(ctx context.Context, candidate *models.Task, fromStepID, oldWorkflowID string, targetStep *wfmodels.WorkflowStep, position int, skipped map[string]struct{}, sessionID string) bool {
 	oldState := candidate.State
 	if candidate.Metadata == nil {
 		candidate.Metadata = make(map[string]interface{})
@@ -872,7 +879,7 @@ func (s *Service) promoteFeederQueuedTask(ctx context.Context, candidate *models
 			s.publishTaskEvent(ctx, events.TaskStateChanged, candidate, &oldState)
 		}
 		s.recordQueuedPromotion(ctx, candidate.ID, fromStepID, targetStep.ID)
-		s.publishTaskMovedEvent(ctx, candidate, oldWorkflowID, fromStepID, targetStep.ID, "")
+		s.publishTaskMovedEvent(ctx, candidate, oldWorkflowID, fromStepID, targetStep.ID, sessionID)
 		return true
 	} else if admissionRepo, ok := s.tasks.(workflowMoveAdmissionRepository); ok {
 		claimed, err := admissionRepo.UpdateTaskWithWorkflowStepAdmission(ctx, candidate, targetStep.ID, targetStep.WIPLimit)
@@ -890,7 +897,7 @@ func (s *Service) promoteFeederQueuedTask(ctx context.Context, candidate *models
 			s.publishTaskEvent(ctx, events.TaskStateChanged, candidate, &oldState)
 		}
 		s.recordQueuedPromotion(ctx, candidate.ID, fromStepID, targetStep.ID)
-		s.publishTaskMovedEvent(ctx, candidate, oldWorkflowID, fromStepID, targetStep.ID, "")
+		s.publishTaskMovedEvent(ctx, candidate, oldWorkflowID, fromStepID, targetStep.ID, sessionID)
 		return true
 	}
 	// ctx here still carries the identity of whoever triggered the move that
@@ -931,18 +938,31 @@ func (s *Service) recordQueuedPromotion(ctx context.Context, taskID, fromStepID,
 	}
 }
 
-func (s *Service) feederCandidateBlocked(ctx context.Context, taskID string) bool {
+func (s *Service) feederCandidateSession(ctx context.Context, taskID string) (*models.TaskSession, bool) {
 	sessions, err := s.sessions.ListTaskSessions(ctx, taskID)
 	if err != nil {
 		s.logger.Warn("skipping feeder task after active session lookup failed", zap.String("task_id", taskID), zap.Error(err))
-		return true
+		return nil, true
 	}
+	var fallback *models.TaskSession
 	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
 		if isSessionMoveBlocked(session.State) {
-			return true
+			return nil, true
+		}
+		if !isSessionActive(session.State) {
+			continue
+		}
+		if session.IsPrimary {
+			return session, false
+		}
+		if fallback == nil {
+			fallback = session
 		}
 	}
-	return false
+	return fallback, false
 }
 
 func (s *Service) nextQueuedCandidate(ctx context.Context, targetStep *wfmodels.WorkflowStep, skipped map[string]struct{}) (*models.Task, error) {

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -944,7 +944,7 @@ func (s *Service) feederCandidateSession(ctx context.Context, taskID string) (*m
 		s.logger.Warn("skipping feeder task after active session lookup failed", zap.String("task_id", taskID), zap.Error(err))
 		return nil, true
 	}
-	var fallback *models.TaskSession
+	var primary, fallback *models.TaskSession
 	for _, session := range sessions {
 		if session == nil {
 			continue
@@ -955,12 +955,15 @@ func (s *Service) feederCandidateSession(ctx context.Context, taskID string) (*m
 		if !isSessionActive(session.State) {
 			continue
 		}
-		if session.IsPrimary {
-			return session, false
+		if session.IsPrimary && primary == nil {
+			primary = session
 		}
-		if fallback == nil {
+		if !session.IsPrimary && fallback == nil {
 			fallback = session
 		}
+	}
+	if primary != nil {
+		return primary, false
 	}
 	return fallback, false
 }

--- a/apps/backend/internal/task/service/service_workflow_feeder_session_test.go
+++ b/apps/backend/internal/task/service/service_workflow_feeder_session_test.go
@@ -76,6 +76,73 @@ func TestService_FeederPromotionSkipsCandidateWhenSessionLookupFails(t *testing.
 	}
 }
 
+// @covers AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+func TestService_FeederPromotionBlocksOnOlderRunningSession(t *testing.T) {
+	svc, eventBus, repo := setupFeederPromotionSessionTest(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-primary", TaskID: "task-promoted", State: models.TaskSessionStateWaitingForInput,
+		StartedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute), IsPrimary: true,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(session-primary): %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-running", TaskID: "task-promoted", State: models.TaskSessionStateRunning,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(session-running): %v", err)
+	}
+	eventBus.ClearEvents()
+
+	if _, err := svc.MoveTask(ctx, "task-vacating", "wf-target", "step-target", 0); err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	promoted, err := repo.GetTask(ctx, "task-promoted")
+	if err != nil {
+		t.Fatalf("GetTask(task-promoted): %v", err)
+	}
+	if promoted.WorkflowStepID != "step-feeder" {
+		t.Fatalf("promoted task step = %q, want step-feeder", promoted.WorkflowStepID)
+	}
+}
+
+// @covers AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+func TestService_FeederPromotionUsesNewestActiveFallback(t *testing.T) {
+	svc, eventBus, repo := setupFeederPromotionSessionTest(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, session := range []*models.TaskSession{
+		{ID: "session-older", TaskID: "task-promoted", State: models.TaskSessionStateWaitingForInput, StartedAt: now, UpdatedAt: now},
+		{ID: "session-newer", TaskID: "task-promoted", State: models.TaskSessionStateWaitingForInput, StartedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute)},
+	} {
+		if err := repo.CreateTaskSession(ctx, session); err != nil {
+			t.Fatalf("CreateTaskSession(%s): %v", session.ID, err)
+		}
+	}
+	eventBus.ClearEvents()
+
+	if _, err := svc.MoveTask(ctx, "task-vacating", "wf-target", "step-target", 0); err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	for _, event := range eventBus.GetPublishedEvents() {
+		if event.Type != events.TaskMoved {
+			continue
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok || data["task_id"] != "task-promoted" {
+			continue
+		}
+		if got := data["session_id"]; got != "session-newer" {
+			t.Fatalf("promoted task session_id = %q, want session-newer", got)
+		}
+		return
+	}
+	t.Fatal("promoted task.moved event not published")
+}
+
 func setupFeederPromotionSessionTest(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repository) {
 	t.Helper()
 	svc, eventBus, repo := createTestService(t)

--- a/apps/backend/internal/task/service/service_workflow_feeder_session_test.go
+++ b/apps/backend/internal/task/service/service_workflow_feeder_session_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+// @covers AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+func TestService_FeederPromotionCarriesPrimarySession(t *testing.T) {
+	svc, eventBus, repo := setupFeederPromotionSessionTest(t)
+	ctx := context.Background()
+	createMoveSession(t, ctx, repo, "session-primary", "task-promoted", models.TaskSessionStateWaitingForInput, models.ReviewStatusNone)
+	newer := time.Now().UTC().Add(time.Minute)
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-newer", TaskID: "task-promoted", State: models.TaskSessionStateWaitingForInput,
+		StartedAt: newer, UpdatedAt: newer,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(session-newer): %v", err)
+	}
+	eventBus.ClearEvents()
+
+	if _, err := svc.MoveTask(ctx, "task-vacating", "wf-target", "step-target", 0); err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	for _, event := range eventBus.GetPublishedEvents() {
+		if event.Type != events.TaskMoved {
+			continue
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok || data["task_id"] != "task-promoted" {
+			continue
+		}
+		if got := data["session_id"]; got != "session-primary" {
+			t.Fatalf("promoted task session_id = %q, want session-primary", got)
+		}
+		return
+	}
+	t.Fatal("promoted task.moved event not published")
+}
+
+// @covers AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+func TestService_FeederPromotionSkipsCandidateWhenSessionLookupFails(t *testing.T) {
+	svc, eventBus, repo := setupFeederPromotionSessionTest(t)
+	svc.sessions = &failingListTaskSessionsRepository{
+		SessionRepository: repo,
+		err:               errors.New("session list failed"),
+		taskID:            "task-promoted",
+	}
+	eventBus.ClearEvents()
+
+	if _, err := svc.MoveTask(context.Background(), "task-vacating", "wf-target", "step-target", 0); err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	promoted, err := repo.GetTask(context.Background(), "task-promoted")
+	if err != nil {
+		t.Fatalf("GetTask(task-promoted): %v", err)
+	}
+	if promoted.WorkflowStepID != "step-feeder" {
+		t.Fatalf("promoted task step = %q, want step-feeder", promoted.WorkflowStepID)
+	}
+	for _, event := range eventBus.GetPublishedEvents() {
+		data, ok := event.Data.(map[string]interface{})
+		if event.Type == events.TaskMoved && ok && data["task_id"] == "task-promoted" {
+			t.Fatal("session lookup failure published a feeder promotion")
+		}
+	}
+}
+
+func setupFeederPromotionSessionTest(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repository) {
+	t.Helper()
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-limited": {
+			ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 0,
+			WIPLimit: 1, PullFromStepID: "step-feeder",
+		},
+		"step-feeder": {ID: "step-feeder", WorkflowID: "wf-source", Name: "Feeder", Position: 1},
+		"step-target": {ID: "step-target", WorkflowID: "wf-target", Name: "Target", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-vacating", "wf-source", "step-limited", nil)
+	createMoveTask(t, ctx, repo, "task-promoted", "wf-source", "step-feeder", nil)
+	return svc, eventBus, repo
+}
+
+type failingListTaskSessionsRepository struct {
+	repository.SessionRepository
+	err    error
+	taskID string
+}
+
+func (r *failingListTaskSessionsRepository) ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error) {
+	if taskID == r.taskID {
+		return nil, r.err
+	}
+	return r.SessionRepository.ListTaskSessions(ctx, taskID)
+}

--- a/docs/plans/feeder-promotion-session-routing/plan.md
+++ b/docs/plans/feeder-promotion-session-routing/plan.md
@@ -102,6 +102,12 @@ different destination profile.
 - `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: add
   `TestService_FeederPromotionSkipsCandidateWhenSessionLookupFails` in the same
   file.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: add
+  `TestService_FeederPromotionBlocksOnOlderRunningSession` to make sure a
+  primary session does not bypass a move-blocking secondary session.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: add
+  `TestService_FeederPromotionUsesNewestActiveFallback` for tasks without an
+  active primary session.
 - Preserve existing feeder admission and blocked-session coverage in
   `service_workflow_test.go`.
 - Preserve existing compatible-profile reuse and different-profile switching
@@ -119,14 +125,18 @@ primary session before the newest active fallback. Both task-service promotion
 branches publish that session ID. Session-list errors still skip the candidate
 before the atomic move.
 
+PR fixup also made the preflight scan every session before selecting the
+primary. Any `STARTING` or `RUNNING` session still blocks promotion. The
+fallback path now has explicit regression coverage.
+
 The exact work-order checks passed:
 
 ```text
-go test -tags fts5 ./internal/task/service ... -count=1: 4 passed
+go test -tags fts5 ./internal/task/service ... -count=1: 6 passed
 go test -tags fts5 ./internal/orchestrator ... -count=1: 23 passed
 ```
 
-The focused task-service checks also passed with `-race`: 4 tests passed.
+The focused task-service checks also passed with `-race`: 6 tests passed.
 
 ## Risks
 

--- a/docs/plans/feeder-promotion-session-routing/plan.md
+++ b/docs/plans/feeder-promotion-session-routing/plan.md
@@ -1,0 +1,138 @@
+---
+created: 2026-08-25
+status: complete
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+legacy_specs: []
+---
+
+# Implementation Plan: Preserve Session Routing During Feeder Promotion
+
+## Overview
+
+Fix issue #3016. Task-service feeder promotion must publish the compatible
+primary or active session on `task.moved`. Ordinary moves and the orchestrator
+feeder-pull path already publish this session. This change restores the existing
+destination-profile routing boundary. It does not change the event schema,
+workflow configuration, or session-switching policy.
+
+## Confirmed root cause
+
+`Service.promoteFeederQueuedTask` commits the feeder-to-destination move through
+the production atomic promoter. Both repository branches then publish
+`task.moved` with an explicit empty session ID. As a result,
+`handleTaskMoved` takes its no-session auto-start branch. This branch can create
+a second session when a compatible primary session is in `WAITING_FOR_INPUT`.
+
+A focused throwaway test reproduced the defect on the current branch. The task
+`task-promoted` had primary session `session-primary`. The published event had
+an empty `session_id`. The test failed with:
+
+```text
+promoted task session_id = "", want session-primary
+```
+
+Ordinary `MoveTaskWithOptions` resolves `resolvePrimaryOrActiveSession` before
+publication. `workflowStore.pullOneFeederTask` also publishes an active session
+ID. Existing profile-entry tests cover compatible-profile reuse and
+different-profile switching after the orchestrator receives this ID.
+
+## Scope
+
+### In scope
+
+- Resolve the routing session for the feeder candidate before the atomic
+  promotion.
+- Preserve the ordinary move rule: prefer an active primary session, otherwise
+  use the most recently started active session.
+- Keep lookup failure fail-closed and logged so promotion does not silently
+  fall through to sessionless auto-start.
+- Publish the resolved session ID from both task-service feeder-promotion
+  repository branches.
+- Add focused regression coverage for session propagation and lookup failure.
+
+### Out of scope
+
+- Changes to destination-profile compatibility or session retirement in the
+  orchestrator.
+- Changes to `task.moved` fields or external APIs.
+- Clarification persistence or transfer between legitimately different
+  sessions.
+- Refactoring the older `workflowStore.pullOneFeederTask` implementation.
+- UI, E2E, schema, migration, or public documentation changes.
+
+## Technical approach
+
+### Candidate preflight and event publication
+
+Update `apps/backend/internal/task/service/service_workflow.go`. Make the
+existing feeder-candidate preflight return eligibility and the lifecycle
+session. Use the task-session list that the preflight already loads. An active
+primary session wins. Otherwise, the newest active session wins. A `STARTING`
+or `RUNNING` session continues to block promotion.
+
+Pass the selected session ID into `promoteFeederQueuedTask`. Then pass the ID
+into both `publishTaskMovedEvent` calls. Resolve the session before the atomic
+task mutation. If the lookup fails, leave the candidate queued and try another
+candidate. Do not commit the move with a sessionless event.
+
+Do not use the routing session for step-ledger actor attribution. System-driven
+WIP pulls keep their ledger `session_id` null. The event session identifies
+lifecycle context. It does not identify the initiating actor.
+
+### Regression boundary
+
+Add a focused test file beside the task service. The first test uses a saturated
+destination and a feeder candidate with a primary `WAITING_FOR_INPUT` session.
+The test then opens a vacancy. It makes sure that the promoted event contains
+the session ID. The second test injects a session-list error. It makes sure that
+the candidate stays in the feeder without a promotion event.
+
+Existing orchestrator tests prove both profile outcomes. The orchestrator reuses
+a carried session for a compatible profile. It replaces the session for a
+different destination profile.
+
+## Tests
+
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: add
+  `TestService_FeederPromotionCarriesPrimarySession` in
+  `apps/backend/internal/task/service/service_workflow_feeder_session_test.go`.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: add
+  `TestService_FeederPromotionSkipsCandidateWhenSessionLookupFails` in the same
+  file.
+- Preserve existing feeder admission and blocked-session coverage in
+  `service_workflow_test.go`.
+- Preserve existing compatible-profile reuse and different-profile switching
+  coverage in `event_handlers_workflow_profile_test.go` and
+  `event_handlers_workflow_moved_test.go`.
+
+## Work orders
+
+- [x] [Task 01: Propagate the feeder promotion session](task-01-propagate-feeder-promotion-session.md)
+
+## Verification results
+
+Task 01 is complete. The task-service feeder preflight now selects an active
+primary session before the newest active fallback. Both task-service promotion
+branches publish that session ID. Session-list errors still skip the candidate
+before the atomic move.
+
+The exact work-order checks passed:
+
+```text
+go test -tags fts5 ./internal/task/service ... -count=1: 4 passed
+go test -tags fts5 ./internal/orchestrator ... -count=1: 23 passed
+```
+
+The focused task-service checks also passed with `-race`: 4 tests passed.
+
+## Risks
+
+- Session selection must match ordinary moves when multiple active sessions
+  exist. Selection of only the newest session can bypass an active primary.
+- A lookup after the atomic promotion cannot fail closed. A transient database
+  error can then preserve the duplicate-session problem.
+- Step-ledger attribution and lifecycle routing use session IDs for different
+  purposes. Coupling them regresses the system-origin WIP pull contract.

--- a/docs/plans/feeder-promotion-session-routing/task-01-propagate-feeder-promotion-session.md
+++ b/docs/plans/feeder-promotion-session-routing/task-01-propagate-feeder-promotion-session.md
@@ -1,0 +1,120 @@
+---
+id: "01-propagate-feeder-promotion-session"
+title: "Propagate the feeder promotion session"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+acceptance_criteria:
+  - AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+---
+
+# Task 01: Propagate the Feeder Promotion Session
+
+## Summary
+
+Carry the compatible primary or active session through task-service feeder
+promotion. The existing destination-profile preflight then decides whether to
+reuse or switch sessions. Keep promotion fail-closed when the session preflight
+cannot read its data.
+
+## In scope
+
+- Add red regression tests for feeder-promotion session propagation and lookup
+  failure.
+- Select an active primary session before the newest active fallback from the
+  feeder-candidate session preflight.
+- Pass the selected session ID through `promoteFeederQueuedTask` to both
+  `publishTaskMovedEvent` calls.
+- Preserve current blocking behavior for `STARTING` and `RUNNING` sessions.
+- Run the focused task-service and orchestrator checks.
+
+## Out of scope
+
+- Orchestrator profile-routing policy changes.
+- Event, API, persistence, or UI contract changes.
+- Clarification handover across a genuine profile change.
+- Step-ledger attribution changes.
+- Public documentation changes.
+
+## Acceptance
+
+- A promoted feeder task with an active primary session publishes that session
+  ID on `task.moved`. Existing profile reuse and profile switching then run.
+- A session-list error leaves the candidate queued and does not publish a
+  sessionless promotion event.
+- Existing feeder blocking, promotion, profile reuse, and profile-switch tests
+  remain green without schema, API, UI, or ledger changes.
+
+## Verification
+
+```bash
+cd apps/backend
+rtk go test -tags fts5 ./internal/task/service -run 'TestService_(FeederPromotionCarriesPrimarySession|FeederPromotionSkipsCandidateWhenSessionLookupFails|MoveTaskPullsNextFeederTaskOnVacate|MoveTaskPullSkipsBlockedFeederCandidate)' -count=1
+rtk go test -tags fts5 ./internal/orchestrator -run 'Test(HandleTaskMovedWithSession|ProcessOnEnter_ProfileSwitch|SwitchSessionForStep_ReusesExistingProfileSession)' -count=1
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/service/service_workflow.go`
+- `apps/backend/internal/task/service/service_workflow_feeder_session_test.go`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- The session selected for lifecycle routing must remain distinct from the
+  system actor recorded for the WIP pull ledger row.
+- Session lookup must happen before the atomic promotion to retain fail-closed
+  behavior.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001` and
+  `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`.
+- `docs/specs/tasks/system-design/wip-limit-pull-system.md`, especially normal
+  destination entry after feeder promotion.
+- Issue #3016 and the failing event-payload reproduction.
+- Existing ordinary move session resolution in
+  `Service.MoveTaskWithOptions`.
+- Existing feeder session propagation in
+  `workflowStore.pullOneFeederTask`.
+- Existing profile routing from issue #2692 / PR #2697.
+
+## Results
+
+Implemented the session propagation fix in
+`apps/backend/internal/task/service/service_workflow.go`.
+
+- `feederCandidateSession` preserves active-primary priority and newest-active
+  fallback selection.
+- `promoteFeederQueuedTask` publishes the selected session ID in both atomic
+  and admission-repository branches.
+- Session-list errors keep the candidate queued before promotion.
+- Added `service_workflow_feeder_session_test.go` with propagation and
+  lookup-failure coverage.
+
+TDD evidence:
+
+```text
+RED: TestService_FeederPromotionCarriesPrimarySession failed with session_id = "".
+GREEN: the two new tests passed after the production change.
+```
+
+Verification:
+
+```text
+go test -tags fts5 ./internal/task/service ... -count=1: 4 passed
+go test -tags fts5 ./internal/orchestrator ... -count=1: 23 passed
+go test -tags fts5 -race ./internal/task/service ... -count=1: 4 passed
+```

--- a/docs/plans/feeder-promotion-session-routing/task-01-propagate-feeder-promotion-session.md
+++ b/docs/plans/feeder-promotion-session-routing/task-01-propagate-feeder-promotion-session.md
@@ -47,6 +47,9 @@ cannot read its data.
   ID on `task.moved`. Existing profile reuse and profile switching then run.
 - A session-list error leaves the candidate queued and does not publish a
   sessionless promotion event.
+- A move-blocking session anywhere in the candidate session list prevents
+  promotion, even when another active session is primary.
+- A task without an active primary session uses its newest active fallback.
 - Existing feeder blocking, promotion, profile reuse, and profile-switch tests
   remain green without schema, API, UI, or ledger changes.
 
@@ -54,7 +57,7 @@ cannot read its data.
 
 ```bash
 cd apps/backend
-rtk go test -tags fts5 ./internal/task/service -run 'TestService_(FeederPromotionCarriesPrimarySession|FeederPromotionSkipsCandidateWhenSessionLookupFails|MoveTaskPullsNextFeederTaskOnVacate|MoveTaskPullSkipsBlockedFeederCandidate)' -count=1
+rtk go test -tags fts5 ./internal/task/service -run 'TestService_(FeederPromotionCarriesPrimarySession|FeederPromotionSkipsCandidateWhenSessionLookupFails|FeederPromotionBlocksOnOlderRunningSession|FeederPromotionUsesNewestActiveFallback|MoveTaskPullsNextFeederTaskOnVacate|MoveTaskPullSkipsBlockedFeederCandidate)' -count=1
 rtk go test -tags fts5 ./internal/orchestrator -run 'Test(HandleTaskMovedWithSession|ProcessOnEnter_ProfileSwitch|SwitchSessionForStep_ReusesExistingProfileSession)' -count=1
 ```
 
@@ -101,14 +104,24 @@ Implemented the session propagation fix in
 - `promoteFeederQueuedTask` publishes the selected session ID in both atomic
   and admission-repository branches.
 - Session-list errors keep the candidate queued before promotion.
-- Added `service_workflow_feeder_session_test.go` with propagation and
-  lookup-failure coverage.
+- Added `service_workflow_feeder_session_test.go` with propagation,
+  lookup-failure, older-blocker, and newest-fallback coverage.
+
+PR fixup remediation:
+
+- `feederCandidateSession` scans every session before selecting the primary,
+  so an older `STARTING` or `RUNNING` session cannot be skipped.
+- The fallback path is covered with two active sessions and asserts the newest
+  active session ID is published.
 
 TDD evidence:
 
 ```text
 RED: TestService_FeederPromotionCarriesPrimarySession failed with session_id = "".
 GREEN: the two new tests passed after the production change.
+RED (PR fixup): TestService_FeederPromotionBlocksOnOlderRunningSession promoted
+the candidate while a primary session was found first.
+GREEN (PR fixup): the blocker and fallback regressions pass after the full scan.
 ```
 
 Verification:


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3017/32be5b95856f.html)
<!-- kandev-pr-walkthrough-end -->

Feeder queue promotion discarded an existing task session ID, so the destination workflow handler treated a live task as sessionless and could start a duplicate agent session. The promotion now carries the compatible active primary session, or the newest active fallback, through `task.moved`.

## Validation

- `go test -tags fts5 ./internal/task/service -run 'TestService_(FeederPromotionCarriesPrimarySession|FeederPromotionSkipsCandidateWhenSessionLookupFails|MoveTaskPullsNextFeederTaskOnVacate|MoveTaskPullSkipsBlockedFeederCandidate)' -count=1`
- `go test -tags fts5 ./internal/orchestrator -run 'Test(HandleTaskMovedWithSession|ProcessOnEnter_ProfileSwitch|SwitchSessionForStep_ReusesExistingProfileSession)' -count=1`
- `go test -tags fts5 -race ./internal/task/service -run 'TestService_(FeederPromotionCarriesPrimarySession|FeederPromotionSkipsCandidateWhenSessionLookupFails|MoveTaskPullsNextFeederTaskOnVacate|MoveTaskPullSkipsBlockedFeederCandidate)' -count=1`
- `python3 scripts/lint-spec-files.py --all`
- Commit hooks: harness, architecture, gofmt, Go lint, public-copy, and Conventional Commits checks passed.

Closes #3016

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->