### PR TITLE
fix(ci): prevent PR walkthrough link false failures

### DIFF
--- a/.github/scripts/pr-walkthrough-workflow-contract_test.py
+++ b/.github/scripts/pr-walkthrough-workflow-contract_test.py
@@ -348,6 +348,8 @@ class PRWalkthroughWorkflowContractTest(unittest.TestCase):
         self.assertIn("scripts/pr-walkthrough-pr-body", self.link)
         self.assertIn("--github-response", self.link)
         self.assertIn("--input", self.link)
+        patch_call = self.link.split("gh api --method PATCH", 1)[1].split("echo", 1)[0]
+        self.assertIn("--silent", patch_call)
         self.assertIn(
             "PUBLIC_URL: ${{ needs.pr-walkthrough-publish.outputs.url }}",
             self.link,

--- a/.github/workflows/pr-walkthrough.yml
+++ b/.github/workflows/pr-walkthrough.yml
@@ -413,5 +413,5 @@ jobs:
           gh api --method PATCH \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
             --input pr-update.json \
-            > /dev/null
+            --silent
           echo "Added the walkthrough link to the top of the PR description." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3039/e0ec38653daf.html)
<!-- kandev-pr-walkthrough-end -->

The PR walkthrough link step could mark a successful GitHub API write as failed when `gh api` could not decode the response body, leaving the link written but the required check red. The workflow now uses silent response mode and the contract test enforces it.

## Validation

- `python3 .github/scripts/pr-walkthrough-workflow-contract_test.py` (22 passed)
- `python3 scripts/pr-walkthrough-pr-body.test.py` (8 passed)
- `python3 .github/scripts/lint-action-pinning_test.py` (9 passed)
- `git diff --check`
- Commit hooks passed for harness lint, architecture lint, public copy validation, and Conventional Commits. Unrelated hooks were skipped because no matching files changed.
- `zizmor .github/workflows/pr-walkthrough.yml` reports the existing `pull_request_target` audit finding, unrelated to this change.
- No public documentation change is required because this is a CI-only correction.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->