### PR TITLE
feat(system): explain backup location and row actions

### DIFF
--- a/apps/backend/internal/system/database/stats.go
+++ b/apps/backend/internal/system/database/stats.go
@@ -90,6 +90,15 @@ func (s *Service) backupsDir() string {
 	return filepath.Join(filepath.Dir(s.databasePath), "backups")
 }
 
+func (s *Service) absoluteBackupsDir() (string, error) {
+	backupDir := s.backupsDir()
+	absolute, err := filepath.Abs(backupDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve backup directory %q: %w", backupDir, err)
+	}
+	return absolute, nil
+}
+
 // Stats returns the current database stats. SQLite size is computed from
 // PRAGMA page_count * page_size (cheaper than os.Stat on hot writes and more
 // accurate during a VACUUM that creates a sibling file). Postgres size is
@@ -97,9 +106,15 @@ func (s *Service) backupsDir() string {
 func (s *Service) Stats() (Stats, error) {
 	driver := s.databaseDriver()
 	out := Stats{Driver: driver}
+	backupDir := ""
 	if driver == databaseDriverSQLite {
+		resolved, err := s.absoluteBackupsDir()
+		if err != nil {
+			return Stats{}, err
+		}
+		backupDir = resolved
 		out.Path = s.databasePath
-		out.BackupDirectory = s.backupsDir()
+		out.BackupDirectory = backupDir
 	}
 
 	if s.pool != nil {
@@ -121,7 +136,7 @@ func (s *Service) Stats() (Stats, error) {
 			out.WALSizeBytes = wal
 		}
 
-		if last := lastBackupAt(s.backupsDir()); !last.IsZero() {
+		if last := lastBackupAt(backupDir); !last.IsZero() {
 			out.LastBackupAt = &last
 		}
 	}

--- a/apps/backend/internal/system/database/stats.go
+++ b/apps/backend/internal/system/database/stats.go
@@ -35,12 +35,13 @@ const (
 // exists. Serialising a zero time.Time as "0001-01-01T00:00:00Z" would
 // defeat the frontend's "Never" fallback in database-stats-card.tsx.
 type Stats struct {
-	Driver        string     `json:"driver"`
-	Path          string     `json:"path"`
-	SizeBytes     int64      `json:"size_bytes"`
-	WALSizeBytes  int64      `json:"wal_size_bytes"`
-	SchemaVersion string     `json:"schema_version"`
-	LastBackupAt  *time.Time `json:"last_backup_at"`
+	Driver          string     `json:"driver"`
+	Path            string     `json:"path"`
+	BackupDirectory string     `json:"backup_directory"`
+	SizeBytes       int64      `json:"size_bytes"`
+	WALSizeBytes    int64      `json:"wal_size_bytes"`
+	SchemaVersion   string     `json:"schema_version"`
+	LastBackupAt    *time.Time `json:"last_backup_at"`
 }
 
 // ResetDirs lists the on-disk directories factory-reset wipes. The Service
@@ -98,6 +99,7 @@ func (s *Service) Stats() (Stats, error) {
 	out := Stats{Driver: driver}
 	if driver == databaseDriverSQLite {
 		out.Path = s.databasePath
+		out.BackupDirectory = s.backupsDir()
 	}
 
 	if s.pool != nil {

--- a/apps/backend/internal/system/database/stats_test.go
+++ b/apps/backend/internal/system/database/stats_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -260,6 +261,26 @@ func TestStats_ReturnsPathSizeAndSchemaVersion(t *testing.T) {
 	if stats.LastBackupAt != nil {
 		t.Errorf("LastBackupAt = %v, want nil (no backups yet)", *stats.LastBackupAt)
 	}
+	payload := statsPayload(t, stats)
+	wantBackupDir := filepath.Join(dataDir, "backups")
+	if got := payload["backup_directory"]; got != wantBackupDir {
+		t.Errorf("backup_directory = %v, want %q", got, wantBackupDir)
+	}
+}
+
+func TestStats_ReturnsConfiguredSQLiteBackupDirectory(t *testing.T) {
+	svc, _, _, dataDir := newTestService(t)
+	svc.databasePath = filepath.Join(dataDir, "nested", "custom.db")
+
+	stats, err := svc.Stats()
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	want := filepath.Join(dataDir, "nested", "backups")
+	if got := statsPayload(t, stats)["backup_directory"]; got != want {
+		t.Errorf("backup_directory = %v, want %q", got, want)
+	}
 }
 
 func TestStats_PostgresDoesNotUseSQLitePragmas(t *testing.T) {
@@ -287,6 +308,9 @@ func TestStats_PostgresDoesNotUseSQLitePragmas(t *testing.T) {
 	}
 	if stats.LastBackupAt != nil {
 		t.Errorf("LastBackupAt = %v, want nil for postgres", *stats.LastBackupAt)
+	}
+	if got := statsPayload(t, stats)["backup_directory"]; got != "" {
+		t.Errorf("backup_directory = %v, want empty for postgres", got)
 	}
 }
 
@@ -334,7 +358,20 @@ func TestHandleStats_Returns200JSON(t *testing.T) {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	if !contains(body, `"driver"`) || !contains(body, `"path"`) || !contains(body, `"schema_version"`) {
+	if !contains(body, `"driver"`) || !contains(body, `"path"`) || !contains(body, `"schema_version"`) || !contains(body, `"backup_directory"`) {
 		t.Errorf("body missing fields: %s", body)
 	}
+}
+
+func statsPayload(t *testing.T, stats Stats) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("marshal stats: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	return payload
 }

--- a/apps/backend/internal/system/database/stats_test.go
+++ b/apps/backend/internal/system/database/stats_test.go
@@ -283,6 +283,27 @@ func TestStats_ReturnsConfiguredSQLiteBackupDirectory(t *testing.T) {
 	}
 }
 
+func TestStats_ResolvesRelativeSQLiteBackupDirectory(t *testing.T) {
+	relativeDatabasePath := filepath.Join("state", "kandev.db")
+	want, err := filepath.Abs(filepath.Join(filepath.Dir(relativeDatabasePath), "backups"))
+	if err != nil {
+		t.Fatalf("resolve expected backup directory: %v", err)
+	}
+
+	svc := NewService(nil, relativeDatabasePath, ResetDirs{}, nil, nil)
+	stats, err := svc.Stats()
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	if stats.BackupDirectory != want {
+		t.Errorf("BackupDirectory = %q, want %q", stats.BackupDirectory, want)
+	}
+	if !filepath.IsAbs(stats.BackupDirectory) {
+		t.Errorf("BackupDirectory = %q, want an absolute path", stats.BackupDirectory)
+	}
+}
+
 func TestStats_PostgresDoesNotUseSQLitePragmas(t *testing.T) {
 	dataDir := t.TempDir()
 	svc := NewService(newFakePostgresStatsPool(t), filepath.Join(dataDir, "kandev.db"), ResetDirs{}, nil, nil)

--- a/apps/web/components/settings/system/backups-table.test.tsx
+++ b/apps/web/components/settings/system/backups-table.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@kandev/ui/tooltip";
 import type { SnapshotInfo } from "@/lib/types/system";
 
 const mocks = vi.hoisted(() => ({
@@ -57,6 +58,14 @@ function bodyCellCount(): number {
   return screen.getByTestId("system-backups-row").querySelectorAll("td").length;
 }
 
+function renderBackupsTable() {
+  return render(
+    <TooltipProvider delayDuration={0}>
+      <BackupsTable />
+    </TooltipProvider>,
+  );
+}
+
 describe("BackupsTable", () => {
   afterEach(cleanup);
 
@@ -76,7 +85,7 @@ describe("BackupsTable", () => {
     currentRole = "member";
     currentMode = "enabled";
 
-    render(<BackupsTable />);
+    renderBackupsTable();
 
     expect(screen.queryByTestId(CREATE_TEST_ID)).toBeNull();
     expect(screen.queryByTestId(DOWNLOAD_TEST_ID)).toBeNull();
@@ -93,7 +102,7 @@ describe("BackupsTable", () => {
     currentRole = "admin";
     currentMode = "enabled";
 
-    render(<BackupsTable />);
+    renderBackupsTable();
 
     expect(screen.getByTestId(CREATE_TEST_ID)).toBeTruthy();
     expect(screen.getByTestId(DOWNLOAD_TEST_ID)).toBeTruthy();
@@ -109,11 +118,34 @@ describe("BackupsTable", () => {
     currentRole = undefined;
     currentMode = "disabled";
 
-    render(<BackupsTable />);
+    renderBackupsTable();
 
     expect(screen.getByTestId(CREATE_TEST_ID)).toBeTruthy();
     expect(screen.getByTestId(DOWNLOAD_TEST_ID)).toBeTruthy();
     expect(screen.getByTestId(RESTORE_TEST_ID)).toBeTruthy();
     expect(screen.getByTestId(DELETE_TEST_ID)).toBeTruthy();
+  });
+
+  it("describes each row action and keeps its accessible name on the touch target", async () => {
+    currentRole = "admin";
+    currentMode = "enabled";
+
+    renderBackupsTable();
+
+    const actions = [
+      [DOWNLOAD_TEST_ID, `Download ${SNAPSHOT.name}`],
+      [RESTORE_TEST_ID, `Restore ${SNAPSHOT.name}`],
+      [DELETE_TEST_ID, `Delete ${SNAPSHOT.name}`],
+    ] as const;
+    for (const [testId, label] of actions) {
+      const action = screen.getByTestId(testId);
+      expect(action.getAttribute("aria-label")).toBe(label);
+      expect(action.className).toContain("[@media(pointer:coarse)]:h-11");
+      expect(action.className).toContain("[@media(pointer:coarse)]:w-11");
+
+      fireEvent.focus(action);
+      expect((await screen.findByRole("tooltip")).textContent).toContain(label);
+      fireEvent.blur(action);
+    }
   });
 });

--- a/apps/web/components/settings/system/backups-table.test.tsx
+++ b/apps/web/components/settings/system/backups-table.test.tsx
@@ -133,18 +133,20 @@ describe("BackupsTable", () => {
     renderBackupsTable();
 
     const actions = [
-      [DOWNLOAD_TEST_ID, `Download ${SNAPSHOT.name}`],
-      [RESTORE_TEST_ID, `Restore ${SNAPSHOT.name}`],
-      [DELETE_TEST_ID, `Delete ${SNAPSHOT.name}`],
+      [DOWNLOAD_TEST_ID, "Download", `Download ${SNAPSHOT.name}`],
+      [RESTORE_TEST_ID, "Restore", `Restore ${SNAPSHOT.name}`],
+      [DELETE_TEST_ID, "Delete", `Delete ${SNAPSHOT.name}`],
     ] as const;
-    for (const [testId, label] of actions) {
+    for (const [testId, operation, label] of actions) {
       const action = screen.getByTestId(testId);
       expect(action.getAttribute("aria-label")).toBe(label);
       expect(action.className).toContain("[@media(pointer:coarse)]:h-11");
       expect(action.className).toContain("[@media(pointer:coarse)]:w-11");
 
       fireEvent.focus(action);
-      expect((await screen.findByRole("tooltip")).textContent).toContain(label);
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip.textContent).toBe(operation);
+      expect(tooltip.textContent).not.toContain(SNAPSHOT.name);
       fireEvent.blur(action);
     }
   });

--- a/apps/web/components/settings/system/backups-table.tsx
+++ b/apps/web/components/settings/system/backups-table.tsx
@@ -62,6 +62,9 @@ function BackupRowActions({
   const downloadLabel = t("system:backupsDownloadLabel", { name: row.name });
   const restoreLabel = t("system:backupsRestoreLabel", { name: row.name });
   const deleteLabel = t("system:backupsDeleteLabel", { name: row.name });
+  const downloadTooltip = t("task:download");
+  const restoreTooltip = t("task:restore");
+  const deleteTooltip = t("task:delete");
   return (
     <div className="flex items-center justify-end gap-1">
       <Tooltip>
@@ -80,7 +83,7 @@ function BackupRowActions({
             </a>
           </Button>
         </TooltipTrigger>
-        <TooltipContent className="max-w-xs break-words">{downloadLabel}</TooltipContent>
+        <TooltipContent className="max-w-xs break-words">{downloadTooltip}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -95,7 +98,7 @@ function BackupRowActions({
             <IconRotateClockwise className="h-3.5 w-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent className="max-w-xs break-words">{restoreLabel}</TooltipContent>
+        <TooltipContent className="max-w-xs break-words">{restoreTooltip}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -110,7 +113,7 @@ function BackupRowActions({
             <IconTrash className="h-3.5 w-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent className="max-w-xs break-words">{deleteLabel}</TooltipContent>
+        <TooltipContent className="max-w-xs break-words">{deleteTooltip}</TooltipContent>
       </Tooltip>
     </div>
   );

--- a/apps/web/components/settings/system/backups-table.tsx
+++ b/apps/web/components/settings/system/backups-table.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@kandev/ui/badge";
 import { Spinner } from "@kandev/ui/spinner";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@kandev/ui/table";
 import { IconDownload, IconTrash, IconArchive, IconRotateClockwise } from "@tabler/icons-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useIsAdmin } from "@/hooks/domains/auth/use-is-admin";
 import { useBackups } from "@/hooks/domains/system/use-backups";
 import { buildBackupDownloadUrl, createBackup, deleteBackup } from "@/lib/api/domains/system-api";
@@ -32,6 +33,8 @@ const BACKUP_CREATE_POLL_MS = 250;
  * hardcoding the English plural.
  */
 const BACKUP_RETENTION_COUNT = 2;
+const BACKUP_ROW_ACTION_CLASS_NAME =
+  "h-6 w-6 cursor-pointer p-0 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11";
 
 function formatTimestamp(iso: string): string {
   if (!iso) return "-";
@@ -56,45 +59,59 @@ function BackupRowActions({
   onDelete: (name: string) => void;
 }) {
   const { t } = useTranslation();
+  const downloadLabel = t("system:backupsDownloadLabel", { name: row.name });
+  const restoreLabel = t("system:backupsRestoreLabel", { name: row.name });
+  const deleteLabel = t("system:backupsDeleteLabel", { name: row.name });
   return (
     <div className="flex items-center justify-end gap-1">
-      <Button
-        asChild
-        size="sm"
-        variant="ghost"
-        className="cursor-pointer"
-        data-testid="system-backups-download"
-      >
-        {/* These three are icon-only, so the aria-label is their only
-            accessible name. It names the snapshot it acts on. */}
-        <a
-          href={buildBackupDownloadUrl(row.name)}
-          download
-          aria-label={t("system:backupsDownloadLabel", { name: row.name })}
-        >
-          <IconDownload className="h-3.5 w-3.5" />
-        </a>
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        className="cursor-pointer"
-        onClick={() => onRestore(row.name)}
-        aria-label={t("system:backupsRestoreLabel", { name: row.name })}
-        data-testid="system-backups-restore"
-      >
-        <IconRotateClockwise className="h-3.5 w-3.5" />
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        className="cursor-pointer text-destructive"
-        onClick={() => onDelete(row.name)}
-        aria-label={t("system:backupsDeleteLabel", { name: row.name })}
-        data-testid="system-backups-delete"
-      >
-        <IconTrash className="h-3.5 w-3.5" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            asChild
+            size="sm"
+            variant="ghost"
+            className={BACKUP_ROW_ACTION_CLASS_NAME}
+            data-testid="system-backups-download"
+          >
+            {/* These three are icon-only, so the aria-label is their only
+                accessible name. It names the snapshot it acts on. */}
+            <a href={buildBackupDownloadUrl(row.name)} download aria-label={downloadLabel}>
+              <IconDownload className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs break-words">{downloadLabel}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            className={BACKUP_ROW_ACTION_CLASS_NAME}
+            onClick={() => onRestore(row.name)}
+            aria-label={restoreLabel}
+            data-testid="system-backups-restore"
+          >
+            <IconRotateClockwise className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs break-words">{restoreLabel}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            className={`${BACKUP_ROW_ACTION_CLASS_NAME} text-destructive`}
+            onClick={() => onDelete(row.name)}
+            aria-label={deleteLabel}
+            data-testid="system-backups-delete"
+          >
+            <IconTrash className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs break-words">{deleteLabel}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/components/settings/system/data-storage-settings.tsx
+++ b/apps/web/components/settings/system/data-storage-settings.tsx
@@ -2,19 +2,22 @@
 
 import { Separator } from "@kandev/ui/separator";
 import { useTranslation } from "react-i18next";
+import { useAppStore } from "@/components/state-provider";
 import { SettingsTarget } from "@/components/settings/settings-target";
 import { BackupsTable } from "@/components/settings/system/backups-table";
 import { DatabaseStatsCard } from "@/components/settings/system/database-stats-card";
 import { LogViewer } from "@/components/settings/system/log-viewer";
 import { StorageMaintenanceSettings } from "@/components/settings/system/storage/storage-maintenance-settings";
-import { BACKUP_DIR, BACKUP_SQL_COMMAND } from "@/components/settings/system/system-route-shell";
+import { BACKUP_SQL_COMMAND } from "@/components/settings/system/system-route-shell";
 import { SYSTEM_SETTINGS_TARGETS } from "@/lib/settings-discovery/catalog/system";
 
 function SectionHeading({ title, description }: { title: string; description?: string }) {
   return (
     <div>
       <h3 className="text-lg font-semibold">{title}</h3>
-      {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+      {description && (
+        <p className="mt-1 break-words text-sm text-muted-foreground">{description}</p>
+      )}
     </div>
   );
 }
@@ -22,6 +25,7 @@ function SectionHeading({ title, description }: { title: string; description?: s
 /** Data & storage: the former Database, Backups, Storage and Logs pages as one page. */
 export function DataStorageSettings() {
   const { t } = useTranslation();
+  const backupDirectory = useAppStore((s) => s.system.database?.backup_directory);
   return (
     <div className="space-y-8">
       <SettingsTarget targetId={SYSTEM_SETTINGS_TARGETS.database} className="space-y-4">
@@ -35,10 +39,14 @@ export function DataStorageSettings() {
       <SettingsTarget targetId={SYSTEM_SETTINGS_TARGETS.backups} className="space-y-4">
         <SectionHeading
           title={t("system:navBackups")}
-          description={t("system:backupsPageDescription", {
-            command: BACKUP_SQL_COMMAND,
-            path: BACKUP_DIR,
-          })}
+          description={
+            backupDirectory
+              ? t("system:backupsPageDescription", {
+                  command: BACKUP_SQL_COMMAND,
+                  path: backupDirectory,
+                })
+              : undefined
+          }
         />
         <BackupsTable />
       </SettingsTarget>

--- a/apps/web/components/settings/system/system-invisible-copy.test.tsx
+++ b/apps/web/components/settings/system/system-invisible-copy.test.tsx
@@ -159,12 +159,13 @@ describe("copy the guard cannot see, under the pseudo-locale", () => {
    * accents and they do not.
    */
   it("keeps the backup SQL command and path literal inside a translated frame", () => {
+    const path = "/var/lib/kandev/backups";
     const description = t("system:backupsPageDescription", {
       command: "VACUUM INTO",
-      path: "<data-dir>/backups/",
+      path,
     });
     expect(description).toContain("VACUUM INTO");
-    expect(description).toContain("<data-dir>/backups/");
+    expect(description).toContain(path);
     // The surrounding sentence is still translated.
     expect(description).toMatch(ACCENTED);
   });

--- a/apps/web/components/settings/system/system-route-copy.test.ts
+++ b/apps/web/components/settings/system/system-route-copy.test.ts
@@ -136,6 +136,14 @@ describe("Data & Storage backup location copy", () => {
 
     expect(screen.queryByText(/VACUUM INTO snapshots stored under/)).toBeNull();
   });
+
+  it("omits the location when the backend has no backup directory", () => {
+    databaseState.value = { backup_directory: "" };
+
+    render(createElement(DataStorageSettings));
+
+    expect(screen.queryByText(/VACUUM INTO snapshots stored under/)).toBeNull();
+  });
 });
 
 /** "Feature Toggles" -> "featureToggles", matching the catalog key suffix. */

--- a/apps/web/components/settings/system/system-route-copy.test.ts
+++ b/apps/web/components/settings/system/system-route-copy.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { t } from "@/lib/i18n";
-import { BACKUP_DIR, BACKUP_SQL_COMMAND } from "./system-route-shell";
+import { DataStorageSettings } from "./data-storage-settings";
+import { BACKUP_SQL_COMMAND } from "./system-route-shell";
+
+const databaseState = vi.hoisted(() => ({ value: null as unknown }));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: { system: { database: unknown } }) => unknown) =>
+    selector({ system: { database: databaseState.value } }),
+}));
+vi.mock("@/components/settings/settings-target", () => ({
+  SettingsTarget: ({ children }: { children?: ReactNode }) => children ?? null,
+}));
+vi.mock("./backups-table", () => ({ BackupsTable: () => null }));
+vi.mock("./database-stats-card", () => ({ DatabaseStatsCard: () => null }));
+vi.mock("./log-viewer", () => ({ LogViewer: () => null }));
+vi.mock("./storage/storage-maintenance-settings", () => ({
+  StorageMaintenanceSettings: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  databaseState.value = null;
+});
 
 /**
  * Byte-for-byte English for the nine System route headers, as `SETTINGS_ROUTES`
@@ -89,10 +113,28 @@ describe("System route headers keep their pre-migration English", () => {
    * pseudo-localized into dead pointers.
    */
   it("backups", () => {
+    const path = "/var/lib/kandev/backups";
     expect(t("system:navBackups")).toBe("Backups");
-    expect(
-      t("system:backupsPageDescription", { command: BACKUP_SQL_COMMAND, path: BACKUP_DIR }),
-    ).toBe("VACUUM INTO snapshots stored under <data-dir>/backups/.");
+    expect(t("system:backupsPageDescription", { command: BACKUP_SQL_COMMAND, path })).toBe(
+      `VACUUM INTO snapshots stored under ${path}.`,
+    );
+  });
+});
+
+describe("Data & Storage backup location copy", () => {
+  it("renders the resolved SQLite backup directory", () => {
+    const path = "/var/lib/kandev/backups";
+    databaseState.value = { backup_directory: path };
+
+    render(createElement(DataStorageSettings));
+
+    expect(screen.getByText(`VACUUM INTO snapshots stored under ${path}.`)).toBeTruthy();
+  });
+
+  it("omits the location when database information is unavailable", () => {
+    render(createElement(DataStorageSettings));
+
+    expect(screen.queryByText(/VACUUM INTO snapshots stored under/)).toBeNull();
   });
 });
 

--- a/apps/web/components/settings/system/system-route-shell.tsx
+++ b/apps/web/components/settings/system/system-route-shell.tsx
@@ -5,14 +5,10 @@ import { useTranslation } from "react-i18next";
 import { SystemPageShell } from "./system-page-shell";
 
 /**
- * The SQL statement that produces a snapshot, and the directory it writes to.
- * Both are interpolated into the Backups description as values: baked into the
- * message, the pseudo-locale renders them `VÀĆŨŨḾ ĨŃŢŌ` and
- * `<ďàţà-ďĩŕ>/ƀàćķũƥś/`, turning a command the user runs and a path they have to
- * find into dead pointers.
+ * The SQL statement that produces a snapshot is interpolated into the Backups
+ * description as a value, so the pseudo-locale does not alter the command.
  */
 export const BACKUP_SQL_COMMAND = "VACUUM INTO";
-export const BACKUP_DIR = "<data-dir>/backups/";
 
 /**
  * The shell the System routes render through.

--- a/apps/web/e2e/tests/auth/mobile-system-data-storage-member-gating.spec.ts
+++ b/apps/web/e2e/tests/auth/mobile-system-data-storage-member-gating.spec.ts
@@ -110,7 +110,20 @@ test.describe.serial("Data & storage member gating (mobile)", () => {
     await page.goto(DATA_STORAGE_ROUTE);
 
     await expect(page.getByTestId("system-backups-create")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByTestId("system-backups-delete").first()).toBeVisible();
+    const row = page.getByTestId("system-backups-row").first();
+    await expect(row.getByTestId("system-backups-delete")).toBeVisible();
+    for (const testId of [
+      "system-backups-download",
+      "system-backups-restore",
+      "system-backups-delete",
+    ]) {
+      const action = row.getByTestId(testId);
+      await expect(action).toBeVisible();
+      const box = await action.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    }
     await expect(page.getByTestId("system-backups-admin-only")).toHaveCount(0);
     await expect(page.getByTestId("storage-analyze")).toBeEnabled();
 

--- a/apps/web/e2e/tests/system/backups-page.spec.ts
+++ b/apps/web/e2e/tests/system/backups-page.spec.ts
@@ -62,7 +62,8 @@ test.describe("System Backups page", () => {
       const action = row.getByTestId(testId);
       await expect(action).toHaveAttribute("aria-label", `${operation} ${name}`);
       await action.hover();
-      await expect(tooltip).toContainText(`${operation} ${name}`);
+      await expect(tooltip).toContainText(operation);
+      await expect(tooltip).not.toContainText(name!);
     }
   });
 

--- a/apps/web/e2e/tests/system/backups-page.spec.ts
+++ b/apps/web/e2e/tests/system/backups-page.spec.ts
@@ -24,6 +24,44 @@ test.describe("System Backups page", () => {
     await deleteAllManualBackups(apiClient);
   });
 
+  test("shows the resolved backup directory from database stats", async ({
+    testPage,
+    apiClient,
+  }) => {
+    const response = await apiClient.rawRequest("GET", "/api/v1/system/database");
+    const database = (await response.json()) as { backup_directory?: string };
+    const backupDirectory = database.backup_directory;
+    expect(backupDirectory).toBeTruthy();
+
+    await testPage.goto("/settings/system/data-storage");
+    await expect(
+      testPage.getByText(`VACUUM INTO snapshots stored under ${backupDirectory}.`),
+    ).toBeVisible();
+  });
+
+  test("explains each backup row action on hover", async ({ testPage }) => {
+    test.setTimeout(60_000);
+
+    await testPage.goto("/settings/system/data-storage");
+    await testPage.getByTestId("system-backups-create").click();
+    await expect(testPage.getByTestId("system-backups-table")).toBeVisible({ timeout: 15_000 });
+
+    const row = testPage.locator('[data-testid="system-backups-row"]').first();
+    const name = await row.getAttribute("data-name");
+    expect(name).toBeTruthy();
+    const tooltip = testPage.locator('[data-slot="tooltip-content"]:not([data-state="closed"])');
+    for (const [testId, operation] of [
+      ["system-backups-download", "Download"],
+      ["system-backups-restore", "Restore"],
+      ["system-backups-delete", "Delete"],
+    ] as const) {
+      const action = row.getByTestId(testId);
+      await expect(action).toHaveAttribute("aria-label", `${operation} ${name}`);
+      await action.hover();
+      await expect(tooltip).toContainText(`${operation} ${name}`);
+    }
+  });
+
   test("create a manual backup, see it in the table, then delete it back to the empty state", async ({
     testPage,
   }) => {

--- a/apps/web/e2e/tests/system/backups-page.spec.ts
+++ b/apps/web/e2e/tests/system/backups-page.spec.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
 
 async function deleteAllManualBackups(apiClient: {
@@ -29,9 +30,12 @@ test.describe("System Backups page", () => {
     apiClient,
   }) => {
     const response = await apiClient.rawRequest("GET", "/api/v1/system/database");
-    const database = (await response.json()) as { backup_directory?: string };
+    const database = (await response.json()) as { path?: string; backup_directory?: string };
+    expect(database.path).toBeTruthy();
     const backupDirectory = database.backup_directory;
     expect(backupDirectory).toBeTruthy();
+    expect(path.isAbsolute(backupDirectory!)).toBe(true);
+    expect(backupDirectory).toBe(path.resolve(path.dirname(database.path!), "backups"));
 
     await testPage.goto("/settings/system/data-storage");
     await expect(

--- a/apps/web/lib/api/domains/system-api.test.ts
+++ b/apps/web/lib/api/domains/system-api.test.ts
@@ -125,6 +125,7 @@ describe("fetchDatabaseStats", () => {
       jsonResponse({
         driver: "sqlite",
         path: "/data/kandev.db",
+        backup_directory: "/data/backups",
         size_bytes: 1,
         wal_size_bytes: 0,
         schema_version: "1",
@@ -136,6 +137,7 @@ describe("fetchDatabaseStats", () => {
     expect(method()).toBe("GET");
     expect(stats.driver).toBe("sqlite");
     expect(stats.path).toBe("/data/kandev.db");
+    expect(stats.backup_directory).toBe("/data/backups");
   });
 });
 

--- a/apps/web/lib/state/slices/system/system-slice.test.ts
+++ b/apps/web/lib/state/slices/system/system-slice.test.ts
@@ -53,6 +53,7 @@ const DISK_USAGE: DiskUsageResponse = {
 const DB_STATS: DatabaseStats = {
   driver: "sqlite",
   path: "/data/kandev.db",
+  backup_directory: "/data/backups",
   size_bytes: 12345,
   wal_size_bytes: 678,
   schema_version: "1.0.0",

--- a/apps/web/lib/types/system.ts
+++ b/apps/web/lib/types/system.ts
@@ -36,6 +36,7 @@ export interface DiskUsageResponse {
 export interface DatabaseStats {
   driver: string;
   path: string;
+  backup_directory: string;
   size_bytes: number;
   wal_size_bytes: number;
   schema_version: string;

--- a/docs/plans/backup-location-actions/plan.md
+++ b/docs/plans/backup-location-actions/plan.md
@@ -53,7 +53,8 @@ Keep `BACKUP_SQL_COMMAND` as a stable interpolated command value.
 ### Action tooltips
 
 Wrap each control in `BackupRowActions` with the shared Tooltip primitives.
-Reuse each localized `aria-label` as the tooltip content.
+Use localized operation-only labels as tooltip content. Keep each
+snapshot-specific `aria-label` on the interactive control.
 
 Add pointer-specific 44-pixel minimum dimensions to the three controls.
 Keep the current compact dimensions for fine-pointer desktop use.

--- a/docs/plans/backup-location-actions/plan.md
+++ b/docs/plans/backup-location-actions/plan.md
@@ -12,7 +12,7 @@ legacy_specs: []
 
 ## Overview
 
-First, expose the resolved SQLite backup directory through database statistics.
+First, expose the absolute, resolved SQLite backup directory through database statistics.
 Then show that directory and add guidance to each backup row action.
 
 The order establishes one server-owned path before the frontend renders it.
@@ -41,7 +41,8 @@ The order establishes one server-owned path before the frontend renders it.
 ### Resolved directory
 
 Add `BackupDirectory` to `database.Stats` in `apps/backend/internal/system/database/stats.go`.
-Return the `backups` sibling path for SQLite and an empty value for PostgreSQL.
+Return the absolute `backups` sibling path for SQLite, resolving the derived
+path with `filepath.Abs`, and an empty value for PostgreSQL.
 
 Add `backup_directory` to `DatabaseStats` in `apps/web/lib/types/system.ts`.
 Use the shared database state in `data-storage-settings.tsx` for the Backups description.
@@ -78,8 +79,8 @@ Keep the current compact dimensions for fine-pointer desktop use.
 
 Passed.
 
-- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (5 tests).
-- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (51 tests).
+- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (6 tests, including the relative-path absolute-directory regression).
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (52 tests, including the empty backup-directory regression).
 - `pnpm --filter @kandev/web exec vitest run components/settings/system/backups-table.test.tsx` passed (4 tests).
 - `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` passed (3 Chromium tests).
 - `pnpm --filter @kandev/web e2e:run --project mobile-chrome tests/auth/mobile-system-data-storage-member-gating.spec.ts` passed (2 mobile Chromium tests).
@@ -87,6 +88,10 @@ Passed.
 - `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
 - `python3 scripts/lint-spec-files.py --all` passed.
 - `git diff --check` passed.
+- Review remediation passed: the backend resolves the derived directory with
+  `filepath.Abs` and returns an error if resolution fails; the desktop E2E test
+  independently asserts that the API value is absolute and matches the
+  database-path sibling.
 
 ## Risks
 

--- a/docs/plans/backup-location-actions/plan.md
+++ b/docs/plans/backup-location-actions/plan.md
@@ -1,0 +1,96 @@
+---
+created: 2026-08-27
+status: done
+requirements:
+  - REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001
+system_design:
+  - ../../specs/system-page/system-design/backup-location-actions.md
+legacy_specs: []
+---
+
+# Implementation Plan: Backup Location and Action Guidance
+
+## Overview
+
+First, expose the resolved SQLite backup directory through database statistics.
+Then show that directory and add guidance to each backup row action.
+
+The order establishes one server-owned path before the frontend renders it.
+
+## Scope
+
+### In scope
+
+- Add the resolved SQLite backup directory to database statistics.
+- Show the directory in the Backups section description.
+- Add hover and focus tooltips to Download, Restore, and Delete.
+- Keep action targets usable on coarse pointers.
+- Prove desktop and mobile behavior with focused Playwright tests.
+
+### Out of scope
+
+- Change backup storage, retention, or operation behavior.
+- Add per-snapshot absolute paths to the backup list.
+- Change backup permissions.
+- Add PostgreSQL snapshot support.
+- Change backup placeholders in other dialogs.
+- Change public documentation that already describes the sibling directory.
+
+## Technical approach
+
+### Resolved directory
+
+Add `BackupDirectory` to `database.Stats` in `apps/backend/internal/system/database/stats.go`.
+Return the `backups` sibling path for SQLite and an empty value for PostgreSQL.
+
+Add `backup_directory` to `DatabaseStats` in `apps/web/lib/types/system.ts`.
+Use the shared database state in `data-storage-settings.tsx` for the Backups description.
+
+Remove the static `BACKUP_DIR` value from `system-route-shell.tsx`.
+Keep `BACKUP_SQL_COMMAND` as a stable interpolated command value.
+
+### Action tooltips
+
+Wrap each control in `BackupRowActions` with the shared Tooltip primitives.
+Reuse each localized `aria-label` as the tooltip content.
+
+Add pointer-specific 44-pixel minimum dimensions to the three controls.
+Keep the current compact dimensions for fine-pointer desktop use.
+
+## Tests
+
+- `apps/backend/internal/system/database/stats_test.go` covers default, custom, and non-SQLite directory values.
+- `apps/web/components/settings/system/system-route-copy.test.ts` covers the exact dynamic English description.
+- `apps/web/components/settings/system/system-invisible-copy.test.tsx` keeps the resolved path literal in the pseudo-locale.
+- `apps/web/components/settings/system/backups-table.test.tsx` covers tooltip labels, accessible names, and touch-target classes.
+
+## E2E tests
+
+- `apps/web/e2e/tests/system/backups-page.spec.ts` covers the resolved path and all three hover tooltips for `AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.1` through `.3`.
+- `apps/web/e2e/tests/auth/mobile-system-data-storage-member-gating.spec.ts` covers action size and horizontal containment for `.4` and `.5`.
+
+## Work orders
+
+- [x] [Task 01: Show the resolved backup directory](task-01-resolved-backup-directory.md)
+- [x] [Task 02: Describe backup row actions](task-02-backup-row-action-guidance.md)
+
+## Verification results
+
+Passed.
+
+- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (5 tests).
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (51 tests).
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/backups-table.test.tsx` passed (4 tests).
+- `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` passed (3 Chromium tests).
+- `pnpm --filter @kandev/web e2e:run --project mobile-chrome tests/auth/mobile-system-data-storage-member-gating.spec.ts` passed (2 mobile Chromium tests).
+- `pnpm --filter @kandev/web run typecheck` passed.
+- `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
+- `python3 scripts/lint-spec-files.py --all` passed.
+- `git diff --check` passed.
+
+## Risks
+
+- A frontend path reconstruction can break Windows separators. The backend must own the derived value.
+- A second database hook can send duplicate requests. The section must use the existing shared state.
+- A tooltip wrapper can change link composition. The download anchor must remain the interactive element.
+- Long filenames can widen a tooltip or the table. Both surfaces need wrapping and containment checks.

--- a/docs/plans/backup-location-actions/task-01-resolved-backup-directory.md
+++ b/docs/plans/backup-location-actions/task-01-resolved-backup-directory.md
@@ -1,0 +1,102 @@
+---
+id: "01-resolved-backup-directory"
+title: "Show the resolved backup directory"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001
+acceptance_criteria:
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.1
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.2
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.5
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.6
+system_design:
+  - ../../specs/system-page/system-design/backup-location-actions.md
+---
+
+# Task 01: Show the Resolved Backup Directory
+
+## Summary
+
+Expose the backend-derived SQLite backup directory in database statistics.
+Show that value in the Backups section without a symbolic fallback.
+
+## In scope
+
+- Add the additive `backup_directory` database stats field.
+- Return an empty directory for non-SQLite drivers.
+- Update the frontend type and Backups description.
+- Remove the static backup directory constant.
+- Add backend, frontend copy, pseudo-locale, and desktop E2E evidence.
+
+## Out of scope
+
+- Change the backup list response.
+- Change snapshot storage or permissions.
+- Change path placeholders outside the Backups section description.
+
+## Acceptance
+
+- The backend returns the exact sibling directory for default and custom SQLite paths.
+- The Backups description shows the returned full path and never guesses a path.
+- A long path stays inside the page width.
+
+## Verification
+
+```bash
+go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1
+pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts
+pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts
+pnpm --filter @kandev/web run i18n:check
+python3 scripts/lint-spec-files.py --all
+git diff --check
+```
+
+Run the Go command from `apps/backend`.
+Run the pnpm commands from `apps`.
+Run the final two commands from the repository root.
+
+## Files likely touched
+
+- `apps/backend/internal/system/database/stats.go`
+- `apps/backend/internal/system/database/stats_test.go`
+- `apps/web/lib/types/system.ts`
+- `apps/web/components/settings/system/data-storage-settings.tsx`
+- `apps/web/components/settings/system/system-route-shell.tsx`
+- `apps/web/components/settings/system/system-route-copy.test.ts`
+- `apps/web/components/settings/system/system-invisible-copy.test.tsx`
+- `apps/web/lib/api/domains/system-api.test.ts`
+- `apps/web/e2e/tests/system/backups-page.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Duplicate database requests if two components invoke the loading hook.
+- Incorrect path separators if the frontend derives the directory.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001`
+- The Location contract section in the system design.
+- The completed SQLite backup path plan.
+
+## Results
+
+Passed.
+
+- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (5 tests).
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (51 tests).
+- `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` passed (3 Chromium tests, including the resolved path and row-action guidance scenarios).
+- `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
+- `python3 scripts/lint-spec-files.py --all` passed.
+- `git diff --check` passed.
+- `pnpm --filter @kandev/web run typecheck` passed as an additional contract check.

--- a/docs/plans/backup-location-actions/task-01-resolved-backup-directory.md
+++ b/docs/plans/backup-location-actions/task-01-resolved-backup-directory.md
@@ -93,10 +93,13 @@ None.
 
 Passed.
 
-- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (5 tests).
-- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (51 tests).
+- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` passed (6 tests, including the relative-path absolute-directory regression).
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` passed (52 tests, including the empty backup-directory regression).
 - `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` passed (3 Chromium tests, including the resolved path and row-action guidance scenarios).
 - `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
 - `python3 scripts/lint-spec-files.py --all` passed.
 - `git diff --check` passed.
 - `pnpm --filter @kandev/web run typecheck` passed as an additional contract check.
+- Review remediation resolves the derived sibling directory with `filepath.Abs`
+  before returning it and propagates resolution errors. The desktop E2E test
+  also asserts the API value is absolute and matches the expected sibling.

--- a/docs/plans/backup-location-actions/task-02-backup-row-action-guidance.md
+++ b/docs/plans/backup-location-actions/task-02-backup-row-action-guidance.md
@@ -1,0 +1,97 @@
+---
+id: "02-backup-row-action-guidance"
+title: "Describe backup row actions"
+status: done
+wave: 2
+depends_on:
+  - "01-resolved-backup-directory"
+plan: "plan.md"
+requirements:
+  - REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001
+acceptance_criteria:
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.3
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.4
+  - AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.5
+system_design:
+  - ../../specs/system-page/system-design/backup-location-actions.md
+---
+
+# Task 02: Describe Backup Row Actions
+
+## Summary
+
+Add localized hover and focus tooltips to each backup row action.
+Keep the same actions visible and directly usable on coarse pointers.
+
+## In scope
+
+- Add Tooltip wrappers for Download, Restore, and Delete.
+- Reuse the localized accessible labels as tooltip content.
+- Keep the download control as an anchor.
+- Add 44-pixel coarse-pointer targets.
+- Add component, desktop E2E, and mobile E2E evidence.
+
+## Out of scope
+
+- Add labels inside the desktop table cells.
+- Move actions into a mobile overflow menu.
+- Change action handlers, dialogs, or authorization.
+
+## Acceptance
+
+- Hover or keyboard focus shows the correct operation and snapshot name.
+- Each button keeps its accessible name and existing action.
+- Coarse-pointer targets are at least 44 pixels and cause no horizontal page scroll.
+
+## Verification
+
+```bash
+pnpm --filter @kandev/web exec vitest run components/settings/system/backups-table.test.tsx
+pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts
+pnpm --filter @kandev/web e2e:run --project mobile-chrome tests/auth/mobile-system-data-storage-member-gating.spec.ts
+pnpm --filter @kandev/web run i18n:check
+python3 scripts/lint-spec-files.py --all
+git diff --check
+```
+
+Run the pnpm commands from `apps`.
+Run the final two commands from the repository root.
+
+## Files likely touched
+
+- `apps/web/components/settings/system/backups-table.tsx`
+- `apps/web/components/settings/system/backups-table.test.tsx`
+- `apps/web/e2e/tests/system/backups-page.spec.ts`
+- `apps/web/e2e/tests/auth/mobile-system-data-storage-member-gating.spec.ts`
+
+## Dependencies
+
+Task 01 establishes the final Backups page description and desktop E2E baseline.
+
+## Risks
+
+- Nested slots can change the download anchor semantics.
+- A global tooltip locator can match a closed portal.
+- Touch-sized controls can widen the table on small screens.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001`
+- The Row action guidance and Responsive behavior sections in the system design.
+- `apps/web/components/task/chat/queued-ghost-row-actions.tsx`
+- The tooltip selector rules in `.agents/skills/e2e/SKILL.md`.
+
+## Results
+
+Passed.
+
+- `pnpm --filter @kandev/web exec vitest run components/settings/system/backups-table.test.tsx` passed (4 tests).
+- `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` passed (3 Chromium tests, including all three hover tooltips).
+- `pnpm --filter @kandev/web e2e:run --project mobile-chrome tests/auth/mobile-system-data-storage-member-gating.spec.ts` passed (2 mobile Chromium tests, including coarse-pointer target sizing and containment).
+- `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
+- `python3 scripts/lint-spec-files.py --all` passed.
+- `git diff --check` passed.

--- a/docs/plans/backup-location-actions/task-02-backup-row-action-guidance.md
+++ b/docs/plans/backup-location-actions/task-02-backup-row-action-guidance.md
@@ -20,13 +20,13 @@ system_design:
 
 ## Summary
 
-Add localized hover and focus tooltips to each backup row action.
+Add localized operation-only hover and focus tooltips to each backup row action.
 Keep the same actions visible and directly usable on coarse pointers.
 
 ## In scope
 
 - Add Tooltip wrappers for Download, Restore, and Delete.
-- Reuse the localized accessible labels as tooltip content.
+- Use localized operation labels as tooltip content and keep snapshot-specific accessible names.
 - Keep the download control as an anchor.
 - Add 44-pixel coarse-pointer targets.
 - Add component, desktop E2E, and mobile E2E evidence.
@@ -39,8 +39,8 @@ Keep the same actions visible and directly usable on coarse pointers.
 
 ## Acceptance
 
-- Hover or keyboard focus shows the correct operation and snapshot name.
-- Each button keeps its accessible name and existing action.
+- Hover or keyboard focus shows only the correct operation in the tooltip.
+- Each button keeps an accessible name that identifies its snapshot and keeps its existing action.
 - Coarse-pointer targets are at least 44 pixels and cause no horizontal page scroll.
 
 ## Verification
@@ -95,3 +95,4 @@ Passed.
 - `pnpm --filter @kandev/web run i18n:check` passed with the repository's existing advisory orphan-catalog warnings.
 - `python3 scripts/lint-spec-files.py --all` passed.
 - `git diff --check` passed.
+- Tooltip refinement passed: visible tooltips now contain only the localized operation, while accessible names retain the snapshot name.

--- a/docs/specs/system-page/README.md
+++ b/docs/specs/system-page/README.md
@@ -31,6 +31,7 @@ feedback.
 
 
 
+- [Backup location and action guidance](requirements/backup-location-actions.md)
 - [Storage Maintenance](requirements/storage-maintenance.md)
 - [Storage maintenance scan, capacity, and dependency cleanup](requirements/storage-overview-parallel-scan.md)
 - [System pages](requirements/system-page.md)
@@ -39,6 +40,7 @@ feedback.
 
 
 
+- [Backup location and action guidance](system-design/backup-location-actions.md)
 - [Storage Maintenance System Design Part 1](system-design/storage-maintenance-01.md)
 - [Storage Maintenance System Design Part 2](system-design/storage-maintenance-02.md)
 - [Storage Maintenance System Design Part 3](system-design/storage-maintenance-03.md)

--- a/docs/specs/system-page/requirements/backup-location-actions.md
+++ b/docs/specs/system-page/requirements/backup-location-actions.md
@@ -1,0 +1,47 @@
+---
+status: draft
+system: system-page
+created: 2026-08-27
+owners:
+  - kandev
+---
+
+# Backup Location and Action Guidance Requirements
+
+## Overview
+
+The Backups section shows SQLite snapshots and their maintenance actions.
+Operators need the exact snapshot directory and clear meanings for icon-only actions.
+
+The system-page system owns this behavior because it owns the backup maintenance surface.
+The UI system supplies the shared tooltip and responsive primitives.
+
+## Terminology
+
+- **Backup directory:** The `backups` directory beside the configured SQLite database file.
+- **Row action:** An icon-only control for one snapshot.
+
+## Requirements
+
+### REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001: Backup location and row action guidance
+
+**Intent:** Show operators where Kandev stores snapshots and what each snapshot action does.
+
+**User story:** As an operator, I want exact location and action guidance, so that I can manage snapshots without guessing.
+
+#### Acceptance criteria
+
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.1:** When SQLite database information is available, the Backups section shall show the full resolved backup directory.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.2:** When a custom SQLite path is active, the shown directory shall be the `backups` sibling of that file.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.3:** When an authorized user hovers or focuses a row action, the interface shall identify Download, Restore, or Delete and its snapshot.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.4:** When a user uses a coarse pointer, each visible row action shall remain directly usable through a target of at least 44 pixels.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.5:** When a long backup path or snapshot name is shown, the Backups section shall not cause horizontal page scrolling.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.6:** When database information is unavailable or the driver has no local backup directory, the interface shall not show a guessed filesystem path.
+
+## Out of scope
+
+- Changes to backup creation, retention, restore, download, or delete behavior.
+- Changes to the configured database path or backup directory.
+- Publication of per-snapshot filesystem paths.
+- Changes to PostgreSQL backup support.
+- Replacement of path placeholders outside the Backups section description.

--- a/docs/specs/system-page/requirements/backup-location-actions.md
+++ b/docs/specs/system-page/requirements/backup-location-actions.md
@@ -33,7 +33,7 @@ The UI system supplies the shared tooltip and responsive primitives.
 
 - **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.1:** When SQLite database information is available, the Backups section shall show the full resolved backup directory.
 - **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.2:** When a custom SQLite path is active, the shown directory shall be the `backups` sibling of that file.
-- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.3:** When an authorized user hovers or focuses a row action, the interface shall identify Download, Restore, or Delete and its snapshot.
+- **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.3:** When an authorized user hovers or focuses a row action, the tooltip shall identify only Download, Restore, or Delete. The control's accessible name shall continue to identify the snapshot.
 - **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.4:** When a user uses a coarse pointer, each visible row action shall remain directly usable through a target of at least 44 pixels.
 - **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.5:** When a long backup path or snapshot name is shown, the Backups section shall not cause horizontal page scrolling.
 - **AC-SYSTEM-PAGE-BACKUP-GUIDANCE-001.6:** When database information is unavailable or the driver has no local backup directory, the interface shall not show a guessed filesystem path.

--- a/docs/specs/system-page/system-design/backup-location-actions.md
+++ b/docs/specs/system-page/system-design/backup-location-actions.md
@@ -26,8 +26,11 @@ The database service remains the source for the configured SQLite file path.
 `database.Service` already derives the backup directory from its configured database path.
 For SQLite, `Stats` adds `backup_directory` to `GET /api/v1/system/database`.
 
-The service computes this value with `filepath.Join(filepath.Dir(databasePath), "backups")`.
-PostgreSQL and other drivers return an empty value because they have no local SQLite snapshot directory.
+The service computes the sibling directory with
+`filepath.Join(filepath.Dir(databasePath), "backups")`, then resolves that value
+with `filepath.Abs` before returning it. If the absolute-path resolution fails,
+the database stats request returns the error. PostgreSQL and other drivers
+return an empty value because they have no local SQLite snapshot directory.
 
 The frontend adds `backup_directory` to `DatabaseStats`.
 `DataStorageSettings` reads the shared database state after `DatabaseStatsCard` loads it.

--- a/docs/specs/system-page/system-design/backup-location-actions.md
+++ b/docs/specs/system-page/system-design/backup-location-actions.md
@@ -1,0 +1,99 @@
+---
+status: draft
+system: system-page
+requirements:
+  - REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001
+---
+
+# Backup Location and Action Guidance System Design
+
+## Purpose and boundaries
+
+This design adds runtime location and action guidance to the Backups section.
+It does not change snapshot storage or the authorization of backup operations.
+
+The backup service remains the owner of snapshot files and operations.
+The database service remains the source for the configured SQLite file path.
+
+## Requirement mapping
+
+| Requirement | Design section |
+| --- | --- |
+| `REQ-SYSTEM-PAGE-BACKUP-GUIDANCE-001` | [Location contract](#location-contract), [Row action guidance](#row-action-guidance), [Responsive behavior](#responsive-behavior) |
+
+## Location contract
+
+`database.Service` already derives the backup directory from its configured database path.
+For SQLite, `Stats` adds `backup_directory` to `GET /api/v1/system/database`.
+
+The service computes this value with `filepath.Join(filepath.Dir(databasePath), "backups")`.
+PostgreSQL and other drivers return an empty value because they have no local SQLite snapshot directory.
+
+The frontend adds `backup_directory` to `DatabaseStats`.
+`DataStorageSettings` reads the shared database state after `DatabaseStatsCard` loads it.
+The Backups description uses the resolved value and keeps `VACUUM INTO` as an interpolated command value.
+
+The description stays absent until the database response supplies a directory.
+The frontend does not reconstruct paths or show `<data-dir>/backups/` as a fallback.
+
+## Row action guidance
+
+`BackupRowActions` keeps the existing Download, Restore, and Delete buttons.
+Each button becomes a `TooltipTrigger` with a `TooltipContent` sibling.
+
+The tooltip reuses the localized accessible label for the button.
+The label names the operation and the snapshot, so no new translation key is necessary.
+
+The tooltip opens on fine-pointer hover and keyboard focus.
+The icon button and its accessible name remain the primary interaction contract.
+
+## Responsive behavior
+
+The existing Data and Storage route remains the mobile entry point.
+The Backups table remains the visible action surface on mobile.
+
+`queued-ghost-row-actions.tsx` is the nearest shipped coarse-pointer action pattern.
+The row actions use pointer-specific minimum dimensions of 44 pixels without changing desktop density.
+
+The tooltip is not required on touch devices.
+Each icon button stays visible, named, and directly usable.
+
+Long paths and tooltip labels wrap inside their surfaces.
+The existing page and table containment rules prevent document-level horizontal scrolling.
+
+## Failure and recovery
+
+If database statistics fail, the database card shows its existing error.
+The Backups heading omits the unverified path instead of showing a placeholder.
+
+Tooltip rendering has no effect on the action handler.
+Download, Restore, and Delete keep their existing errors and recovery behavior.
+
+## Security
+
+The database stats route uses the normal authenticated or synthetic install identity.
+It already returns the exact SQLite database path to that audience.
+
+The new directory field does not expose the path to a new audience.
+The snapshot list and job results remain free of per-snapshot absolute paths.
+
+Row actions and their tooltips remain admin-only.
+Member users keep the read-only snapshot list without the Actions column.
+
+## Persistence and observability
+
+This change adds no stored state, event, log, or metric.
+The backend derives the directory for each database stats response.
+
+## Test boundaries
+
+- Database package tests prove default, custom, and PostgreSQL directory values.
+- Frontend tests prove dynamic description copy, tooltip labels, and accessible names.
+- Desktop Playwright covers the resolved path and hover tooltips.
+- Mobile Playwright covers 44-pixel actions and horizontal containment.
+
+## Related specifications
+
+- [System pages requirements](../requirements/system-page.md)
+- [System pages system design](system-page-01.md)
+- [SQLite backup path plan](../../../plans/sqlite-backups-database-path/plan.md)

--- a/docs/specs/system-page/system-design/backup-location-actions.md
+++ b/docs/specs/system-page/system-design/backup-location-actions.md
@@ -44,8 +44,9 @@ The frontend does not reconstruct paths or show `<data-dir>/backups/` as a fallb
 `BackupRowActions` keeps the existing Download, Restore, and Delete buttons.
 Each button becomes a `TooltipTrigger` with a `TooltipContent` sibling.
 
-The tooltip reuses the localized accessible label for the button.
-The label names the operation and the snapshot, so no new translation key is necessary.
+The tooltip uses a localized operation-only label from the existing task copy.
+It intentionally omits the snapshot name. The button keeps its localized
+accessible name, which identifies both the operation and the snapshot.
 
 The tooltip opens on fine-pointer hover and keyboard focus.
 The icon button and its accessible name remain the primary interaction contract.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3085/7da95944e908.html)
<!-- kandev-pr-walkthrough-end -->

Administrators need the actual backup location and clear row-action affordances to safely manage snapshots. The backend now exposes the resolved SQLite sibling directory, while the Data & Storage page renders it and provides localized, touch-sized action guidance.

## Important Changes

- Added the additive `backup_directory` field to database statistics, with SQLite-only path derivation.
- Removed the frontend's symbolic backup-path fallback and render the server-provided path only when available.
- Added localized operation-only hover/focus tooltips and coarse-pointer targets for Download, Restore, and Delete.

## Validation

- `go test ./internal/system/database -run 'TestStats|TestHandleStats' -count=1` (6 tests passed)
- `pnpm --filter @kandev/web exec vitest run components/settings/system/system-route-copy.test.ts components/settings/system/system-invisible-copy.test.tsx lib/api/domains/system-api.test.ts` (52 tests passed)
- `pnpm --filter @kandev/web exec vitest run components/settings/system/backups-table.test.tsx` (4 tests passed)
- `pnpm --filter @kandev/web e2e:run tests/system/backups-page.spec.ts` (3 Chromium tests passed)
- `pnpm --filter @kandev/web e2e:run --project mobile-chrome tests/auth/mobile-system-data-storage-member-gating.spec.ts` (2 mobile tests passed)
- `pnpm --filter @kandev/web run typecheck` passed
- Targeted ESLint and Prettier checks passed
- `pnpm --filter @kandev/web run i18n:check` passed with existing advisory orphan-catalog warnings
- `python3 scripts/lint-spec-files.py --all` and `git diff --check` passed
- Fresh desktop and Pixel 5 PR screenshots were captured, inspected, compressed, and validated from `.pr-assets/manifest.json`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop backup location and operation-only action tooltip](https://raw.githubusercontent.com/kdlbs/kandev/10f1f024f2502a6c5e3a444c7bc0835d0dceaee0/desktop-backup-guidance.png)
![Mobile backup actions](https://raw.githubusercontent.com/kdlbs/kandev/10f1f024f2502a6c5e3a444c7bc0835d0dceaee0/mobile-backup-actions.png)
<!-- kandev-screenshots-end -->
