### PR TITLE
fix(auth): hide the Docker build control from non-admins

### DIFF
--- a/apps/backend/internal/agent/docker/handlers_auth_test.go
+++ b/apps/backend/internal/agent/docker/handlers_auth_test.go
@@ -486,3 +486,39 @@ func TestBuildWithoutAnyIdentityIsRejected(t *testing.T) {
 		t.Fatalf("identity-free build reached Docker: %v", client.builtTags)
 	}
 }
+
+// TestUnownedContainerIsDeniedOnStopAndRemove is the other half of the task
+// fallback: a container that resolves through neither label must stay denied,
+// so the fallback cannot be widened into a fail-open path.
+func TestUnownedContainerIsDeniedOnStopAndRemove(t *testing.T) {
+	client, authorizer, titles := twoUserFixture()
+	client.containers = append(client.containers, ContainerInfo{
+		ID: "ctr-unlabeled", Name: "stray", State: "running",
+	})
+	// A container carrying Kandev's marker label but neither ownership label
+	// must be denied too, not just a wholly unlabeled one.
+	client.containers = append(client.containers, ContainerInfo{
+		ID: "ctr-marker-only", Name: "marked", State: "running",
+		Labels: map[string]string{"kandev.managed": "true"},
+	})
+	router := dockerTestRouter(t, client, titles.provider(), authorizer, member("user-a"))
+
+	for _, containerID := range []string{"ctr-unlabeled", "ctr-marker-only"} {
+		stop := do(router, http.MethodPost, "/api/v1/docker/containers/"+containerID+"/stop", "")
+		if stop.Code != http.StatusNotFound {
+			t.Fatalf("%s stop = %d, want 404; body = %s", containerID, stop.Code, stop.Body.String())
+		}
+		remove := do(router, http.MethodDelete, "/api/v1/docker/containers/"+containerID, "")
+		if remove.Code != http.StatusNotFound {
+			t.Fatalf("%s remove = %d, want 404; body = %s", containerID, remove.Code, remove.Body.String())
+		}
+	}
+	if len(client.stopped) != 0 || len(client.removed) != 0 {
+		t.Fatalf("unowned container reached Docker: stopped=%v removed=%v", client.stopped, client.removed)
+	}
+
+	list := do(router, http.MethodGet, "/api/v1/docker/containers", "")
+	if strings.Contains(list.Body.String(), "ctr-unlabeled") || strings.Contains(list.Body.String(), "ctr-marker-only") {
+		t.Fatalf("unowned container leaked into listing: %s", list.Body.String())
+	}
+}

