### PR TITLE
feat(kanban): add mouse grab panning for desktop boards

### DIFF
--- a/.kandev/review-notes.md
+++ b/.kandev/review-notes.md
@@ -1,0 +1,4 @@
+## Fixed during review
+- apps/web/components/kanban/adaptive-desktop-kanban.tsx:70 - disabled scroll snap synchronously before the first active pan scroll mutation, so browser snap cannot undo the initial grab-pan movement. Also restored snap on pan cancellation. (commit b0f64d9b5)
+- apps/web/components/kanban-card-content.tsx:617 - added an explicit data-kanban-card marker and excluded it from background panning, so task-card descendants cannot arm the board pan gesture. (commit b0f64d9b5)
+- apps/web/e2e/tests/kanban/kanban-board.spec.ts:146 - removed a fragile exact-position assertion after mouseleave, because restored CSS snap may settle the board independently of the canceled gesture. (commit b0f64d9b5)

--- a/.kandev/review-notes.md
+++ b/.kandev/review-notes.md
@@ -1,4 +1,0 @@
-## Fixed during review
-- apps/web/components/kanban/adaptive-desktop-kanban.tsx:70 - disabled scroll snap synchronously before the first active pan scroll mutation, so browser snap cannot undo the initial grab-pan movement. Also restored snap on pan cancellation. (commit b0f64d9b5)
-- apps/web/components/kanban-card-content.tsx:617 - added an explicit data-kanban-card marker and excluded it from background panning, so task-card descendants cannot arm the board pan gesture. (commit b0f64d9b5)
-- apps/web/e2e/tests/kanban/kanban-board.spec.ts:146 - removed a fragile exact-position assertion after mouseleave, because restored CSS snap may settle the board independently of the canceled gesture. (commit b0f64d9b5)

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -614,6 +614,7 @@ export function KanbanCardShell({
       ref={setNodeRef}
       style={style}
       data-testid={`task-card-${task.id}`}
+      data-kanban-card=""
       className={cn(
         "group max-h-48 bg-card rounded-sm data-[size=sm]:py-1 cursor-pointer mb-2 w-full py-0 relative border border-border overflow-visible shadow-none ring-0",
         "touch-none md:touch-auto",

--- a/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
@@ -12,6 +12,9 @@ function renderBoard() {
           <button type="button" data-testid="card-action">
             <svg data-testid="card-action-icon" />
           </button>
+          <div data-kanban-card="" data-testid="task-card-shell">
+            <span data-testid="task-card-shell-child" />
+          </div>
           <div data-testid="draggable-card" draggable />
         </div>
       )}
@@ -60,6 +63,10 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
     expect(window.scrollLeft).toBe(400);
 
+    fireEvent.mouseDown(screen.getByTestId("task-card-shell-child"), { button: 0, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(400);
+
     fireEvent.mouseDown(screen.getByTestId("draggable-card"), { button: 0, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
     expect(window.scrollLeft).toBe(400);
@@ -70,7 +77,9 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     window.scrollLeft = 400;
 
     startPan(window);
+    expect(window.style.scrollSnapType).toBe("none");
     fireEvent.mouseUp(window);
+    expect(window.style.scrollSnapType).toBe("");
     const releasedPosition = window.scrollLeft;
     fireEvent.mouseMove(window, { buttons: 0, clientX: 100 });
     expect(window.scrollLeft).toBe(releasedPosition);

--- a/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
@@ -101,7 +101,7 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     const window = renderBoard();
     window.scrollLeft = 400;
 
-    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX: 200 });
+    fireEvent.mouseDown(screen.getByTestId("blank-list-space"), { button: 0, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
     expect(window.scrollLeft).toBe(500);
 

--- a/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
@@ -2,13 +2,16 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { AdaptiveDesktopKanban } from "./adaptive-desktop-kanban";
 
+const blankColumnSpaceTestId = "blank-column-space";
+const grabbingCursorClass = "cursor-grabbing";
+
 function renderBoard() {
   render(
     <AdaptiveDesktopKanban
       steps={[{ id: "backlog", title: "Backlog", color: "bg-blue-500" }]}
       renderColumn={() => (
         <div>
-          <div data-testid="blank-column-space" />
+          <div data-testid={blankColumnSpaceTestId} />
           <button type="button" data-testid="card-action">
             <svg data-testid="card-action-icon" />
           </button>
@@ -25,12 +28,28 @@ function renderBoard() {
 }
 
 function startPan(window: HTMLElement, clientX = 200) {
-  fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 0, clientX });
+  fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX });
   fireEvent.mouseMove(window, { buttons: 1, clientX: clientX - 20 });
 }
 
 afterEach(cleanup);
 describe("AdaptiveDesktopKanban mouse panning", () => {
+  it("shows a grabbing cursor only while holding an eligible board background", () => {
+    const window = renderBoard();
+
+    expect(window.classList.contains("cursor-grab")).toBe(false);
+    expect(window.classList.contains(grabbingCursorClass)).toBe(false);
+
+    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX: 200 });
+    expect(window.classList.contains(grabbingCursorClass)).toBe(true);
+
+    fireEvent.mouseUp(window);
+    expect(window.classList.contains(grabbingCursorClass)).toBe(false);
+
+    fireEvent.mouseDown(screen.getByTestId("task-card-shell-child"), { button: 0, clientX: 200 });
+    expect(window.classList.contains(grabbingCursorClass)).toBe(false);
+  });
+
   it("@covers AC-1 AC-2 pans from the original pointer and scroll baseline", () => {
     const window = renderBoard();
     window.scrollLeft = 400;
@@ -46,11 +65,11 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     const window = renderBoard();
     window.scrollLeft = 400;
 
-    fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 2, clientX: 200 });
+    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 2, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 2, clientX: 100 });
     expect(window.scrollLeft).toBe(400);
 
-    fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 0, clientX: 200 });
+    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 1, clientX: 196 });
     expect(window.scrollLeft).toBe(400);
   });

