### PR TITLE
fix: preserve flat models across session resume

### DIFF
--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -508,18 +508,35 @@ func appendSessionModelsMessage(sessionID string, session *models.TaskSession, l
 	if lifecycleMgr == nil {
 		return result
 	}
-	modelState := lifecycleMgr.GetModelStateForSession(sessionID)
-	if modelState == nil || (modelState.CurrentModelID == "" && len(modelState.Models) == 0) {
+	return appendSessionModelsMessageFromState(
+		sessionID,
+		session,
+		lifecycleMgr.GetModelStateForSession(sessionID),
+		result,
+	)
+}
+
+func appendSessionModelsMessageFromState(sessionID string, session *models.TaskSession, modelState *lifecycle.CachedModelState, result []*ws.Message) []*ws.Message {
+	if modelState == nil {
 		return result
 	}
 	snapshot, _ := lifecycle.LoadSessionModelsSnapshot(session.Metadata[models.SessionMetaKeyACPModelState])
+	replayState := *modelState
+	if len(replayState.Models) == 0 && len(snapshot.Models) > 0 {
+		replayState.CurrentModelID = snapshot.CurrentModelID
+		replayState.Models = snapshot.Models
+		replayState.ConfigOptions = snapshot.ConfigOptions
+	}
+	if replayState.CurrentModelID == "" && len(replayState.Models) == 0 {
+		return result
+	}
 	notification, err := ws.NewNotification(ws.ActionSessionModelsUpdated, lifecycle.SessionModelsEventPayload{
 		TaskID:               session.TaskID,
 		SessionID:            sessionID,
-		CurrentModelID:       modelState.CurrentModelID,
-		Models:               modelState.Models,
-		ConfigOptions:        modelState.ConfigOptions,
-		ConfigOptionsSettled: modelState.ConfigOptionsSettled || snapshot.ConfigOptionsSettled,
+		CurrentModelID:       replayState.CurrentModelID,
+		Models:               replayState.Models,
+		ConfigOptions:        replayState.ConfigOptions,
+		ConfigOptionsSettled: replayState.ConfigOptionsSettled || snapshot.ConfigOptionsSettled,
 		ConfigBaseline:       sessionACPConfigBaseline(session),
 	})
 	if err == nil {

--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -522,10 +522,11 @@ func appendSessionModelsMessageFromState(sessionID string, session *models.TaskS
 	}
 	snapshot, _ := lifecycle.LoadSessionModelsSnapshot(session.Metadata[models.SessionMetaKeyACPModelState])
 	replayState := *modelState
-	if len(replayState.Models) == 0 && len(snapshot.Models) > 0 {
-		replayState.CurrentModelID = snapshot.CurrentModelID
+	if len(replayState.Models) == 0 &&
+		len(replayState.ConfigOptions) == 0 &&
+		!replayState.ConfigOptionsSettled &&
+		len(snapshot.Models) > 0 {
 		replayState.Models = snapshot.Models
-		replayState.ConfigOptions = snapshot.ConfigOptions
 	}
 	if replayState.CurrentModelID == "" && len(replayState.Models) == 0 {
 		return result

--- a/apps/backend/internal/backendapp/helpers_session_models_test.go
+++ b/apps/backend/internal/backendapp/helpers_session_models_test.go
@@ -1,0 +1,46 @@
+package backendapp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestAppendSessionModelsMessageFallsBackToPersistedFlatModels(t *testing.T) {
+	persistedModels := make([]streams.SessionModelInfo, 15)
+	for i := range persistedModels {
+		modelID := fmt.Sprintf("claude-model-%d", i+1)
+		persistedModels[i] = streams.SessionModelInfo{ModelID: modelID, Name: modelID}
+	}
+	session := &models.TaskSession{
+		ID:     "session-1",
+		TaskID: "task-1",
+		Metadata: map[string]interface{}{
+			models.SessionMetaKeyACPModelState: lifecycle.SessionModelsSnapshot{
+				CurrentModelID: "claude-model-1",
+				Models:         persistedModels,
+			},
+		},
+	}
+	liveState := &lifecycle.CachedModelState{CurrentModelID: "stale-live-model"}
+
+	messages := appendSessionModelsMessageFromState(session.ID, session, liveState, nil)
+
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	var payload lifecycle.SessionModelsEventPayload
+	if err := json.Unmarshal(messages[0].Payload, &payload); err != nil {
+		t.Fatalf("decode session models payload: %v", err)
+	}
+	if len(payload.Models) != len(persistedModels) {
+		t.Fatalf("models = %d, want %d", len(payload.Models), len(persistedModels))
+	}
+	if payload.CurrentModelID != "claude-model-1" {
+		t.Fatalf("current model = %q, want %q", payload.CurrentModelID, "claude-model-1")
+	}
+}

--- a/apps/backend/internal/backendapp/helpers_session_models_test.go
+++ b/apps/backend/internal/backendapp/helpers_session_models_test.go
@@ -26,7 +26,7 @@ func TestAppendSessionModelsMessageFallsBackToPersistedFlatModels(t *testing.T) 
 			},
 		},
 	}
-	liveState := &lifecycle.CachedModelState{CurrentModelID: "stale-live-model"}
+	liveState := &lifecycle.CachedModelState{CurrentModelID: "live-model"}
 
 	messages := appendSessionModelsMessageFromState(session.ID, session, liveState, nil)
 
@@ -40,7 +40,72 @@ func TestAppendSessionModelsMessageFallsBackToPersistedFlatModels(t *testing.T) 
 	if len(payload.Models) != len(persistedModels) {
 		t.Fatalf("models = %d, want %d", len(payload.Models), len(persistedModels))
 	}
-	if payload.CurrentModelID != "claude-model-1" {
-		t.Fatalf("current model = %q, want %q", payload.CurrentModelID, "claude-model-1")
+	if payload.CurrentModelID != "live-model" {
+		t.Fatalf("current model = %q, want %q", payload.CurrentModelID, "live-model")
+	}
+}
+
+func TestAppendSessionModelsMessageKeepsLiveStateAuthoritative(t *testing.T) {
+	session := &models.TaskSession{
+		ID:     "session-1",
+		TaskID: "task-1",
+		Metadata: map[string]interface{}{
+			models.SessionMetaKeyACPModelState: lifecycle.SessionModelsSnapshot{
+				CurrentModelID: "persisted-flat-model",
+				Models: []streams.SessionModelInfo{{
+					ModelID: "persisted-flat-model",
+					Name:    "Persisted flat model",
+				}},
+			},
+		},
+	}
+	liveOptions := []streams.ConfigOption{{
+		Type:         "select",
+		ID:           "model",
+		CurrentValue: "live-config-model",
+	}}
+	tests := []struct {
+		name            string
+		liveState       *lifecycle.CachedModelState
+		wantConfigCount int
+	}{
+		{
+			name: "live config options",
+			liveState: &lifecycle.CachedModelState{
+				CurrentModelID: "live-config-model",
+				ConfigOptions:  liveOptions,
+			},
+			wantConfigCount: len(liveOptions),
+		},
+		{
+			name: "settled empty catalog",
+			liveState: &lifecycle.CachedModelState{
+				CurrentModelID:       "live-config-model",
+				ConfigOptionsSettled: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := appendSessionModelsMessageFromState(session.ID, session, tt.liveState, nil)
+
+			if len(messages) != 1 {
+				t.Fatalf("messages = %d, want 1", len(messages))
+			}
+			var payload lifecycle.SessionModelsEventPayload
+			if err := json.Unmarshal(messages[0].Payload, &payload); err != nil {
+				t.Fatalf("decode session models payload: %v", err)
+			}
+			if len(payload.Models) != 0 {
+				t.Fatalf("models = %d, want 0", len(payload.Models))
+			}
+			if payload.CurrentModelID != tt.liveState.CurrentModelID {
+				t.Fatalf("current model = %q, want %q", payload.CurrentModelID, tt.liveState.CurrentModelID)
+			}
+			if len(payload.ConfigOptions) != tt.wantConfigCount {
+				t.Fatalf("config options = %d, want %d", len(payload.ConfigOptions), tt.wantConfigCount)
+			}
+		})
 	}
 }

--- a/apps/web/lib/ws/handlers/session-models-startup.test.ts
+++ b/apps/web/lib/ws/handlers/session-models-startup.test.ts
@@ -232,3 +232,30 @@ it("preserves populated flat models when a partial replay drops them", () => {
 
   expect(store.getState().sessionModels.bySessionId["session-1"].models).toEqual(existingModels);
 });
+
+it("clears populated flat models when a settled update removes them", () => {
+  const store = makeStore({
+    sessionModels: {
+      bySessionId: {
+        "session-1": {
+          currentModelId: providerModelId,
+          models: [{ modelId: providerModelId, name: providerModelName }],
+          configOptions: [],
+        },
+      },
+    } as AppState["sessionModels"],
+  });
+  const handler = registerSessionModelsHandlers(store)["session.models_updated"]!;
+
+  handler(
+    makeMessage(
+      makePayload(providerModelId, {
+        models: [],
+        config_options: [],
+        config_options_settled: true,
+      }),
+    ),
+  );
+
+  expect(store.getState().sessionModels.bySessionId["session-1"].models).toEqual([]);
+});

--- a/apps/web/lib/ws/handlers/session-models-startup.test.ts
+++ b/apps/web/lib/ws/handlers/session-models-startup.test.ts
@@ -209,3 +209,26 @@ it("hydrates from a settled startup payload when the model differs from persiste
   handler(makeMessage(makeStartupPayload(providerModelId, providerModelId, false, "high")));
   expectCurrentModel(store, providerModelId);
 });
+
+it("preserves populated flat models when a partial replay drops them", () => {
+  const existingModels = [
+    { modelId: providerModelId, name: providerModelName },
+    { modelId: lunaModelId, name: "GPT-5.6 Luna" },
+  ];
+  const store = makeStore({
+    sessionModels: {
+      bySessionId: {
+        "session-1": {
+          currentModelId: providerModelId,
+          models: existingModels,
+          configOptions: [],
+        },
+      },
+    } as AppState["sessionModels"],
+  });
+  const handler = registerSessionModelsHandlers(store)["session.models_updated"]!;
+
+  handler(makeMessage(makePayload(providerModelId, { models: [], config_options: [] })));
+
+  expect(store.getState().sessionModels.bySessionId["session-1"].models).toEqual(existingModels);
+});

--- a/apps/web/lib/ws/handlers/session-models.ts
+++ b/apps/web/lib/ws/handlers/session-models.ts
@@ -160,7 +160,7 @@ function shouldPreserveExistingModels(
   sessionId: string,
   payload: SessionModelsPayload,
 ): boolean {
-  if (payload.models?.length) return false;
+  if (payload.models?.length || payload.config_options_settled === true) return false;
   const existing = state.sessionModels.bySessionId[sessionId];
   return !!existing && existing.models.length > 0;
 }

--- a/apps/web/lib/ws/handlers/session-models.ts
+++ b/apps/web/lib/ws/handlers/session-models.ts
@@ -155,6 +155,35 @@ function shouldPreserveExistingConfigOptions(
   return !!existing && existing.configOptions.length > 0;
 }
 
+function shouldPreserveExistingModels(
+  state: AppState,
+  sessionId: string,
+  payload: SessionModelsPayload,
+): boolean {
+  if (payload.models?.length) return false;
+  const existing = state.sessionModels.bySessionId[sessionId];
+  return !!existing && existing.models.length > 0;
+}
+
+function shouldSkipModelsUpdate(resolved: { isEmpty: boolean; populated: boolean }): boolean {
+  return resolved.isEmpty && resolved.populated;
+}
+
+function resolveModels(
+  preserve: boolean,
+  existing: SessionModelsState["bySessionId"][string]["models"] | undefined,
+  acpModels: SessionModelsPayload["models"],
+): SessionModelsState["bySessionId"][string]["models"] {
+  if (preserve && existing) return existing;
+  return (acpModels ?? []).map((model) => ({
+    modelId: model.model_id,
+    name: model.name,
+    description: model.description,
+    usageMultiplier: model.usage_multiplier,
+    meta: model.meta,
+  }));
+}
+
 function debugModelsUpdate(
   state: AppState,
   sessionId: string,
@@ -164,6 +193,7 @@ function debugModelsUpdate(
     isEmpty: boolean;
     populated: boolean;
     preserveConfigOptions: boolean;
+    preserveModels: boolean;
   },
 ) {
   if (!isDebug()) return;
@@ -179,8 +209,9 @@ function debugModelsUpdate(
     existingCurrentModelId: existing?.currentModelId ?? "",
     existingModelsLen: existing?.models.length ?? 0,
     existingConfigOptionIds: (existing?.configOptions ?? []).map((o) => o.id),
-    willSkip: resolved.isEmpty && resolved.populated,
+    willSkip: shouldSkipModelsUpdate(resolved),
     preserveConfigOptions: resolved.preserveConfigOptions,
+    preserveModels: resolved.preserveModels,
   });
 }
 
