### PR TITLE
fix: promoted WIP-queued MCP tasks without sessions are not auto-started.

### DIFF
--- a/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
+++ b/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	taskservice "github.com/kandev/kandev/internal/task/service"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -374,6 +377,163 @@ func TestFailedLaunchReleasesTheClaimedIntent(t *testing.T) {
 	if flag, _ := launch[models.DeferredLaunchStartWhenUnblockedKey].(bool); !flag {
 		t.Fatal("the restored intent must keep its start-when-unblocked flag or the gate stops recognising it")
 	}
+}
+
+func TestQueuePromotionOfBlockedWIPOverflowDoesNotLaunch(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "wip-occupant", "wip-occupant-session", "step-limited")
+	seedChainStepTask(t, repo, deferredChainTaskID)
+
+	counter := newLaunchCounter()
+	steps := newMockStepGetter()
+	steps.steps["step-source"] = &wfmodels.WorkflowStep{
+		ID: "step-source", WorkflowID: "wf1", Name: "Source", Position: 0,
+	}
+	steps.steps["step-limited"] = &wfmodels.WorkflowStep{
+		ID: "step-limited", WorkflowID: "wf1", Name: "Limited", Position: 1, WIPLimit: 1,
+	}
+	steps.steps["step-next"] = &wfmodels.WorkflowStep{
+		ID: "step-next", WorkflowID: "wf1", Name: "Next", Position: 2,
+	}
+
+	svc := newDeferredLaunchTestService(t, repo, counter)
+	svc.SetWorkflowStepGetter(steps)
+	// Model an unresolved blocked_by edge. Promotion is deliberately allowed;
+	// only the deferred agent launch must remain gated.
+	dependencies := &launchDependencyReader{blocked: true}
+	svc.SetTaskDependencyReader(dependencies)
+	store := newWorkflowStore(repo, steps, svc.agentManager, noopPublisher, testLogger(),
+		func(eventCtx context.Context, task *models.Task) {
+			svc.handleTaskQueuePromoted(eventCtx, watcher.TaskEventData{TaskID: task.ID})
+		})
+
+	// First overflow the limited step while its only WIP slot is occupied.
+	require.NoError(t, store.ApplyTransition(
+		ctx, deferredChainTaskID, "", "step-source", "step-limited", "manual_move",
+	))
+	queued, err := repo.GetTask(ctx, deferredChainTaskID)
+	require.NoError(t, err)
+	require.False(t, queued.WIPAdmitted)
+	require.Equal(t, "step-limited", queued.QueuedForStepID)
+
+	// Vacating the slot promotes the same-step queue entry and synchronously
+	// delivers task.queue_promoted to the handler under test.
+	require.NoError(t, store.ApplyTransition(
+		ctx, "wip-occupant", "wip-occupant-session", "step-limited", "step-next", "on_turn_complete",
+	))
+	promoted, err := repo.GetTask(ctx, deferredChainTaskID)
+	require.NoError(t, err)
+	require.True(t, promoted.WIPAdmitted)
+	require.Empty(t, promoted.QueuedForStepID)
+	_, promotionPending := promoted.Metadata[models.MetaKeyQueuePromotionPending]
+	require.True(t, promotionPending, "blocked promotion must retain its retry token")
+	_, launchPending := promoted.Metadata[models.MetaKeyDeferredLaunch]
+	require.True(t, launchPending, "blocked promotion must retain its deferred launch intent")
+
+	select {
+	case <-counter.fired:
+		t.Fatal("dependency-blocked WIP promotion launched an agent")
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.Equal(t, 0, sessionCount(t, repo, deferredChainTaskID))
+
+	// Dependency resolution enters the normal auto-start chokepoint. It must
+	// resume the still-pending promotion lifecycle rather than leave the token
+	// stranded after launching directly.
+	dependencies.blocked = false
+	svc.autoStartTaskForStep(ctx, deferredChainTaskID, "step-limited", "task.dependencies_resolved", 0)
+	require.True(t, counter.awaitLaunch(0), "resolved dependency did not launch the promoted task")
+	awaitLaunchedSession(t, repo, deferredChainTaskID)
+	started, err := repo.GetTask(ctx, deferredChainTaskID)
+	require.NoError(t, err)
+	_, promotionPending = started.Metadata[models.MetaKeyQueuePromotionPending]
+	require.False(t, promotionPending, "resolved promotion left its lifecycle token behind")
+}
+
+func TestFailedPromotedDeferredLaunchRestoresTokenAndRetries(t *testing.T) {
+	ctx := context.Background()
+	baseRepo := setupTestRepo(t)
+	seedChainStepTask(t, baseRepo, deferredChainTaskID)
+	require.NoError(t, baseRepo.SetTaskMetadataKey(
+		ctx, deferredChainTaskID, models.MetaKeyQueuePromotionPending, true,
+	))
+	task, err := baseRepo.GetTask(ctx, deferredChainTaskID)
+	require.NoError(t, err)
+	task.WorkflowStepID = "step-draft"
+	task.WIPAdmitted = true
+	require.NoError(t, baseRepo.UpdateTask(ctx, task))
+
+	steps := newMockStepGetter()
+	steps.steps["step-draft"] = &wfmodels.WorkflowStep{
+		ID: "step-draft", WorkflowID: "wf1", Name: "Draft", Position: 0,
+	}
+	steps.steps["step-review"] = &wfmodels.WorkflowStep{
+		ID: "step-review", WorkflowID: "wf1", Name: "Review", Position: 1,
+	}
+	// Fail the scheduler's task projection lookup on the first attempt. This
+	// injects a transient LaunchSession failure before any session or workspace
+	// is created, making a successful retry safe and deterministic.
+	taskRepo := newMockTaskRepo()
+	taskRepo.getTaskErr = errors.New("transient scheduler projection failure")
+	var agentLaunches atomic.Int32
+	launchAttempted := make(chan struct{}, 1)
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: baseRepo,
+		launchAgentFunc: func(context.Context, *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentLaunches.Add(1)
+			launchAttempted <- struct{}{}
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-retry"}, nil
+		},
+	}
+	svc := createTestServiceWithScheduler(baseRepo, steps, taskRepo, agentMgr)
+	svc.SetTaskDependencyReader(&resolvedDependencyReader{})
+
+	svc.handleTaskQueuePromoted(ctx, watcher.TaskEventData{TaskID: deferredChainTaskID})
+
+	// The failure is handled in the detached launch goroutine. Wait until both
+	// durable retry inputs have been restored before running startup recovery.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		stored, loadErr := baseRepo.GetTask(ctx, deferredChainTaskID)
+		require.NoError(t, loadErr)
+		_, deferredRestored := stored.Metadata[models.MetaKeyDeferredLaunch]
+		_, promotionRestored := stored.Metadata[models.MetaKeyQueuePromotionPending]
+		if deferredRestored && promotionRestored {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("launch retry metadata was not restored: %#v", stored.Metadata)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, 0, sessionCount(t, baseRepo, deferredChainTaskID))
+
+	// Repair the transient scheduler projection failure, then exercise the same
+	// startup sweep that retries durable queue-promotion lifecycle tokens.
+	taskRepo.mu.Lock()
+	taskRepo.getTaskErr = nil
+	taskRepo.tasks[deferredChainTaskID] = &v1.Task{
+		ID: deferredChainTaskID, WorkflowID: "wf1",
+		Title: "Chain step", Description: "desc", State: v1.TaskStateCreated,
+	}
+	taskRepo.mu.Unlock()
+
+	svc.reconcileTaskLifecycleTokens(ctx)
+	select {
+	case <-launchAttempted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup lifecycle recovery did not retry the promoted launch")
+	}
+	awaitLaunchedSession(t, baseRepo, deferredChainTaskID)
+
+	stored, err := baseRepo.GetTask(ctx, deferredChainTaskID)
+	require.NoError(t, err)
+	_, deferredPending := stored.Metadata[models.MetaKeyDeferredLaunch]
+	assert.False(t, deferredPending)
+	_, promotionPending := stored.Metadata[models.MetaKeyQueuePromotionPending]
+	assert.False(t, promotionPending)
+	assert.Equal(t, int32(1), agentLaunches.Load())
 }
 
 // intentObserver records the dangerous state: does the task still carry a

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -726,6 +726,12 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 		return
 	}
 	session, sessionErr := s.repo.GetActiveTaskSessionByTaskID(ctx, task.ID)
