### PR TITLE
fix(auth): deny a workflow whose workspace no longer exists

### DIFF
--- a/apps/backend/internal/task/service/service_access.go
+++ b/apps/backend/internal/task/service/service_access.go
@@ -93,16 +93,24 @@ func (s *Service) authorizeWorkflowID(ctx context.Context, workflowID string) er
 	if workflow.WorkspaceID == "" {
 		return nil
 	}
+	// A workflow whose workspace cannot be resolved has no owner to check
+	// against, so neither outcome below is "authorized". This used to be one
+	// `return nil` covering both, which handed any workflow ID that survived
+	// a failed lookup to whoever guessed it.
+	//
+	// The pre-auth unowned row is not this case: workspace_id == "" is
+	// answered above and stays visible to everyone. Here the workflow names a
+	// workspace that is not there — `workflows.workspace_id` carries no
+	// foreign key, so a deleted workspace can leave one behind — and an
+	// orphan belongs to nobody, which under per-user scoping means nobody
+	// sees it.
 	workspace, err := s.workspaces.GetWorkspace(ctx, workflow.WorkspaceID)
 	switch {
 	case errors.Is(err, repoerrors.ErrWorkspaceNotFound):
-		// A dangling workspace reference should not hide the workflow from the
-		// single user who can already see everything else about it.
-		return nil
+		return repoerrors.ErrWorkspaceNotFound
 	case err != nil:
-		// Anything else is a failed lookup, not an answer. Treating it as
-		// "authorized" would let a transient database error hand a guessed
-		// workflow ID to whoever asked, so it fails closed by propagating.
+		// A failed lookup is not an answer at all: propagate it rather than
+		// letting a transient database error read as either allow or deny.
 		return err
 	}
 	if !workspaceVisibleTo(workspace, userID) {

--- a/apps/backend/internal/task/service/service_access_test.go
+++ b/apps/backend/internal/task/service/service_access_test.go
@@ -211,6 +211,17 @@ func TestAuthorizeWorkflowAccess(t *testing.T) {
 	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-a"), "wf-legacy"); err != nil {
 		t.Fatalf("legacy workflow access: %v", err)
 	}
+	// So does a workflow carrying no workspace at all (schema default, never
+	// backfilled). This is the pre-auth row the orphan branch above must not
+	// swallow: it names no owner rather than naming a missing one.
+	if err := repo.CreateWorkflow(context.Background(), &models.Workflow{
+		ID: "wf-no-workspace", Name: "Pre-auth, workspaceless",
+	}); err != nil {
+		t.Fatalf("create workspaceless workflow: %v", err)
+	}
+	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-a"), "wf-no-workspace"); err != nil {
+		t.Fatalf("workspaceless workflow access: %v", err)
+	}
 	// A failed workspace lookup is not an answer. The dangling-reference
 	// fallback below it returns nil, so a transient database error used to
 	// read as "authorized" and hand a guessed workflow ID to whoever asked.
@@ -219,11 +230,23 @@ func TestAuthorizeWorkflowAccess(t *testing.T) {
 	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-a"), "wf-b"); !errors.Is(err, broken) {
 		t.Fatalf("failed workspace lookup: %v, want the lookup error", err)
 	}
-	// A workspace row that is genuinely gone keeps the documented fallback:
-	// the workflow stays visible rather than disappearing from its owner.
+	// A workspace row that is genuinely gone is a different answer from a
+	// failed lookup, and it is still not "authorized": the workflow names an
+	// owner that does not exist, so nobody sees it. (An unowned pre-auth row
+	// is the workspace_id == "" case below, not this one.)
 	svc.workspaces = &brokenWorkspaceReader{WorkspaceRepository: repo, err: repoerrors.ErrWorkspaceNotFound}
-	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-a"), "wf-b"); err != nil {
-		t.Fatalf("dangling workspace reference: %v, want the visibility fallback", err)
+	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-a"), "wf-b"); !errors.Is(err, repoerrors.ErrWorkspaceNotFound) {
+		t.Fatalf("orphaned workflow: %v, want the not-found denial", err)
+	}
+	if err := svc.AuthorizeWorkflowAccess(ctxAs("user-b"), "wf-b"); !errors.Is(err, repoerrors.ErrWorkspaceNotFound) {
+		t.Fatalf("orphaned workflow for its former owner: %v, want the not-found denial", err)
+	}
+	// Unscoped callers are unaffected: they never reach the lookup.
+	if err := svc.AuthorizeWorkflowAccess(context.Background(), "wf-b"); err != nil {
+		t.Fatalf("internal caller hit the orphan branch: %v", err)
+	}
+	if err := svc.AuthorizeWorkflowAccess(ctxSynthetic(), "wf-b"); err != nil {
+		t.Fatalf("synthetic caller hit the orphan branch: %v", err)
 	}
 	svc.workspaces = repo
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3040/6189bc480251.html)
<!-- kandev-pr-walkthrough-end -->

#3031 merged with the P1 review thread only half-addressed. That PR split the single `return nil` covering every failed workspace lookup, but kept a *missing* workspace row as "visible", reasoning by analogy with `authorizeTaskID`'s dangling-reference fallback. The analogy does not hold, so an orphaned workflow stayed readable and writable by any authenticated user.

The pre-auth unowned row is answered earlier and is unaffected: `workspace_id == ""` means the workflow names no owner and stays visible to everyone, which is what legacy single-user installs actually have. Reaching the lookup at all means the workflow names a workspace that is *not there* — `workflows.workspace_id` carries no foreign key, so a deleted workspace can leave one behind — and an orphan belongs to nobody, which under per-user scoping means nobody sees it.

## Important Changes

- `authorizeWorkflowID` now gives three distinct answers where there used to be one: a missing workspace denies with the not-found sentinel, a failed lookup propagates as the failure it is, and a resolved workspace is checked against its owner as before.
- Unscoped callers (no identity, or the synthetic identity injected while auth is disabled) return before any of it, so single-user behaviour is unchanged.
- The identical `//nolint:nilerr` fallback in `authorizeTaskID` is knowingly left alone. Same shape, but it sits on a far wider hot path and needs its own change with its own tests.

## Validation

- `make -C apps/backend test` — full suite, 248 packages, 0 failures.
- `make -C apps/backend lint` — 0 issues.
- `TestAuthorizeWorkflowAccess` covers all four branches: orphaned workflow denied (for a stranger *and* for its former owner), failed lookup propagated as itself rather than as allow or deny, workspace-less pre-auth row still visible, unscoped callers never reaching the lookup.
- Mutation-tested: flipping each of those four branches turns the test red.

## Possible Improvements

Low risk, and the blast radius is bounded to workflows whose `workspace_id` names a row that no longer exists. If any install has such orphans, they become invisible under enforced auth rather than universally accessible — which is the intent, but it is the one behaviour change worth knowing about. Deleting them needs the workspace-scoped cleanup path, not this route.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->