--- a/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
@@ -12,6 +12,12 @@ function renderBoard() {
       renderColumn={() => (
         <div>
           <div data-testid={blankColumnSpaceTestId} />
+          <div role="list">
+            <div data-testid="blank-list-space" />
+          </div>
+          <div tabIndex={-1}>
+            <div data-testid="blank-focus-container-space" />
+          </div>
           <button type="button" data-testid="card-action">
             <svg data-testid="card-action-icon" />
           </button>
@@ -69,7 +75,7 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     fireEvent.mouseMove(window, { buttons: 2, clientX: 100 });
     expect(window.scrollLeft).toBe(400);
 
-    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX: 200 });
+    fireEvent.mouseDown(screen.getByTestId("blank-list-space"), { button: 0, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 1, clientX: 196 });
     expect(window.scrollLeft).toBe(400);
   });
@@ -89,6 +95,22 @@ describe("AdaptiveDesktopKanban mouse panning", () => {
     fireEvent.mouseDown(screen.getByTestId("draggable-card"), { button: 0, clientX: 200 });
     fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
     expect(window.scrollLeft).toBe(400);
+  });
+
+  it("@covers AC-1 allows panning through structural and programmatic-focus wrappers", () => {
+    const window = renderBoard();
+    window.scrollLeft = 400;
+
+    fireEvent.mouseDown(screen.getByTestId(blankColumnSpaceTestId), { button: 0, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(500);
+
+    fireEvent.mouseDown(screen.getByTestId("blank-focus-container-space"), {
+      button: 0,
+      clientX: 200,
+    });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(600);
   });
 
   it("@covers AC-3 AC-4 cancels on mouse-up and does not resume after leaving", () => {

--- a/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AdaptiveDesktopKanban } from "./adaptive-desktop-kanban";
+
+function renderBoard() {
+  render(
+    <AdaptiveDesktopKanban
+      steps={[{ id: "backlog", title: "Backlog", color: "bg-blue-500" }]}
+      renderColumn={() => (
+        <div>
+          <div data-testid="blank-column-space" />
+          <button type="button" data-testid="card-action">
+            <svg data-testid="card-action-icon" />
+          </button>
+          <div data-testid="draggable-card" draggable />
+        </div>
+      )}
+    />,
+  );
+
+  return screen.getByTestId("desktop-kanban-scroll-window");
+}
+
+function startPan(window: HTMLElement, clientX = 200) {
+  fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 0, clientX });
+  fireEvent.mouseMove(window, { buttons: 1, clientX: clientX - 20 });
+}
+
+afterEach(cleanup);
+describe("AdaptiveDesktopKanban mouse panning", () => {
+  it("@covers AC-1 AC-2 pans from the original pointer and scroll baseline", () => {
+    const window = renderBoard();
+    window.scrollLeft = 400;
+
+    startPan(window);
+    expect(window.scrollLeft).toBe(420);
+
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 120 });
+    expect(window.scrollLeft).toBe(480);
+  });
+
+  it("@covers AC-1 AC-6 requires a primary drag beyond the threshold", () => {
+    const window = renderBoard();
+    window.scrollLeft = 400;
+
+    fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 2, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 2, clientX: 100 });
+    expect(window.scrollLeft).toBe(400);
+
+    fireEvent.mouseDown(screen.getByTestId("blank-column-space"), { button: 0, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 196 });
+    expect(window.scrollLeft).toBe(400);
+  });
+
+  it("@covers AC-5 ignores interactive and draggable descendants", () => {
+    const window = renderBoard();
+    window.scrollLeft = 400;
+
+    fireEvent.mouseDown(screen.getByTestId("card-action-icon"), { button: 0, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(400);
+
+    fireEvent.mouseDown(screen.getByTestId("draggable-card"), { button: 0, clientX: 200 });
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(400);
+  });
+
+  it("@covers AC-3 AC-4 cancels on mouse-up and does not resume after leaving", () => {
+    const window = renderBoard();
+    window.scrollLeft = 400;
+
+    startPan(window);
+    fireEvent.mouseUp(window);
+    const releasedPosition = window.scrollLeft;
+    fireEvent.mouseMove(window, { buttons: 0, clientX: 100 });
+    expect(window.scrollLeft).toBe(releasedPosition);
+
+    startPan(window);
+    fireEvent.mouseLeave(window);
+    const leftPosition = window.scrollLeft;
+    fireEvent.mouseMove(window, { buttons: 1, clientX: 100 });
+    expect(window.scrollLeft).toBe(leftPosition);
+  });
+});