+	if errors.Is(sessionErr, models.ErrTaskSessionNotFound) {
+		// Queued tasks deliberately have no session until promotion. Continue
+		// into the no-session destination-entry path so deferred auto-start can run.
+		session = nil
+		sessionErr = nil
+	}
 	if sessionErr != nil {
 		s.logger.Warn("task.queue_promoted: failed to load active session",
 			zap.String("task_id", task.ID), zap.Error(sessionErr))

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -737,6 +737,12 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 			zap.String("task_id", task.ID), zap.Error(sessionErr))
 		return
 	}
+	if session == nil && s.dependencyBlocksAutoStart(ctx, task.ID, "task.queue_promoted") {
+		// Promotion controls WIP admission, not dependency readiness. Keep both
+		// the promotion lifecycle token and deferred launch intent intact so the
+		// dependency-resolution path can start the task once its blockers clear.
+		return
+	}
 	if !s.claimTaskEventMetadata(ctx, task, models.MetaKeyQueuePromotionPending) {
 		return
 	}
@@ -1099,10 +1105,19 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 	if s.dependencyBlocksAutoStart(ctx, taskID, eventName) {
 		return
 	}
+	if hasQueuePromotionPending(task) {
+		// A dependency may resolve after same-step WIP promotion was admitted.
+		// Resume through the promotion handler so destination-entry lifecycle is
+		// claimed and its token participates in deferred-launch failure recovery.
+		s.handleTaskQueuePromoted(ctx, watcher.TaskEventData{
+			TaskID: task.ID, StepTransitionID: stepTransitionID,
+		})
+		return
+	}
 	if task != nil && s.shouldSkipTerminalPRAutoStart(ctx, task) {
 		return
 	}
