### PR TITLE
feat(plugins): plugins can now tell what moving a task to a step will do

### DIFF
--- a/apps/backend/internal/plugins/host_data_mappers.go
+++ b/apps/backend/internal/plugins/host_data_mappers.go
@@ -237,15 +237,15 @@ func workflowModelToDTO(w *taskmodels.Workflow) pluginsdk.Workflow {
 
 func workflowStepModelToDTO(s *wfmodels.WorkflowStep) pluginsdk.WorkflowStep {
 	return pluginsdk.WorkflowStep{
-		ID:             s.ID,
-		WorkflowID:     s.WorkflowID,
-		Name:           s.Name,
-		Position:       int32(s.Position),
-		StageType:      string(s.StageType),
-		Color:          s.Color,
-		IsStartStep:    s.IsStartStep,
-		WIPLimit:       int32(s.WIPLimit),
-		AgentProfileID: s.AgentProfileID,
+		ID:                 s.ID,
+		WorkflowID:         s.WorkflowID,
+		Name:               s.Name,
+		Position:           int32(s.Position),
+		StageType:          string(s.StageType),
+		Color:              s.Color,
+		IsStartStep:        s.IsStartStep,
+		WIPLimit:           int32(s.WIPLimit),
+		AgentProfileID:     s.AgentProfileID,
 		OnEnterActionTypes: onEnterActionTypesToDTO(s.Events.OnEnter),
 	}
 }

--- a/apps/backend/internal/plugins/host_data_mappers.go
+++ b/apps/backend/internal/plugins/host_data_mappers.go
@@ -246,7 +246,22 @@ func workflowStepModelToDTO(s *wfmodels.WorkflowStep) pluginsdk.WorkflowStep {
 		IsStartStep:    s.IsStartStep,
 		WIPLimit:       int32(s.WIPLimit),
 		AgentProfileID: s.AgentProfileID,
+		OnEnterActionTypes: onEnterActionTypesToDTO(s.Events.OnEnter),
 	}
+}
+
+// onEnterActionTypesToDTO exposes only the on_enter action TYPES, order
+// preserved as authored. Action Config (target task ids, payloads, participant
+// roles, agent profile ids) is deliberately not exposed to plugins.
+func onEnterActionTypesToDTO(actions []wfmodels.OnEnterAction) []string {
+	if len(actions) == 0 {
+		return nil
+	}
+	out := make([]string, len(actions))
+	for i, action := range actions {
+		out[i] = string(action.Type)
+	}
+	return out
 }
 
 func repositoryModelToDTO(r *taskmodels.Repository) pluginsdk.Repository {

--- a/apps/backend/internal/plugins/host_data_test.go
+++ b/apps/backend/internal/plugins/host_data_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -513,7 +514,18 @@ func TestPluginHost_Workflows_SucceedsWithCapability(t *testing.T) {
 		"ws-1": {{ID: "wf-1", WorkspaceID: "ws-1", Name: "Default"}},
 	}
 	d.steps.steps = map[string][]*wfmodels.WorkflowStep{
-		"wf-1": {{ID: "step-1", WorkflowID: "wf-1", Name: "Todo", Position: 0, StageType: wfmodels.StageType("work")}},
+		"wf-1": {
+			{ID: "step-1", WorkflowID: "wf-1", Name: "Todo", Position: 0, StageType: wfmodels.StageType("work")},
+			{
+				ID: "step-2", WorkflowID: "wf-1", Name: "Work", Position: 1, StageType: wfmodels.StageType("custom"),
+				Events: wfmodels.StepEvents{
+					OnEnter: []wfmodels.OnEnterAction{
+						{Type: wfmodels.OnEnterAutoStartAgent},
+						{Type: wfmodels.OnEnterRunCodeReview, Config: map[string]interface{}{"agent_profile_id": "profile-1"}},
+					},
+				},
+			},
+		},
 	}
 
 	workflows, _, err := d.host.Workflows().List(context.Background(), "ws-1", pluginsdk.Page{})
@@ -528,8 +540,15 @@ func TestPluginHost_Workflows_SucceedsWithCapability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSteps() unexpected error: %v", err)
 	}