--- a/apps/web/components/kanban/adaptive-desktop-kanban.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.tsx
@@ -23,6 +23,7 @@ const INTERACTIVE_TARGET_SELECTOR = [
   "summary",
   "[contenteditable]",
   "[draggable='true']",
+  "[data-kanban-card]",
   "[role]",
   "[tabindex]",
 ].join(", ");
@@ -37,11 +38,13 @@ export function AdaptiveDesktopKanban({
   isDragging = false,
   renderColumn,
 }: AdaptiveDesktopKanbanProps) {
+  const scrollWindowRef = useRef<HTMLDivElement | null>(null);
   const panStartRef = useRef<PanStart | null>(null);
   const [isPanning, setIsPanning] = useState(false);
 
   const cancelPan = () => {
     panStartRef.current = null;
+    scrollWindowRef.current?.style.removeProperty("scroll-snap-type");
     setIsPanning(false);
   };
 
@@ -67,6 +70,7 @@ export function AdaptiveDesktopKanban({
 
     if (!isPanning) {
       window.getSelection()?.removeAllRanges();
+      event.currentTarget.style.scrollSnapType = "none";
       setIsPanning(true);
     }
     event.preventDefault();
@@ -76,6 +80,7 @@ export function AdaptiveDesktopKanban({
   return (
     <div data-testid="desktop-kanban-layout" className="h-full min-h-0 min-w-0">
       <div
+        ref={scrollWindowRef}
         data-testid="desktop-kanban-scroll-window"
         className={`h-full min-h-0 min-w-0 overflow-x-auto snap-x snap-mandatory ${
           isPanning ? "cursor-grabbing select-none" : "cursor-grab"

--- a/apps/web/components/kanban/adaptive-desktop-kanban.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.tsx
@@ -40,11 +40,13 @@ export function AdaptiveDesktopKanban({
 }: AdaptiveDesktopKanbanProps) {
   const scrollWindowRef = useRef<HTMLDivElement | null>(null);
   const panStartRef = useRef<PanStart | null>(null);
+  const [isPanCandidate, setIsPanCandidate] = useState(false);
   const [isPanning, setIsPanning] = useState(false);
 
   const cancelPan = () => {
     panStartRef.current = null;
     scrollWindowRef.current?.style.removeProperty("scroll-snap-type");
+    setIsPanCandidate(false);
     setIsPanning(false);
   };
 
@@ -55,6 +57,7 @@ export function AdaptiveDesktopKanban({
       clientX: event.clientX,
       scrollLeft: event.currentTarget.scrollLeft,
     };
+    setIsPanCandidate(true);
   };
 
   const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
@@ -83,8 +86,8 @@ export function AdaptiveDesktopKanban({
         ref={scrollWindowRef}
         data-testid="desktop-kanban-scroll-window"
         className={`h-full min-h-0 min-w-0 overflow-x-auto snap-x snap-mandatory ${
-          isPanning ? "cursor-grabbing select-none" : "cursor-grab"
-        }`}
+          isPanCandidate ? "cursor-grabbing" : ""
+        } ${isPanning ? "select-none" : ""}`}
         style={{ scrollSnapType: isPanning ? "none" : undefined }}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}

--- a/apps/web/components/kanban/adaptive-desktop-kanban.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.tsx
@@ -24,8 +24,8 @@ const INTERACTIVE_TARGET_SELECTOR = [
   "[contenteditable]",
   "[draggable='true']",
   "[data-kanban-card]",
-  "[role]",
-  "[tabindex]",
+  "[role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='menuitem'], [role='option'], [role='switch'], [role='tab'], [role='combobox'], [role='textbox'], [role='gridcell'], [role='treeitem']",
+  "[tabindex]:not([tabindex='-1'])",
 ].join(", ");
 
 type PanStart = {

--- a/apps/web/components/kanban/adaptive-desktop-kanban.tsx
+++ b/apps/web/components/kanban/adaptive-desktop-kanban.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useRef, useState, type MouseEvent, type ReactNode } from "react";
 import type { WorkflowStep } from "@/components/kanban-column";
 import { getKanbanColumnGridTemplate, KANBAN_COLUMN_MIN_PX } from "./kanban-grid-template";
 
@@ -12,16 +12,79 @@ type AdaptiveDesktopKanbanProps = {
 
 export const KANBAN_DRAG_END_PADDING = `max(0px, calc(100% - ${KANBAN_COLUMN_MIN_PX}px))`;
 
+const PAN_ACTIVATION_DISTANCE_PX = 4;
+const INTERACTIVE_TARGET_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "label",
+  "summary",
+  "[contenteditable]",
+  "[draggable='true']",
+  "[role]",
+  "[tabindex]",
+].join(", ");
+
+type PanStart = {
+  clientX: number;
+  scrollLeft: number;
+};
+
 export function AdaptiveDesktopKanban({
   steps,
   isDragging = false,
   renderColumn,
 }: AdaptiveDesktopKanbanProps) {
+  const panStartRef = useRef<PanStart | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+
+  const cancelPan = () => {
+    panStartRef.current = null;
+    setIsPanning(false);
+  };
+
+  const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || isInteractiveTarget(event.target, event.currentTarget)) return;
+
+    panStartRef.current = {
+      clientX: event.clientX,
+      scrollLeft: event.currentTarget.scrollLeft,
+    };
+  };
+
+  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    const panStart = panStartRef.current;
+    if (!panStart) return;
+    if ((event.buttons & 1) === 0) {
+      cancelPan();
+      return;
+    }
+
+    const delta = panStart.clientX - event.clientX;
+    if (!isPanning && Math.abs(delta) <= PAN_ACTIVATION_DISTANCE_PX) return;
+
+    if (!isPanning) {
+      window.getSelection()?.removeAllRanges();
+      setIsPanning(true);
+    }
+    event.preventDefault();
+    event.currentTarget.scrollLeft = panStart.scrollLeft + delta;
+  };
+
   return (
     <div data-testid="desktop-kanban-layout" className="h-full min-h-0 min-w-0">
       <div
         data-testid="desktop-kanban-scroll-window"
-        className="h-full min-h-0 min-w-0 overflow-x-auto snap-x snap-mandatory"
+        className={`h-full min-h-0 min-w-0 overflow-x-auto snap-x snap-mandatory ${
+          isPanning ? "cursor-grabbing select-none" : "cursor-grab"
+        }`}
+        style={{ scrollSnapType: isPanning ? "none" : undefined }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={cancelPan}
+        onMouseLeave={cancelPan}
       >
         <div
           data-testid="desktop-kanban-lane-grid"
@@ -40,4 +103,17 @@ export function AdaptiveDesktopKanban({
       </div>
     </div>
   );
+}
+
+function isInteractiveTarget(target: EventTarget | null, boundary: HTMLElement): boolean {
+  if (!(target instanceof Element)) return true;
+
+  for (
+    let element: Element | null = target;
+    element && element !== boundary;
+    element = element.parentElement
+  ) {
+    if (element.matches(INTERACTIVE_TARGET_SELECTOR)) return true;
+  }
+  return false;
 }

--- a/apps/web/e2e/tests/kanban/kanban-board.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-board.spec.ts
@@ -102,6 +102,7 @@ test.describe("Kanban board", () => {
     testPage,
     apiClient,
     seedData,
+    prCapture,
   }) => {
     await testPage.setViewportSize({ width: 1280, height: 800 });
     const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Mouse pan workflow");
@@ -142,6 +143,9 @@ test.describe("Kanban board", () => {
     await expect
       .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
       .toBeGreaterThan(0);
+    await prCapture.screenshot("desktop-kanban-mouse-pan", {
+      caption: "Desktop Kanban after dragging empty board space to pan horizontally.",
+    });
 
     const pannedPosition = await scrollWindow.evaluate((element) => element.scrollLeft);
     expect(pannedPosition).toBeGreaterThan(0);
@@ -167,7 +171,27 @@ test.describe("Kanban board", () => {
     await scrollWindow.evaluate((element) => {
       element.scrollLeft = 0;
     });
-    await kanban.moveTaskWithinWorkflow(task.id, targetStep.id);
+    const sourceCard = kanban.taskCard(task.id);
+    const targetColumn = kanban.columnByStepId(targetStep.id);
+    const sourceBox = await sourceCard.boundingBox();
+    if (!sourceBox) throw new Error("Kanban DnD source has no layout box");
+    await testPage.mouse.move(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await testPage.mouse.down();
+    await testPage.mouse.move(
+      sourceBox.x + sourceBox.width / 2 + 20,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await expect(sourceCard).toHaveClass(/opacity-50/);
+    const targetBox = await targetColumn.boundingBox();
+    if (!targetBox) throw new Error("Kanban DnD target has no layout box");
+    await testPage.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height / 2,
+    );
+    await testPage.mouse.up();
 
     await expect
       .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id)

--- a/apps/web/e2e/tests/kanban/kanban-board.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-board.spec.ts
@@ -98,4 +98,101 @@ test.describe("Kanban board", () => {
     await expect(search).toBeVisible({ timeout: 5_000 });
     await expect(stageNavigator).toHaveCount(0);
   });
+  test("pans overflowing board space without blocking card moves", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await testPage.setViewportSize({ width: 1280, height: 800 });
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Mouse pan workflow");
+    const sourceStep = await apiClient.createWorkflowStep(workflow.id, "Source", 0, {
+      is_start_step: true,
+    });
+    const targetStep = await apiClient.createWorkflowStep(workflow.id, "Target", 1);
+    for (let position = 2; position < 6; position += 1) {
+      await apiClient.createWorkflowStep(workflow.id, `Overflow ${position}`, position);
+    }
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+    });
+    const task = await apiClient.createTask(seedData.workspaceId, "Mouse pan move task", {
+      workflow_id: workflow.id,
+      workflow_step_id: sourceStep.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    const scrollWindow = testPage.getByTestId("desktop-kanban-scroll-window");
+    const sourceScrollRegion = kanban
+      .columnByStepId(sourceStep.id)
+      .getByTestId("kanban-column-scroll");
+    await expect(sourceScrollRegion).toBeVisible();
+    const [windowBox, sourceScrollBox] = await Promise.all([
+      scrollWindow.boundingBox(),
+      sourceScrollRegion.boundingBox(),
+    ]);
+    if (!windowBox || !sourceScrollBox) throw new Error("Kanban pan targets have no layout boxes");
+
+    const startX = sourceScrollBox.x + Math.min(sourceScrollBox.width - 12, 80);
+    const startY = sourceScrollBox.y + sourceScrollBox.height - 8;
+    await testPage.mouse.move(startX, startY);
+    await testPage.mouse.down();
+    await testPage.mouse.move(startX - 60, startY);
+    await expect
+      .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
+      .toBeGreaterThan(0);
+
+    const pannedPosition = await scrollWindow.evaluate((element) => element.scrollLeft);
+    await testPage.mouse.move(windowBox.x - 8, startY);
+    await testPage.mouse.move(startX - 100, startY);
+    await expect
+      .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
+      .toBe(pannedPosition);
+    await testPage.mouse.up();
+    await testPage.mouse.move(startX - 140, startY);
+    await expect
+      .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
+      .toBe(pannedPosition);
+    await expect
+      .poll(() =>
+        testPage.evaluate(
+          () => document.documentElement.scrollWidth === document.documentElement.clientWidth,
+        ),
+      )
+      .toBe(true);
+
+    await scrollWindow.evaluate((element) => {
+      element.scrollLeft = 0;
+    });
+    const sourceCard = kanban.taskCard(task.id);
+    const targetColumn = kanban.columnByStepId(targetStep.id);
+    const [sourceBox, targetBox] = await Promise.all([
+      sourceCard.boundingBox(),
+      targetColumn.boundingBox(),
+    ]);
+    if (!sourceBox || !targetBox) throw new Error("Kanban DnD targets have no layout boxes");
+    await testPage.mouse.move(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await testPage.mouse.down();
+    await testPage.mouse.move(
+      sourceBox.x + sourceBox.width / 2 + 20,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await testPage.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height / 2,
+      {
+        steps: 12,
+      },
+    );
+    await testPage.mouse.up();
+
+    await expect
+      .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id)
+      .toBe(targetStep.id);
+    await expect(kanban.taskCardInColumn("Mouse pan move task", targetStep.id)).toBeVisible();
+  });
 });

--- a/apps/web/e2e/tests/kanban/kanban-board.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-board.spec.ts
@@ -157,7 +157,7 @@ test.describe("Kanban board", () => {
     await testPage.mouse.move(reentryX, startY);
     await expect.poll(() => scrollWindow.evaluate((element) => element.scrollLeft)).toBe(0);
     await testPage.mouse.up();
-    await expect(scrollWindow).toHaveClass(/cursor-grab/);
+    await expect(scrollWindow).not.toHaveClass(/cursor-grab/);
     await testPage.mouse.move(startX - 140, startY);
     await expect.poll(() => scrollWindow.evaluate((element) => element.scrollLeft)).toBe(0);
     await expect

--- a/apps/web/e2e/tests/kanban/kanban-board.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-board.spec.ts
@@ -144,16 +144,18 @@ test.describe("Kanban board", () => {
       .toBeGreaterThan(0);
 
     const pannedPosition = await scrollWindow.evaluate((element) => element.scrollLeft);
+    expect(pannedPosition).toBeGreaterThan(0);
     await testPage.mouse.move(windowBox.x - 8, startY);
-    await testPage.mouse.move(startX - 100, startY);
-    await expect
-      .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
-      .toBe(pannedPosition);
+    await scrollWindow.evaluate((element) => {
+      element.scrollLeft = 0;
+    });
+    const reentryX = windowBox.x + 16;
+    await testPage.mouse.move(reentryX, startY);
+    await expect.poll(() => scrollWindow.evaluate((element) => element.scrollLeft)).toBe(0);
     await testPage.mouse.up();
+    await expect(scrollWindow).toHaveClass(/cursor-grab/);
     await testPage.mouse.move(startX - 140, startY);
-    await expect
-      .poll(() => scrollWindow.evaluate((element) => element.scrollLeft))
-      .toBe(pannedPosition);
+    await expect.poll(() => scrollWindow.evaluate((element) => element.scrollLeft)).toBe(0);
     await expect
       .poll(() =>
         testPage.evaluate(
@@ -165,30 +167,7 @@ test.describe("Kanban board", () => {
     await scrollWindow.evaluate((element) => {
       element.scrollLeft = 0;
     });
-    const sourceCard = kanban.taskCard(task.id);
-    const targetColumn = kanban.columnByStepId(targetStep.id);
-    const [sourceBox, targetBox] = await Promise.all([
-      sourceCard.boundingBox(),
-      targetColumn.boundingBox(),
-    ]);
-    if (!sourceBox || !targetBox) throw new Error("Kanban DnD targets have no layout boxes");
-    await testPage.mouse.move(
-      sourceBox.x + sourceBox.width / 2,
-      sourceBox.y + sourceBox.height / 2,
-    );
-    await testPage.mouse.down();
-    await testPage.mouse.move(
-      sourceBox.x + sourceBox.width / 2 + 20,
-      sourceBox.y + sourceBox.height / 2,
-    );
-    await testPage.mouse.move(
-      targetBox.x + targetBox.width / 2,
-      targetBox.y + targetBox.height / 2,
-      {
-        steps: 12,
-      },
-    );
-    await testPage.mouse.up();
+    await kanban.moveTaskWithinWorkflow(task.id, targetStep.id);
 
     await expect
       .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3052/c8a6ec2390d9.html)
<!-- kandev-pr-walkthrough-end -->

Overflowing desktop Kanban boards were hard to navigate with a mouse, which made wide workflows depend on native scrolling controls. This adds grab-style background panning while preserving task-card drag and the existing mobile behavior.

## Validation

- `cd apps && corepack pnpm --filter @kandev/web exec vitest run components/kanban/adaptive-desktop-kanban.test.tsx`
- `cd apps && corepack pnpm --filter @kandev/web exec eslint components/kanban/adaptive-desktop-kanban.tsx components/kanban/adaptive-desktop-kanban.test.tsx e2e/tests/kanban/kanban-board.spec.ts`
- `cd apps/web && corepack pnpm run typecheck`
- `cd apps/web && corepack pnpm e2e:run tests/kanban/kanban-board.spec.ts` (blocked in this VM: `go: not found` during backend build)
- `cd apps/web && corepack pnpm e2e:run --project mobile-chrome tests/kanban/mobile-kanban.spec.ts` (blocked in this VM: `go: not found` during backend build)


[Screencast from 2026-08-27 00-45-29.webm](https://github.com/user-attachments/assets/d9ac2859-4c60-4f88-91f4-7db26b6286ca)

## Possible Improvements

Low risk: rerun the desktop and mobile Playwright specs once Go is available on the task host so the production E2E path is revalidated locally.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- kandev-screenshots-start -->
## Screenshots

![Desktop Kanban mouse panning](https://raw.githubusercontent.com/yattdev/kandev/c8a7d390deb89678206136f4f0352d3808f37ebc/desktop-kanban-mouse-pan.png)
Desktop Kanban after dragging empty board space to pan horizontally.

![Mobile Kanban unchanged](https://raw.githubusercontent.com/yattdev/kandev/c8a7d390deb89678206136f4f0352d3808f37ebc/mobile-kanban-unchanged.png)
Mobile Kanban remains on the existing focused-column flow; this change is limited to desktop mouse interaction.
<!-- kandev-screenshots-end -->