@@ -244,6 +275,7 @@ function resolveModelsUpdatedState(
   isEmpty: boolean;
   populated: boolean;
   preserveConfigOptions: boolean;
+  preserveModels: boolean;
   existingEntry: SessionModelsState["bySessionId"][string] | undefined;
   existingFallback: string | undefined;
 } {
@@ -262,6 +294,7 @@ function resolveModelsUpdatedState(
     ),
     populated: hasPopulatedModels(state, sessionId),
     preserveConfigOptions: shouldPreserveExistingConfigOptions(state, sessionId, payload),
+    preserveModels: shouldPreserveExistingModels(state, sessionId, payload),
     existingEntry,
     existingFallback,
   };
@@ -323,7 +356,7 @@ export function registerSessionModelsHandlers(store: StoreApi<AppState>): WsHand
         : {};
       const resolved = resolveModelsUpdatedState(state, sessionId, payload, pendingRuntime);
       debugModelsUpdate(state, sessionId, payload, resolved);
-      if (resolved.isEmpty && resolved.populated) {
+      if (shouldSkipModelsUpdate(resolved)) {
         return;
       }
       clearStaleContextWindow(state, sessionId, resolved.currentModelId);
@@ -336,17 +369,16 @@ export function registerSessionModelsHandlers(store: StoreApi<AppState>): WsHand
         resolved.currentModelId,
       );
       const configOptionsSettled = resolvedConfigOptionsSettled(payload, resolved.existingEntry);
