### PR TITLE
fix: restore queued task promotion autostart (#3079)

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_queue_promotion_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_promotion_test.go
@@ -1,0 +1,99 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+type queuePromotionSessionLookupErrorRepo struct {
+	sessionExecutorStore
+	err error
+}
+
+func (r *queuePromotionSessionLookupErrorRepo) GetActiveTaskSessionByTaskID(context.Context, string) (*models.TaskSession, error) {
+	return nil, r.err
+}
+
+func TestQueuePromotionWithoutSessionLaunchesDeferredTask(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedChainStepTask(t, repo, deferredChainTaskID)
+
+	task, err := repo.GetTask(ctx, deferredChainTaskID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	task.WorkflowStepID = "destination-step"
+	task.WIPAdmitted = true
+	task.Metadata[models.MetaKeyQueuePromotionPending] = true
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("promote task: %v", err)
+	}
+
+	counter := newLaunchCounter()
+	svc := newDeferredLaunchTestService(t, repo, counter)
+	steps := svc.workflowStepGetter.(*mockStepGetter)
+	steps.steps["destination-step"] = &wfmodels.WorkflowStep{
+		ID: "destination-step", WorkflowID: "wf1", Name: "Destination",
+	}
+
+	svc.handleTaskQueuePromoted(ctx, watcher.TaskEventData{TaskID: deferredChainTaskID})
+	if !counter.awaitLaunch(0) {
+		t.Fatal("promotion did not launch the deferred task")
+	}
+	awaitLaunchedSession(t, repo, deferredChainTaskID)
+
+	if got := sessionCount(t, repo, deferredChainTaskID); got != 1 {
+		t.Fatalf("session count = %d, want exactly one", got)
+	}
+	stored, err := repo.GetTask(ctx, deferredChainTaskID)
+	if err != nil {
+		t.Fatalf("reload promoted task: %v", err)
+	}
+	if _, pending := stored.Metadata[models.MetaKeyQueuePromotionPending]; pending {
+		t.Fatal("queue promotion token remained after deferred launch")
+	}
+}
+
+func TestQueuePromotionSessionLookupFailureKeepsToken(t *testing.T) {
+	ctx := context.Background()
+	const taskID = "promotion-session-lookup-failure"
+	repo := setupTestRepo(t)
+	seedChainStepTask(t, repo, taskID)
+
+	task, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	task.WorkflowStepID = "destination-step"
+	task.WIPAdmitted = true
+	task.Metadata[models.MetaKeyQueuePromotionPending] = true
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("promote task: %v", err)
+	}
+
+	steps := newMockStepGetter()
+	steps.steps["destination-step"] = &wfmodels.WorkflowStep{
+		ID: "destination-step", WorkflowID: "wf1", Name: "Destination",
+	}
+	svc := createTestService(repo, steps, newMockTaskRepo())
+	svc.repo = &queuePromotionSessionLookupErrorRepo{
+		sessionExecutorStore: repo,
+		err:                  errors.New("active session lookup failed"),
+	}
+
+	svc.handleTaskQueuePromoted(ctx, watcher.TaskEventData{TaskID: taskID})
+
+	stored, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if _, pending := stored.Metadata[models.MetaKeyQueuePromotionPending]; !pending {
+		t.Fatal("queue promotion token was consumed after an active-session lookup failure")
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -727,9 +727,13 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 	}
 	session, sessionErr := s.repo.GetActiveTaskSessionByTaskID(ctx, task.ID)
 	if sessionErr != nil {
-		s.logger.Warn("task.queue_promoted: failed to load active session",
-			zap.String("task_id", task.ID), zap.Error(sessionErr))
-		return
+		if errors.Is(sessionErr, models.ErrTaskSessionNotFound) {
+			session = nil
+		} else {
+			s.logger.Warn("task.queue_promoted: failed to load active session",
+				zap.String("task_id", task.ID), zap.Error(sessionErr))
+			return
+		}
 	}
 	if !s.claimTaskEventMetadata(ctx, task, models.MetaKeyQueuePromotionPending) {
 		return

--- a/apps/backend/internal/orchestrator/session_ensure.go
+++ b/apps/backend/internal/orchestrator/session_ensure.go
@@ -17,7 +17,7 @@ type EnsureSessionResponse struct {
 	SessionID      string `json:"session_id,omitempty"`
 	State          string `json:"state"`
 	AgentProfileID string `json:"agent_profile_id,omitempty"`
-	Source         string `json:"source"`                   // existing_primary | existing_newest | created_prepare | created_start | skipped_terminal_pr
+	Source         string `json:"source"`                   // existing_primary | existing_newest | created_prepare | created_start | skipped_terminal_pr | skipped_wip_queue
 	NewlyCreated   bool   `json:"newly_created"`            // true when a new session was created by this call
 	WorkspacePath  string `json:"workspace_path,omitempty"` // effective workspace path (for quick-chat sessions without worktrees)
 }
@@ -58,7 +58,9 @@ func acquireEnsureLock(taskID string) func() {
 // a task: it returns the existing primary (or newest) session if any, otherwise
 // resolves the agent profile from the task's full context and creates a session
 // via prepare (workspace-only) or start (with agent), gated by the task's
-// workflow step.
+// workflow step. A task still waiting for WIP capacity returns a successful
+// no-session response so opening its task view cannot allocate resources before
+// queue promotion.
 //
 // When opts.EnsureExecution is true and the session already exists, the method
 // also verifies that the agent process (agentctl) is running and resumes it if
@@ -80,16 +82,24 @@ func (s *Service) EnsureSession(ctx context.Context, taskID string, opts ...Ensu
 		o = opts[0]
 	}
 
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("task not found: %w", err)
+	}
+	if task.QueuedForStepID != "" {
+		return &EnsureSessionResponse{
+			Success:      true,
+			TaskID:       taskID,
+			Source:       "skipped_wip_queue",
+			NewlyCreated: false,
+		}, nil
+	}
+
 	if existing := s.findExistingSession(ctx, taskID); existing != nil {
 		if o.EnsureExecution {
 			s.tryEnsureExecution(ctx, existing.SessionID)
 		}
 		return existing, nil
-	}
-
-	task, err := s.repo.GetTask(ctx, taskID)
-	if err != nil {
-		return nil, fmt.Errorf("task not found: %w", err)
 	}
 
 	agentProfileID, step := s.resolveTaskAgentProfile(ctx, task)

--- a/apps/backend/internal/orchestrator/session_ensure_queue_test.go
+++ b/apps/backend/internal/orchestrator/session_ensure_queue_test.go
@@ -1,0 +1,92 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type queuedEnsureSessionLookupTracker struct {
+	sessionExecutorStore
+	getTaskSessionCalls int
+}
+
+func (r *queuedEnsureSessionLookupTracker) GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error) {
+	r.getTaskSessionCalls++
+	return nil, errors.New("execution lookup should not happen")
+}
+
+func TestEnsureSession_QueuedTaskSkipsSessionCreation(t *testing.T) {
+	ctx := context.Background()
+	const taskID = "queued-without-session"
+	repo := setupTestRepo(t)
+	seedTaskWithoutSession(t, repo, taskID, "destination-step")
+
+	task, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	task.QueuedForStepID = "destination-step"
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("queue task: %v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[taskID] = &v1.Task{ID: taskID, State: v1.TaskStateInProgress}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, &mockAgentManager{})
+	resp, err := svc.EnsureSession(ctx, taskID)
+	if err != nil {
+		t.Fatalf("ensure queued task: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("ensure queued task returned no response")
+	}
+	if !resp.Success {
+		t.Fatal("expected queued task ensure to succeed")
+	}
+	if resp.SessionID != "" {
+		t.Fatalf("session id = %q, want no session", resp.SessionID)
+	}
+	if resp.Source != "skipped_wip_queue" {
+		t.Fatalf("source = %q, want skipped_wip_queue", resp.Source)
+	}
+	if resp.NewlyCreated {
+		t.Fatal("queued task ensure must not report a new session")
+	}
+	if got := sessionCount(t, repo, taskID); got != 0 {
+		t.Fatalf("session count = %d, want zero", got)
+	}
+}
+
+func TestEnsureSession_QueuedTaskSkipsExistingExecutionResume(t *testing.T) {
+	ctx := context.Background()
+	const taskID = "queued-with-existing-session"
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, "existing-session", models.TaskSessionStateWaitingForInput)
+
+	task, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	task.QueuedForStepID = "destination-step"
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("queue task: %v", err)
+	}
+
+	tracker := &queuedEnsureSessionLookupTracker{sessionExecutorStore: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{})
+	svc.repo = tracker
+	resp, err := svc.EnsureSession(ctx, taskID, EnsureSessionOptions{EnsureExecution: true})
+	if err != nil {
+		t.Fatalf("ensure queued task: %v", err)
+	}
+	if resp.Source != "skipped_wip_queue" || resp.SessionID != "" {
+		t.Fatalf("response = %#v, want skipped_wip_queue without a session", resp)
+	}
+	if tracker.getTaskSessionCalls != 0 {
+		t.Fatalf("existing session was inspected %d time(s), want no execution resume", tracker.getTaskSessionCalls)
+	}
+}

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -283,6 +283,7 @@ function useTaskPageData(
     id: task?.id,
     workflowStepId: task?.workflow_step_id,
     workflowId: task?.workflow_id,
+    queuedForStepId: task?.queued_for_step_id,
   });
   const initialSessionId = sessionId ?? agent.taskSessionId ?? null;
   const effectiveSessionId = validatedActiveSessionId ?? initialSessionId;