-	if len(steps) != 1 || steps[0].StageType != "work" {
-		t.Fatalf("ListSteps() = %+v, want one step with StageType=work", steps)
+	if len(steps) != 2 || steps[0].StageType != "work" {
+		t.Fatalf("ListSteps() = %+v, want two steps, first with StageType=work", steps)
+	}
+	if steps[0].OnEnterActionTypes != nil {
+		t.Fatalf("steps[0].OnEnterActionTypes = %+v, want nil for a step with no on_enter actions", steps[0].OnEnterActionTypes)
+	}
+	wantTypes := []string{"auto_start_agent", "run_code_review"}
+	if !reflect.DeepEqual(steps[1].OnEnterActionTypes, wantTypes) {
+		t.Fatalf("steps[1].OnEnterActionTypes = %+v, want %+v", steps[1].OnEnterActionTypes, wantTypes)
 	}
 }
 

--- a/apps/backend/internal/plugins/host_data_wire_test.go
+++ b/apps/backend/internal/plugins/host_data_wire_test.go
@@ -38,6 +38,7 @@ import (
 	analyticsmodels "github.com/kandev/kandev/internal/analytics/models"
 	"github.com/kandev/kandev/internal/plugins/manifest"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	"github.com/kandev/kandev/pkg/pluginsdk"
 )
 
@@ -413,4 +414,50 @@ func TestPluginHostData_Wire_SessionsPagination(t *testing.T) {
 	require.NotNil(t, secondPageInfo)
 	require.False(t, secondPageInfo.HasMore)
 	require.Empty(t, secondPageInfo.NextCursor)
+}
+
+// TestPluginHostData_Wire_WorkflowSteps_OnEnterActionTypes proves the full
+// model -> DTO -> proto -> gRPC wire -> pluginsdk chain for WorkflowStep's
+// on_enter_action_types field: a step with several on_enter actions reports
+// their types in authored order, a step with none reports nil (not an empty
+// slice) at every hop, and action Config never travels — pluginsdk.WorkflowStep
+// has no Config field at all, so there is no wire shape for it to leak
+// through.
+func TestPluginHostData_Wire_WorkflowSteps_OnEnterActionTypes(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"workflows"}})
+	d.steps.steps = map[string][]*wfmodels.WorkflowStep{
+		"wf-1": {
+			{
+				ID:         "step-work",
+				WorkflowID: "wf-1",
+				Name:       "Work",
+				Position:   0,
+				StageType:  wfmodels.StageType("work"),
+				Events: wfmodels.StepEvents{
+					OnEnter: []wfmodels.OnEnterAction{
+						{Type: wfmodels.OnEnterAutoStartAgent, Config: map[string]interface{}{"agent_profile_id": "profile-1"}},
+						{Type: wfmodels.OnEnterRunCodeReview},
+					},
+				},
+			},
+			{
+				ID:         "step-todo",
+				WorkflowID: "wf-1",
+				Name:       "Todo",
+				Position:   1,
+				StageType:  wfmodels.StageType("custom"),
+			},
+		},
+	}
+	host := dialPluginHostOverWire(t, d.host)
+
+	steps, err := host.Workflows().ListSteps(context.Background(), "wf-1")
+	require.NoError(t, err)
+	require.Len(t, steps, 2)
+
+	require.Equal(t, "step-work", steps[0].ID)
+	require.Equal(t, []string{"auto_start_agent", "run_code_review"}, steps[0].OnEnterActionTypes)
+
+	require.Equal(t, "step-todo", steps[1].ID)
+	require.Nil(t, steps[1].OnEnterActionTypes)
 }

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -508,23 +508,28 @@ type WorkflowStep struct {
 	IsStartStep    bool
 	WIPLimit       int32 // 0 means unlimited
 	AgentProfileID string
-	// OnEnterActionTypes is nil when the step has no on_enter actions, never
-	// an empty non-nil slice. Config maps are deliberately not exposed.
-	// Callers must ignore action types they do not recognize.
+	// OnEnterActionTypes lists the on_enter action types configured on this
+	// step, as authored. This lists what is configured, not a guarantee that
+	// every listed type executes on every transition path. The ordinary move
+	// path handles auto_start_agent, configure_session, enable_plan_mode,
+	// set_session_mode and reset_agent_context. Other action types can run only
+	// on applicable workflow-engine paths. Config maps are deliberately not
+	// exposed. Nil when the step has no on_enter actions, never an empty
+	// non-nil slice. Callers must ignore action types they do not recognize.
 	OnEnterActionTypes []string
 }
 
 func (s WorkflowStep) toProto() *pluginv1.WorkflowStep {
 	return &pluginv1.WorkflowStep{
-		Id:             s.ID,
-		WorkflowId:     s.WorkflowID,
-		Name:           s.Name,
-		Position:       s.Position,
-		StageType:      s.StageType,
-		Color:          s.Color,
-		IsStartStep:    s.IsStartStep,
-		WipLimit:       s.WIPLimit,
-		AgentProfileId: s.AgentProfileID,
+		Id:                 s.ID,
+		WorkflowId:         s.WorkflowID,
+		Name:               s.Name,
+		Position:           s.Position,
+		StageType:          s.StageType,
+		Color:              s.Color,
+		IsStartStep:        s.IsStartStep,
+		WipLimit:           s.WIPLimit,
+		AgentProfileId:     s.AgentProfileID,
 		OnEnterActionTypes: s.OnEnterActionTypes,
 	}
 }
