### PR TITLE
fix(workflow): stop rejecting a move_to_step target that resolves to nothing

### DIFF
--- a/apps/backend/internal/workflow/controller/controller.go
+++ b/apps/backend/internal/workflow/controller/controller.go
@@ -317,17 +317,33 @@ func (c *Controller) validateStepReferences(ctx context.Context, step *models.Wo
 // with whatever it finds there — that step's prompt and agent profile — so a
 // target in somebody else's workflow both parks the task outside its board and
 // runs it under their configuration.
+//
+// A target that resolves to nothing is left alone, because reaching nothing is
+// the whole point: `move_to_step` configs are authored with symbolic IDs
+// ("review", "in-progress") that only the template applier remaps, and the
+// engine skips an unresolvable target rather than failing the trigger. That
+// tolerance is load-bearing product behaviour, not an oversight, so rejecting
+// it here broke ordinary step edits that had nothing to do with scoping.
+//
+// It is also safe: an unresolvable ID reaches no other user's step, and it
+// cannot be armed later, since step IDs are generated server-side on every
+// write path (create, template apply, import, sync) and never accepted from a
+// caller.
 func (c *Controller) validateEventStepTarget(ctx context.Context, step *models.WorkflowStep, targetID string) error {
 	if targetID == step.ID {
 		return nil // a self-transition names no other step
 	}
-	if err := c.svc.AuthorizeStep(ctx, targetID); err != nil {
-		return err
-	}
 	target, err := c.svc.GetStep(ctx, targetID)
 	if err != nil {
+		if service.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("move_to_step target is invalid: %w", err)
 	}
+	// Membership carries the authorization: the step being written lives in an
+	// already-authorized workflow, so a target inside that same workflow is
+	// authorized by construction, and one outside it is refused whether or not
+	// the caller can see it.
 	if target.WorkflowID != step.WorkflowID {
 		return fmt.Errorf("move_to_step must reference a step in the same workflow")
 	}

--- a/apps/backend/internal/workflow/handlers/step_reference_scope_test.go
+++ b/apps/backend/internal/workflow/handlers/step_reference_scope_test.go
@@ -58,7 +58,10 @@ func TestMoveToStepTargetCannotLeaveTheWorkflow(t *testing.T) {
 		h.queries.reset()
 		rec := doAs(t, h, asUser(userB), http.MethodPost, "/api/v1/workflow/steps",
 			moveToStepBody("wf-b", "Smuggler", h.stepA))
-		requireNotFound(t, rec)
+		requireStatus(t, rec, http.StatusBadRequest)
+		if !strings.Contains(rec.Body.String(), "same workflow") {
+			t.Fatalf("body = %s, want the same-workflow reason", rec.Body.String())
+		}
 		requireNoStepWrites(t, h)
 	})
 
@@ -71,19 +74,47 @@ func TestMoveToStepTargetCannotLeaveTheWorkflow(t *testing.T) {
 					{"type": "move_to_step", "config": map[string]any{"step_id": h.stepA}},
 				},
 			}})
-		requireNotFound(t, rec)
+		requireStatus(t, rec, http.StatusBadRequest)
 		requireNoStepWrites(t, h)
 	})
 