--- a/apps/web/hooks/domains/session/use-ensure-task-session.test.ts
+++ b/apps/web/hooks/domains/session/use-ensure-task-session.test.ts
@@ -122,6 +122,24 @@ describe("useEnsureTaskSession", () => {
     expect(mockEnsureTaskSession).not.toHaveBeenCalled();
   });
 
+  it("waits for a queued task to be promoted before ensuring a session", () => {
+    const queuedTask: { id: string; queuedForStepId?: string } = {
+      id: "task-1",
+      queuedForStepId: "step-1",
+    };
+    const { rerender } = renderHook(
+      ({ task }: { task: { id: string; queuedForStepId?: string } }) => useEnsureTaskSession(task),
+      { initialProps: { task: queuedTask } },
+    );
+
+    expect(mockEnsureTaskSession).not.toHaveBeenCalled();
+
+    rerender({ task: { id: "task-1" } });
+
+    expect(mockEnsureTaskSession).toHaveBeenCalledTimes(1);
+    expect(mockEnsureTaskSession).toHaveBeenCalledWith("task-1", undefined);
+  });
+
   it("is idempotent across re-renders for the same task", () => {
     const { rerender } = renderHook(() => useEnsureTaskSession(TASK));
     rerender();

--- a/apps/web/hooks/domains/session/use-ensure-task-session.ts
+++ b/apps/web/hooks/domains/session/use-ensure-task-session.ts
@@ -10,6 +10,8 @@ export type EnsureTaskInput = {
   workflowStepId?: string | null;
   /** Snake_case workflow_id from the HTTP Task type. */
   workflowId?: string | null;
+  /** Destination step while the task waits for WIP capacity. */
+  queuedForStepId?: string | null;
 } | null;
 
 export type KanbanStepLike = {
@@ -139,6 +141,7 @@ export function useEnsureTaskSession(
 ): UseEnsureTaskSessionResult {
   const enabled = opts?.enabled ?? true;
   const taskId = task?.id ?? null;
+  const queuedForStepId = task?.queuedForStepId ?? null;
   const { sessions, isLoaded, loadSessions } = useTaskSessions(taskId);
 
   const [status, setStatus] = useState<EnsureTaskSessionStatus>("idle");
@@ -181,6 +184,7 @@ export function useEnsureTaskSession(
   /* eslint-disable react-hooks/set-state-in-effect -- ensuring a session is a side effect; status mirrors that external work */
   useEffect(() => {
     if (!enabled || !taskId || !isLoaded) return;
+    if (queuedForStepId) return;
     if (sessions.length > 0) return;
     // Wait for the workflow steps to resolve before deciding the gate. This
     // branch does NOT latch, so a later steps hydration re-runs the effect
@@ -218,6 +222,7 @@ export function useEnsureTaskSession(
   }, [
     enabled,
     taskId,
+    queuedForStepId,
     isLoaded,
     loadSessions,
     sessions.length,

--- a/apps/web/lib/services/session-launch-service.ts
+++ b/apps/web/lib/services/session-launch-service.ts
@@ -69,7 +69,8 @@ export type EnsureSessionResponse = {
     | "existing_newest"
     | "created_prepare"
     | "created_start"
-    | "skipped_terminal_pr";
+    | "skipped_terminal_pr"
+    | "skipped_wip_queue";
   newly_created: boolean;
   workspace_path?: string;
 };

--- a/docs/plans/promoted-wip-task-autostart/plan.md
+++ b/docs/plans/promoted-wip-task-autostart/plan.md
@@ -1,0 +1,120 @@
+---
+created: 2026-08-27
+status: complete
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+legacy_specs: []
+---
+
+# Implementation Plan: Promoted WIP Task Auto-Start
+
+## Overview
+
+This fix restores automatic launch after Kandev promotes a WIP-queued task.
+It also prevents task inspection from creating runtime resources before promotion.
+
+The first work order corrects the promotion handler and proves the deferred launch.
+The second work order closes the task-open bypass in the backend and the shared web hook.
+
+## Scope
+
+### In scope
+
+- Treat `models.ErrTaskSessionNotFound` as the expected no-session promotion state.
+- Preserve the retry token for other active-session lookup errors.
+- Consume the deferred launch after promotion and create one session.
+- Make `EnsureSession` return a successful no-session result for queued tasks.
+- Prevent the shared task-open hook from calling `session.ensure` while a task is queued.
+- Retry normal session creation when a task update clears its queue destination.
+
+### Out of scope
+
+- Changes to WIP admission, promotion order, or queue persistence.
+- Changes to direct user-requested session launch operations.
+- Changes to task cards, queue badges, layouts, or mobile navigation.
+- New queue controls or public documentation.
+
+## Technical approach
+
+### Promotion without an active session
+
+Update `handleTaskQueuePromoted` in
+`apps/backend/internal/orchestrator/event_handlers_workflow.go`.
+Convert only `models.ErrTaskSessionNotFound` to a `nil` session.
+Keep the current early return for all other repository errors.
+
+The handler will then claim `MetaKeyQueuePromotionPending` and enter the existing
+no-session branch. `launchDeferredTask` will claim the durable launch intent and
+call `LaunchSession` after the promotion is committed.
+
+Add focused tests in a new orchestrator test file. One test will use the SQLite
+repository's real missing-session result. It will assert that promotion creates
+one session without an `EnsureSession` call. A second test will inject a different
+repository error and assert that the promotion token remains available for retry.
+
+### Queued task inspection
+
+Update `EnsureSession` in `apps/backend/internal/orchestrator/session_ensure.go`.
+Load the task before existing-session resume logic. If `QueuedForStepID` is not
+empty, return a successful response with source `skipped_wip_queue` and no session.
+This check also prevents `EnsureExecution` from resuming an old queued session.
+
+Extend `EnsureSessionResponse` and the frontend response union with the new source.
+Add `queuedForStepId` to `EnsureTaskInput` in the shared session hook.
+The hook will remain idle while that field is present. When promotion clears the
+field, the same hook will run its normal session-ensure path.
+
+The full task route will map `task.queued_for_step_id` into the hook input.
+The Kanban preview already passes the mapped `KanbanTask`, which carries
+`queuedForStepId`.
+
+## Tests
+
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: A promoted task without a session
+  consumes its promotion token and launches its deferred session.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: A genuine repository error keeps the
+  promotion token for retry.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: `EnsureSession` creates no session or
+  execution for a queued task.
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`: The shared task-open hook skips queued
+  tasks and runs after a task update clears the queue destination.
+
+## E2E tests
+
+No new Playwright test is required. The frontend change only normalizes shared
+state inside the existing desktop and mobile task-open hook. Targeted backend and
+hook tests cover the changed boundary without a layout or touch change.
+
+## Work orders
+
+- [x] [Task 01: Restore promotion auto-start](task-01-restore-promotion-autostart.md)
+- [x] [Task 02: Guard queued task inspection](task-02-guard-queued-task-inspection.md)
+
+## Verification results
+
+Passed the exact work-order checks:
+
+```text
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestQueuePromotion(WithoutSessionLaunchesDeferredTask|SessionLookupFailureKeepsToken)' -count=1
+Go test: 2 passed in 1 packages
+
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestEnsureSession.*Queued' -count=1
+Go test: 2 passed in 1 packages
+
+rtk pnpm exec vitest run hooks/domains/session/use-ensure-task-session.test.ts lib/services/session-launch-service.test.ts
+Test Files  2 passed (2)
+Tests  25 passed (25)
+```
+
+No new mobile Playwright test was added because the frontend change only
+normalizes shared task-open state and has no layout, navigation, touch, or
+viewport-dependent behavior.
+
+## Risks
+
+- The missing-session sentinel must not hide database errors.
+- A no-session skip response must not latch the frontend after promotion.
+- Existing queued tasks can contain stale sessions from the current bypass.
+  The backend guard must run before `EnsureExecution` resume logic.

--- a/docs/plans/promoted-wip-task-autostart/task-01-restore-promotion-autostart.md
+++ b/docs/plans/promoted-wip-task-autostart/task-01-restore-promotion-autostart.md
@@ -1,0 +1,83 @@
+---
+id: "01-restore-promotion-autostart"
+title: "Restore promotion auto-start"
+status: completed
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+acceptance_criteria:
+  - AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+---
+
+# Task 01: Restore Promotion Auto-Start
+
+## Summary
+
+Make queue promotion accept the expected missing-session result.
+Then the existing no-session branch can consume the deferred launch and create one session.
+
+## In scope
+
+- Handle `models.ErrTaskSessionNotFound` as a `nil` active session.
+- Preserve the current retry behavior for all other repository errors.
+- Add focused regression tests for successful launch and repository failure.
+
+## Out of scope
+
+- Session creation from task inspection.
+- WIP admission and queue selection.
+- Deferred launch storage changes.
+
+## Acceptance
+
+- Promotion of a task with no session reaches the no-session launch path.
+- A deferred launch creates exactly one session without UI interaction.
+- A different active-session lookup error leaves the promotion token unchanged.
+
+## Verification
+
+```bash
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestQueuePromotion(WithoutSessionLaunchesDeferredTask|SessionLookupFailureKeepsToken)' -count=1
+```
+
+Run this command from `apps/backend`.
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/event_handlers_queue_promotion_test.go`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Broad error suppression can hide a database failure and consume the retry token.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`.
+- `docs/specs/tasks/system-design/wip-limit-pull-system.md`.
+- Issue 3079 and the failing focused reproduction.
+- `handleTaskQueuePromoted` and `TestQueuePromotionTokenRemainsPendingWhenTargetLookupFails`.
+
+## Results
+
+Implemented the sentinel-only session lookup handling in
+`handleTaskQueuePromoted`.
+
+Verification passed:
+
+```text
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestQueuePromotion(WithoutSessionLaunchesDeferredTask|SessionLookupFailureKeepsToken)' -count=1
+Go test: 2 passed in 1 packages
+```

--- a/docs/plans/promoted-wip-task-autostart/task-02-guard-queued-task-inspection.md
+++ b/docs/plans/promoted-wip-task-autostart/task-02-guard-queued-task-inspection.md
@@ -1,0 +1,106 @@
+---
+id: "02-guard-queued-task-inspection"
+title: "Guard queued task inspection"
+status: completed
+wave: 2
+depends_on:
+  - "01-restore-promotion-autostart"
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+acceptance_criteria:
+  - AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+---
+
+# Task 02: Guard Queued Task Inspection
+
+## Summary
+
+Prevent task inspection from creating or resuming a session before WIP promotion.
+Enable normal session creation after a task update clears the queue destination.
+
+## In scope
+
+- Return `skipped_wip_queue` from `EnsureSession` while a task is queued.
+- Run the queue guard before existing-session execution resume logic.
+- Extend the frontend response source union.
+- Skip `session.ensure` in the shared task-open hook while `queuedForStepId` is present.
+- Map the HTTP task queue field into the full task route's hook input.
+- Add backend and frontend unit tests for the guard and promotion update.
+
+## Out of scope
+
+- Direct user-requested launch operations.
+- New rendered states, copy, controls, or responsive layouts.
+- A new mobile Playwright test. The shared hook has no viewport-specific behavior.
+
+## Acceptance
+
+- `EnsureSession` creates no session or execution for a queued task.
+- The task-open hook does not call `session.ensure` while the task is queued.
+- The hook calls `session.ensure` after the same task becomes admitted.
+
+## Verification
+
+```bash
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestEnsureSession.*Queued' -count=1
+```
+
+Run this command from `apps/backend`.
+
+```bash
+rtk pnpm exec vitest run hooks/domains/session/use-ensure-task-session.test.ts lib/services/session-launch-service.test.ts
+```
+
+Run this command from `apps/web`.
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/session_ensure.go`
+- `apps/backend/internal/orchestrator/session_ensure_queue_test.go`
+- `apps/web/lib/services/session-launch-service.ts`
+- `apps/web/hooks/domains/session/use-ensure-task-session.ts`
+- `apps/web/hooks/domains/session/use-ensure-task-session.test.ts`
+- `apps/web/components/task/task-page-content.tsx`
+
+## Dependencies
+
+Task 01 restores the promotion launch that replaces the task-open workaround.
+
+## Risks
+
+- The frontend can remain latched if queue admission is not a hook dependency.
+- A late task update can overwrite a newer session list.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2`.
+- `docs/specs/tasks/system-design/wip-limit-pull-system.md`.
+- `EnsureSession`, `useEnsureTaskSession`, and their current tests.
+- The shared desktop and mobile task-open path.
+
+## Results
+
+Implemented the backend queue guard, the frontend source union and task
+mapping, and the shared hook dependency/early return.
+
+Verification passed:
+
+```text
+rtk go test -tags fts5 ./internal/orchestrator -run 'TestEnsureSession.*Queued' -count=1
+Go test: 2 passed in 1 packages
+
+rtk pnpm exec vitest run hooks/domains/session/use-ensure-task-session.test.ts lib/services/session-launch-service.test.ts
+Test Files  2 passed (2)
+Tests  25 passed (25)
+```
+
+No mobile Playwright test was added because this is shared state and request
+normalization only. It changes no layout, navigation, touch behavior, or
+viewport-dependent interaction.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3084/d6bc69370faf.html)
<!-- kandev-pr-walkthrough-end -->

Opening a WIP-queued task could create a session before capacity was available, while promotion could stop before consuming the deferred launch. The queue guard now keeps inspection resource-free, and promotion starts the deferred session exactly once.

## Validation

- `rtk go test -tags fts5 ./internal/orchestrator -count=1` (2,146 passed)
- `rtk go test -tags fts5 ./internal/orchestrator -run 'TestQueuePromotion(WithoutSessionLaunchesDeferredTask|SessionLookupFailureKeepsToken)' -count=1` (2 passed)
- `rtk go test -tags fts5 ./internal/orchestrator -run 'TestEnsureSession.*Queued' -count=1` (2 passed)
- `rtk pnpm exec vitest run hooks/domains/session/use-ensure-task-session.test.ts lib/services/session-launch-service.test.ts` (25 passed)
- `rtk pnpm run typecheck`
- Targeted ESLint for changed frontend files
- Commit hooks passed after formatter output was restaged
- Public docs reviewed; no `docs/public/**` change is needed because this is an internal lifecycle/state fix.
- No new Playwright test is needed because the frontend change only normalizes shared state and does not change layout, navigation, touch behavior, or viewport-dependent interaction.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Related Issues

Closes #3079


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->