--- a/apps/web/components/settings/profile-edit/docker-build-card-permissions.test.tsx
+++ b/apps/web/components/settings/profile-edit/docker-build-card-permissions.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DockerfileBuildCard } from "./docker-sections";
+
+const roleMock: { value: string | undefined } = { value: undefined };
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: { auth: { user?: { role?: string } } }) => unknown) =>
+    selector({
+      auth: { user: roleMock.value === undefined ? undefined : { role: roleMock.value } },
+    }),
+}));
+
+// The Dockerfile editor is a CodeMirror surface with no bearing on the
+// permission wiring under test.
+vi.mock("./script-editor", () => ({
+  ScriptEditor: () => <div data-testid="script-editor" />,
+}));
+
+const BUILD_BUTTON = /build image/i;
+const ADMIN_ONLY_COPY = "Only administrators can build images.";
+
+function renderCard(role: string | undefined) {
+  roleMock.value = role;
+  render(
+    <DockerfileBuildCard
+      dockerfile="FROM scratch"
+      onDockerfileChange={vi.fn()}
+      imageTag="kandev/multi-agent:latest"
+      onImageTagChange={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  roleMock.value = undefined;
+});
+
+// canBuildDockerImage is unit-tested separately; these cover the hop from that
+// decision into the rendered control, which a leaf-only test would miss.
+describe("DockerfileBuildCard build permissions", () => {
+  it("disables the build button and explains why for a member", () => {
+    renderCard("member");
+
+    expect(screen.getByRole("button", { name: BUILD_BUTTON }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByText(ADMIN_ONLY_COPY)).not.toBeNull();
+  });
+
+  it("leaves the build button usable for an admin", () => {
+    renderCard("admin");
+
+    expect(screen.getByRole("button", { name: BUILD_BUTTON }).hasAttribute("disabled")).toBe(false);
+    expect(screen.queryByText(ADMIN_ONLY_COPY)).toBeNull();
+  });
+
+  it("leaves the build button usable when authentication is disabled", () => {
+    renderCard(undefined);
+
+    expect(screen.getByRole("button", { name: BUILD_BUTTON }).hasAttribute("disabled")).toBe(false);
+    expect(screen.queryByText(ADMIN_ONLY_COPY)).toBeNull();
+  });
+});

--- a/apps/web/components/settings/profile-edit/docker-sections.test.ts
+++ b/apps/web/components/settings/profile-edit/docker-sections.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { containerTaskLabel } from "./docker-sections";
+import { canBuildDockerImage, containerTaskLabel } from "./docker-sections";
 import type { DockerContainer } from "@/lib/api/domains/settings-api";
 
 const taskID = "task-abc123";
@@ -47,5 +47,28 @@ describe("containerTaskLabel", () => {
   it("returns null when the container carries no task labels", () => {
     expect(containerTaskLabel(container())).toBeNull();
     expect(containerTaskLabel(container({ "kandev.task_title": "  " }))).toBeNull();
+  });
+});
+
+describe("canBuildDockerImage", () => {
+  // POST /api/v1/docker/build is admin-gated on the backend, so a member must
+  // not be shown an enabled control that can only end in a 403.
+  it("denies members", () => {
+    expect(canBuildDockerImage("member")).toBe(false);
+  });
+
+  it("allows admins", () => {
+    expect(canBuildDockerImage("admin")).toBe(true);
+  });
+
+  // An undefined role means authentication is disabled (the synthetic
+  // single-user admin), which must behave exactly as before.
+  it("allows the single user when authentication is disabled", () => {
+    expect(canBuildDockerImage(undefined)).toBe(true);
+  });
+
+  it("denies an unrecognized role rather than defaulting open", () => {
+    expect(canBuildDockerImage("")).toBe(false);
+    expect(canBuildDockerImage("Admin")).toBe(false);
   });
 });

--- a/apps/web/components/settings/profile-edit/docker-sections.tsx
+++ b/apps/web/components/settings/profile-edit/docker-sections.tsx
@@ -19,6 +19,7 @@ import type { DockerContainer } from "@/lib/api/domains/settings-api";
 import { SettingsCard } from "@/components/settings/settings-card";
 import { SettingsCardHeader } from "@/components/settings/settings-card-header";
 import { settingsActionClassName } from "@/components/settings/settings-control";
+import { useAppStore } from "@/components/state-provider";
 import { useTranslation } from "react-i18next";
 
 const DEFAULT_IMAGE_TAG = "kandev/multi-agent:latest";
@@ -170,6 +171,48 @@ type DockerfileBuildCardProps = {
   onBuildSuccess?: (result: DockerBuildSuccess) => void;
 };
 
+/** Build trigger plus its status badge, or the admin-only explanation. */
+function BuildActionRow({
+  canBuild,
+  buildStatus,
+  disabled,
+  onBuild,
+}: {
+  canBuild: boolean;
+  buildStatus: BuildStatus;
+  disabled: boolean;
+  onBuild: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-3">
+      <Button onClick={onBuild} disabled={disabled} className="cursor-pointer">
+        {buildStatus === "building" ? (
+          <IconLoader2 className="mr-1.5 h-4 w-4 animate-spin" />
+        ) : (
+          <IconPlayerPlay className="mr-1.5 h-4 w-4" />
+        )}
+        {t("executors:buildImage")}
+      </Button>
+      {canBuild ? (
+        <BuildStatusBadge status={buildStatus} />
+      ) : (
+        <p className="text-sm text-muted-foreground">{t("executors:buildImageAdminOnly")}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Building an image is a host-level operation with no per-user resource, so the
+ * backend gates POST /api/v1/docker/build on the admin role. An undefined role
+ * means authentication is disabled (the synthetic single-user admin), which
+ * keeps the control enabled exactly as before.
+ */
+export function canBuildDockerImage(role: string | undefined): boolean {
+  return role === undefined || role === "admin";
+}
+
 export function DockerfileBuildCard({
   dockerfile,
   onDockerfileChange,
@@ -182,13 +225,15 @@ export function DockerfileBuildCard({
   const { t } = useTranslation();
   const { buildStatus, buildLog, runBuild } = useBuildStream(onBuildSuccess);
   const logRef = useRef<HTMLPreElement>(null);
+  const role = useAppStore((state) => state.auth.user?.role);
+  const canBuild = canBuildDockerImage(role);
 
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [buildLog]);
 
   const handleBuild = () => {
-    if (dockerfile.trim() && imageTag.trim()) void runBuild(dockerfile, imageTag);
+    if (canBuild && dockerfile.trim() && imageTag.trim()) void runBuild(dockerfile, imageTag);
   };
 
   const canFillDefaults = !dockerfile.trim() || !imageTag.trim();
@@ -245,21 +290,14 @@ export function DockerfileBuildCard({
             />
           </div>
         </div>
-        <div className="flex items-center gap-3">
-          <Button
-            onClick={handleBuild}
-            disabled={buildStatus === "building" || !dockerfile.trim() || !imageTag.trim()}
-            className="cursor-pointer"
-          >
-            {buildStatus === "building" ? (
-              <IconLoader2 className="mr-1.5 h-4 w-4 animate-spin" />
-            ) : (
-              <IconPlayerPlay className="mr-1.5 h-4 w-4" />
-            )}
-            {t("executors:buildImage")}
-          </Button>
-          <BuildStatusBadge status={buildStatus} />
-        </div>
+        <BuildActionRow
+          canBuild={canBuild}
+          buildStatus={buildStatus}
+          disabled={
+            !canBuild || buildStatus === "building" || !dockerfile.trim() || !imageTag.trim()
+          }
+          onBuild={handleBuild}
+        />
         {buildLog && (
           <pre
             ref={logRef}

--- a/apps/web/e2e/tests/settings/docker-profile-persistence.spec.ts
+++ b/apps/web/e2e/tests/settings/docker-profile-persistence.spec.ts
@@ -204,4 +204,41 @@ test.describe("Docker executor profile persistence", () => {
       await apiClient.deleteExecutor(exec.id).catch(() => {});
     }
   });
+
+  /**
+   * POST /api/v1/docker/build is admin-gated on the backend, so a member must
+   * not be shown an enabled control that can only end in a 403. Auth is
+   * disabled in e2e, which leaves the role undefined and the button enabled,
+   * so the member identity is injected through the store bridge the same way
+   * the message-queue settings spec does.
+   */
+  test("member sees the build control disabled with an explanation", async ({ testPage }) => {
+    await testPage.goto("/settings/executors/new/local_docker");
+    await expect(testPage.locator("#profile-name")).toHaveValue("Docker", { timeout: 10_000 });
+    await testPage.getByRole("button", { name: "Use defaults" }).click();
+
+    const buildButton = testPage.getByRole("button", { name: "Build Image" });
+    await expect(buildButton).toBeEnabled();
+
+    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
+    await testPage.evaluate(() => {
+      const store = window.__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge is unavailable");
+      store.getState().setAuthState({
+        mode: "enabled",
+        authenticated: true,
+        user: {
+          id: "e2e-member",
+          email: "member@e2e.dev",
+          display_name: "E2E Member",
+          role: "member",
+          status: "active",
+        },
+        ssoProviders: [],
+      });
+    });
+
+    await expect(buildButton).toBeDisabled();
+    await expect(testPage.getByText("Only administrators can build images.")).toBeVisible();
+  });
 });

--- a/apps/web/src/locales/en/executors.json
+++ b/apps/web/src/locales/en/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "Build failed: {{message}}",
   "buildFailedWithStatus": "Build failed ({{status}}): {{text}}",
   "buildImage": "Build Image",
+  "buildImageAdminOnly": "Only administrators can build images.",
   "buildThisDockerImageBeforeCreating": "Build this Docker image before creating the profile.",
   "building": "Building...",
   "checking": "Checking...",

--- a/apps/web/src/locales/pseudo/executors.json
+++ b/apps/web/src/locales/pseudo/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "Ɓũĩĺď ƒàĩĺēď: {{message}}",
   "buildFailedWithStatus": "Ɓũĩĺď ƒàĩĺēď ({{status}}): {{text}}",
   "buildImage": "Ɓũĩĺď Ĩḿàĝē",
+  "buildImageAdminOnly": "Ōńĺŷ àďḿĩńĩśţŕàţōŕś ćàń ƀũĩĺď ĩḿàĝēś.",
   "buildThisDockerImageBeforeCreating": "Ɓũĩĺď ţĥĩś Ďōćķēŕ ĩḿàĝē ƀēƒōŕē ćŕēàţĩńĝ ţĥē ƥŕōƒĩĺē.",
   "building": "Ɓũĩĺďĩńĝ...",
   "checking": "Ćĥēćķĩńĝ...",

--- a/apps/web/src/locales/pt-pt/executors.json
+++ b/apps/web/src/locales/pt-pt/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "A compilação falhou: {{message}}",
   "buildFailedWithStatus": "A compilação falhou ({{status}}): {{text}}",
   "buildImage": "Construir imagem",
+  "buildImageAdminOnly": "Apenas os administradores podem construir imagens.",
   "buildThisDockerImageBeforeCreating": "Construa esta imagem Docker antes de criar o perfil.",
   "building": "A construir...",
   "checking": "A verificar...",

--- a/apps/web/src/locales/zh-cn/executors.json
+++ b/apps/web/src/locales/zh-cn/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "构建失败：{{message}}",
   "buildFailedWithStatus": "构建失败（{{status}}）：{{text}}",
   "buildImage": "构建镜像",
+  "buildImageAdminOnly": "只有管理员可以构建镜像。",
   "buildThisDockerImageBeforeCreating": "创建配置前请先构建此 Docker 镜像。",
   "building": "正在构建…",
   "checking": "正在检查…",

--- a/apps/web/src/locales/zh-hk/executors.json
+++ b/apps/web/src/locales/zh-hk/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "構建失敗：{{message}}",
   "buildFailedWithStatus": "構建失敗（{{status}}）：{{text}}",
   "buildImage": "構建鏡像",
+  "buildImageAdminOnly": "只有管理員可以構建鏡像。",
   "buildThisDockerImageBeforeCreating": "建立設定前請先構建此 Docker 鏡像。",
   "building": "正在構建…",
   "checking": "正在檢查…",

--- a/apps/web/src/locales/zh-tw/executors.json
+++ b/apps/web/src/locales/zh-tw/executors.json
@@ -17,6 +17,7 @@
   "buildFailedWithMessage": "構建失敗：{{message}}",
   "buildFailedWithStatus": "構建失敗（{{status}}）：{{text}}",
   "buildImage": "構建映象",
+  "buildImageAdminOnly": "只有管理員可以構建映象。",
   "buildThisDockerImageBeforeCreating": "建立設定前請先構建此 Docker 映象。",
   "building": "正在構建…",
   "checking": "正在檢查…",


### PR DESCRIPTION
Admin-gating `POST /api/v1/docker/build` in #3025 left the Build Image button enabled for everyone, so a member with `features.auth` enabled could edit a Dockerfile, press Build, get a raw 403 back, and then save a profile referring to an image that was never built. This is the frontend half of that change, raised by the automated review on #3025 and split out because #3025 merged first.

**This PR is not the security boundary.** `authn.RequireAdmin()` on `POST /api/v1/docker/build`, merged in #3025, is — and this PR does not touch, weaken, or duplicate it. A member who calls the endpoint directly still gets 403; `TestBuildImageIsAdminOnly` in `internal/agent/docker` covers that and continues to pass. What changes here is only that the UI stops offering a control whose sole outcome would be that 403.

## Important Changes

- The Build Image button is disabled for members, with an admin-only explanation in place of the status badge, following the role idiom already used by the message-queue and sleep-inhibition settings: `role === undefined` means authentication is disabled, so the single user keeps today's behavior exactly.
- The click handler checks the same permission, so the gate does not rest on the `disabled` attribute alone.
- Backend: adds the other half of #3025's stale-session fallback, that a container resolving through *neither* ownership label stays denied on stop and remove as well as in listings, including one carrying `kandev.managed` but no owner. That test is what keeps the fallback from being widened into a fail-open path.

## Validation

- `go test ./internal/agent/docker/` and `make -C apps/backend lint` (0 issues)
- `pnpm test -- --run components/settings/profile-edit/` (51 pass), `pnpm run typecheck`, `pnpm run lint`, `pnpm run i18n:check` (all five locales complete)
- Desktop e2e: `pnpm e2e:run e2e/tests/settings/docker-profile-persistence.spec.ts` (4 pass)
- Mobile e2e: `pnpm e2e:run --project=mobile-chrome e2e/tests/settings/mobile-docker-build-permissions.spec.ts` (2 pass at Pixel 5)
- Mutation-verified at every level, each mutation asserting it matched the source before running: making the permission helper always return `true` reddens the unit tests; dropping the gate from the rendered prop reddens the component test and both e2e specs but *not* the helper unit test, which is the inert-gate case a leaf-only test would wave through; making an unowned container resolve as visible reddens both backend denial tests. The e2e mutations ran against a rebuilt dist.

## Mobile parity

Playwright selects projects by filename, so a spec that is not named `mobile-*` only ever runs at Desktop Chrome. `mobile-docker-build-permissions.spec.ts` covers the same user value at Pixel 5 and additionally asserts what only the narrow viewport can break: the explanation replaces the status badge inside a horizontal flex row, so the test checks it stays within the viewport and adds no document-level horizontal scrolling.

Noted, not fixed here: the Build Image button renders 28px tall, below the 44px touch-target guidance in the repo's own mobile-parity skill. That is the default `Button` sizing and is byte-identical before and after this change, so fixing it would alter an unrelated control on desktop too. Flagged for a separate change rather than silently asserted at the lower value.

## Possible Improvements

Low risk, UI-only apart from one added backend test. The same "enabled control that can only 403" pattern will exist for every other admin-gated surface the multi-user auth audit produces, so a sweep across them may be worth doing once rather than per-PR.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
