### PR TITLE
fix(mcp): clarify configuration chat dispatch boundary

### DIFF
--- a/apps/backend/config/prompts/config-context.md
+++ b/apps/backend/config/prompts/config-context.md
@@ -46,6 +46,11 @@ TASK TOOLS:
 - archive_task_kandev: Archive a task. Required: task_id.
 - update_task_state_kandev: Update task state. Required: task_id, state (TODO, CREATED, SCHEDULING, IN_PROGRESS, REVIEW, BLOCKED, WAITING_FOR_INPUT, COMPLETED, FAILED, CANCELLED).
 
+DISPATCH BOUNDARY:
+- Configuration Chat is a repository-less ephemeral task. It cannot create persistent subtasks or sessions; `create_task_kandev`, `spawn_session_kandev`, and `message_task_kandev` are unavailable here.
+- For persistent subtask dispatch, continue from a normal Kandev task session and use `create_task_kandev` with `parent_id="self"`. Do not retry those tools from Configuration Chat.
+- The external `/mcp` endpoint can create top-level tasks, but an ephemeral Configuration Chat task cannot be their parent.
+
 INTERACTION:
 - ask_user_question_kandev: Ask the user one or more clarifying questions in a single tool call. Required: questions (array of 1-4 question objects; each has prompt and options (2-6 {label, description})). Optional: context.
 

--- a/apps/backend/internal/sysprompt/sysprompt_test.go
+++ b/apps/backend/internal/sysprompt/sysprompt_test.go
@@ -66,6 +66,16 @@ func TestConfigContext_ContainsSections(t *testing.T) {
 	assert.Contains(t, ConfigContext(), "EXAMPLE REQUESTS")
 }
 
+func TestConfigContext_ExplainsDispatchBoundary(t *testing.T) {
+	context := ConfigContext()
+
+	assert.Contains(t, context, "repository-less ephemeral task")
+	assert.Contains(t, context, "create_task_kandev")
+	assert.Contains(t, context, `parent_id="self"`)
+	assert.Contains(t, context, "Do not retry those tools from Configuration Chat")
+}
+
+
 func TestConfigContext_HasExactlyOneSessionIDPlaceholder(t *testing.T) {
 	count := strings.Count(ConfigContext(), "{session_id}")
 	assert.Equal(t, 1, count, "ConfigContext should have exactly 1 {session_id} placeholder")


### PR DESCRIPTION
## Summary

- clarify that Configuration Chat is repository-less and ephemeral
- explain that persistent subtask dispatch requires a normal Kandev task session
- document the external MCP top-level-task limitation for ephemeral parents
- add a regression test for the prompt boundary

## Verification

- `docker run --rm -v /home/clem/kandev-source:/src -w /src/apps/backend golang:1.26 go test ./internal/sysprompt -run 'TestConfigContext_(ContainsAllTools|ExplainsDispatchBoundary)' -count=1`
- `git diff --check`

Authored by `openai-codex/gpt-5.6-luna`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3021-bwo7.sprites.app |
| **Commit** | `29b8b85` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->