@@ -534,17 +539,27 @@ func workflowStepFromProto(p *pluginv1.WorkflowStep) WorkflowStep {
 		return WorkflowStep{}
 	}
 	return WorkflowStep{
-		ID:             p.GetId(),
-		WorkflowID:     p.GetWorkflowId(),
-		Name:           p.GetName(),
-		Position:       p.GetPosition(),
-		StageType:      p.GetStageType(),
-		Color:          p.GetColor(),
-		IsStartStep:    p.GetIsStartStep(),
-		WIPLimit:       p.GetWipLimit(),
-		AgentProfileID: p.GetAgentProfileId(),
-		OnEnterActionTypes: p.GetOnEnterActionTypes(),
+		ID:                 p.GetId(),
+		WorkflowID:         p.GetWorkflowId(),
+		Name:               p.GetName(),
+		Position:           p.GetPosition(),
+		StageType:          p.GetStageType(),
+		OnEnterActionTypes: nonEmptyStrings(p.GetOnEnterActionTypes()),
+		Color:              p.GetColor(),
+		IsStartStep:        p.GetIsStartStep(),
+		WIPLimit:           p.GetWipLimit(),
+		AgentProfileID:     p.GetAgentProfileId(),
 	}
+}
+
+// nonEmptyStrings enforces the documented nil-not-empty invariant at the SDK
+// decode boundary, independent of what a caller happened to serialize onto
+// the wire.
+func nonEmptyStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
 }
 
 func workflowStepsFromProto(items []*pluginv1.WorkflowStep) []WorkflowStep {

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -508,6 +508,10 @@ type WorkflowStep struct {
 	IsStartStep    bool
 	WIPLimit       int32 // 0 means unlimited
 	AgentProfileID string
+	// OnEnterActionTypes is nil when the step has no on_enter actions, never
+	// an empty non-nil slice. Config maps are deliberately not exposed.
+	// Callers must ignore action types they do not recognize.
+	OnEnterActionTypes []string
 }
 
 func (s WorkflowStep) toProto() *pluginv1.WorkflowStep {
@@ -521,6 +525,7 @@ func (s WorkflowStep) toProto() *pluginv1.WorkflowStep {
 		IsStartStep:    s.IsStartStep,
 		WipLimit:       s.WIPLimit,
 		AgentProfileId: s.AgentProfileID,
+		OnEnterActionTypes: s.OnEnterActionTypes,
 	}
 }
 
@@ -538,6 +543,7 @@ func workflowStepFromProto(p *pluginv1.WorkflowStep) WorkflowStep {
 		IsStartStep:    p.GetIsStartStep(),
 		WIPLimit:       p.GetWipLimit(),
 		AgentProfileID: p.GetAgentProfileId(),
+		OnEnterActionTypes: p.GetOnEnterActionTypes(),
 	}
 }
 