-	if s.launchDeferredTask(ctx, task, eventName) {
+	if s.launchDeferredTask(ctx, task, eventName, false) {
 		return
 	}
 
@@ -1125,7 +1140,7 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 	if s.shouldSkipTerminalPRAutoStart(ctx, task) {
 		return
 	}
-	if s.launchDeferredTask(ctx, task, eventName) {
+	if s.launchDeferredTask(ctx, task, eventName, restoreQueuePromotion) {
 		return
 	}
 	if step == nil || !step.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent) {
@@ -1308,7 +1323,7 @@ func (s *Service) handleAutoStartFailure(ctx context.Context, taskID, eventName 
 	s.setTaskAutoStartFailedMarker(ctx, taskID, eventName)
 }
 
-func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eventName string) bool {
+func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eventName string, restoreQueuePromotion bool) bool {
 	if task.Metadata == nil {
 		return false
 	}
@@ -1352,6 +1367,9 @@ func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eve
 		if launchErr != nil {
 			s.logger.Error(eventName+": failed to launch deferred task", zap.String("task_id", task.ID), zap.Error(launchErr))
 			s.restoreDeferredLaunch(launchCtx, task.ID, raw, eventName, metadataClaimed)
+			if restoreQueuePromotion {
+				s.restoreTaskLifecycleToken(launchCtx, task.ID, models.MetaKeyQueuePromotionPending, eventName)
+			}
 			return
 		}
 		delete(task.Metadata, models.MetaKeyDeferredLaunch)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_test.go
@@ -207,6 +207,36 @@ func TestQueuePromotionTokenRemainsPendingWhenTargetLookupFails(t *testing.T) {
 	}
 }
 
+func TestQueuePromotionWithoutSessionCompletesDestinationEntry(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "promotion-no-session", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "destination-step",
+		Title: "Promotion without session", State: v1.TaskStateTODO, WIPAdmitted: true,
+		Metadata: map[string]interface{}{models.MetaKeyQueuePromotionPending: true},
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	steps := newMockStepGetter()
+	steps.steps["destination-step"] = &wfmodels.WorkflowStep{
+		ID: "destination-step", WorkflowID: "wf1", Name: "Destination", Position: 0,
+	}
+	steps.steps["next-step"] = &wfmodels.WorkflowStep{
+		ID: "next-step", WorkflowID: "wf1", Name: "Next", Position: 1,
+	}
+	svc := createTestService(repo, steps, newMockTaskRepo())
+	svc.handleTaskQueuePromoted(ctx, watcher.TaskEventData{TaskID: "promotion-no-session"})
+
+	stored, err := repo.GetTask(ctx, "promotion-no-session")
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if _, pending := stored.Metadata[models.MetaKeyQueuePromotionPending]; pending {
+		t.Fatal("queue promotion token remained after destination entry completed without a session")
+	}
+}
+
 func TestQueuedMoveWithoutSessionCompletesSourceExitBarrier(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)


### PR DESCRIPTION
Fixes https://github.com/kdlbs/kandev/issues/3079

<!--
AGENT INSTRUCTIONS — read this before filling in the template below.

Generate each section using the rules below. Remove a section entirely if it adds no value for the size of the change. Remove all agent instruction comments from the final output.

SUMMARY (required)
  1–2 sentences max. Do not include a "Summary" heading — write directly as prose.
  Lead with the problem or goal, end with the outcome.
  Say WHY, not what. No filler phrases ("This PR...", "In order to...", "As part of...").

IMPORTANT CHANGES (optional)
  Include only for significant architectural changes. Skip for small or straightforward changes.
  Very short bullet list. Each bullet says WHAT changed and why (very short).

VALIDATION (required)
  How this was tested or verified. List commands or checks run (e.g. `go test ./...`, `make lint`).

DIAGRAM (optional)
  Include a Mermaid diagram only when it genuinely helps the reader understand a non-obvious flow,
  architecture change, or component relationship. Skip if the change is self-explanatory.

POSSIBLE IMPROVEMENTS (optional)
  One line: risk level + what could go wrong or be improved. Skip if negligible.

RELATED ISSUES
  Use "Closes #N" if this resolves an issue. Remove the line if there is no related issue.

RULES
  - Do not add "🤖 Generated with..." or any tool attribution footer.
  - Do not leave placeholder text or unfilled sections in the output.
  - Render the final PR body without any of these instruction comments.
  - Always keep the Checklist section as-is; do not remove or pre-fill its items.
-->

<!-- Summary: replace this comment with 1–2 sentences of prose, no heading -->

## Important Changes

Sessionless MCP tasks promoted from WIP queues could remain idle, bypass dependency gates, or become unrecoverable after a transient launch failure. Promotion now completes automatically while respecting blockers and retaining durable retry state until launch succeeds.

<!-- Optional: bullet list of significant architectural changes. Remove section if not needed. -->

## Validation

<!-- List commands run or manual steps taken to verify the change. -->

```
go test ./internal/orchestrator -count=1
git diff --cached --check
```

## Diagram

<!-- Optional: Mermaid diagram for non-obvious flows. Remove section if not needed. -->

## Possible Improvements

<!-- Optional: one line on risk level and what could go wrong. Remove section if not needed. -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

