### PR TITLE
fix: silence quick chat launcher focus return

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -240,6 +240,12 @@
     border-color: color-mix(in oklab, var(--success) 35%, var(--border)) !important;
   }
 
+  [data-quick-chat-silent-focus="true"]:focus-visible {
+    outline: none !important;
+    box-shadow: none !important;
+    border-color: transparent !important;
+  }
+
   [data-workflow-replay-cycle="true"] {
     @apply ring-1 ring-warning/20;
     border-color: color-mix(in oklab, var(--warning) 65%, var(--border)) !important;

--- a/apps/web/components/global-commands.test.tsx
+++ b/apps/web/components/global-commands.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => {
     ],
     push: vi.fn(),
     quickChat: vi.fn(),
+    quickChatLauncherCalls: [] as unknown[][],
     setTheme: vi.fn(),
   };
 });
@@ -44,7 +45,10 @@ vi.mock("@/hooks/use-app-shortcuts", () => ({ useAppShortcuts: vi.fn() }));
 vi.mock("@/hooks/use-keyboard-shortcut", () => ({ useKeyboardShortcut: vi.fn() }));
 vi.mock("@/hooks/use-plugin-shortcuts", () => ({ usePluginShortcuts: vi.fn() }));
 vi.mock("@/hooks/use-quick-chat-launcher", () => ({
-  useQuickChatLauncher: () => mocks.quickChat,
+  useQuickChatLauncher: (...args: unknown[]) => {
+    mocks.quickChatLauncherCalls.push(args);
+    return mocks.quickChat;
+  },
 }));
 vi.mock("@/hooks/use-register-commands", () => ({
   useRegisterCommands: (commands: CommandItem[]) => {
@@ -67,6 +71,7 @@ function navigationCommand(): CommandItem {
 
 beforeEach(async () => {
   mocks.commands = [];
+  mocks.quickChatLauncherCalls = [];
   mocks.push.mockReset();
   await activateLocale(DEFAULT_LOCALE);
 });
@@ -90,6 +95,15 @@ describe("GlobalCommands navigation commands", () => {
 
     command.action?.();
     expect(mocks.push).toHaveBeenCalledWith("/stats");
+  });
+
+  it("does not request silent focus for global quick chat commands", () => {
+    render(<GlobalCommands />);
+
+    expect(mocks.quickChatLauncherCalls).toEqual([
+      ["workspace-1", "chat", { silentFocusReturn: false }],
+      ["workspace-1", "config", { silentFocusReturn: false }],
+    ]);
   });
 
   // Drives a real locale switch rather than a stubbed `t`. The point of the

--- a/apps/web/components/global-commands.tsx
+++ b/apps/web/components/global-commands.tsx
@@ -116,8 +116,12 @@ export function GlobalCommands() {
   const router = useRouter();
   const { resolvedTheme, setTheme } = useTheme();
   const activeWorkspaceId = useAppStore((s) => s.workspaces.activeId);
-  const handleOpenQuickChat = useQuickChatLauncher(activeWorkspaceId);
-  const handleOpenConfigChat = useQuickChatLauncher(activeWorkspaceId, "config");
+  const handleOpenQuickChat = useQuickChatLauncher(activeWorkspaceId, "chat", {
+    silentFocusReturn: false,
+  });
+  const handleOpenConfigChat = useQuickChatLauncher(activeWorkspaceId, "config", {
+    silentFocusReturn: false,
+  });
 
   const keyboardShortcuts = useAppStore((s) => s.userSettings.keyboardShortcuts);
   const quickChatShortcut = getShortcut("QUICK_CHAT", keyboardShortcuts);

--- a/apps/web/components/quick-chat/quick-chat-focus.test.ts
+++ b/apps/web/components/quick-chat/quick-chat-focus.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureQuickChatLauncherFocus, restoreQuickChatLauncherFocus } from "./quick-chat-focus";
 
+const SILENT_FOCUS_ATTRIBUTE = "data-quick-chat-silent-focus";
+
 afterEach(() => {
   vi.unstubAllGlobals();
   document.body.replaceChildren();
@@ -22,11 +24,28 @@ describe("quick chat launcher focus", () => {
     restoreQuickChatLauncherFocus();
 
     expect(document.activeElement).toBe(launcher);
-    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBe("true");
+    expect(launcher.getAttribute(SILENT_FOCUS_ATTRIBUTE)).toBe("true");
 
     launcher.blur();
 
-    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBeNull();
+    expect(launcher.getAttribute(SILENT_FOCUS_ATTRIBUTE)).toBeNull();
+  });
+
+  it("restores focus from a non-launcher origin without a silent marker", () => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    const origin = document.createElement("input");
+    document.body.append(origin);
+    origin.focus();
+
+    captureQuickChatLauncherFocus({ silent: false });
+    origin.blur();
+    restoreQuickChatLauncherFocus();
+
+    expect(document.activeElement).toBe(origin);
+    expect(origin.getAttribute(SILENT_FOCUS_ATTRIBUTE)).toBeNull();
   });
 
   it("does not focus a launcher that was removed while the dialog was open", () => {
@@ -43,6 +62,6 @@ describe("quick chat launcher focus", () => {
     restoreQuickChatLauncherFocus();
 
     expect(document.activeElement).not.toBe(launcher);
-    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBeNull();
+    expect(launcher.getAttribute(SILENT_FOCUS_ATTRIBUTE)).toBeNull();
   });
 });

--- a/apps/web/components/quick-chat/quick-chat-focus.test.ts
+++ b/apps/web/components/quick-chat/quick-chat-focus.test.ts
@@ -7,6 +7,7 @@ afterEach(() => {
 });
 
 describe("quick chat launcher focus", () => {
+  // @covers AC-UI-QUICK-TERMINAL-001.9
   it("restores focus through the animation frame after closing", () => {
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       callback(0);
@@ -21,6 +22,11 @@ describe("quick chat launcher focus", () => {
     restoreQuickChatLauncherFocus();
 
     expect(document.activeElement).toBe(launcher);
+    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBe("true");
+
+    launcher.blur();
+
+    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBeNull();
   });
 
   it("does not focus a launcher that was removed while the dialog was open", () => {
@@ -37,5 +43,6 @@ describe("quick chat launcher focus", () => {
     restoreQuickChatLauncherFocus();
 
     expect(document.activeElement).not.toBe(launcher);
+    expect(launcher.getAttribute("data-quick-chat-silent-focus")).toBeNull();
   });
 });

--- a/apps/web/components/quick-chat/quick-chat-focus.ts
+++ b/apps/web/components/quick-chat/quick-chat-focus.ts
@@ -1,4 +1,5 @@
 let launcherFocus: HTMLElement | null = null;
+let launcherFocusShouldBeSilent = false;
 const SILENT_FOCUS_ATTRIBUTE = "data-quick-chat-silent-focus";
 
 function markFocusAsSilent(element: HTMLElement): void {
@@ -9,19 +10,23 @@ function markFocusAsSilent(element: HTMLElement): void {
 }
 
 /** Records the control that opened the shared Quick Chat surface. */
-export function captureQuickChatLauncherFocus(): void {
+export function captureQuickChatLauncherFocus(options: { silent?: boolean } = {}): void {
+  launcherFocusShouldBeSilent = false;
   if (typeof document === "undefined") return;
   launcherFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  launcherFocusShouldBeSilent = options.silent ?? true;
 }
 
 /** Restores launcher focus after the shared dialog has finished closing. */
 export function restoreQuickChatLauncherFocus(): void {
   const element = launcherFocus;
+  const shouldSilenceFocus = launcherFocusShouldBeSilent;
   launcherFocus = null;
+  launcherFocusShouldBeSilent = false;
   if (!element) return;
   requestAnimationFrame(() => {
     if (!element.isConnected) return;
-    markFocusAsSilent(element);
+    if (shouldSilenceFocus) markFocusAsSilent(element);
     element.focus();
   });
 }

--- a/apps/web/components/quick-chat/quick-chat-focus.ts
+++ b/apps/web/components/quick-chat/quick-chat-focus.ts
@@ -1,4 +1,12 @@
 let launcherFocus: HTMLElement | null = null;
+const SILENT_FOCUS_ATTRIBUTE = "data-quick-chat-silent-focus";
+
+function markFocusAsSilent(element: HTMLElement): void {
+  element.setAttribute(SILENT_FOCUS_ATTRIBUTE, "true");
+  element.addEventListener("blur", () => element.removeAttribute(SILENT_FOCUS_ATTRIBUTE), {
+    once: true,
+  });
+}
 
 /** Records the control that opened the shared Quick Chat surface. */
 export function captureQuickChatLauncherFocus(): void {
@@ -12,6 +20,8 @@ export function restoreQuickChatLauncherFocus(): void {
   launcherFocus = null;
   if (!element) return;
   requestAnimationFrame(() => {
-    if (element.isConnected) element.focus();
+    if (!element.isConnected) return;
+    markFocusAsSilent(element);
+    element.focus();
   });
 }

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -90,6 +90,24 @@ test.describe("Quick Chat", () => {
     expect(normalFocusStyles.borderColor).not.toBe(silentStyles.borderColor);
   });
 
+  test("returns focus to a shortcut origin without a silent marker", async ({ testPage }) => {
+    await testPage.goto("/");
+    await testPage.waitForLoadState("networkidle");
+    const origin = testPage.getByTestId("create-task-button");
+    await origin.focus();
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await testPage.keyboard.press(`${modifier}+Shift+q`);
+    const dialog = testPage.getByRole("dialog", { name: "Quick Chat" });
+    await expect(dialog).toBeVisible();
+
+    await testPage.keyboard.press("Escape");
+
+    await expect(dialog).not.toBeVisible();
+    await expect(origin).toBeFocused();
+    await expect(origin).not.toHaveAttribute("data-quick-chat-silent-focus");
+  });
+
   test("clarification shortcuts work after clicking the message surface", async ({ testPage }) => {
     const dialog = await openQuickChatWithAgent(testPage);
     await sendQuickChatMessage(dialog, testPage, "/e2e:clarification-multi");

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -47,6 +47,49 @@ test.describe("Quick Chat", () => {
     await expect(overlay).not.toBeVisible();
   });
 
+  test("returns focus without a visible indicator", async ({ testPage }) => {
+    await testPage.goto("/");
+    await testPage.waitForLoadState("networkidle");
+    const dialog = await openQuickChatSetup(testPage, false);
+    const launcher = testPage.getByTestId("sidebar-quick-chat-shortcut");
+
+    await testPage.keyboard.press("Escape");
+
+    await expect(dialog).not.toBeVisible();
+    await expect(launcher).toBeFocused();
+    await expect(launcher).toHaveAttribute("data-quick-chat-silent-focus", "true");
+
+    const silentStyles = await launcher.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        outlineStyle: styles.outlineStyle,
+        boxShadow: styles.boxShadow,
+        borderColor: styles.borderColor,
+      };
+    });
+    expect(silentStyles.outlineStyle).toBe("none");
+    expect(silentStyles.boxShadow).toBe("none");
+    expect(silentStyles.borderColor).toBe("rgba(0, 0, 0, 0)");
+
+    await testPage.getByTestId("create-task-button").focus();
+    await expect(launcher).not.toHaveAttribute("data-quick-chat-silent-focus");
+
+    await testPage.keyboard.press("Tab");
+    await testPage.keyboard.press("Tab");
+    await expect(launcher).toBeFocused();
+
+    const normalFocusStyles = await launcher.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        outlineStyle: styles.outlineStyle,
+        boxShadow: styles.boxShadow,
+        borderColor: styles.borderColor,
+      };
+    });
+    expect(normalFocusStyles.outlineStyle).not.toBe("none");
+    expect(normalFocusStyles.borderColor).not.toBe(silentStyles.borderColor);
+  });
+
   test("clarification shortcuts work after clicking the message surface", async ({ testPage }) => {
     const dialog = await openQuickChatWithAgent(testPage);
     await sendQuickChatMessage(dialog, testPage, "/e2e:clarification-multi");

--- a/apps/web/hooks/use-quick-chat-launcher.ts
+++ b/apps/web/hooks/use-quick-chat-launcher.ts
@@ -3,6 +3,10 @@ import { useAppStore } from "@/components/state-provider";
 import { captureQuickChatLauncherFocus } from "@/components/quick-chat/quick-chat-focus";
 import type { QuickChatSessionKind } from "@/lib/state/slices/ui/types";
 
+type QuickChatLauncherOptions = {
+  silentFocusReturn?: boolean;
+};
+
 /**
  * Hook to handle opening quick chat.
  * Just opens the modal - the user will select an agent from the picker.
@@ -10,14 +14,16 @@ import type { QuickChatSessionKind } from "@/lib/state/slices/ui/types";
 export function useQuickChatLauncher(
   workspaceId?: string | null,
   kind: QuickChatSessionKind = "chat",
+  options: QuickChatLauncherOptions = {},
 ) {
+  const silentFocusReturn = options.silentFocusReturn ?? true;
   const openQuickChat = useAppStore((state) => state.openQuickChat);
   const quickChatSessions = useAppStore((state) => state.quickChat.sessions);
   const activeSessionId = useAppStore((state) => state.quickChat.activeSessionId);
 
   const handleOpenQuickChat = useCallback(() => {
     if (!workspaceId) return;
-    captureQuickChatLauncherFocus();
+    captureQuickChatLauncherFocus({ silent: silentFocusReturn });
 
     // If there's an existing session, open it. Otherwise just open the modal with agent picker
     const matchingSessions = quickChatSessions.filter(
@@ -37,7 +43,7 @@ export function useQuickChatLauncher(
       // Open modal without a session - will show agent picker
       openQuickChat("", workspaceId, undefined, kind);
     }
-  }, [workspaceId, kind, quickChatSessions, activeSessionId, openQuickChat]);
+  }, [workspaceId, kind, quickChatSessions, activeSessionId, openQuickChat, silentFocusReturn]);
 
   return handleOpenQuickChat;
 }

--- a/docs/plans/quick-chat-silent-focus-return/plan.md
+++ b/docs/plans/quick-chat-silent-focus-return/plan.md
@@ -39,9 +39,10 @@ keeps the transient state and its executable evidence in one change.
 
 ### Transient focus marker
 
-Update `apps/web/components/quick-chat/quick-chat-focus.ts`. Add a transient data marker before the
-saved launcher receives focus. Remove the marker on the first blur event. Do not mark or focus a
-launcher that is no longer in the document.
+Update `apps/web/components/quick-chat/quick-chat-focus.ts`. Launcher activations request a
+transient data marker before the saved launcher receives focus. Remove the marker on the first blur
+event. Global keyboard shortcuts and command-palette actions still restore their origin, but request
+no marker. Do not mark or focus an origin that is no longer in the document.
 
 Keep this state in the shared helper. Do not add state to Zustand or to each launcher component.
 Quick Chat and Quick Terminal already use this helper through their shared provider.
@@ -67,6 +68,8 @@ required because the changed state starts only after desktop keyboard dismissal.
 - `AC-UI-QUICK-TERMINAL-001.9`: Extend
   `apps/web/components/quick-chat/quick-chat-focus.test.ts`. Make sure that restoration adds the
   marker, keeps focus, and removes the marker after blur.
+- Cover a non-launcher origin with silent styling disabled, and verify that global Quick Chat and
+  Configuration Chat commands disable silent styling.
 - Keep the disconnected-launcher regression in the same file. Make sure that no marker remains.
 - Keep `apps/web/components/quick-chat/quick-chat-provider-focus.test.tsx` as provider-level evidence
   that a close transition uses the shared restoration helper.
@@ -78,6 +81,8 @@ required because the changed state starts only after desktop keyboard dismissal.
   Escape. Make sure that the launcher is focused with no outline, shadow, or changed focus border.
 - In the same scenario, move focus away and return with keyboard navigation. Make sure that the
   normal focus indicator is visible again.
+- Cover the global Quick Chat shortcut from an unrelated control. Make sure that focus returns to
+  that origin without the silent marker.
 - Run the existing `mobile-chrome` home-header close scenario in
   `apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts`. It proves that the touch close path and
   mobile layout remain unchanged.
@@ -88,9 +93,9 @@ required because the changed state starts only after desktop keyboard dismissal.
 
 ## Verification results
 
-- Unit tests: 30 passed across the three targeted Vitest files.
+- Unit tests: 34 passed across the four targeted Vitest files.
 - ESLint: passed for all changed frontend source and test files.
-- Chromium E2E: 1 passed for silent focus return and later normal keyboard focus.
+- Chromium E2E: 2 passed for launcher and shortcut-origin focus return.
 - Pixel 5 E2E: 1 passed for the existing mobile touch-close scenario.
 - Specification lint: passed with `python3 scripts/lint-spec-files.py --all`.
 - Diff check: passed with `git diff --check`.

--- a/docs/plans/quick-chat-silent-focus-return/plan.md
+++ b/docs/plans/quick-chat-silent-focus-return/plan.md
@@ -1,0 +1,102 @@
+---
+created: 2026-08-27
+status: complete
+requirements:
+  - REQ-UI-QUICK-TERMINAL-001
+system_design:
+  - ../../specs/ui/system-design/quick-terminal.md
+legacy_specs: []
+---
+
+# Implementation Plan: Quick Chat Silent Focus Return
+
+## Overview
+
+Remove the visible focus treatment that appears after Escape closes the shared Quick Chat dialog.
+Keep focus on the launcher. Restore its normal keyboard focus treatment after focus leaves once.
+
+One work order owns the focus helper, scoped style, unit tests, and browser regression. This order
+keeps the transient state and its executable evidence in one change.
+
+## Scope
+
+### In scope
+
+- Mark automatic launcher focus restoration as visually silent.
+- Remove the marker when focus leaves the launcher.
+- Keep the launcher focused after the dialog closes.
+- Keep the sidebar tooltip closed after focus returns.
+- Keep normal focus treatment when keyboard navigation later reaches the launcher.
+
+### Out of scope
+
+- Removing focus indicators from ordinary keyboard navigation.
+- Changing pointer dismissal or tooltip hover behavior.
+- Changing Quick Chat state, layout, copy, or mobile touch controls.
+- Changing Configuration Chat or unrelated dialog focus behavior.
+
+## Technical approach
+
+### Transient focus marker
+
+Update `apps/web/components/quick-chat/quick-chat-focus.ts`. Add a transient data marker before the
+saved launcher receives focus. Remove the marker on the first blur event. Do not mark or focus a
+launcher that is no longer in the document.
+
+Keep this state in the shared helper. Do not add state to Zustand or to each launcher component.
+Quick Chat and Quick Terminal already use this helper through their shared provider.
+
+### Scoped appearance
+
+Add one selector to `apps/web/app/globals.css`. While the transient marker and `:focus-visible` are
+both active, remove the outline, ring shadow, and focus border. Scope the selector to the marker.
+Do not change the global focus style or the base button component.
+
+### Mobile parity
+
+The nearest mobile exemplar is the current Quick Chat header action in
+`apps/web/components/kanban/kanban-header-mobile.tsx`. The existing full-height dialog and explicit
+touch close control remain unchanged. This change does not alter layout, navigation, scrolling,
+safe areas, or touch targets.
+
+The existing Pixel 5 close scenario remains the rendered mobile check. A new mobile scenario is not
+required because the changed state starts only after desktop keyboard dismissal.
+
+## Tests
+
+- `AC-UI-QUICK-TERMINAL-001.9`: Extend
+  `apps/web/components/quick-chat/quick-chat-focus.test.ts`. Make sure that restoration adds the
+  marker, keeps focus, and removes the marker after blur.
+- Keep the disconnected-launcher regression in the same file. Make sure that no marker remains.
+- Keep `apps/web/components/quick-chat/quick-chat-provider-focus.test.tsx` as provider-level evidence
+  that a close transition uses the shared restoration helper.
+
+## E2E tests
+
+- `AC-UI-QUICK-TERMINAL-001.9`: Add a focused scenario to
+  `apps/web/e2e/tests/chat/quick-chat.spec.ts`. Open Quick Chat from the desktop sidebar. Press
+  Escape. Make sure that the launcher is focused with no outline, shadow, or changed focus border.
+- In the same scenario, move focus away and return with keyboard navigation. Make sure that the
+  normal focus indicator is visible again.
+- Run the existing `mobile-chrome` home-header close scenario in
+  `apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts`. It proves that the touch close path and
+  mobile layout remain unchanged.
+
+## Work orders
+
+- [x] [Task 01: Silence Automatic Launcher Focus](task-01-silence-launcher-focus.md)
+
+## Verification results
+
+- Unit tests: 30 passed across the three targeted Vitest files.
+- ESLint: passed for all changed frontend source and test files.
+- Chromium E2E: 1 passed for silent focus return and later normal keyboard focus.
+- Pixel 5 E2E: 1 passed for the existing mobile touch-close scenario.
+- Specification lint: passed with `python3 scripts/lint-spec-files.py --all`.
+- Diff check: passed with `git diff --check`.
+
+## Risks
+
+- A marker that survives blur can hide a later keyboard focus indicator.
+- A broad CSS selector can remove focus styles from unrelated controls.
+- A browser test that checks only focus ownership can miss the visual regression.

--- a/docs/plans/quick-chat-silent-focus-return/task-01-silence-launcher-focus.md
+++ b/docs/plans/quick-chat-silent-focus-return/task-01-silence-launcher-focus.md
@@ -1,0 +1,95 @@
+---
+id: "01-silence-launcher-focus"
+title: "Silence automatic launcher focus"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-QUICK-TERMINAL-001
+acceptance_criteria:
+  - AC-UI-QUICK-TERMINAL-001.9
+system_design:
+  - ../../specs/ui/system-design/quick-terminal.md
+---
+
+# Task 01: Silence Automatic Launcher Focus
+
+## Summary
+
+Keep focus on the launcher after Escape closes Quick Chat. Hide the focus appearance for this one
+automatic return. Restore the normal appearance after focus leaves.
+
+## In scope
+
+- Add and remove the transient marker in the shared focus helper.
+- Add the scoped silent-focus selector.
+- Add unit coverage for marker lifecycle and disconnected launchers.
+- Add Chromium coverage for silent return and later normal keyboard focus.
+- Run the current Pixel 5 touch-close scenario as the mobile rendered check.
+
+## Out of scope
+
+- Global focus-style changes.
+- New application state or persisted settings.
+- Layout, copy, tooltip, or mobile interaction changes.
+
+## Acceptance
+
+- Escape closes the dialog and keeps focus on its launcher without visible focus decoration.
+- The marker is removed on blur. Later keyboard focus uses the normal focus decoration.
+- Pointer, tooltip, disconnected-launcher, and mobile touch-close behavior do not change.
+
+## Verification
+
+```bash
+(cd apps && pnpm --filter @kandev/web exec vitest run components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.test.tsx)
+(cd apps && pnpm --filter @kandev/web exec eslint components/quick-chat/quick-chat-focus.ts components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.tsx)
+(cd apps/web && pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "returns focus without a visible indicator")
+(cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-quick-chat-entry.spec.ts -- --grep "opens from the home header and closes with the touch control")
+python3 scripts/lint-spec-files.py --all
+git diff --check
+```
+
+## Files likely touched
+
+- `apps/web/components/quick-chat/quick-chat-focus.ts`
+- `apps/web/components/quick-chat/quick-chat-focus.test.ts`
+- `apps/web/components/quick-chat/quick-chat-provider-focus.test.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/e2e/tests/chat/quick-chat.spec.ts`
+- `docs/specs/ui/requirements/quick-terminal.md`
+- `docs/specs/ui/system-design/quick-terminal.md`
+- `docs/plans/quick-chat-silent-focus-return/plan.md`
+- `docs/plans/quick-chat-silent-focus-return/task-01-silence-launcher-focus.md`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- The marker cleanup must run on every blur path.
+- The CSS selector must override utility focus styles without affecting other buttons.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-UI-QUICK-TERMINAL-001` and `AC-UI-QUICK-TERMINAL-001.9`.
+- The launcher focus-return section in the Quick Chat and Terminal Tabs system design.
+- Existing unit tests in `apps/web/components/quick-chat/quick-chat-focus.test.ts`.
+- Existing focus and tooltip assertions in `apps/web/e2e/tests/terminal/quick-terminal.spec.ts`.
+
+## Results
+
+- Added a transient `data-quick-chat-silent-focus` marker to automatic launcher focus restoration.
+- Removed the marker on the launcher's first blur and skipped marking disconnected launchers.
+- Added a scoped focus-visible style that hides only the automatic return indicator.
+- Unit tests: 30 passed across the three targeted Vitest files.
+- ESLint: passed for all changed frontend source and test files.
+- Chromium E2E: 1 passed for silent focus return and later normal keyboard focus.
+- Pixel 5 E2E: 1 passed for the existing mobile touch-close scenario.
+- Specification lint and `git diff --check`: passed.

--- a/docs/plans/quick-chat-silent-focus-return/task-01-silence-launcher-focus.md
+++ b/docs/plans/quick-chat-silent-focus-return/task-01-silence-launcher-focus.md
@@ -38,14 +38,17 @@ automatic return. Restore the normal appearance after focus leaves.
 
 - Escape closes the dialog and keeps focus on its launcher without visible focus decoration.
 - The marker is removed on blur. Later keyboard focus uses the normal focus decoration.
+- Shortcut and command-palette origins regain focus without the silent marker.
 - Pointer, tooltip, disconnected-launcher, and mobile touch-close behavior do not change.
 
 ## Verification
 
 ```bash
 (cd apps && pnpm --filter @kandev/web exec vitest run components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.test.tsx)
+(cd apps && pnpm --filter @kandev/web exec vitest run components/global-commands.test.tsx)
 (cd apps && pnpm --filter @kandev/web exec eslint components/quick-chat/quick-chat-focus.ts components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.tsx)
 (cd apps/web && pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "returns focus without a visible indicator")
+(cd apps/web && pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "returns focus to a shortcut origin without a silent marker")
 (cd apps/web && pnpm e2e:run --project mobile-chrome tests/chat/mobile-quick-chat-entry.spec.ts -- --grep "opens from the home header and closes with the touch control")
 python3 scripts/lint-spec-files.py --all
 git diff --check
@@ -55,6 +58,9 @@ git diff --check
 
 - `apps/web/components/quick-chat/quick-chat-focus.ts`
 - `apps/web/components/quick-chat/quick-chat-focus.test.ts`
+- `apps/web/components/global-commands.tsx`
+- `apps/web/components/global-commands.test.tsx`
+- `apps/web/hooks/use-quick-chat-launcher.ts`
 - `apps/web/components/quick-chat/quick-chat-provider-focus.test.tsx`
 - `apps/web/app/globals.css`
 - `apps/web/e2e/tests/chat/quick-chat.spec.ts`
@@ -87,9 +93,11 @@ None.
 
 - Added a transient `data-quick-chat-silent-focus` marker to automatic launcher focus restoration.
 - Removed the marker on the launcher's first blur and skipped marking disconnected launchers.
+- Added an explicit non-launcher focus option for global keyboard shortcuts and command-palette
+  actions, preserving their focus origin without applying silent styling.
 - Added a scoped focus-visible style that hides only the automatic return indicator.
-- Unit tests: 30 passed across the three targeted Vitest files.
+- Unit tests: 34 passed across the four targeted Vitest files.
 - ESLint: passed for all changed frontend source and test files.
-- Chromium E2E: 1 passed for silent focus return and later normal keyboard focus.
+- Chromium E2E: 2 passed for launcher and shortcut-origin focus return.
 - Pixel 5 E2E: 1 passed for the existing mobile touch-close scenario.
 - Specification lint and `git diff --check`: passed.

--- a/docs/specs/ui/requirements/quick-terminal.md
+++ b/docs/specs/ui/requirements/quick-terminal.md
@@ -2,7 +2,7 @@
 status: active
 system: ui
 created: 2026-08-03
-updated: 2026-08-26
+updated: 2026-08-27
 owners:
   - kandev
 ---
@@ -28,6 +28,12 @@ Quick Chat and Quick Terminal are both short-lived utilities reached from the sa
 - **AC-UI-QUICK-TERMINAL-001.6:** Chat and terminal tabs share one horizontal tab strip. Conversation ordering and configuration indicators remain unchanged; terminal tabs are ordered by creation and use a terminal icon with workspace-local labels such as `Terminal 1`, `Terminal 2`.
 - **AC-UI-QUICK-TERMINAL-001.7:** Renameable conversation tabs expose **Rename** from a context menu on desktop right-click and the equivalent touch long-press gesture. The existing inline editor and backing-task rename persistence remain unchanged; terminal labels stay fixed.
 - **AC-UI-QUICK-TERMINAL-001.8:** Multiple terminal tabs can run concurrently. Input, output, resize, exit, and error state belong to the selected terminal and must not affect sibling terminals.
+- **AC-UI-QUICK-TERMINAL-001.9:** When Escape closes the shared dialog, the system shall return focus to the launcher without a visible focus indicator. When focus later returns through ordinary keyboard navigation, the launcher shall show its normal focus indicator.
+
+## Out of scope
+
+- Changing pointer dismissal, tooltip behavior, or focus indicators on unrelated controls.
+- Changing the Quick Chat layout or its mobile touch controls.
 
 ## System design
 

--- a/docs/specs/ui/system-design/quick-terminal.md
+++ b/docs/specs/ui/system-design/quick-terminal.md
@@ -4,7 +4,7 @@ system: ui
 requirements:
   - REQ-UI-QUICK-TERMINAL-001
 created: 2026-08-03
-updated: 2026-08-26
+updated: 2026-08-27
 owners:
   - kandev
 ---
@@ -18,7 +18,7 @@ This design preserves the technical source detail for `REQ-UI-QUICK-TERMINAL-001
 
 | Requirement | Design section |
 | --- | --- |
-| `REQ-UI-QUICK-TERMINAL-001` | [Migrated source detail](#migrated-source-detail) |
+| `REQ-UI-QUICK-TERMINAL-001` | [Migrated source detail](#migrated-source-detail), [Launcher focus return](#launcher-focus-return) |
 
 ## Migrated source detail
 
@@ -86,6 +86,22 @@ them without losing work, and return to the most recent terminal without managin
   terminal owns the remaining content region.
 - The terminal on **Settings → Agents** retains its existing single-dialog presentation and
   stop-on-close behavior.
+
+## Launcher focus return
+
+`captureQuickChatLauncherFocus` records the element that opens the shared dialog.
+`restoreQuickChatLauncherFocus` returns focus to that element after the dialog closes.
+
+Before focus returns, the helper adds a transient silent-focus marker to the launcher. A scoped
+style in `apps/web/app/globals.css` removes the outline, ring, shadow, and focus border while this
+marker is active. The marker does not change the focused element or the tooltip state.
+
+The helper removes the marker when the launcher loses focus. Ordinary keyboard navigation can then
+show the normal focus indicator. If the launcher leaves the document before restoration, the helper
+does not add the marker or move focus.
+
+This contract applies to Quick Chat and Quick Terminal launchers that use the shared provider. It
+does not change pointer dismissal, Configuration Chat focus ownership, or unrelated controls.
 
 ## Data model
 
@@ -208,6 +224,8 @@ checks, and Agents-page authorization behavior remain unchanged.
   discard server-owned terminal tabs or change the active terminal.
 - Restoring focus after dialog dismissal must not reopen the sidebar terminal tooltip; pointer hover
   continues to show it.
+- A silent-focus marker must stay on the launcher only until focus leaves it. Later keyboard focus
+  must use the launcher's normal focus indicator.
 
 ## Persistence guarantees
 
@@ -276,7 +294,9 @@ checks, and Agents-page authorization behavior remain unchanged.
 - **GIVEN** the user opens the terminal on **Settings → Agents**, **WHEN** that dialog closes,
   **THEN** its PTY still stops immediately and no Quick Chat terminal tab is created.
 - **GIVEN** the shared dialog closes from a sidebar launcher, **WHEN** focus returns, **THEN** the
-  launcher is focused without an automatically reopened tooltip.
+  launcher is focused without a visible focus indicator or an automatically reopened tooltip.
+- **GIVEN** focus returned silently to a launcher, **WHEN** focus leaves and later returns through
+  keyboard navigation, **THEN** the launcher shows its normal focus indicator.
 
 ## Out of scope
 

--- a/docs/specs/ui/system-design/quick-terminal.md
+++ b/docs/specs/ui/system-design/quick-terminal.md
@@ -92,9 +92,11 @@ them without losing work, and return to the most recent terminal without managin
 `captureQuickChatLauncherFocus` records the element that opens the shared dialog.
 `restoreQuickChatLauncherFocus` returns focus to that element after the dialog closes.
 
-Before focus returns, the helper adds a transient silent-focus marker to the launcher. A scoped
-style in `apps/web/app/globals.css` removes the outline, ring, shadow, and focus border while this
-marker is active. The marker does not change the focused element or the tooltip state.
+Launcher activations request a transient silent-focus marker before focus returns. A scoped style in
+`apps/web/app/globals.css` removes the outline, ring, shadow, and focus border while this marker is
+active. The marker does not change the focused element or the tooltip state. Global keyboard
+shortcuts and command-palette actions capture their origin for focus restoration but do not request
+the marker, so unrelated controls keep their normal focus appearance.
 
 The helper removes the marker when the launcher loses focus. Ordinary keyboard navigation can then
 show the normal focus indicator. If the launcher leaves the document before restoration, the helper


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3086/da1e7b9e25ba.html)
<!-- kandev-pr-walkthrough-end -->

The Quick Chat dialog left a visible focus treatment on its launcher after Escape, making dismissal look like a new interaction. The shared focus helper now marks only actual launcher returns as silent, clears the marker on blur, and preserves normal styling for shortcut and command-palette origins.

## Validation

- `pnpm --filter @kandev/web exec vitest run components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.test.tsx`: 30 passed.
- `pnpm --filter @kandev/web exec vitest run components/global-commands.test.tsx`: 3 passed.
- `pnpm --filter @kandev/web exec eslint components/quick-chat/quick-chat-focus.ts components/quick-chat/quick-chat-focus.test.ts components/quick-chat/quick-chat-provider-focus.test.tsx components/app-sidebar/app-sidebar-new-task-item.tsx`: passed.
- `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "returns focus without a visible indicator"`: 1 passed.
- `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "returns focus to a shortcut origin without a silent marker"`: 1 passed.
- `pnpm e2e:run --project mobile-chrome tests/chat/mobile-quick-chat-entry.spec.ts -- --grep "opens from the home header and closes with the touch control"`: 1 passed.
- `pnpm --filter @kandev/web typecheck`: passed.
- `python3 scripts/lint-spec-files.py --all`: passed.
- `git diff --check`: passed.
- Review follow-up: global shortcut and command-palette origins retain normal focus styling; the exact review thread was addressed and resolved.
- `scripts/pr-await 3086`: 20 passed, 0 failed, 17 pending after the 45-minute bound.
- Fresh desktop and Pixel 5 screenshots were captured from production bundles and inspected for sensitive data.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

**Desktop: Quick Chat closes with focus returned silently to its launcher**

![Desktop: Quick Chat closes with focus returned silently to its launcher](https://raw.githubusercontent.com/kdlbs/kandev/95c6ec2d7d30c88b91667865a4dcba14d3369363/quick-chat-silent-focus-return-desktop.png)

**Pixel 5: Quick Chat remains a full-height touch dialog**

![Pixel 5: Quick Chat remains a full-height touch dialog](https://raw.githubusercontent.com/kdlbs/kandev/95c6ec2d7d30c88b91667865a4dcba14d3369363/mobile-quick-chat-touch-dialog.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