+      const models = resolveModels(
+        resolved.preserveModels,
+        resolved.existingEntry?.models,
+        acpModels,
+      );
 
       state.setSessionModels(sessionId, {
         currentModelId: resolved.currentModelId,
         fallbackModel: resolved.existingFallback,
-        models: acpModels.map((m) => ({
-          modelId: m.model_id,
-          name: m.name,
-          description: m.description,
-          usageMultiplier: m.usage_multiplier,
-          meta: m.meta,
-        })),
+        models,
         configOptions,
         ...(configOptionsSettled === undefined ? {} : { configOptionsSettled }),
         configBaseline:


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3030/3cc795f6795c.html)
<!-- kandev-pr-walkthrough-end -->

Resumed flat-model sessions could lose their hydrated model list when the WebSocket replay used an incomplete live cache. The replay now falls back to the persisted ACP snapshot, while the client preserves an existing flat list against empty partial updates.

## Validation

- `go test -v -run TestAppendSessionModelsMessageFallsBackToPersistedFlatModels ./internal/backendapp`
- `env -u KANDEV_INTERNAL_CONFIG_FILE -u KANDEV_INTERNAL_CONFIG_HOME_FILE make -C apps/backend test`
- `make -C apps/backend lint`
- `pnpm --filter @kandev/web test -- --run lib/ws/handlers/session-models.test.ts lib/ws/handlers/session-models-startup.test.ts`
- `pnpm --filter @kandev/web lint`
- `pnpm run typecheck`
- Desktop Chromium model-selector capture scenario
- Mobile Chromium model-selector capture scenario
- No public documentation change is needed because the WebSocket payload and user workflow are unchanged.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop model selector remains populated after session replay](https://raw.githubusercontent.com/kdlbs/kandev/211d9e5622c6bbb8dc82e1893a5e3219b288fc91/model-selector-desktop.png)

![Mobile model selector remains reachable by touch](https://raw.githubusercontent.com/kdlbs/kandev/211d9e5622c6bbb8dc82e1893a5e3219b288fc91/model-selector-mobile.png)
<!-- kandev-screenshots-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->