### PR TITLE
test: cover direct tasks sidebar PR hydration

### DIFF
--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -102,6 +102,61 @@ async function expectTopbarReadyState(
 }
 
 test.describe("PR status badge", () => {
+  test("hydrates the sidebar PR badge on /tasks when details are off", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const baselineShowDetails =
+      (await apiClient.getUserSettings()).settings.tasks_list_show_details === true;
+
+    try {
+      const { task } = await seedBadgeTest(
+        apiClient,
+        seedData.workspaceId,
+        seedData.agentProfileId,
+        seedData.repositoryId,
+        "Direct tasks sidebar PR badge",
+      );
+      await apiClient.saveUserSettings({ tasks_list_show_details: false });
+      await apiClient.mockGitHubAssociateTaskPR({
+        task_id: task.id,
+        owner: "testorg",
+        repo: "testrepo",
+        pr_number: 100,
+        pr_url: "https://github.com/testorg/testrepo/pull/100",
+        pr_title: "Hydrate sidebar badge on direct tasks load",
+        head_branch: "fix/direct-tasks-hydration",
+        base_branch: "main",
+        author_login: "test-user",
+        state: "open",
+        review_state: "approved",
+        checks_state: "success",
+        mergeable_state: "clean",
+      });
+      await waitForTaskPRFields(apiClient, task.id, {
+        state: "open",
+        review_state: "approved",
+        checks_state: "success",
+        mergeable_state: "clean",
+      });
+
+      await testPage.goto("/tasks");
+      await expect(testPage.getByTestId("tasks-list")).toBeVisible();
+
+      const sidebar = testPage.getByTestId("app-sidebar");
+      const taskRow = sidebar.getByTestId("sidebar-task-item").filter({ hasText: task.title });
+      const icon = taskRow.getByTestId(`pr-task-icon-${task.id}`);
+      await expect(icon).toBeVisible();
+      await expect(icon).toHaveAttribute("data-pr-count", "1");
+      await expect(icon).toHaveAttribute("data-pr-state", "open");
+      await expect(icon).toHaveAttribute("data-pr-ready-to-merge", "true");
+    } finally {
+      await apiClient.saveUserSettings({ tasks_list_show_details: baselineShowDetails });
+    }
+  });
+
   /**
    * Regression for the "CI pending" bug: GitHub reports all checks passed
    * (one skipped, many successful). We used to compute "pending" because

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -102,6 +102,16 @@ async function expectTopbarReadyState(
 }
 
 test.describe("PR status badge", () => {
+  // seedBadgeTest selects a temporary workflow and changes preview behavior.
+  // Restore the fixture defaults so those changes do not leak between tests.
+  test.afterEach(async ({ apiClient, seedData }) => {
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: seedData.workflowId,
+      enable_preview_on_click: false,
+    });
+  });
+
   test("hydrates the sidebar PR badge on /tasks when details are off", async ({
     testPage,
     apiClient,
@@ -109,7 +119,7 @@ test.describe("PR status badge", () => {
   }) => {
     test.setTimeout(120_000);
     const baselineShowDetails =
-      (await apiClient.getUserSettings()).settings.tasks_list_show_details === true;
+      (await apiClient.getUserSettings()).settings.tasks_list_show_details ?? false;
 
     try {
       const { task } = await seedBadgeTest(


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3051/d21324275ac1.html)
<!-- kandev-pr-walkthrough-end -->

Direct /tasks loads with task details disabled previously lost sidebar GitHub PR badges because the regression only had unit coverage. This adds a focused Playwright test that proves the sidebar badge still hydrates from the tasks page path.

## Validation

- mise exec -- make -C apps/backend build
- cd apps && mise exec -- corepack pnpm --filter @kandev/web test -- --run app/tasks/tasks-page-client.mr-hydration.test.tsx
- cd apps && mise exec -- corepack pnpm --filter @kandev/web lint -- e2e/tests/pr/pr-status-badge.spec.ts
- cd apps/web && mise exec -- corepack pnpm run typecheck
- cd apps/web && mise exec -- corepack pnpm e2e:run tests/pr/pr-status-badge.spec.ts -- --grep "hydrates the sidebar PR badge on /tasks when details are off"

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (apps/web/), I have added or updated Playwright e2e tests in apps/web/e2e/ and verified them with make test-e2e.
- [ ] I checked whether this affects public docs in docs/public/** and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->