### PR TITLE
test(system): await the backup job before the authz test returns

### DIFF
--- a/apps/backend/internal/system/system_authz_test.go
+++ b/apps/backend/internal/system/system_authz_test.go
@@ -10,7 +10,9 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
@@ -18,6 +20,8 @@ import (
 	"github.com/kandev/kandev/internal/auth/httpmw"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/system/backups"
 	"github.com/kandev/kandev/internal/system/jobs"
 	systemsettings "github.com/kandev/kandev/internal/system/settings"
@@ -37,6 +41,11 @@ const (
 	authzJSONContentType = "application/json"
 )
 
+// authzJobTimeout bounds the wait for an async backup job. It only has to
+// cover a VACUUM INTO of a one-table database, so a generous value costs
+// nothing on the happy path and still fails loudly rather than hanging.
+const authzJobTimeout = 30 * time.Second
+
 // systemRouterForSyntheticIdentity mirrors the auth-disabled request path:
 // httpmw injects the synthetic single-user admin on every request.
 func systemRouterForSyntheticIdentity() *gin.Engine {
@@ -52,6 +61,49 @@ type backupsAuthzFixture struct {
 	service    *backups.Service
 	tracker    *jobs.Tracker
 	backupsDir string
+
+	// POST /backups returns a job id and does its filesystem work in a
+	// tracker goroutine, so a test that returns without waiting races
+	// t.TempDir()'s RemoveAll against a VACUUM INTO still writing into
+	// backupsDir. The tracker publishes every transition on the event bus,
+	// so awaiting the terminal one is a real barrier rather than a sleep:
+	// jobs.Tracker.run publishes it only after the job function has
+	// returned, which is after the last write.
+	mu   sync.Mutex
+	done map[string]chan struct{}
+}
+
+// jobDone returns the channel closed when jobID reaches a terminal state,
+// creating it if neither side has seen the job yet. Both the subscriber and
+// the waiter go through here, so a job that finishes before anyone waits is
+// still observed.
+func (f *backupsAuthzFixture) jobDone(jobID string) chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	channel, ok := f.done[jobID]
+	if !ok {
+		channel = make(chan struct{})
+		f.done[jobID] = channel
+	}
+	return channel
+}
+
+// awaitJob blocks until the job finishes. It is the barrier that keeps the
+// tracker goroutine from outliving the test and its temporary directory.
+func (f *backupsAuthzFixture) awaitJob(t *testing.T, response *httptest.ResponseRecorder) {
+	t.Helper()
+	var body struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || body.JobID == "" {
+		t.Fatalf("create response carried no job id: %s", response.Body.String())
+	}
+	select {
+	case <-f.jobDone(body.JobID):
+	case <-time.After(authzJobTimeout):
+		t.Fatalf("backup job %s did not finish in %s; state = %+v",
+			body.JobID, authzJobTimeout, f.tracker.Get(body.JobID))
+	}
 }
 
 func newBackupsAuthzFixture(t *testing.T) *backupsAuthzFixture {
@@ -75,9 +127,27 @@ func newBackupsAuthzFixture(t *testing.T) *backupsAuthzFixture {
 	if err := os.WriteFile(snapshot, []byte(authzSnapshotContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	tracker := jobs.NewTracker(nil, testLoggerForAuthz(t))
-	service := backups.NewService(databasePath, db.NewPool(connection, connection), tracker, testLoggerForAuthz(t))
-	return &backupsAuthzFixture{service: service, tracker: tracker, backupsDir: backupsDir}
+	fixture := &backupsAuthzFixture{backupsDir: backupsDir, done: map[string]chan struct{}{}}
+	// A real logger: MemoryEventBus.Subscribe logs unconditionally and nil-
+	// derefs on a nil one, even though Publish tolerates it.
+	eventBus := bus.NewMemoryEventBus(testLoggerForAuthz(t))
+	subscription, err := eventBus.Subscribe(events.SystemJobUpdate, func(_ context.Context, event *bus.Event) error {
+		job, ok := event.Data.(*jobs.Job)
+		if !ok || (job.State != jobs.StateSucceeded && job.State != jobs.StateFailed) {
+			return nil
+		}
+		close(fixture.jobDone(job.ID))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = subscription.Unsubscribe() })
+	fixture.tracker = jobs.NewTracker(eventBus, testLoggerForAuthz(t))
+	fixture.service = backups.NewService(
+		databasePath, db.NewPool(connection, connection), fixture.tracker, testLoggerForAuthz(t),
+	)
+	return fixture
 }
 
 func (f *backupsAuthzFixture) router(t *testing.T, router *gin.Engine) *gin.Engine {
@@ -198,6 +268,10 @@ func TestBackupsRoutesUnchangedForAdminAndSyntheticIdentity(t *testing.T) {
 			if create.Code != http.StatusAccepted {
 				t.Fatalf("create status = %d, want 202; body=%s", create.Code, create.Body.String())
 			}
+			// Wait here, not at the end: the job writes into the same
+			// directory the assertions below read, so letting it run loose
+			// would race the delete assertion as well as the cleanup.
+			fixture.awaitJob(t, create)
 
 			restore := serve(router, newRequest(http.MethodPost, authzSnapshotPath+"/restore", `{"confirm":"NOPE"}`))
 			if restore.Code != http.StatusBadRequest {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3050/0be9f4c529cd.html)
<!-- kandev-pr-walkthrough-end -->

`TestBackupsRoutesUnchangedForAdminAndSyntheticIdentity` left `main` red. `POST /backups` returns a job id immediately and does its filesystem work in a `jobs.Tracker` goroutine, so the test returned while `VACUUM INTO` was still writing and `t.TempDir()`'s `RemoveAll` raced it (`unlinkat .../001/backups: directory not empty`). The assertions were never wrong; only the cleanup lost the race, which is why it passed on the PR and failed on main.

## Important Changes

- The fixture waits on the tracker's own terminal event instead of sleeping. `jobs.Tracker` publishes every transition on the event bus and publishes the terminal one only after the job function has returned, which is after the last write, so it is a real barrier. The fixture subscribes to `system.job.update` and closes a per-job channel; both the subscriber and the waiter go through `jobDone`, so a job that finishes before anyone waits is still observed.
- The wait sits immediately after the create, not at the end of the test. The job writes into the same directory the later assertions read, so it was racing the delete assertion too, not only the cleanup.

## Validation

- Reproduced before the fix: `go test ./internal/system/ -run TestBackupsRoutesUnchangedForAdminAndSyntheticIdentity -race -count=25` fails. Both subtests are affected, not only the `synthetic` one CI reported.
- After the fix: same test stable at `-race -count=200`.
- Removing the barrier reproduces the failure again in 8 of 50 runs, so the barrier is what makes it stable.
- Siblings swept: `go test ./internal/system/... -race -count=10` and `go test ./internal/system/backups/ -race -count=50`, both clean. The other async-looking sites are safe by construction: the member `POST /backups` case is denied 403 before any job starts (and asserts the tracker is empty), and the storage cases use in-memory fakes that neither spawn goroutines nor touch the filesystem.
- `make -C apps/backend lint` and `golangci-lint run ./... --new-from-rev=origin/main`: 0 issues.

## Possible Improvements

Test-only change, no production code. One incidental finding worth knowing: `bus.NewMemoryEventBus(nil)` nil-derefs inside `Subscribe`, which logs unconditionally, even though `Publish` tolerates a nil logger. Existing callers only get away with it because they never subscribe.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->