### PR TITLE
test(e2e): cover the Docker build gate at phone viewport

### DIFF
--- a/apps/web/e2e/helpers/session-store.ts
+++ b/apps/web/e2e/helpers/session-store.ts
@@ -7,6 +7,12 @@ type E2EStoreWindow = Window & {
       tasks: { activeSessionId: string | null };
       sessionAgentctl: { itemsBySessionId: Record<string, { status?: string }> };
       setAvailableCommands: (sessionId: string, commands: AvailableCommand[]) => void;
+      setAuthState: (state: {
+        mode: string;
+        authenticated: boolean;
+        user: StoreUser;
+        ssoProviders: unknown[];
+      }) => void;
     };
     setState: (
       updater: (state: {
@@ -16,11 +22,55 @@ type E2EStoreWindow = Window & {
   };
 };
 
+type StoreUser = {
+  id: string;
+  email: string;
+  display_name: string;
+  role: string;
+  status: string;
+};
+
 type AvailableCommand = {
   name: string;
   description?: string;
   input_hint?: string;
 };
+
+/**
+ * Inject an authenticated identity through the store bridge.
+ *
+ * E2E runs with authentication disabled, which leaves the role undefined and
+ * every role-gated control in its permissive single-user state. Specs that
+ * need to prove a member/admin difference set the identity directly rather
+ * than standing up a real login, matching what the system settings specs do.
+ */
+export async function setStoreRole(
+  page: Page,
+  role: "member" | "admin",
+  overrides: Partial<StoreUser> = {},
+): Promise<void> {
+  await page.waitForFunction(() => Boolean((window as E2EStoreWindow).__KANDEV_E2E_STORE__));
+  await page.evaluate(
+    ({ role, overrides }) => {
+      const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge is unavailable");
+      store.getState().setAuthState({
+        mode: "enabled",
+        authenticated: true,
+        user: {
+          id: `e2e-${role}`,
+          email: `${role}@e2e.dev`,
+          display_name: role === "admin" ? "E2E Admin" : "E2E Member",
+          role,
+          status: "active",
+          ...overrides,
+        },
+        ssoProviders: [],
+      });
+    },
+    { role, overrides },
+  );
+}
 
 /** Wait until the session agentctl is ready for controls that require it. */
 export async function waitForSessionAgentctlReady(

--- a/apps/web/e2e/tests/settings/docker-profile-persistence.spec.ts
+++ b/apps/web/e2e/tests/settings/docker-profile-persistence.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import { setStoreRole } from "../../helpers/session-store";
 
 /**
  * Regression test for the Docker executor profile UI persisting Dockerfile
@@ -220,23 +221,7 @@ test.describe("Docker executor profile persistence", () => {
     const buildButton = testPage.getByRole("button", { name: "Build Image" });
     await expect(buildButton).toBeEnabled();
 
-    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
-    await testPage.evaluate(() => {
-      const store = window.__KANDEV_E2E_STORE__;
-      if (!store) throw new Error("E2E store bridge is unavailable");
-      store.getState().setAuthState({
-        mode: "enabled",
-        authenticated: true,
-        user: {
-          id: "e2e-member",
-          email: "member@e2e.dev",
-          display_name: "E2E Member",
-          role: "member",
-          status: "active",
-        },
-        ssoProviders: [],
-      });
-    });
+    await setStoreRole(testPage, "member");
 
     await expect(buildButton).toBeDisabled();
     await expect(testPage.getByText("Only administrators can build images.")).toBeVisible();

--- a/apps/web/e2e/tests/settings/mobile-docker-build-permissions.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-docker-build-permissions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import { setStoreRole } from "../../helpers/session-store";
 
 /**
  * Mobile parity for the admin gating on the Dockerfile build control.
@@ -25,23 +26,7 @@ test.describe("Docker build permissions on mobile", () => {
     const buildButton = testPage.getByRole("button", { name: "Build Image" });
     await expect(buildButton).toBeEnabled();
 
-    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
-    await testPage.evaluate(() => {
-      const store = window.__KANDEV_E2E_STORE__;
-      if (!store) throw new Error("E2E store bridge is unavailable");
-      store.getState().setAuthState({
-        mode: "enabled",
-        authenticated: true,
-        user: {
-          id: "e2e-member",
-          email: "member@e2e.dev",
-          display_name: "E2E Member",
-          role: "member",
-          status: "active",
-        },
-        ssoProviders: [],
-      });
-    });
+    await setStoreRole(testPage, "member");
 
     await expect(buildButton).toBeDisabled();
     const explanation = testPage.getByText("Only administrators can build images.");
@@ -56,11 +41,13 @@ test.describe("Docker build permissions on mobile", () => {
     expect(explanationBox!.x).toBeGreaterThanOrEqual(0);
     expect(explanationBox!.x + explanationBox!.width).toBeLessThanOrEqual(viewportWidth);
 
-    // And it must not introduce document-level horizontal scrolling.
+    // And it must not introduce document-level horizontal scrolling. The DOM
+    // guarantees scrollWidth >= clientWidth, so the only passing value is 0;
+    // asserting that exactly keeps the failure message readable.
     const horizontalOverflow = await testPage.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
     );
-    expect(horizontalOverflow).toBeLessThanOrEqual(0);
+    expect(horizontalOverflow).toBe(0);
   });
 
   test("admin keeps the build control usable at phone width", async ({ testPage }) => {
@@ -68,23 +55,7 @@ test.describe("Docker build permissions on mobile", () => {
     await expect(testPage.locator("#profile-name")).toHaveValue("Docker", { timeout: 10_000 });
     await testPage.getByRole("button", { name: "Use defaults" }).click();
 
-    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
-    await testPage.evaluate(() => {
-      const store = window.__KANDEV_E2E_STORE__;
-      if (!store) throw new Error("E2E store bridge is unavailable");
-      store.getState().setAuthState({
-        mode: "enabled",
-        authenticated: true,
-        user: {
-          id: "e2e-admin",
-          email: "admin@e2e.dev",
-          display_name: "E2E Admin",
-          role: "admin",
-          status: "active",
-        },
-        ssoProviders: [],
-      });
-    });
+    await setStoreRole(testPage, "admin");
 
     await expect(testPage.getByRole("button", { name: "Build Image" })).toBeEnabled();
     await expect(testPage.getByText("Only administrators can build images.")).toHaveCount(0);

--- a/apps/web/e2e/tests/settings/mobile-docker-build-permissions.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-docker-build-permissions.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "../../fixtures/test-base";
+
+/**
+ * Mobile parity for the admin gating on the Dockerfile build control.
+ *
+ * The desktop coverage lives in docker-profile-persistence.spec.ts, which the
+ * `chromium` project runs at desktop viewport; only `mobile-*.spec.ts` files
+ * reach the Pixel 5 `mobile-chrome` project. The gating swaps the build status
+ * badge for a sentence of explanation inside a horizontal flex row, so the
+ * narrow viewport is where that row can overflow, and it is asserted here
+ * rather than assumed from the desktop run.
+ *
+ * The security boundary is the backend's authn.RequireAdmin() on
+ * POST /api/v1/docker/build; this covers the UI not offering a control that
+ * can only 403.
+ */
+test.describe("Docker build permissions on mobile", () => {
+  test("member sees the build control disabled and readable at phone width", async ({
+    testPage,
+  }) => {
+    await testPage.goto("/settings/executors/new/local_docker");
+    await expect(testPage.locator("#profile-name")).toHaveValue("Docker", { timeout: 10_000 });
+    await testPage.getByRole("button", { name: "Use defaults" }).click();
+
+    const buildButton = testPage.getByRole("button", { name: "Build Image" });
+    await expect(buildButton).toBeEnabled();
+
+    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
+    await testPage.evaluate(() => {
+      const store = window.__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge is unavailable");
+      store.getState().setAuthState({
+        mode: "enabled",
+        authenticated: true,
+        user: {
+          id: "e2e-member",
+          email: "member@e2e.dev",
+          display_name: "E2E Member",
+          role: "member",
+          status: "active",
+        },
+        ssoProviders: [],
+      });
+    });
+
+    await expect(buildButton).toBeDisabled();
+    const explanation = testPage.getByText("Only administrators can build images.");
+    await expect(explanation).toBeVisible();
+
+    // The explanation must sit inside the viewport, not run off the side of
+    // the flex row it shares with the button.
+    const viewportWidth = testPage.viewportSize()?.width ?? 0;
+    expect(viewportWidth).toBeGreaterThan(0);
+    const explanationBox = await explanation.boundingBox();
+    expect(explanationBox).not.toBeNull();
+    expect(explanationBox!.x).toBeGreaterThanOrEqual(0);
+    expect(explanationBox!.x + explanationBox!.width).toBeLessThanOrEqual(viewportWidth);
+
+    // And it must not introduce document-level horizontal scrolling.
+    const horizontalOverflow = await testPage.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(horizontalOverflow).toBeLessThanOrEqual(0);
+  });
+
+  test("admin keeps the build control usable at phone width", async ({ testPage }) => {
+    await testPage.goto("/settings/executors/new/local_docker");
+    await expect(testPage.locator("#profile-name")).toHaveValue("Docker", { timeout: 10_000 });
+    await testPage.getByRole("button", { name: "Use defaults" }).click();
+
+    await testPage.waitForFunction(() => Boolean(window.__KANDEV_E2E_STORE__));
+    await testPage.evaluate(() => {
+      const store = window.__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge is unavailable");
+      store.getState().setAuthState({
+        mode: "enabled",
+        authenticated: true,
+        user: {
+          id: "e2e-admin",
+          email: "admin@e2e.dev",
+          display_name: "E2E Admin",
+          role: "admin",
+          status: "active",
+        },
+        ssoProviders: [],
+      });
+    });
+
+    await expect(testPage.getByRole("button", { name: "Build Image" })).toBeEnabled();
+    await expect(testPage.getByText("Only administrators can build images.")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3041/4ff92a3ee7ff.html)
<!-- kandev-pr-walkthrough-end -->

The member gating on the Dockerfile build control shipped in #3034 with desktop-only Playwright coverage. Playwright selects projects by filename here, so a spec not named `mobile-*` runs at Desktop Chrome and never at Pixel 5, leaving the phone path unproven.

## Important Changes

- Adds `mobile-docker-build-permissions.spec.ts`, which the `mobile-chrome` project picks up automatically, covering both roles at Pixel 5: a member gets the disabled button plus the admin-only explanation, an admin keeps a usable control.
- It asserts what only the narrow viewport can break, rather than restating the desktop test: the gating replaces the build status badge with a sentence of copy inside a horizontal flex row, so the spec checks the explanation stays within the viewport bounds and introduces no document-level horizontal scrolling.

Test-only. No production code changes, and the security boundary is unchanged: `authn.RequireAdmin()` on `POST /api/v1/docker/build` (merged in #3025) is what actually stops a member, and `TestBuildImageIsAdminOnly` covers it.

## Validation

- `pnpm e2e:run --project=mobile-chrome e2e/tests/settings/mobile-docker-build-permissions.spec.ts` (2 pass at Pixel 5, against a rebuilt dist)
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run i18n:check`
- Mutation-verified: dropping the gate from the rendered prop reddens the member test and leaves the admin one green. The mutation ran through `e2e:run`, which rebuilds, so it exercised the changed component rather than a stale bundle.

## Possible Improvements

Noted, not fixed here: the Build Image button renders 28px tall, below the 44px touch-target guidance in the repo's own mobile-parity skill. That is default `Button` sizing, byte-identical before and after the gating change, so raising it would alter an unrelated control on desktop too. I dropped the assertion rather than weaken it to the passing value, and am flagging it for a separate change.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