-	t.Run("a foreign target answers exactly like a nonexistent one", func(t *testing.T) {
+	// A target that resolves to nothing is accepted, and a target that resolves
+	// into another workflow is not. Those two answers differ on purpose.
+	//
+	// The alternative — one reply for both — is what shipped in #3031, and it
+	// broke ordinary step edits: `move_to_step` configs are routinely authored
+	// with symbolic IDs ("review") that only the template applier remaps, and
+	// the engine skips an unresolvable target instead of failing the trigger.
+	// Refusing those rejected a documented, load-bearing behaviour.
+	//
+	// The cost is that a caller holding a step UUID can learn it belongs to
+	// some other workflow. That is a UUID they already had, it stays refused
+	// either way, and no ID they supply can ever become valid later: step IDs
+	// are generated server-side on every write path.
+	t.Run("an unresolvable target is accepted, a foreign one is not", func(t *testing.T) {
 		h := setupScopedRouter(t)
+		symbolic := doAs(t, h, asUser(userB), http.MethodPost, "/api/v1/workflow/steps",
+			moveToStepBody("wf-b", "Symbolic", "review"))
+		requireStatus(t, symbolic, http.StatusCreated)
+
 		foreign := doAs(t, h, asUser(userB), http.MethodPost, "/api/v1/workflow/steps",
 			moveToStepBody("wf-b", "Smuggler", h.stepA))
-		missing := doAs(t, h, asUser(userB), http.MethodPost, "/api/v1/workflow/steps",
-			moveToStepBody("wf-b", "Smuggler", "no-such-step"))
-		if foreign.Code != missing.Code || foreign.Body.String() != missing.Body.String() {
-			t.Fatalf("foreign target %d %s differs from missing target %d %s",
-				foreign.Code, foreign.Body.String(), missing.Code, missing.Body.String())
+		requireStatus(t, foreign, http.StatusBadRequest)
+	})
+
+	// The e2e suite runs with authentication disabled and edits steps exactly
+	// this way (workflow-automation.spec.ts). Pinning it here means the next
+	// change to this validator fails in a Go test in seconds rather than in a
+	// browser shard an hour later.
+	t.Run("a symbolic target is accepted with auth disabled", func(t *testing.T) {
+		h := setupScopedRouter(t)
+		for _, ctx := range []context.Context{asSyntheticUser(), context.Background()} {
+			rec := doAs(t, h, ctx, http.MethodPut, "/api/v1/workflow/steps/"+h.stepB,
+				map[string]any{"events": map[string]any{
+					"on_turn_start":    []map[string]any{{"type": "move_to_next"}},
+					"on_turn_complete": []map[string]any{{"type": "move_to_step", "config": map[string]any{"step_id": "review"}}},
+				}})
+			requireStatus(t, rec, http.StatusOK)
 		}
 	})
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3046/20d8296a1d1a.html)
<!-- kandev-pr-walkthrough-end -->

main is red on `workflow-automation.spec.ts:381`, deterministically, and #3031 (`7d9f81be8`) caused it. That PR added a same-workflow rule for `move_to_step` targets and enforced it by resolving the target, treating an unresolved one as a rejection — so editing a step whose transition names a symbolic target answered `404 {"error":"Step not found"}` with authentication **disabled**, where the write had always succeeded.

Reaching nothing is the point of those targets. `move_to_step` configs are authored with template-level IDs (`"review"`, `"in-progress"`) that only the template applier remaps, and the engine skips a target it cannot resolve rather than failing the trigger. The failing spec writes exactly that shape through the step API and asserts the skip — its own doc comment says so: *"the on_turn_complete events use template-level step_id references which don't resolve to actual step UUIDs — they're no-ops"*.

## Important Changes

- An unresolvable `move_to_step` target is accepted again. A target that resolves into **another workflow** is still refused, which is all the scoping rule ever needed.
- The separate `AuthorizeStep` call on the target is dropped as redundant: the step being written lives in an already-authorized workflow, so a target inside that same workflow is authorized by construction.
- Safety of allowing dangling targets is not incidental — an unresolvable ID reaches no other user's step, and it cannot be armed later, because step IDs are generated server-side on every write path (create, template apply, import, sync) and never accepted from a caller.

The trade: a caller holding a step UUID can now learn it belongs to some other workflow, from a 400 rather than a 404. They already had the UUID, it stays refused either way, and the alternative is rejecting documented product behaviour. That reasoning is a comment on the validator and a comment on the test, so the next person does not "tighten" it back.

## Validation

- **Reproduced at the API layer** first: `PUT /api/v1/workflow/steps/<id>` with `on_turn_complete: move_to_step{step_id: "review"}` and no identity on the request → `404 {"error":"Step not found"}`, byte-identical to CI.
- **Reproduced end to end, both directions.** `pnpm run e2e:run -- tests/workflow/workflow-automation.spec.ts --grep "kanban workflow"`: fails at `updateWorkflowStep` (spec line 400) without this change, passes in 4.4s with it. The backend is rebuilt by the runner, so the mutant is real.
- Every other spec that uses `move_to_step` passes a real UUID in the same workflow and is unaffected either way — checked the whole `apps/web/e2e` tree.
- Both shapes are now pinned in Go tests, including the auth-disabled path (synthetic identity *and* no identity), so the next change to this validator fails in seconds rather than in a browser shard an hour later.
- `make -C apps/backend lint` clean; backend suites for the touched packages green.

## Possible Improvements

Low risk; the diff narrows a check that should never have been this wide. The remaining audit note is that `queue_run` task targets are still authorized strictly (a literal `task_id` naming a deleted task is refused when auth is enabled) — that path has no symbolic-ID convention and no spec depends on it, but it is the nearest neighbour if something else turns up.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3046-bwo7.sprites.app |
| **Commit** | `20d8296` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->