--- a/apps/backend/pkg/pluginsdk/data_types_test.go
+++ b/apps/backend/pkg/pluginsdk/data_types_test.go
@@ -176,6 +176,19 @@ func TestWorkflowStepProtoRoundTrip(t *testing.T) {
 	require.Equal(t, step, workflowStepFromProto(proto))
 }
 
+func TestWorkflowStepProtoRoundTrip_OnEnterActionTypes(t *testing.T) {
+	step := WorkflowStep{
+		ID:                 "step-1",
+		WorkflowID:         "wf-1",
+		Name:               "Work",
+		Position:           1,
+		StageType:          "work",
+		OnEnterActionTypes: []string{"auto_start_agent", "run_code_review", "set_session_mode"},
+	}
+	proto := step.toProto()
+	require.Equal(t, step, workflowStepFromProto(proto))
+}
+
 func TestAgentProfileProtoRoundTrip(t *testing.T) {
 	profile := AgentProfile{
 		ID:          "profile-1",

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3610,13 +3610,17 @@ type WorkflowStep struct {
 	WipLimit    int32  `protobuf:"varint,8,opt,name=wip_limit,json=wipLimit,proto3" json:"wip_limit,omitempty"` // 0 means unlimited
 	// The agent profile this step runs work under, empty when it inherits.
 	AgentProfileId string `protobuf:"bytes,9,opt,name=agent_profile_id,json=agentProfileId,proto3" json:"agent_profile_id,omitempty"`
-	// The on_enter action TYPES this step runs, so a plugin can describe what
-	// moving a task here will do. Action config is deliberately not exposed:
-	// it carries target task ids, payloads and profile ids. The ordinary move
-	// path handles auto_start_agent, configure_session, enable_plan_mode,
-	// set_session_mode and reset_agent_context. Other action types can run only
-	// on applicable workflow-engine paths. Plugins must ignore action types they
-	// do not recognize.
+	// The on_enter action TYPES configured on this step, as authored
+	// (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
+	// step's intent instead of guessing from the step name or stage_type.
+	// This lists what is configured, not a guarantee that every listed type
+	// executes on every transition path: an ordinary task move currently runs
+	// only a subset (auto_start_agent, configure_session, enable_plan_mode,
+	// set_session_mode, reset_agent_context); queue_run,
+	// queue_run_for_each_participant, clear_decisions, and run_code_review
+	// currently execute only via engine-driven triggers (e.g. Office). Action
+	// config is deliberately not exposed: it carries target task ids, payloads
+	// and profile ids. Plugins must ignore action types they do not recognize.
 	OnEnterActionTypes []string `protobuf:"bytes,10,rep,name=on_enter_action_types,json=onEnterActionTypes,proto3" json:"on_enter_action_types,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3610,8 +3610,16 @@ type WorkflowStep struct {
 	WipLimit    int32  `protobuf:"varint,8,opt,name=wip_limit,json=wipLimit,proto3" json:"wip_limit,omitempty"` // 0 means unlimited
 	// The agent profile this step runs work under, empty when it inherits.
 	AgentProfileId string `protobuf:"bytes,9,opt,name=agent_profile_id,json=agentProfileId,proto3" json:"agent_profile_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The on_enter action TYPES this step runs, so a plugin can describe what
+	// moving a task here will do. Action config is deliberately not exposed:
+	// it carries target task ids, payloads and profile ids. The ordinary move
+	// path handles auto_start_agent, configure_session, enable_plan_mode,
+	// set_session_mode and reset_agent_context. Other action types can run only
+	// on applicable workflow-engine paths. Plugins must ignore action types they
+	// do not recognize.
+	OnEnterActionTypes []string `protobuf:"bytes,10,rep,name=on_enter_action_types,json=onEnterActionTypes,proto3" json:"on_enter_action_types,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *WorkflowStep) Reset() {
@@ -3705,6 +3713,13 @@ func (x *WorkflowStep) GetAgentProfileId() string {
 		return x.AgentProfileId
 	}
 	return ""
+}
+
+func (x *WorkflowStep) GetOnEnterActionTypes() []string {
+	if x != nil {
+		return x.OnEnterActionTypes
+	}
+	return nil
 }
 
 type ListWorkflowStepsRequest struct {
@@ -7381,7 +7396,7 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x04page\x18\x02 \x01(\v2\x16.kandev.plugin.v1.PageR\x04page\"\x8a\x01\n" +
 	"\x15ListWorkflowsResponse\x128\n" +
 	"\tworkflows\x18\x01 \x03(\v2\x1a.kandev.plugin.v1.WorkflowR\tworkflows\x127\n" +
-	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"\x8f\x02\n" +
+	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"\xc2\x02\n" +
 	"\fWorkflowStep\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -7393,7 +7408,9 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x05color\x18\x06 \x01(\tR\x05color\x12\"\n" +
 	"\ris_start_step\x18\a \x01(\bR\visStartStep\x12\x1b\n" +
 	"\twip_limit\x18\b \x01(\x05R\bwipLimit\x12(\n" +
-	"\x10agent_profile_id\x18\t \x01(\tR\x0eagentProfileId\";\n" +
+	"\x10agent_profile_id\x18\t \x01(\tR\x0eagentProfileId\x121\n" +
+	"\x15on_enter_action_types\x18\n" +
+	" \x03(\tR\x12onEnterActionTypes\";\n" +
 	"\x18ListWorkflowStepsRequest\x12\x1f\n" +
 	"\vworkflow_id\x18\x01 \x01(\tR\n" +
 	"workflowId\"Q\n" +

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -515,13 +515,17 @@ message WorkflowStep {
   int32 wip_limit = 8; // 0 means unlimited
   // The agent profile this step runs work under, empty when it inherits.
   string agent_profile_id = 9;
-  // The on_enter action TYPES this step runs, so a plugin can describe what
-  // moving a task here will do. Action config is deliberately not exposed:
-  // it carries target task ids, payloads and profile ids. The ordinary move
-  // path handles auto_start_agent, configure_session, enable_plan_mode,
-  // set_session_mode and reset_agent_context. Other action types can run only
-  // on applicable workflow-engine paths. Plugins must ignore action types they
-  // do not recognize.
+  // The on_enter action TYPES configured on this step, as authored
+  // (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
+  // step's intent instead of guessing from the step name or stage_type.
+  // This lists what is configured, not a guarantee that every listed type
+  // executes on every transition path: an ordinary task move currently runs
+  // only a subset (auto_start_agent, configure_session, enable_plan_mode,
+  // set_session_mode, reset_agent_context); queue_run,
+  // queue_run_for_each_participant, clear_decisions, and run_code_review
+  // currently execute only via engine-driven triggers (e.g. Office). Action
+  // config is deliberately not exposed: it carries target task ids, payloads
+  // and profile ids. Plugins must ignore action types they do not recognize.
   repeated string on_enter_action_types = 10;
 }
 message ListWorkflowStepsRequest {

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -515,6 +515,14 @@ message WorkflowStep {
   int32 wip_limit = 8; // 0 means unlimited
   // The agent profile this step runs work under, empty when it inherits.
   string agent_profile_id = 9;
+  // The on_enter action TYPES this step runs, so a plugin can describe what
+  // moving a task here will do. Action config is deliberately not exposed:
+  // it carries target task ids, payloads and profile ids. The ordinary move
+  // path handles auto_start_agent, configure_session, enable_plan_mode,
+  // set_session_mode and reset_agent_context. Other action types can run only
+  // on applicable workflow-engine paths. Plugins must ignore action types they
+  // do not recognize.
+  repeated string on_enter_action_types = 10;
 }
 message ListWorkflowStepsRequest {
   string workflow_id = 1;


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3053/f4c3f7a22b53.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** A plugin reading `ListSteps` cannot tell what moving a task to a step will actually do. `stage_type` is `custom` on 207 of 210 steps on a live board, so it carries no usable signal, and the step name is unreliable too — a step called "Review" has `auto_start_agent` in one workflow and not in another on the same instance.
**After this:** Each `WorkflowStep` in the plugin API carries the `on_enter` action types it runs (e.g. `auto_start_agent`, `queue_run`, `run_code_review`), so a plugin can render "Move 9 tasks → Work (starts an agent on each)" instead of a bare "Start" button.
**Who hits this:** Plugin authors building step-aware UI on `Workflows().ListSteps` — first consumer is the Conductor plugin.
**Scope:** Standalone. Read-only; rides the existing `api_read:workflows` capability that already gates `ListSteps`. No new contract.
**Not here:** Action `Config` (target task ids, payloads, participant roles, agent profile ids) stays private — types only, deliberately. Moving a task through the plugin API is a separate card with its own actor-identity question.

Plugins currently have no way to distinguish a step that starts an agent from one that does nothing, because the only fields that could signal it (`stage_type`, step name) don't carry that information reliably. This adds the `on_enter` action type strings to `WorkflowStep` across proto, `pluginsdk`, and the host mapper, so a plugin can describe a step's behavior instead of guessing at it.

## Important Changes

- New field is `on_enter_action_types = 10` on `WorkflowStep` (proto3, repeated string). PR #3044 (open, same message) already claims fields 6-9 for `color`/`is_start_step`/`wip_limit`/`agent_profile_id`. Starting at 10 avoids collision; a merge conflict on that message is expected when #3044 lands and should be resolved by keeping both field sets, not renumbering either side.

## Validation

No UI files touched (`apps/web/` diff is empty), so per the repo's mechanical E2E rule, E2E was not required — backend package tests + full lint/test gauntlet instead.

```
$ go test -count=1 -run 'TestWorkflowStep|TestPluginHostData_Wire_WorkflowSteps' ./pkg/pluginsdk/... ./internal/plugins/...
ok  	github.com/kandev/kandev/pkg/pluginsdk	0.517s
ok  	github.com/kandev/kandev/internal/plugins	1.070s

$ make -C apps/backend lint
Running linter...
golangci-lint run ./...
0 issues.

$ make typecheck test lint   # repo root
Type-checking all apps...          # passed, no errors
... (full go test ./... — 8 pre-existing failures, none in touched packages, see below)
Running linter...
golangci-lint run ./...
0 issues.
Linting web app... (eslint --max-warnings 0)   # passed
Linting harness files... All 120 harness file(s) passed.
Linting specification files... All specification files passed.
Linting architecture... passed

$ make lint-format
All matched files use Prettier code style!

$ cd apps/web && pnpm run i18n:ratchet
✓ i18n new-code ratchet — no UI source added or modified
✓ guard allowlist intact — 644 entr(ies)
```

The full `go test ./...` run has 8 failing tests across packages this change never touches (`internal/agent/managedruntime`, `internal/agent/runtime/lifecycle`, `internal/agent/settings/controller`, `internal/agentctl/server/api`, `internal/agentctl/server/config`, `internal/agentctl/server/process`, `internal/common/config`, `internal/system/storage/workspaces`). Verified pre-existing, not caused by this diff: ran the identical set of package paths in a scratch worktree checked out at the merge-base commit, with no diff applied, and got the same failure set with the same test names. `internal/plugins` and `pkg/pluginsdk` — the packages this PR actually touches — report `ok`.

Both the mapper round-trip test and the full-wire test (model → proto → real go-plugin gRPC broker → `pluginsdk`) cover a step with several `on_enter` actions (one carrying a `Config` map, to prove it doesn't leak) and a step with none, asserting `nil` rather than an empty slice.

Independent review: Kandev's own `code-review` skill (0 findings) and a cross-vendor `codex exec` pass (0 findings, "Ready to merge") both reviewed the diff `2db9af2a3...efc9cda02` with no blockers or suggestions.

## Possible Improvements

Low risk — additive proto field, no capability change, no write path. The only foreseeable follow-up is the field-number merge conflict with #3044 noted above, which is expected and mechanical to resolve.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->