### PR TITLE
test: cover Codex usage-limit dynamic fallback

### DIFF
--- a/apps/backend/internal/agent/runtime/dynamic/engine_test.go
+++ b/apps/backend/internal/agent/runtime/dynamic/engine_test.go
@@ -93,6 +93,42 @@ func TestEngineAppliesCandidateErrorActions(t *testing.T) {
 	}
 }
 
+// Contract coverage: Codex's complete usage-limit envelope must reach the
+// existing hard-error policy without adding a provider branch to the engine.
+func TestEngineRoutesCodexUsageLimitThroughHardPolicy(t *testing.T) {
+	failure := routingerr.Classify(routingerr.Input{
+		Phase:      routingerr.PhasePromptSend,
+		ProviderID: "codex-acp",
+		Stderr:     `{"code":-32603,"message":"Internal error","data":{"codexErrorInfo":"usageLimitExceeded","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Sep 1st, 2026 3:14 PM."}}`,
+	})
+	if failure.Code != routingerr.CodeQuotaLimited || failure.Class != routingerr.ClassHard {
+		t.Fatalf("classification = %+v, want hard quota_limited", failure)
+	}
+
+	profile := Profile{
+		ID: "dynamic-1", Version: 1,
+		Candidates: []Candidate{
+			{ID: "codex", Enabled: true, BindingKey: "codex", Policies: routingpolicy.DefaultDocument()},
+			{ID: "fallback", Enabled: true, BindingKey: "fallback", Policies: routingpolicy.DefaultDocument()},
+		},
+	}
+	engine := NewEngine()
+	initial, err := engine.Select("session-1", profile, 0, "")
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+
+	decision, err := engine.ApplyFailure(
+		"session-1", profile, initial.Generation, initial.ExecutionProfileID, failure,
+	)
+	if err != nil {
+		t.Fatalf("ApplyFailure: %v", err)
+	}
+	if decision.ExecutionProfileID != "fallback" || decision.Reason != "policy_skip" {
+		t.Fatalf("decision = %#v, want fallback selected by hard policy", decision)
+	}
+}
+
 func TestEngineRetrySameKeepsTheFailedCandidate(t *testing.T) {
 	profile := Profile{
 		ID: "dynamic-1", Version: 1,

--- a/apps/backend/internal/agent/runtime/routingerr/classify_test.go
+++ b/apps/backend/internal/agent/runtime/routingerr/classify_test.go
@@ -59,7 +59,12 @@ func TestClassify_ProviderRules(t *testing.T) {
 		{"claude auth", "claude-acp", "you are not authenticated", CodeAuthRequired},
 		{"claude model", "claude-acp", "model claude-foo not found here", CodeModelUnavailable},
 		{"codex quota", "codex-acp", "insufficient_quota for project", CodeQuotaLimited},
-		{"codex usage limit", "codex-acp", `{"codexErrorInfo":"usageLimitExceeded"}`, CodeQuotaLimited},
+		{
+			"codex usage limit",
+			"codex-acp",
+			`{"code":-32603,"message":"Internal error","data":{"codexErrorInfo":"usageLimitExceeded","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Sep 1st, 2026 3:14 PM."}}`,
+			CodeQuotaLimited,
+		},
 		{"codex rate", "codex-acp", "rate_limit_exceeded", CodeRateLimited},
 		{"codex apikey", "codex-acp", "invalid api key provided", CodeMissingCredentials},
 		{"opencode auth", "opencode-acp", "Unauthorized request", CodeAuthRequired},

--- a/apps/backend/internal/orchestrator/dynamic_evidence_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_evidence_test.go
@@ -6,29 +6,41 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 )
 
+// Contract coverage: a recognized provider failure still cannot override the
+// dynamic route's pre-result and effect-safety gate.
 func TestDynamicPreResultRequiresExplicitKnownEvidence(t *testing.T) {
-	if dynamicPreResultSafe(watcher.AgentEventData{DynamicRouteAttempt: true}) {
-		t.Fatal("unknown dynamic attempt was treated as pre-result safe")
-	}
-	if !dynamicPreResultSafe(watcher.AgentEventData{
+	usageLimitFailure := watcher.AgentEventData{
+		AgentID:             "codex-acp",
+		ErrorMessage:        `{"code":-32603,"message":"Internal error","data":{"codexErrorInfo":"usageLimitExceeded","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Sep 1st, 2026 3:14 PM."}}`,
 		DynamicRouteAttempt: true,
 		EvidenceKnown:       true,
-	}) {
-		t.Fatal("known no-output/no-effect attempt was not pre-result safe")
 	}
-	if dynamicPreResultSafe(watcher.AgentEventData{
-		DynamicRouteAttempt: true,
-		EvidenceKnown:       true,
-		OutputObserved:      true,
-	}) {
-		t.Fatal("output-producing attempt was treated as pre-result safe")
+	if !dynamicPreResultSafe(usageLimitFailure) {
+		t.Fatal("pre-result usage-limit failure was not safe to route")
 	}
-	if dynamicPreResultSafe(watcher.AgentEventData{
-		DynamicRouteAttempt: true,
-		EvidenceKnown:       true,
-		EffectObserved:      true,
-	}) {
-		t.Fatal("effect-producing attempt was treated as pre-result safe")
+
+	unsafeCases := []struct {
+		name string
+		data watcher.AgentEventData
+	}{
+		{name: "unknown evidence", data: watcher.AgentEventData{DynamicRouteAttempt: true}},
+		{name: "assistant output", data: func() watcher.AgentEventData {
+			data := usageLimitFailure
+			data.OutputObserved = true
+			return data
+		}()},
+		{name: "tool effect", data: func() watcher.AgentEventData {
+			data := usageLimitFailure
+			data.EffectObserved = true
+			return data
+		}()},
+	}
+	for _, test := range unsafeCases {
+		t.Run(test.name, func(t *testing.T) {
+			if dynamicPreResultSafe(test.data) {
+				t.Fatal("usage-limit failure with unsafe evidence was allowed to route")
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/orchestrator/dynamic_evidence_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_evidence_test.go
@@ -38,7 +38,7 @@ func TestDynamicPreResultRequiresExplicitKnownEvidence(t *testing.T) {
 	for _, test := range unsafeCases {
 		t.Run(test.name, func(t *testing.T) {
 			if dynamicPreResultSafe(test.data) {
-				t.Fatal("usage-limit failure with unsafe evidence was allowed to route")
+				t.Fatalf("case %q was incorrectly treated as pre-result safe", test.name)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3088/1fe52e55e2c3.html)
<!-- kandev-pr-walkthrough-end -->

Provider usage-limit errors from Codex already classify as `quota_limited`, but prior tests covered only a fragment of the ACP envelope. This adds regression coverage for the complete payload, dynamic hard-error candidate advancement, and safety gates for output and tool effects.

## Validation

- `go test ./internal/agent/runtime/routingerr ./internal/agent/runtime/dynamic ./internal/orchestrator -count=1`
- `git diff --check`
- Commit hooks: Go formatting, changed-file Go lint, and Conventional Commits validation

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->