### PR TITLE
perf: reduce frontend runtime CPU

### DIFF
--- a/apps/web/components/task/chat/message-list-native-scroll.ts
+++ b/apps/web/components/task/chat/message-list-native-scroll.ts
@@ -25,6 +25,14 @@ import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const paginationDebug = createDebugLogger("messages:pagination");
 
+const NATIVE_BOTTOM_SCROLL_TOP = Number.MAX_SAFE_INTEGER;
+
+/** Writes a clamped maximum so the browser resolves the native bottom without
+ * forcing a synchronous scrollHeight layout read. */
+export function scrollNativeToBottom(element: HTMLElement): void {
+  element.scrollTop = NATIVE_BOTTOM_SCROLL_TOP;
+}
+
 type PaginationRequest = {
   boundaryBefore: string | null;
   debug?: {
@@ -429,7 +437,7 @@ export function useAutoScroll(params: {
     ) {
       const el = scrollRef.current;
       if (el) {
-        el.scrollTop = el.scrollHeight;
+        scrollNativeToBottom(el);
         isNearBottomRef.current = true;
       }
     }
@@ -449,7 +457,7 @@ export function useAutoScroll(params: {
       }) &&
       enabled
     ) {
-      el.scrollTop = el.scrollHeight;
+      scrollNativeToBottom(el);
     }
   }, [messages, scrollRef, enabled, isProgrammaticScrollLocked]);
 
@@ -539,7 +547,7 @@ function useCatchUpOnReEnable(
         isAtBottom,
       })
     ) {
-      el.scrollTop = el.scrollHeight;
+      scrollNativeToBottom(el);
       isNearBottomRef.current = true;
     }
   }, [enabled, scrollRef, messages]);

--- a/apps/web/components/task/chat/message-list-native.test.tsx
+++ b/apps/web/components/task/chat/message-list-native.test.tsx
@@ -407,6 +407,44 @@ describe("useScrollToDividerOrBottom — anchored-bar offset", () => {
     expect(scrollContainer.scrollTop).toBe(123);
   });
 
+  it("pins an appended message without reading content size", () => {
+    const { rerender } = render(
+      <AutoScrollHarness isWorking={false} hasUnreadDivider={false} messages={TEST_MESSAGES} />,
+    );
+    const scrollContainer = screen.getByTestId("auto-scroll-container");
+    let scrollTop = 600;
+    let writes = 0;
+    Object.defineProperties(scrollContainer, {
+      scrollHeight: {
+        configurable: true,
+        get: () => {
+          throw new Error("pinned append must not read scrollHeight");
+        },
+      },
+      clientHeight: { configurable: true, value: 400 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          writes += 1;
+          scrollTop = value;
+        },
+      },
+    });
+
+    expect(() => {
+      rerender(
+        <AutoScrollHarness
+          isWorking={false}
+          hasUnreadDivider={false}
+          messages={[...TEST_MESSAGES, {} as Message]}
+        />,
+      );
+    }).not.toThrow();
+    expect(writes).toBe(1);
+    expect(scrollTop).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
   it("restores the disabled offset after a transient layout clamp", () => {
     const { rerender } = render(
       <AutoScrollHarness isWorking={false} hasUnreadDivider={false} enabled />,

--- a/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
@@ -173,6 +173,35 @@ test.describe("Transcript auto-scroll toggle", () => {
     expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(targetScrollTop - 10);
   });
 
+  test("enabled auto-scroll stays at the bottom for live messages", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedOverflowingTask(
+      testPage,
+      apiClient,
+      seedData,
+      "Auto-scroll Toggle Enabled Live Message",
+    );
+    await waitForOverflow(testPage);
+
+    const list = chatList(testPage);
+    const toggle = session.chatStatusBar().getByTestId("auto-scroll-toggle-button");
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    await session.sendMessage('e2e:message("New content while enabled")');
+    await expect(session.chat.getByText("New content while enabled").last()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect
+      .poll(async () => list.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
+        timeout: 5_000,
+        message: "enabled auto-scroll should stay at the bottom after live content",
+      })
+      .toBeLessThan(10);
+  });
+
   test("disabling while genuinely at the bottom still freezes the view when new content arrives", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
@@ -147,6 +147,42 @@ test.describe("Mobile transcript auto-scroll toggle", () => {
     expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(targetScrollTop - 10);
   });
 
+  test("enabled auto-scroll stays at the bottom for live messages on mobile", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedOverflowingTask(
+      testPage,
+      apiClient,
+      seedData,
+      "Mobile Auto-scroll Toggle Enabled Live Message",
+    );
+    const activeChat = session.activeChat();
+    const list = activeChat.locator(".chat-message-list");
+    await expect
+      .poll(async () => list.evaluate((el) => el.scrollHeight - el.clientHeight), {
+        timeout: 15_000,
+        message: "Waiting for chat to overflow",
+      })
+      .toBeGreaterThan(200);
+
+    const toggle = session.chatStatusBar().getByTestId("auto-scroll-toggle-button");
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    const marker = "New content while enabled on mobile";
+    await session.sendMessageViaButton(`e2e:message("${marker}")`);
+    await expect(activeChat.getByText(marker, { exact: false }).last()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect
+      .poll(async () => list.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
+        timeout: 5_000,
+        message: "enabled mobile auto-scroll should stay at the bottom after live content",
+      })
+      .toBeLessThan(10);
+  });
+
   test("disabling from the bottom freezes the view when new content arrives", async ({
     testPage,
     apiClient,

--- a/apps/web/hooks/use-processed-messages-fallback.test.ts
+++ b/apps/web/hooks/use-processed-messages-fallback.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   sessionId as toSessionId,
   taskId as toTaskId,
@@ -48,4 +48,40 @@ describe("useProcessedMessages task description fallback", () => {
 
     expect(result.current.allMessages.map((message) => message.id)).toEqual(["agent-1"]);
   });
+
+  it("emits the latest processed-message debug sample at most once per 250 ms", () => {
+    vi.useFakeTimers();
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+
+    try {
+      const initialMessage = makeMessage("agent-1", "agent", "boot");
+      const { rerender } = renderHook(
+        ({ messages }: { messages: Message[] }) => useProcessedMessages(messages, "t1", "s1", ""),
+        { initialProps: { messages: [initialMessage] } },
+      );
+
+      rerender({
+        messages: [
+          initialMessage,
+          makeMessage("agent-2", "agent", "second"),
+          makeMessage("agent-3", "agent", "latest"),
+        ],
+      });
+
+      expect(debugSpy).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(249);
+      expect(debugSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(debugSpy.mock.calls[0]?.[0]).toContain('input={"count":3');
+    } finally {
+      debugSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });

--- a/apps/web/hooks/use-processed-messages-fallback.test.ts
+++ b/apps/web/hooks/use-processed-messages-fallback.test.ts
@@ -80,6 +80,33 @@ describe("useProcessedMessages task description fallback", () => {
       vi.useRealTimers();
     }
   });
+
+  it("flushes pending debug samples on session changes and unmount", () => {
+    vi.useFakeTimers();
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const firstMessage = makeMessage("agent-1", "agent", "first");
+    const secondMessage = makeMessage("agent-2", "agent", "second");
+    const { rerender, unmount } = renderHook(
+      ({ sessionId, messages }: { sessionId: string; messages: Message[] }) =>
+        useProcessedMessages(messages, "t1", sessionId, ""),
+      { initialProps: { sessionId: "s1", messages: [firstMessage] } },
+    );
+
+    try {
+      rerender({ sessionId: "s2", messages: [firstMessage, secondMessage] });
+
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(debugSpy.mock.calls[0]?.[0]).toContain('input={"count":1');
+
+      unmount();
+
+      expect(debugSpy).toHaveBeenCalledTimes(2);
+      expect(debugSpy.mock.calls[1]?.[0]).toContain('input={"count":2');
+    } finally {
+      debugSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });
 
 afterEach(() => {

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   sessionId as toSessionId,
   taskId as toTaskId,
@@ -32,6 +32,7 @@ export {
 } from "./processed-message-filtering";
 
 const debug = createDebugLogger("messages:process");
+const PROCESSED_PIPELINE_DEBUG_INTERVAL_MS = 250;
 
 function countByType(messages: Message[]): Record<string, number> {
   const out: Record<string, number> = {};
@@ -49,24 +50,45 @@ function useDebugProcessedPipeline(args: {
   footerActionCount: number;
   groupedItems: RenderItem[];
 }) {
-  const { sessionId, messages, visibleMessages, footerActionCount, groupedItems } = args;
+  const latestArgsRef = useRef(args);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
+    latestArgsRef.current = args;
     if (!isDebug()) return;
-    debug("pipeline", {
-      sessionId,
-      input: { count: messages.length, byType: countByType(messages) },
-      afterFilter: { count: visibleMessages.length, byType: countByType(visibleMessages) },
-      droppedByFilter: messages.length - visibleMessages.length,
-      footerActionCount,
-      groupedItemKinds: groupedItems.reduce<Record<string, number>>((acc, item) => {
-        acc[item.type] = (acc[item.type] ?? 0) + 1;
-        return acc;
-      }, {}),
-      turnGroupSizes: groupedItems
-        .filter((i): i is TurnGroup => i.type === "turn_group")
-        .map((g) => ({ turnId: g.turnId, size: g.messages.length })),
-    });
-  }, [sessionId, messages, visibleMessages, footerActionCount, groupedItems]);
+    if (timerRef.current !== null) return;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const latest = latestArgsRef.current;
+      debug("pipeline", {
+        sessionId: latest.sessionId,
+        input: { count: latest.messages.length, byType: countByType(latest.messages) },
+        afterFilter: {
+          count: latest.visibleMessages.length,
+          byType: countByType(latest.visibleMessages),
+        },
+        droppedByFilter: latest.messages.length - latest.visibleMessages.length,
+        footerActionCount: latest.footerActionCount,
+        groupedItemKinds: latest.groupedItems.reduce<Record<string, number>>((acc, item) => {
+          acc[item.type] = (acc[item.type] ?? 0) + 1;
+          return acc;
+        }, {}),
+        turnGroupSizes: latest.groupedItems
+          .filter((i): i is TurnGroup => i.type === "turn_group")
+          .map((g) => ({ turnId: g.turnId, size: g.messages.length })),
+      });
+    }, PROCESSED_PIPELINE_DEBUG_INTERVAL_MS);
+  }, [args]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    },
+    [],
+  );
 }
 
 const ACTIVITY_MESSAGE_TYPES: Set<MessageType> = new Set([

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -43,49 +43,62 @@ function countByType(messages: Message[]): Record<string, number> {
   return out;
 }
 
-function useDebugProcessedPipeline(args: {
+type ProcessedPipelineDebugArgs = {
   sessionId: string | null;
   messages: Message[];
   visibleMessages: Message[];
   footerActionCount: number;
   groupedItems: RenderItem[];
-}) {
+};
+
+function useDebugProcessedPipeline(args: ProcessedPipelineDebugArgs) {
   const latestArgsRef = useRef(args);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const emitLatestDebugSample = () => {
+    const latest = latestArgsRef.current;
+    debug("pipeline", {
+      sessionId: latest.sessionId,
+      input: { count: latest.messages.length, byType: countByType(latest.messages) },
+      afterFilter: {
+        count: latest.visibleMessages.length,
+        byType: countByType(latest.visibleMessages),
+      },
+      droppedByFilter: latest.messages.length - latest.visibleMessages.length,
+      footerActionCount: latest.footerActionCount,
+      groupedItemKinds: latest.groupedItems.reduce<Record<string, number>>((acc, item) => {
+        acc[item.type] = (acc[item.type] ?? 0) + 1;
+        return acc;
+      }, {}),
+      turnGroupSizes: latest.groupedItems
+        .filter((i): i is TurnGroup => i.type === "turn_group")
+        .map((g) => ({ turnId: g.turnId, size: g.messages.length })),
+    });
+  };
+
+  const flushPendingDebugSample = () => {
+    if (timerRef.current === null) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+    emitLatestDebugSample();
+  };
+
   useEffect(() => {
+    if (latestArgsRef.current.sessionId !== args.sessionId) {
+      flushPendingDebugSample();
+    }
     latestArgsRef.current = args;
     if (!isDebug()) return;
     if (timerRef.current !== null) return;
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
-      const latest = latestArgsRef.current;
-      debug("pipeline", {
-        sessionId: latest.sessionId,
-        input: { count: latest.messages.length, byType: countByType(latest.messages) },
-        afterFilter: {
-          count: latest.visibleMessages.length,
-          byType: countByType(latest.visibleMessages),
-        },
-        droppedByFilter: latest.messages.length - latest.visibleMessages.length,
-        footerActionCount: latest.footerActionCount,
-        groupedItemKinds: latest.groupedItems.reduce<Record<string, number>>((acc, item) => {
-          acc[item.type] = (acc[item.type] ?? 0) + 1;
-          return acc;
-        }, {}),
-        turnGroupSizes: latest.groupedItems
-          .filter((i): i is TurnGroup => i.type === "turn_group")
-          .map((g) => ({ turnId: g.turnId, size: g.messages.length })),
-      });
+      emitLatestDebugSample();
     }, PROCESSED_PIPELINE_DEBUG_INTERVAL_MS);
   }, [args]);
 
   useEffect(
     () => () => {
-      if (timerRef.current !== null) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
+      flushPendingDebugSample();
     },
     [],
   );

--- a/apps/web/lib/logger/buffer.ts
+++ b/apps/web/lib/logger/buffer.ts
@@ -28,6 +28,8 @@ export const MAX_ENTRY_BYTES = 64 * 1024;
 
 type StoredEntry = { entry: LogEntry; bytes: number };
 
+export type PreparedLogEntry = Readonly<StoredEntry>;
+
 export class RingBuffer {
   private entries: StoredEntry[] = [];
   private bytes = 0;
@@ -39,8 +41,11 @@ export class RingBuffer {
   ) {}
 
   push(entry: LogEntry): boolean {
-    const detached = cloneEntry(entry);
-    const bytes = encodedBytes(detached);
+    return this.pushPrepared(prepareLogEntry(entry));
+  }
+
+  pushPrepared(prepared: PreparedLogEntry): boolean {
+    const { entry, bytes } = prepared;
     if (bytes > MAX_ENTRY_BYTES) {
       this.loss.entry_too_large += 1;
       return false;
@@ -58,7 +63,7 @@ export class RingBuffer {
       this.bytes -= removed.bytes;
       this.loss.capacity += 1;
     }
-    this.entries.push({ entry: detached, bytes });
+    this.entries.push(prepared);
     this.bytes += bytes;
     return true;
   }
@@ -112,6 +117,11 @@ export function clearLogs(): void {
 
 export function encodedBytes(entry: LogEntry): number {
   return new TextEncoder().encode(JSON.stringify(entry)).byteLength;
+}
+
+export function prepareLogEntry(entry: LogEntry): PreparedLogEntry {
+  const detached = cloneEntry(entry);
+  return { entry: detached, bytes: encodedBytes(detached) };
 }
 
 function cloneEntry(entry: LogEntry): LogEntry {

--- a/apps/web/lib/logger/indexeddb-store.test.ts
+++ b/apps/web/lib/logger/indexeddb-store.test.ts
@@ -1,7 +1,7 @@
 import "fake-indexeddb/auto";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { LogEntry } from "./buffer";
+import { prepareLogEntry, type LogEntry, type PreparedLogEntry } from "./buffer";
 import { IndexedDBLogStore, retentionPlan } from "./indexeddb-store";
 
 const DATABASE_NAME = "kandev-diagnostic-logs-v1";
@@ -89,15 +89,17 @@ describe("IndexedDB log retention planning and schema", () => {
     const store = new IndexedDBLogStore();
 
     try {
-      await expect(store.append([logEntry("a", Date.now(), "blocked")])).rejects.toThrow(
-        "IndexedDB upgrade blocked",
-      );
+      await expect(
+        store.append(prepareEntries([logEntry("a", Date.now(), "blocked")])),
+      ).rejects.toThrow("IndexedDB upgrade blocked");
     } finally {
       blocker.close();
     }
 
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    await expect(store.append([logEntry("a", Date.now(), "retried")])).resolves.toBeUndefined();
+    await expect(
+      store.append(prepareEntries([logEntry("a", Date.now(), "retried")])),
+    ).resolves.toBeUndefined();
     await expect(store.snapshot("a")).resolves.toEqual([
       expect.objectContaining({ message: "retried" }),
     ]);
@@ -105,6 +107,16 @@ describe("IndexedDB log retention planning and schema", () => {
 });
 
 describe("IndexedDB log retention writes", () => {
+  it("persists the prepared entry byte count without re-encoding it", async () => {
+    const store = new IndexedDBLogStore();
+    const prepared = prepareLogEntry(logEntry("a", Date.now(), "prepared"));
+
+    await store.append([prepared]);
+
+    const records = await readEntries();
+    expect(records[0]?.bytes).toBe(prepared.bytes);
+  });
+
   it("retains the newest entries and records exact transactional totals", async () => {
     const now = Date.now();
     const store = new IndexedDBLogStore();
@@ -115,7 +127,7 @@ describe("IndexedDB log retention writes", () => {
       ),
     ];
 
-    await store.append(entries);
+    await store.append(prepareEntries(entries));
 
     const records = await readEntries();
     expect(records).toHaveLength(MAX_ENTRIES);
@@ -135,7 +147,7 @@ describe("IndexedDB log retention writes", () => {
       logEntry("a", now - 4_300 + index, `${index}-${"x".repeat(5_000)}`),
     );
 
-    await store.append(entries);
+    await store.append(prepareEntries(entries));
 
     const records = await readEntries();
     const metadata = await readMetadata();
@@ -149,10 +161,12 @@ describe("IndexedDB log retention writes", () => {
 
   it("keeps identity snapshots partitioned while sharing the global caps", async () => {
     const store = new IndexedDBLogStore();
-    await store.append([
-      logEntry("identity-a", Date.now(), "a"),
-      logEntry("identity-b", Date.now() + 1, "b"),
-    ]);
+    await store.append(
+      prepareEntries([
+        logEntry("identity-a", Date.now(), "a"),
+        logEntry("identity-b", Date.now() + 1, "b"),
+      ]),
+    );
 
     await expect(store.snapshot("identity-a")).resolves.toHaveLength(1);
     await expect(store.snapshot("identity-b")).resolves.toHaveLength(1);
@@ -162,10 +176,10 @@ describe("IndexedDB log retention writes", () => {
 describe("IndexedDB log retention repair and concurrency", () => {
   it("repairs missing or invalid totals during the next write", async () => {
     const store = new IndexedDBLogStore();
-    await store.append([logEntry("a", Date.now(), "before repair")]);
+    await store.append(prepareEntries([logEntry("a", Date.now(), "before repair")]));
     await overwriteMetadata({ key: RETENTION_KEY, count: -1, bytes: Number.NaN });
 
-    await store.append([logEntry("a", Date.now() + 1, "after repair")]);
+    await store.append(prepareEntries([logEntry("a", Date.now() + 1, "after repair")]));
 
     const records = await readEntries();
     await expect(readMetadata()).resolves.toEqual({
@@ -177,7 +191,7 @@ describe("IndexedDB log retention repair and concurrency", () => {
 
   it("clears entries and resets totals in one transaction", async () => {
     const store = new IndexedDBLogStore();
-    await store.append([logEntry("a", Date.now(), "to clear")]);
+    await store.append(prepareEntries([logEntry("a", Date.now(), "to clear")]));
 
     await store.clear();
 
@@ -201,7 +215,9 @@ describe("IndexedDB log retention repair and concurrency", () => {
       ),
     );
 
-    await Promise.all(batches.map((batch, index) => stores[index % stores.length].append(batch)));
+    await Promise.all(
+      batches.map((batch, index) => stores[index % stores.length].append(prepareEntries(batch))),
+    );
 
     const records = await readEntries();
     const metadata = await readMetadata();
@@ -215,13 +231,13 @@ describe("IndexedDB log retention repair and concurrency", () => {
 
   it("uses only the bounded timestamp cursor for a within-limit append", async () => {
     const store = new IndexedDBLogStore();
-    await store.append([logEntry("a", Date.now(), "first")]);
+    await store.append(prepareEntries([logEntry("a", Date.now(), "first")]));
 
     const objectStoreCursor = vi.spyOn(IDBObjectStore.prototype, "openCursor");
     const timestampCursor = vi.spyOn(IDBIndex.prototype, "openCursor");
 
     try {
-      await store.append([logEntry("a", Date.now() + 1, "second")]);
+      await store.append(prepareEntries([logEntry("a", Date.now() + 1, "second")]));
 
       expect(objectStoreCursor).not.toHaveBeenCalled();
       expect(timestampCursor).toHaveBeenCalledTimes(1);
@@ -244,6 +260,10 @@ function logEntry(identityScope: string, timestamp: number, message: string): Lo
     message,
     identity_scope: identityScope,
   };
+}
+
+function prepareEntries(entries: LogEntry[]): PreparedLogEntry[] {
+  return entries.map(prepareLogEntry);
 }
 
 function persisted(entry: LogEntry, timestamp: number, bytes: number): PersistedTestEntry {

--- a/apps/web/lib/logger/indexeddb-store.ts
+++ b/apps/web/lib/logger/indexeddb-store.ts
@@ -1,4 +1,4 @@
-import type { LogEntry } from "./buffer";
+import type { LogEntry, PreparedLogEntry } from "./buffer";
 
 const DATABASE_NAME = "kandev-diagnostic-logs-v1";
 const DATABASE_VERSION = 2;
@@ -26,18 +26,17 @@ const EMPTY_TOTALS: RetentionTotals = { count: 0, bytes: 0 };
 export class IndexedDBLogStore {
   private database: Promise<IDBDatabase> | null = null;
 
-  async append(entries: LogEntry[]): Promise<void> {
-    const persistedEntries = entries.flatMap((entry) => {
+  async append(entries: readonly PreparedLogEntry[]): Promise<void> {
+    const persistedEntries = entries.flatMap(({ entry, bytes }) => {
       const identity = entry.identity_scope;
       if (!identity) return [];
 
-      const serialized = JSON.stringify(entry);
       const timestamp = Date.parse(entry.timestamp);
       return [
         {
           identity_scope: identity,
           timestamp_ms: Number.isNaN(timestamp) ? Date.now() : timestamp,
-          bytes: new TextEncoder().encode(serialized).byteLength,
+          bytes,
           entry,
         } satisfies PersistedEntry,
       ];

--- a/apps/web/lib/logger/runtime.test.ts
+++ b/apps/web/lib/logger/runtime.test.ts
@@ -11,6 +11,8 @@ const storeMocks = vi.hoisted(() => ({
   append: vi.fn(),
   snapshot: vi.fn(),
 }));
+const TEST_SOURCE = "test";
+const TEST_SCOPE = "default-user";
 
 vi.mock("./indexeddb-store", () => ({
   IndexedDBLogStore: class {
@@ -27,30 +29,23 @@ beforeEach(() => {
 });
 
 describe("browser logger collection", () => {
-  it("collects an idle log burst for 250 ms before one bounded append", async () => {
+  it("coalesces a log burst in one 250 ms window before one bounded append", async () => {
     vi.useFakeTimers();
-    let idleCallback: (() => void) | undefined;
-    vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
-      idleCallback = callback;
-      return 1;
-    });
 
     try {
       stageLogEntry({
         timestamp: new Date().toISOString(),
         level: "info",
-        source: "test",
+        source: TEST_SOURCE,
         message: "first",
       });
       stageLogEntry({
         timestamp: new Date().toISOString(),
         level: "info",
-        source: "test",
+        source: TEST_SOURCE,
         message: "second",
       });
 
-      idleCallback?.();
-      await Promise.resolve();
       expect(storeMocks.append).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(249);
@@ -65,7 +60,6 @@ describe("browser logger collection", () => {
         ]),
       );
     } finally {
-      vi.unstubAllGlobals();
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
     }
@@ -73,13 +67,12 @@ describe("browser logger collection", () => {
 
   it("passes one prepared entry and canonical byte count to persistence", async () => {
     vi.useFakeTimers();
-    vi.stubGlobal("requestIdleCallback", undefined);
 
     try {
       stageLogEntry({
         timestamp: new Date().toISOString(),
         level: "info",
-        source: "test",
+        source: TEST_SOURCE,
         message: "prepared once",
         args: [{ detail: "value" }],
       });
@@ -96,7 +89,6 @@ describe("browser logger collection", () => {
       ]);
       expect(batch[0].bytes).toBe(encodedBytes(batch[0].entry));
     } finally {
-      vi.unstubAllGlobals();
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
     }
@@ -104,6 +96,31 @@ describe("browser logger collection", () => {
 });
 
 describe("browser logger runtime", () => {
+  it("flushes a pending collection window before snapshotting", async () => {
+    vi.useFakeTimers();
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: TEST_SOURCE,
+        message: "flush before snapshot",
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await snapshotBrowserLogs(TEST_SCOPE);
+      expect(storeMocks.append).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(storeMocks.append).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not stage entries rejected by the bounded memory buffer", async () => {
     stageLogEntry({
       timestamp: new Date().toISOString(),
@@ -112,7 +129,7 @@ describe("browser logger runtime", () => {
       message: "x".repeat(MAX_ENTRY_BYTES + 1),
     });
 
-    await snapshotBrowserLogs("default-user");
+    await snapshotBrowserLogs(TEST_SCOPE);
 
     expect(storeMocks.append).not.toHaveBeenCalled();
   });
@@ -122,11 +139,11 @@ describe("browser logger runtime", () => {
     stageLogEntry({
       timestamp: new Date().toISOString(),
       level: "error",
-      source: "test",
+      source: TEST_SOURCE,
       message: "kept in memory",
     });
 
-    await expect(snapshotBrowserLogs("default-user")).resolves.toHaveLength(1);
+    await expect(snapshotBrowserLogs(TEST_SCOPE)).resolves.toHaveLength(1);
     expect(browserLogMetadata()).toMatchObject({
       storage_mode: "memory",
       persistence_failures: 1,
@@ -154,16 +171,16 @@ describe("browser logger runtime", () => {
       stageLogEntry({
         timestamp: new Date().toISOString(),
         level: "info",
-        source: "test",
+        source: TEST_SOURCE,
         message: "first",
       });
-      const snapshot = snapshotBrowserLogs("default-user");
+      const snapshot = snapshotBrowserLogs(TEST_SCOPE);
       await vi.waitFor(() => expect(storeMocks.append).toHaveBeenCalledTimes(1));
 
       stageLogEntry({
         timestamp: new Date().toISOString(),
         level: "info",
-        source: "test",
+        source: TEST_SOURCE,
         message: "second",
       });
       vi.runOnlyPendingTimers();

--- a/apps/web/lib/logger/runtime.test.ts
+++ b/apps/web/lib/logger/runtime.test.ts
@@ -28,6 +28,113 @@ beforeEach(() => {
   storeMocks.snapshot.mockReset().mockResolvedValue([]);
 });
 
+describe("browser logger scheduling", () => {
+  it("keeps the collection window before scheduling browser-idle persistence", async () => {
+    vi.useFakeTimers();
+    let idleCallback: (() => void) | undefined;
+    const requestIdle = vi.fn((callback: () => void, options: { timeout: number }) => {
+      idleCallback = callback;
+      return options.timeout;
+    });
+    const cancelIdle = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdle);
+    vi.stubGlobal("cancelIdleCallback", cancelIdle);
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: TEST_SOURCE,
+        message: "idle-after-window",
+      });
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(requestIdle).not.toHaveBeenCalled();
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(requestIdle).toHaveBeenCalledTimes(1);
+      expect(requestIdle.mock.calls[0]?.[1]).toEqual({ timeout: 750 });
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      idleCallback?.();
+      await vi.waitFor(() => expect(storeMocks.append).toHaveBeenCalledTimes(1));
+    } finally {
+      vi.unstubAllGlobals();
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the bounded deadline when browser idle time does not arrive", async () => {
+    vi.useFakeTimers();
+    const requestIdle = vi.fn(() => 7);
+    const cancelIdle = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdle);
+    vi.stubGlobal("cancelIdleCallback", cancelIdle);
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: TEST_SOURCE,
+        message: "idle-deadline",
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(749);
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(storeMocks.append).toHaveBeenCalledTimes(1));
+      expect(cancelIdle).toHaveBeenCalledWith(7);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("bypasses a pending browser-idle wait when snapshotting", async () => {
+    vi.useFakeTimers();
+    let idleCallback: (() => void) | undefined;
+    const requestIdle = vi.fn((callback: () => void) => {
+      idleCallback = callback;
+      return 7;
+    });
+    const cancelIdle = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdle);
+    vi.stubGlobal("cancelIdleCallback", cancelIdle);
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: TEST_SOURCE,
+        message: "snapshot-idle-bypass",
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      expect(requestIdle).toHaveBeenCalledTimes(1);
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await snapshotBrowserLogs(TEST_SCOPE);
+      expect(storeMocks.append).toHaveBeenCalledTimes(1);
+      expect(cancelIdle).toHaveBeenCalledWith(7);
+
+      idleCallback?.();
+      await vi.advanceTimersByTimeAsync(750);
+      expect(storeMocks.append).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("browser logger collection", () => {
   it("coalesces a log burst in one 250 ms window before one bounded append", async () => {
     vi.useFakeTimers();

--- a/apps/web/lib/logger/runtime.test.ts
+++ b/apps/web/lib/logger/runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { _resetForTesting, MAX_ENTRY_BYTES } from "./buffer";
+import { encodedBytes, _resetForTesting, MAX_ENTRY_BYTES } from "./buffer";
 import {
   _resetRuntimeForTesting,
   browserLogMetadata,
@@ -24,6 +24,83 @@ beforeEach(() => {
   _resetRuntimeForTesting();
   storeMocks.append.mockReset();
   storeMocks.snapshot.mockReset().mockResolvedValue([]);
+});
+
+describe("browser logger collection", () => {
+  it("collects an idle log burst for 250 ms before one bounded append", async () => {
+    vi.useFakeTimers();
+    let idleCallback: (() => void) | undefined;
+    vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+      idleCallback = callback;
+      return 1;
+    });
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: "test",
+        message: "first",
+      });
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: "test",
+        message: "second",
+      });
+
+      idleCallback?.();
+      await Promise.resolve();
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(storeMocks.append).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(storeMocks.append).toHaveBeenCalledTimes(1));
+      expect(storeMocks.append).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ entry: expect.objectContaining({ message: "first" }) }),
+          expect.objectContaining({ entry: expect.objectContaining({ message: "second" }) }),
+        ]),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes one prepared entry and canonical byte count to persistence", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestIdleCallback", undefined);
+
+    try {
+      stageLogEntry({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        source: "test",
+        message: "prepared once",
+        args: [{ detail: "value" }],
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(storeMocks.append).toHaveBeenCalledTimes(1));
+
+      const batch = storeMocks.append.mock.calls[0]?.[0];
+      expect(batch).toEqual([
+        expect.objectContaining({
+          entry: expect.objectContaining({ message: "prepared once" }),
+          bytes: expect.any(Number),
+        }),
+      ]);
+      expect(batch[0].bytes).toBe(encodedBytes(batch[0].entry));
+    } finally {
+      vi.unstubAllGlobals();
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("browser logger runtime", () => {

--- a/apps/web/lib/logger/runtime.ts
+++ b/apps/web/lib/logger/runtime.ts
@@ -1,18 +1,26 @@
-import { encodedBytes, getLogBuffer, snapshotLogs, type LogEntry, type LogLevel } from "./buffer";
+import {
+  getLogBuffer,
+  prepareLogEntry,
+  snapshotLogs,
+  type LogEntry,
+  type LogLevel,
+  type PreparedLogEntry,
+} from "./buffer";
 import { IndexedDBLogStore } from "./indexeddb-store";
 
 const DRAIN_ENTRY_LIMIT = 50;
 const DRAIN_BYTE_LIMIT = 256 * 1024;
 const STAGING_ENTRY_LIMIT = 500;
 const STAGING_BYTE_LIMIT = 2 * 1024 * 1024;
+const COLLECTION_WINDOW_MS = 250;
 
-type Staged = { entry: LogEntry; bytes: number };
+type Staged = PreparedLogEntry;
 
 const store = new IndexedDBLogStore();
 let identityScope: string | null = "default-user";
 let staging: Staged[] = [];
 let stagingBytes = 0;
-let scheduled = false;
+let collectionTimer: ReturnType<typeof setTimeout> | null = null;
 let drainPromise: Promise<void> | null = null;
 let storageMode: "indexeddb" | "memory" = "indexeddb";
 let persistenceFailures = 0;
@@ -24,15 +32,15 @@ export function setLogIdentity(scope: string | null): void {
 
 export function stageLogEntry(entry: Omit<LogEntry, "identity_scope">): void {
   const scoped = { ...entry, identity_scope: identityScope ?? undefined };
-  if (!getLogBuffer().push(scoped)) return;
+  const prepared = prepareLogEntry(scoped);
+  if (!getLogBuffer().pushPrepared(prepared)) return;
   if (!identityScope || storageMode === "memory") return;
-  const bytes = encodedBytes(scoped);
-  if (!makeStagingRoom(entry.level, bytes)) {
+  if (!makeStagingRoom(prepared.entry.level, prepared.bytes)) {
     stagingDropped += 1;
     return;
   }
-  staging.push({ entry: scoped, bytes });
-  stagingBytes += bytes;
+  staging.push(prepared);
+  stagingBytes += prepared.bytes;
   scheduleDrain();
 }
 
@@ -86,17 +94,11 @@ function makeStagingRoom(level: LogLevel, bytes: number): boolean {
 }
 
 function scheduleDrain(): void {
-  if (scheduled || drainPromise) return;
-  scheduled = true;
-  const drain = () => {
-    scheduled = false;
+  if (collectionTimer !== null || drainPromise) return;
+  collectionTimer = setTimeout(() => {
+    collectionTimer = null;
     void requestDrain();
-  };
-  if (typeof requestIdleCallback === "function") {
-    requestIdleCallback(drain, { timeout: 1_000 });
-  } else {
-    setTimeout(drain, 250);
-  }
+  }, COLLECTION_WINDOW_MS);
 }
 
 function requestDrain(): Promise<void> {
@@ -128,7 +130,7 @@ async function drainBatch(): Promise<boolean> {
     bytes += next.bytes;
   }
   try {
-    await store.append(batch.map(({ entry }) => entry));
+    await store.append(batch);
   } catch {
     for (const item of batch.reverse()) {
       staging.unshift(item);
@@ -141,9 +143,16 @@ async function drainBatch(): Promise<boolean> {
 }
 
 async function flushStaging(): Promise<void> {
+  cancelCollectionTimer();
   while (drainPromise || (storageMode === "indexeddb" && staging.length > 0)) {
     await requestDrain();
   }
+}
+
+function cancelCollectionTimer(): void {
+  if (collectionTimer === null) return;
+  clearTimeout(collectionTimer);
+  collectionTimer = null;
 }
 
 function degradePersistence(): void {
@@ -162,10 +171,10 @@ function randomID(): string {
 }
 
 export function _resetRuntimeForTesting(): void {
+  cancelCollectionTimer();
   identityScope = "default-user";
   staging = [];
   stagingBytes = 0;
-  scheduled = false;
   drainPromise = null;
   storageMode = "indexeddb";
   persistenceFailures = 0;

--- a/apps/web/lib/logger/runtime.ts
+++ b/apps/web/lib/logger/runtime.ts
@@ -13,6 +13,8 @@ const DRAIN_BYTE_LIMIT = 256 * 1024;
 const STAGING_ENTRY_LIMIT = 500;
 const STAGING_BYTE_LIMIT = 2 * 1024 * 1024;
 const COLLECTION_WINDOW_MS = 250;
+const IDLE_DEADLINE_MS = 1_000;
+const POST_COLLECTION_IDLE_TIMEOUT_MS = IDLE_DEADLINE_MS - COLLECTION_WINDOW_MS;
 
 type Staged = PreparedLogEntry;
 
@@ -21,6 +23,9 @@ let identityScope: string | null = "default-user";
 let staging: Staged[] = [];
 let stagingBytes = 0;
 let collectionTimer: ReturnType<typeof setTimeout> | null = null;
+let idleCallbackHandle: number | null = null;
+let idleFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+let idleGeneration = 0;
 let drainPromise: Promise<void> | null = null;
 let storageMode: "indexeddb" | "memory" = "indexeddb";
 let persistenceFailures = 0;
@@ -94,11 +99,43 @@ function makeStagingRoom(level: LogLevel, bytes: number): boolean {
 }
 
 function scheduleDrain(): void {
-  if (collectionTimer !== null || drainPromise) return;
+  if (
+    collectionTimer !== null ||
+    idleCallbackHandle !== null ||
+    idleFallbackTimer !== null ||
+    drainPromise
+  ) {
+    return;
+  }
   collectionTimer = setTimeout(() => {
     collectionTimer = null;
-    void requestDrain();
+    schedulePostWindowDrain();
   }, COLLECTION_WINDOW_MS);
+}
+
+function schedulePostWindowDrain(): void {
+  if (drainPromise || storageMode === "memory" || staging.length === 0) return;
+  if (typeof requestIdleCallback !== "function") {
+    void requestDrain();
+    return;
+  }
+
+  const generation = ++idleGeneration;
+  const drain = () => {
+    if (generation !== idleGeneration) return;
+    idleCallbackHandle = null;
+    cancelIdleFallbackTimer();
+    void requestDrain();
+  };
+  idleCallbackHandle = requestIdleCallback(drain, {
+    timeout: POST_COLLECTION_IDLE_TIMEOUT_MS,
+  });
+  idleFallbackTimer = setTimeout(() => {
+    if (generation !== idleGeneration) return;
+    idleFallbackTimer = null;
+    cancelIdleCallback();
+    void requestDrain();
+  }, POST_COLLECTION_IDLE_TIMEOUT_MS);
 }
 
 function requestDrain(): Promise<void> {
@@ -144,6 +181,7 @@ async function drainBatch(): Promise<boolean> {
 
 async function flushStaging(): Promise<void> {
   cancelCollectionTimer();
+  cancelIdleCallback();
   while (drainPromise || (storageMode === "indexeddb" && staging.length > 0)) {
     await requestDrain();
   }
@@ -155,7 +193,26 @@ function cancelCollectionTimer(): void {
   collectionTimer = null;
 }
 
+function cancelIdleFallbackTimer(): void {
+  if (idleFallbackTimer === null) return;
+  clearTimeout(idleFallbackTimer);
+  idleFallbackTimer = null;
+}
+
+function cancelIdleCallback(): void {
+  idleGeneration += 1;
+  if (idleCallbackHandle !== null) {
+    if (typeof globalThis.cancelIdleCallback === "function") {
+      globalThis.cancelIdleCallback(idleCallbackHandle);
+    }
+    idleCallbackHandle = null;
+  }
+  cancelIdleFallbackTimer();
+}
+
 function degradePersistence(): void {
+  cancelCollectionTimer();
+  cancelIdleCallback();
   persistenceFailures += 1;
   storageMode = "memory";
   staging = [];
@@ -172,6 +229,7 @@ function randomID(): string {
 
 export function _resetRuntimeForTesting(): void {
   cancelCollectionTimer();
+  cancelIdleCallback();
   identityScope = "default-user";
   staging = [];
   stagingBytes = 0;

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -70,6 +70,17 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
   }
 }
 
+function mergeMessageAtIndex(messages: Message[], message: Message): void {
+  const index = messages.findIndex((candidate) => candidate.id === message.id);
+  if (index === -1) return;
+  const merged = { ...messages[index] };
+  mergeMessageFields(
+    merged as unknown as Record<string, unknown>,
+    message as unknown as Record<string, unknown>,
+  );
+  messages[index] = merged;
+}
+
 /** Return a new messages array with the message matching `messageId` removed. */
 function removeMessageByID(messages: Message[], messageId: string) {
   return messages.filter((message) => message.id !== messageId);
@@ -311,14 +322,14 @@ function buildMessageActions(set: ImmerSet) {
       set((draft) => {
         const messages = draft.messages.bySession[message.session_id];
         if (!messages) return;
-        const index = messages.findIndex((m) => m.id === message.id);
-        if (index === -1) return;
-        const merged = { ...messages[index] };
-        mergeMessageFields(
-          merged as unknown as Record<string, unknown>,
-          message as unknown as Record<string, unknown>,
-        );
-        messages[index] = merged;
+        mergeMessageAtIndex(messages, message);
+      }),
+    updateMessages: (messages: Parameters<SessionSlice["updateMessages"]>[0]) =>
+      set((draft) => {
+        for (const message of messages) {
+          const sessionMessages = draft.messages.bySession[message.session_id];
+          if (sessionMessages) mergeMessageAtIndex(sessionMessages, message);
+        }
       }),
     removeMessage: (
       sessionId: Parameters<SessionSlice["removeMessage"]>[0],

--- a/apps/web/lib/state/slices/session/session-slice.update-messages.test.ts
+++ b/apps/web/lib/state/slices/session/session-slice.update-messages.test.ts
@@ -1,0 +1,88 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { describe, expect, it } from "vitest";
+import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
+import { createSessionSlice } from "./session-slice";
+import type { SessionSlice } from "./types";
+
+const SESSION = "session-1";
+
+function makeStore() {
+  return create<SessionSlice>()(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    immer((set) => ({ ...(createSessionSlice as any)(set) })),
+  );
+}
+
+function makeMessage(
+  id: string,
+  content: string,
+  session: string = SESSION,
+  overrides: Partial<Message> = {},
+): Message {
+  return {
+    id,
+    task_id: toTaskId("task-1"),
+    session_id: toSessionId(session),
+    author_type: "agent",
+    content,
+    type: "message",
+    created_at: "2026-08-27T00:00:00Z",
+    updated_at: "2026-08-27T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("updateMessages", () => {
+  it("notifies subscribers once for one replacement frame", () => {
+    const store = makeStore();
+    const initial = [makeMessage("message-a", "a"), makeMessage("message-b", "b")];
+    store.getState().setMessages(SESSION, initial);
+
+    const notifications: Message[][] = [];
+    const unsubscribe = store.subscribe((state) => {
+      notifications.push(state.messages.bySession[SESSION] ?? []);
+    });
+
+    const updateMessages = store.getState().updateMessages;
+    expect(updateMessages).toBeTypeOf("function");
+    updateMessages([makeMessage("message-a", "a2"), makeMessage("message-b", "b2")]);
+
+    expect(notifications).toHaveLength(1);
+    expect(store.getState().messages.bySession[SESSION].map((message) => message.content)).toEqual([
+      "a2",
+      "b2",
+    ]);
+    unsubscribe();
+  });
+
+  it("preserves partial fields and unaffected session identities", () => {
+    const store = makeStore();
+    const first = makeMessage("message-a", "a", SESSION, {
+      metadata: { retained: true },
+      prompt_index: 3,
+    });
+    const second = makeMessage("message-b", "b");
+    const otherSessionMessage = makeMessage("message-c", "c", "session-2");
+    store.getState().setMessages(SESSION, [first, second]);
+    store.getState().setMessages("session-2", [otherSessionMessage]);
+
+    const sessionMessages = store.getState().messages.bySession[SESSION];
+    const otherSessionMessages = store.getState().messages.bySession["session-2"];
+    store.getState().updateMessages([
+      makeMessage("message-a", "a2", SESSION, {
+        metadata: undefined,
+        prompt_index: undefined,
+      }),
+    ]);
+
+    const nextSessionMessages = store.getState().messages.bySession[SESSION];
+    expect(nextSessionMessages).not.toBe(sessionMessages);
+    expect(nextSessionMessages[0].content).toBe("a2");
+    expect(nextSessionMessages[0].metadata).toEqual({ retained: true });
+    expect(nextSessionMessages[0].prompt_index).toBe(3);
+    expect(nextSessionMessages[1]).toBe(sessionMessages[1]);
+    expect(store.getState().messages.bySession["session-2"]).toBe(otherSessionMessages);
+    expect(store.getState().messages.bySession["session-2"][0]).toBe(otherSessionMessage);
+  });
+});

--- a/apps/web/lib/state/slices/session/types.ts
+++ b/apps/web/lib/state/slices/session/types.ts
@@ -214,6 +214,7 @@ export type SessionSliceActions = {
   ) => void;
   addMessage: (message: Message) => void;
   updateMessage: (message: Message) => void;
+  updateMessages: (messages: Message[]) => void;
   removeMessage: (sessionId: string, messageId: string) => void;
   /**
    * Idempotent full-snapshot merge: reconciles `messages` against the current

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -427,6 +427,7 @@ export type AppState = KanbanSlice & {
   /** Records that the session's full persisted turn history is in the store. */
   markTurnsLoaded: (sessionId: string) => void;
   updateMessage: (message: Message) => void;
+  updateMessages: (messages: Message[]) => void;
   removeMessage: (sessionId: string, messageId: string) => void;
   prependMessages: (
     sessionId: string,

--- a/apps/web/lib/ws/handlers/messages.test.ts
+++ b/apps/web/lib/ws/handlers/messages.test.ts
@@ -398,7 +398,7 @@ describe("session message pending-action ordering", () => {
 
 describe("session message snapshot ordering", () => {
   it("does not apply a batched update older than a refetched snapshot", () => {
-    const { store, updateMessage } = makeStore({
+    const { store, updateMessage, updateMessages } = makeStore({
       "session-1": [
         {
           id: "message-1",
@@ -415,6 +415,7 @@ describe("session message snapshot ordering", () => {
     frame.runFrame();
 
     expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).not.toHaveBeenCalled();
     registration.dispose();
   });
 });

--- a/apps/web/lib/ws/handlers/messages.test.ts
+++ b/apps/web/lib/ws/handlers/messages.test.ts
@@ -49,11 +49,13 @@ function makeUpdated(sessionId: string, messageId: string, content: string): Upd
 
 function makeStore(currentMessages: Record<string, unknown[]> = {}, completedTurn = false) {
   const updateMessage = vi.fn();
+  const updateMessages = vi.fn();
   const addMessage = vi.fn();
   const removeMessage = vi.fn();
   const setTaskSessionPendingAction = vi.fn();
   const state = {
     updateMessage,
+    updateMessages,
     addMessage,
     removeMessage,
     setTaskSessionPendingAction,
@@ -69,6 +71,7 @@ function makeStore(currentMessages: Record<string, unknown[]> = {}, completedTur
   return {
     store: { getState: () => state } as unknown as StoreApi<AppState>,
     updateMessage,
+    updateMessages,
     addMessage,
     removeMessage,
     setTaskSessionPendingAction,
@@ -97,7 +100,7 @@ function makeFrameScheduler() {
 
 describe("session message frame scheduler", () => {
   it("applies hundreds of same-key updates once with the newest full payload", () => {
-    const { store, updateMessage } = makeStore();
+    const { store, updateMessage, updateMessages } = makeStore();
     const frame = makeFrameScheduler();
     const registration = createMessagesHandlerRegistration(store, frame);
     const handler = registration.handlers["session.message.updated"]!;
@@ -110,19 +113,20 @@ describe("session message frame scheduler", () => {
     expect(frame.schedule).toHaveBeenCalledTimes(1);
     frame.runFrame();
 
-    expect(updateMessage).toHaveBeenCalledTimes(1);
-    expect(updateMessage).toHaveBeenLastCalledWith(
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenCalledTimes(1);
+    expect(updateMessages).toHaveBeenLastCalledWith([
       expect.objectContaining({
         id: "message-1",
         session_id: "session-1",
         content: "content-299",
       }),
-    );
+    ]);
     registration.dispose();
   });
 
-  it("updates different message keys once each in insertion order", () => {
-    const { store, updateMessage } = makeStore();
+  it("applies different message keys with one bulk store action", () => {
+    const { store, updateMessage, updateMessages } = makeStore();
     const frame = makeFrameScheduler();
     const registration = createMessagesHandlerRegistration(store, frame);
     const handler = registration.handlers["session.message.updated"]!;
@@ -132,13 +136,16 @@ describe("session message frame scheduler", () => {
     handler(makeUpdated("session-1", "message-a", "a2"));
     frame.runFrame();
 
-    expect(updateMessage).toHaveBeenCalledTimes(2);
-    expect(updateMessage.mock.calls.map(([message]) => message.content)).toEqual(["a2", "b1"]);
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenCalledTimes(1);
+    expect(
+      updateMessages.mock.calls[0]?.[0].map((message: { content: string }) => message.content),
+    ).toEqual(["a2", "b1"]);
     registration.dispose();
   });
 
   it("flushes pending updates before add and delete barriers", () => {
-    const { store, updateMessage, addMessage, removeMessage } = makeStore();
+    const { store, updateMessage, updateMessages, addMessage, removeMessage } = makeStore();
     const frame = makeFrameScheduler();
     const registration = createMessagesHandlerRegistration(store, frame);
     const handlers = registration.handlers;
@@ -151,10 +158,11 @@ describe("session message frame scheduler", () => {
       payload: makePayload("session-1", "message-1", "ignored"),
       timestamp: TEST_TIMESTAMP,
     });
-    expect(updateMessage).toHaveBeenCalledTimes(1);
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenCalledTimes(1);
     expect(removeMessage).toHaveBeenCalledWith("session-1", "message-1");
     frame.runFrame();
-    expect(updateMessage).toHaveBeenCalledTimes(1);
+    expect(updateMessages).toHaveBeenCalledTimes(1);
 
     handlers["session.message.updated"]!(makeUpdated("session-1", "message-2", "before-add"));
     handlers[ADD_ACTION]!({
@@ -164,15 +172,15 @@ describe("session message frame scheduler", () => {
       payload: makePayload("session-1", "message-3", "added"),
       timestamp: TEST_TIMESTAMP,
     });
-    expect(updateMessage).toHaveBeenCalledTimes(2);
+    expect(updateMessages).toHaveBeenCalledTimes(2);
     expect(addMessage).toHaveBeenCalledTimes(1);
     frame.runFrame();
-    expect(updateMessage).toHaveBeenCalledTimes(2);
+    expect(updateMessages).toHaveBeenCalledTimes(2);
     registration.dispose();
   });
 
   it("clears scheduled work when the handler registration is disposed", () => {
-    const { store, updateMessage } = makeStore();
+    const { store, updateMessage, updateMessages } = makeStore();
     const frame = makeFrameScheduler();
     const registration = createMessagesHandlerRegistration(store, frame);
     registration.handlers["session.message.updated"]!(
@@ -183,18 +191,22 @@ describe("session message frame scheduler", () => {
     expect(frame.cancel).toHaveBeenCalledTimes(1);
     frame.runFrame();
     expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).not.toHaveBeenCalled();
   });
 
   it("flushes a pending update as a turn-settle barrier", () => {
-    const { store, updateMessage } = makeStore();
+    const { store, updateMessage, updateMessages } = makeStore();
     const frame = makeFrameScheduler();
     const scheduler = createMessageUpdateScheduler(store, frame);
     scheduler.enqueue(makePayload("session-1", "message-1", "settled"));
 
     scheduler.flush();
 
-    expect(updateMessage).toHaveBeenCalledTimes(1);
-    expect(updateMessage).toHaveBeenLastCalledWith(expect.objectContaining({ content: "settled" }));
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenCalledTimes(1);
+    expect(updateMessages).toHaveBeenLastCalledWith([
+      expect.objectContaining({ content: "settled" }),
+    ]);
     scheduler.dispose();
   });
 });
@@ -222,7 +234,7 @@ describe("session message prompt_index mapping", () => {
   });
 
   it("maps prompt_index from a session.message.updated payload", () => {
-    const { store, updateMessage } = makeStore();
+    const { store, updateMessage, updateMessages } = makeStore();
     const registration = createMessagesHandlerRegistration(store);
 
     const payload = makePayload("session-1", "message-1", "edited", {
@@ -235,9 +247,10 @@ describe("session message prompt_index mapping", () => {
     });
     registration.scheduler.flush();
 
-    expect(updateMessage).toHaveBeenLastCalledWith(
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenLastCalledWith([
       expect.objectContaining({ id: "message-1", prompt_index: 5 }),
-    );
+    ]);
     registration.dispose();
   });
 
@@ -431,7 +444,7 @@ describe("late tool messages", () => {
   });
 
   it("does not let a late running update reintroduce a spinner", () => {
-    const { store, updateMessage } = makeStore({}, true);
+    const { store, updateMessage, updateMessages } = makeStore({}, true);
     const registration = createMessagesHandlerRegistration(store);
 
     registration.handlers["session.message.updated"]!(
@@ -449,11 +462,12 @@ describe("late tool messages", () => {
     } as never);
     registration.scheduler.flush();
 
-    expect(updateMessage).toHaveBeenLastCalledWith(
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenLastCalledWith([
       expect.objectContaining({
         metadata: { tool_call_id: "call-1", status: "complete" },
       }),
-    );
+    ]);
     registration.dispose();
   });
 });

--- a/apps/web/lib/ws/handlers/messages.ts
+++ b/apps/web/lib/ws/handlers/messages.ts
@@ -137,11 +137,13 @@ export function createMessageUpdateScheduler(
     }
     const updates = [...pending.values()];
     pending.clear();
+    const messages: Message[] = [];
     for (const payload of updates) {
       if (!payload.session_id || !payload.message_id) continue;
       if (isOlderThanCurrentSnapshot(store, payload)) continue;
-      store.getState().updateMessage(settleMessageForCompletedTurn(store, toMessage(payload)));
+      messages.push(settleMessageForCompletedTurn(store, toMessage(payload)));
     }
+    if (messages.length > 0) store.getState().updateMessages(messages);
   };
 
   const enqueue = (payload: MessagePayload) => {

--- a/docs/plans/frontend-runtime-cpu/plan.md
+++ b/docs/plans/frontend-runtime-cpu/plan.md
@@ -1,0 +1,221 @@
+---
+created: 2026-08-27
+status: completed
+requirements:
+  - REQ-PLATFORM-DIAGNOSTIC-LOGGING-001
+  - REQ-PLATFORM-BROWSER-CONSOLE-RETENTION-001
+  - REQ-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001
+  - REQ-UI-TRANSCRIPT-AUTO-SCROLL-001
+system_design:
+  - ../../specs/platform/system-design/diagnostic-logging-01.md
+  - ../../specs/platform/system-design/browser-console-retention.md
+  - ../../specs/platform/system-design/bounded-task-status-delivery.md
+  - ../../specs/ui/system-design/transcript-auto-scroll.md
+legacy_specs: []
+---
+
+# Implementation Plan: Reduce Frontend Runtime CPU
+
+## Overview
+
+Reduce avoidable browser CPU work during active Kandev sessions. Keep the
+current diagnostic content, transcript data, event ordering, and scroll
+behavior.
+
+The package targets three app-owned costs from the attached 5.779 second Chrome
+performance capture:
+
+- Repeated debug-log preparation and IndexedDB drain work.
+- One Zustand transaction for each message key in one animation frame.
+- A forced content-size layout read for each pinned transcript update.
+
+## Scope
+
+### In scope
+
+- Coalesce browser-log persistence over the documented 250 ms window.
+- Reuse one detached entry and exact byte count through browser-log storage.
+- Bound the growing `messages:process` debug summary to one latest sample per
+  250 ms.
+- Apply one frame of replacement message updates in one store transaction.
+- Keep message add, delete, and turn-settle events as ordered barriers.
+- Place an enabled pinned transcript at the bottom without reading its content
+  size in the message-commit path.
+- Add deterministic work-count tests and desktop and mobile scroll evidence.
+
+### Out of scope
+
+- Removing any captured console level or changing diagnostic retention limits.
+- Changing backend stream coalescing, WebSocket protocol payloads, or database
+  persistence.
+- Transcript virtualization, message-grouping changes, or a new state library.
+- Changes to transcript controls, copy, layout, or persisted preferences.
+- Optimizing React DevTools or the Kandy plugin. They are separate runtime
+  contributors outside the Kandev host implementation.
+- A fixed CPU-time CI threshold. Shared runners make wall-clock samples too
+  variable for a stable correctness gate.
+
+## Confirmed root cause
+
+The renderer main thread was idle for 4.963 seconds of the 5.767 second renderer
+window. App work was bursty, not a continuous busy loop. After excluding the
+236.434 ms profiler-start task, renderer CPU was about 498 ms, or 8.6% of one
+core during the capture.
+
+The trace contained 47 `V8Console::Debug` calls. Samples attributed about 35 to
+40 ms to browser-log append, drain scheduling, callback, and encoding work.
+The current path can encode one entry in `buildLogEntry`, `RingBuffer.push`,
+`stageLogEntry`, and `IndexedDBLogStore.append`. An idle callback can also run
+before the documented 250 ms collection opportunity, which turns a burst into
+small transactions.
+
+The WebSocket scheduler already keeps the newest update per message for one
+animation frame. Its `flush()` loop still calls `updateMessage()` once for each
+message key. Every call opens a separate Zustand and Immer transaction and can
+notify transcript selectors. Derived message processing then repeats for those
+notifications.
+
+Ten message commits caused ten `scrollHeight` reads followed by `scrollTop`
+writes in the pinned transcript path. These reads initiated about 5.643 ms of
+style recalculation and 2.893 ms of layout in the capture.
+
+React DevTools added about 48 ms of sampled JavaScript and initiated separate
+style and layout work. Kandy celebration animation callbacks added about 6 ms.
+These values remain measurement context, not Kandev host fixes.
+
+## Requirement conformance
+
+The fixes preserve accepted product behavior. They refine resource boundaries
+that the current implementation does not fully enforce.
+
+- Diagnostic bundles still retain `console.debug`, `console.info`,
+  `console.warn`, and `console.error` with the same identity, size, and age
+  limits.
+- Final transcript content remains lossless. Replacement updates can still
+  skip only intermediate render states.
+- Message add, delete, and turn-settle actions keep their ordering guarantees.
+- Enabled auto-scroll stays pinned. Disabled auto-scroll stays frozen.
+- Desktop and mobile use the same store and native transcript behavior.
+
+No ADR is required. The package keeps the accepted privacy, persistence,
+transport, and UI boundaries. It changes internal scheduling and mutation
+granularity only.
+
+## Technical approach
+
+### Browser diagnostics
+
+- Replace the idle-first drain trigger with one collection gate. The first
+  staged entry starts a 250 ms timer. The timer then starts the existing
+  serialized drain. Snapshot collection cancels the wait and joins that drain.
+- Prepare an accepted log entry once after adding `identity_scope`. Reuse its
+  detached object and exact UTF-8 byte count in the memory buffer, staging
+  limits, IndexedDB record, and retention totals.
+- Keep the 50-entry, 256 KiB transaction bounds and the 500-entry, 2 MiB
+  staging bounds.
+- Make `useDebugProcessedPipeline` keep the latest inputs in a ref. Compute and
+  emit its growing collection summary at most once per 250 ms.
+
+### Message frame transaction
+
+- Add a `updateMessages(messages)` session-store action.
+- Convert and settle all accepted frame payloads before the store mutation.
+- Apply the array of replacements in one Immer callback. Preserve first-key
+  insertion order from the scheduler map.
+- Keep `updateMessage(message)` as the single-message API for existing callers.
+  Share one internal merge helper so both actions keep partial-field behavior.
+- Flush the batch before add and delete barriers, as the current scheduler
+  does.
+
+### Layout-free bottom placement
+
+- Add one native transcript helper that writes a maximum scroll offset.
+- Use it for work-start and pinned message updates.
+- Do not read `scrollHeight`, `clientHeight`, rectangles, or computed style in
+  those common paths.
+- Keep geometry reads for user scroll detection, catch-up decisions,
+  pagination, and prepend restoration. Those reads answer different questions
+  and do not run for every streamed commit.
+
+## Test mapping
+
+| Acceptance criterion                             | Test evidence                                                                                                         |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `AC-PLATFORM-DIAGNOSTIC-LOGGING-001.9`           | Fake-time hook test proves that continuous message updates emit no more than one latest debug summary per 250 ms.     |
+| `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.5`    | Runtime test holds one append and proves maximum append concurrency remains one.                                      |
+| `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.8`    | Fake-time runtime test stages a burst and proves idle availability cannot create early one-entry transactions.        |
+| `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.9`    | Runtime test proves a snapshot bypasses the collection timer and waits for the shared drain.                          |
+| `AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.7` | Existing scheduler tests prove newest-payload replacement, stale rejection, and semantic barriers.                    |
+| `AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.9` | Scheduler and real-store tests prove that several message keys cause one bulk action and one subscriber notification. |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.1`             | Existing unit and browser tests prove that disabled auto-scroll keeps its captured position.                          |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.2`             | Existing unit and browser tests prove catch-up after re-enable.                                                       |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.5`             | Desktop and mobile browser tests prove enabled transcripts remain at the bottom.                                      |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.7`             | Unit test fails on any content-size read in the pinned append path and records one maximum-offset write.              |
+
+## E2E tests
+
+- Desktop: extend `apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts` in the
+  `chromium` project.
+- Mobile: extend
+  `apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts` in the
+  `mobile-chrome` project.
+- Shared cues: enabled bottom distance, disabled `scrollTop`, incoming live
+  message visibility, and the existing native transcript scroll owner.
+
+Logger and store work use deterministic Vitest counters. They do not require a
+browser timing threshold.
+
+## Mobile design contract
+
+- Desktop outcome: the native transcript follows live content with fewer
+  layout and store operations.
+- Mobile entry point: the existing Chat tab in the full-height task layout.
+- Nearest exemplar: `apps/web/components/task/task-layout.tsx` and the shipped
+  mobile auto-scroll tests.
+- Hierarchy and surface: the transcript remains the only vertical scroll owner.
+- Shared logic: desktop and mobile use one frame scheduler, session store, and
+  bottom-placement helper.
+- Mobile proof: the mobile test covers enabled bottom pinning and disabled
+  position freezing after a live message arrives.
+
+## Work orders
+
+- [completed] [Task 01: Coalesce Browser Diagnostic Work](task-01-coalesce-browser-diagnostic-work.md)
+- [completed] [Task 02: Batch Message Frame Mutations](task-02-batch-message-frame-mutations.md)
+- [completed] [Task 03: Remove Pinned-scroll Layout Reads](task-03-remove-pinned-scroll-layout-reads.md)
+
+## Verification protocol
+
+Each work order starts with its named failing regression and runs its targeted
+tests before broader checks.
+
+After all work orders, capture the same interaction twice with browser
+extensions disabled:
+
+1. Use a production-like build to measure app-owned streaming and scroll work.
+2. Use debug mode to measure the bounded diagnostics path.
+
+Compare app-originated console work, IndexedDB append count, Zustand subscriber
+notifications, forced layout initiators, and renderer CPU. Keep React DevTools
+and Kandy plugin samples separate from host results.
+
+The deterministic acceptance budgets are:
+
+- One browser-log drain start for entries inside one 250 ms collection window.
+- One store transaction and subscriber notification per message frame.
+- Zero content-size reads in the pinned message-commit path.
+- Unchanged final logs, transcript content, event order, and scroll outcomes.
+
+## Risks
+
+- Timer cancellation can lose a pending browser-log drain during test resets or
+  snapshot capture.
+- Reusing a byte count before identity scoping can make retention totals wrong.
+- Bulk store mutation can change barrier order if payload conversion moves
+  across the barrier.
+- A shared message merge helper can clear fields that an omitted partial field
+  must preserve.
+- A maximum scroll write can run while another scroll owner is active if the
+  existing guards are bypassed.
+- Browser extensions can hide improvements or create false regressions in a
+  comparison profile.

--- a/docs/plans/frontend-runtime-cpu/plan.md
+++ b/docs/plans/frontend-runtime-cpu/plan.md
@@ -105,16 +105,19 @@ granularity only.
 
 ### Browser diagnostics
 
-- Replace the idle-first drain trigger with one collection gate. The first
-  staged entry starts a 250 ms timer. The timer then starts the existing
-  serialized drain. Snapshot collection cancels the wait and joins that drain.
+- Replace the idle-first drain trigger with one collection gate followed by
+  bounded idle scheduling. The first staged entry starts a 250 ms timer. When
+  it closes, the runtime requests browser idle time with the remaining
+  one-second deadline and keeps a cancellable timer fallback. Snapshot
+  collection cancels both waits and joins that drain.
 - Prepare an accepted log entry once after adding `identity_scope`. Reuse its
   detached object and exact UTF-8 byte count in the memory buffer, staging
   limits, IndexedDB record, and retention totals.
 - Keep the 50-entry, 256 KiB transaction bounds and the 500-entry, 2 MiB
   staging bounds.
 - Make `useDebugProcessedPipeline` keep the latest inputs in a ref. Compute and
-  emit its growing collection summary at most once per 250 ms.
+  emit its growing collection summary at most once per 250 ms, flushing the
+  pending latest sample on session change and unmount.
 
 ### Message frame transaction
 
@@ -145,7 +148,7 @@ granularity only.
 | `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.5`    | Runtime test holds one append and proves maximum append concurrency remains one.                                      |
 | `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.8`    | Fake-time runtime test stages a burst and proves idle availability cannot create early one-entry transactions.        |
 | `AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.9`    | Runtime test proves a snapshot bypasses the collection timer and waits for the shared drain.                          |
-| `AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.7` | Existing scheduler tests prove newest-payload replacement, stale rejection, and semantic barriers.                    |
+| `AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.7` | Existing scheduler tests prove newest-payload replacement, stale rejection through the bulk path, and semantic barriers. |
 | `AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.9` | Scheduler and real-store tests prove that several message keys cause one bulk action and one subscriber notification. |
 | `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.1`             | Existing unit and browser tests prove that disabled auto-scroll keeps its captured position.                          |
 | `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.2`             | Existing unit and browser tests prove catch-up after re-enable.                                                       |

--- a/docs/plans/frontend-runtime-cpu/task-01-coalesce-browser-diagnostic-work.md
+++ b/docs/plans/frontend-runtime-cpu/task-01-coalesce-browser-diagnostic-work.md
@@ -1,0 +1,117 @@
+---
+id: "01-coalesce-browser-diagnostic-work"
+title: "Coalesce browser diagnostic work"
+status: completed
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-PLATFORM-DIAGNOSTIC-LOGGING-001
+  - REQ-PLATFORM-BROWSER-CONSOLE-RETENTION-001
+acceptance_criteria:
+  - AC-PLATFORM-DIAGNOSTIC-LOGGING-001.9
+  - AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.5
+  - AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.8
+  - AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.9
+system_design:
+  - ../../specs/platform/system-design/diagnostic-logging-01.md
+  - ../../specs/platform/system-design/browser-console-retention.md
+---
+
+# Task 01: Coalesce Browser Diagnostic Work
+
+## Summary
+
+Collect browser logs for the full 250 ms window. Prepare each accepted entry
+once, then reuse it through memory and IndexedDB storage. Bound the growing
+message-pipeline debug summary to the same cadence.
+
+## Failing regression first
+
+Add a fake-time test named `collects an idle log burst for 250 ms before one
+bounded append`. Stage several entries, run an idle callback before 250 ms, and
+prove that `IndexedDBLogStore.append` has not run. Advance to 250 ms and prove
+that one append receives the burst.
+
+Add a hook regression named `emits the latest processed-message debug sample
+at most once per 250 ms`. Re-render the hook several times inside one window
+and prove that only the latest counts are formatted and emitted.
+
+## In scope
+
+- Add a cancellable 250 ms collection gate to the logger runtime.
+- Make snapshot flush bypass the collection wait.
+- Keep one in-flight append and the current batch and staging limits.
+- Introduce one prepared-entry shape with detached data and exact bytes.
+- Reuse prepared entries in the ring buffer and IndexedDB store.
+- Coalesce `messages:process` derived debug work to one latest sample per
+  window.
+- Preserve capture levels, identity partitioning, loss counts, and fallback.
+
+## Out of scope
+
+- Removing debug logs or changing bundle contents.
+- Changing retention age, entry count, byte limits, or database name.
+- Changing backend diagnostics or bundle transport.
+
+## Acceptance
+
+- An idle callback cannot split one collection window into one-entry writes.
+- A snapshot starts and joins the serialized drain without waiting 250 ms.
+- One accepted entry has one canonical exact byte count across all stores.
+- A continuous processed-message stream creates at most four derived debug
+  samples per second and retains the latest sample.
+- Persistence failure still switches to the bounded memory fallback.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- lib/logger/buffer.test.ts lib/logger/intercept.test.ts lib/logger/runtime.test.ts lib/logger/indexeddb-store.test.ts hooks/use-processed-messages.test.ts
+cd apps && pnpm --filter @kandev/web run typecheck
+cd apps/web && pnpm exec eslint lib/logger/buffer.ts lib/logger/buffer.test.ts lib/logger/intercept.ts lib/logger/intercept.test.ts lib/logger/runtime.ts lib/logger/runtime.test.ts lib/logger/indexeddb-store.ts lib/logger/indexeddb-store.test.ts hooks/use-processed-messages.ts hooks/use-processed-messages.test.ts
+```
+
+## Files likely touched
+
+- `apps/web/lib/logger/buffer.ts`
+- `apps/web/lib/logger/buffer.test.ts`
+- `apps/web/lib/logger/intercept.ts`
+- `apps/web/lib/logger/intercept.test.ts`
+- `apps/web/lib/logger/runtime.ts`
+- `apps/web/lib/logger/runtime.test.ts`
+- `apps/web/lib/logger/indexeddb-store.ts`
+- `apps/web/lib/logger/indexeddb-store.test.ts`
+- `apps/web/hooks/use-processed-messages.ts`
+- `apps/web/hooks/use-processed-messages.test.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- A stale timer can start a second drain after a snapshot.
+- A prepared entry can become mutable if the memory buffer exposes its object.
+- Byte totals can drift if the identity scope changes after preparation.
+- A trailing debug sample can outlive its session unless cleanup cancels it.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- Browser CPU trace findings in `plan.md`.
+- Browser console retention requirements and system design.
+- Diagnostic logging performance contract.
+
+## Results
+
+Implemented the 250 ms collection gate, prepared-entry reuse, serialized
+IndexedDB append path, and latest-sample coalescing for the processed-message
+debug summary. Snapshot flush still bypasses the collection wait, persistence
+failure still degrades to the bounded memory buffer, and retention limits are
+unchanged.
+
+Targeted verification passed: 6 files and 83 tests across the logger buffer,
+interceptor, runtime, IndexedDB store, and processed-message hook suites.

--- a/docs/plans/frontend-runtime-cpu/task-01-coalesce-browser-diagnostic-work.md
+++ b/docs/plans/frontend-runtime-cpu/task-01-coalesce-browser-diagnostic-work.md
@@ -22,16 +22,18 @@ system_design:
 
 ## Summary
 
-Collect browser logs for the full 250 ms window. Prepare each accepted entry
+Collect browser logs for the full 250 ms window, then schedule persistence
+during browser idle time with a bounded deadline. Prepare each accepted entry
 once, then reuse it through memory and IndexedDB storage. Bound the growing
-message-pipeline debug summary to the same cadence.
+message-pipeline debug summary to the same cadence and flush its final sample
+when a session ends.
 
 ## Failing regression first
 
-Add a fake-time test named `collects an idle log burst for 250 ms before one
-bounded append`. Stage several entries, run an idle callback before 250 ms, and
-prove that `IndexedDBLogStore.append` has not run. Advance to 250 ms and prove
-that one append receives the burst.
+Add fake-time tests that stage a burst, prove that an idle callback cannot run
+before 250 ms, then prove that post-window idle time starts one bounded append.
+Also prove that the remaining deadline fallback drains when idle time does not
+arrive, and that snapshot flush cancels both waits.
 
 Add a hook regression named `emits the latest processed-message debug sample
 at most once per 250 ms`. Re-render the hook several times inside one window
@@ -40,12 +42,15 @@ and prove that only the latest counts are formatted and emitted.
 ## In scope
 
 - Add a cancellable 250 ms collection gate to the logger runtime.
-- Make snapshot flush bypass the collection wait.
+- Schedule the serialized drain during browser idle time after the gate, with a
+  one-second overall deadline and cancellable fallback.
+- Make snapshot flush bypass and cancel the collection and idle waits.
 - Keep one in-flight append and the current batch and staging limits.
 - Introduce one prepared-entry shape with detached data and exact bytes.
 - Reuse prepared entries in the ring buffer and IndexedDB store.
 - Coalesce `messages:process` derived debug work to one latest sample per
   window.
+- Flush a pending processed-message debug sample on session change and unmount.
 - Preserve capture levels, identity partitioning, loss counts, and fallback.
 
 ## Out of scope
@@ -57,6 +62,8 @@ and prove that only the latest counts are formatted and emitted.
 ## Acceptance
 
 - An idle callback cannot split one collection window into one-entry writes.
+- Post-window browser idle time starts persistence, and the bounded deadline
+  fallback starts it when idle time does not arrive.
 - A snapshot starts and joins the serialized drain without waiting 250 ms.
 - One accepted entry has one canonical exact byte count across all stores.
 - A continuous processed-message stream creates at most four derived debug
@@ -66,7 +73,7 @@ and prove that only the latest counts are formatted and emitted.
 ## Verification
 
 ```bash
-cd apps && pnpm --filter @kandev/web test -- lib/logger/buffer.test.ts lib/logger/intercept.test.ts lib/logger/runtime.test.ts lib/logger/indexeddb-store.test.ts hooks/use-processed-messages.test.ts
+cd apps && pnpm --filter @kandev/web test -- lib/logger/buffer.test.ts lib/logger/intercept.test.ts lib/logger/runtime.test.ts lib/logger/indexeddb-store.test.ts hooks/use-processed-messages.test.ts hooks/use-processed-messages-fallback.test.ts
 cd apps && pnpm --filter @kandev/web run typecheck
 cd apps/web && pnpm exec eslint lib/logger/buffer.ts lib/logger/buffer.test.ts lib/logger/intercept.ts lib/logger/intercept.test.ts lib/logger/runtime.ts lib/logger/runtime.test.ts lib/logger/indexeddb-store.ts lib/logger/indexeddb-store.test.ts hooks/use-processed-messages.ts hooks/use-processed-messages.test.ts
 ```
@@ -91,9 +98,12 @@ None.
 ## Risks
 
 - A stale timer can start a second drain after a snapshot.
+- A stale idle callback or fallback timer can start a second drain after a
+  snapshot.
 - A prepared entry can become mutable if the memory buffer exposes its object.
 - Byte totals can drift if the identity scope changes after preparation.
-- A trailing debug sample can outlive its session unless cleanup cancels it.
+- Cleanup can lose a trailing debug sample unless it emits the latest state
+  before cancelling its timer.
 
 ## Parallelism
 
@@ -107,11 +117,14 @@ None.
 
 ## Results
 
-Implemented the 250 ms collection gate, prepared-entry reuse, serialized
-IndexedDB append path, and latest-sample coalescing for the processed-message
-debug summary. Snapshot flush still bypasses the collection wait, persistence
-failure still degrades to the bounded memory buffer, and retention limits are
-unchanged.
+Implemented the 250 ms collection gate followed by browser-idle scheduling with
+a bounded one-second overall deadline and a timer fallback. Snapshot flush
+cancels both waits and joins the serialized drain. Prepared-entry reuse,
+serialized IndexedDB append, and latest-sample coalescing remain in place; a
+pending processed-message sample now flushes on session change and unmount.
+Persistence failure still degrades to the bounded memory buffer, and retention
+limits are unchanged.
 
-Targeted verification passed: 6 files and 83 tests across the logger buffer,
-interceptor, runtime, IndexedDB store, and processed-message hook suites.
+Targeted verification passed across the logger buffer, interceptor, runtime,
+IndexedDB store, and processed-message hook suites, including the idle-gate,
+deadline, snapshot-cancellation, session-change, and unmount regressions.

--- a/docs/plans/frontend-runtime-cpu/task-02-batch-message-frame-mutations.md
+++ b/docs/plans/frontend-runtime-cpu/task-02-batch-message-frame-mutations.md
@@ -1,0 +1,111 @@
+---
+id: "02-batch-message-frame-mutations"
+title: "Batch message frame mutations"
+status: completed
+wave: 2
+depends_on:
+  - "01-coalesce-browser-diagnostic-work"
+plan: "plan.md"
+requirements:
+  - REQ-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001
+acceptance_criteria:
+  - AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.7
+  - AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.9
+system_design:
+  - ../../specs/platform/system-design/bounded-task-status-delivery.md
+---
+
+# Task 02: Batch Message Frame Mutations
+
+## Summary
+
+Apply all accepted replacement messages from one animation frame in one
+Zustand and Immer transaction. Preserve message merge and barrier behavior.
+
+## Failing regression first
+
+Add a scheduler test named `applies different message keys with one bulk store
+action`. Enqueue two message keys, flush one frame, and prove that the store
+receives one ordered array instead of two `updateMessage` calls.
+
+Add a real-store test named `notifies subscribers once for one replacement
+frame`. Seed two messages, subscribe to the session message array, apply the
+bulk action, and prove that both messages change after one notification.
+
+## In scope
+
+- Add `updateMessages(messages)` to the session slice type and implementation.
+- Share partial-field merge logic with `updateMessage(message)`.
+- Convert, settle, and stale-filter frame payloads before one store action.
+- Preserve first-key insertion order from the scheduler map.
+- Preserve add, delete, and turn-settle barriers.
+- Keep unaffected session arrays and message objects stable.
+- Extend scheduler and slice tests for multi-session frames.
+
+## Out of scope
+
+- Backend lifecycle or gateway coalescing changes.
+- Protocol payload or timestamp changes.
+- Incremental transcript grouping or virtualization.
+- A replacement for Zustand or Immer.
+
+## Acceptance
+
+- Several accepted message keys in one frame cause one bulk store call.
+- A real store emits at most one subscriber notification for that frame.
+- Final message fields match the current single-update behavior.
+- Stale payloads remain rejected.
+- Add and delete events cannot be reordered around pending replacements.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- lib/ws/handlers/messages.test.ts lib/state/slices/session/session-slice.update-messages.test.ts lib/state/slices/session/session-slice.merge-messages.test.ts
+cd apps && pnpm --filter @kandev/web run typecheck
+cd apps/web && pnpm exec eslint lib/ws/handlers/messages.ts lib/ws/handlers/messages.test.ts lib/state/slices/session/types.ts lib/state/slices/session/session-slice.ts lib/state/slices/session/session-slice.update-messages.test.ts
+```
+
+## Files likely touched
+
+- `apps/web/lib/ws/handlers/messages.ts`
+- `apps/web/lib/ws/handlers/messages.test.ts`
+- `apps/web/lib/state/slices/session/types.ts`
+- `apps/web/lib/state/slices/session/session-slice.ts`
+- `apps/web/lib/state/slices/session/session-slice.update-messages.test.ts`
+
+## Dependencies
+
+- Task 01 completes first so the later comparison trace can attribute logger
+  and store work separately.
+
+## Risks
+
+- Payload conversion inside the mutation can observe different turn state.
+- A multi-session frame can accidentally replace an unaffected session array.
+- Partial updates can clear known fields if undefined values are merged.
+- Barrier tests can pass with mocks while real subscriber count still grows.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- Bounded task status delivery acceptance criteria 7 and 9.
+- The accepted replaceable session stream decision.
+- Existing message scheduler and session slice tests.
+
+## Results
+
+Implemented the bulk replacement action and scheduler batching. Accepted
+replacement payloads are converted and settled before one `updateMessages`
+transaction, while add, delete, and turn-settle events remain ordered barriers.
+The shared merge helper preserves partial-field behavior and unaffected session
+state remains stable.
+
+Targeted verification passed:
+
+- `lib/ws/handlers/messages.test.ts`
+- `lib/state/slices/session/session-slice.update-messages.test.ts`
+
+The broader work-order verification remains in the package-level check.

--- a/docs/plans/frontend-runtime-cpu/task-02-batch-message-frame-mutations.md
+++ b/docs/plans/frontend-runtime-cpu/task-02-batch-message-frame-mutations.md
@@ -101,7 +101,8 @@ Implemented the bulk replacement action and scheduler batching. Accepted
 replacement payloads are converted and settled before one `updateMessages`
 transaction, while add, delete, and turn-settle events remain ordered barriers.
 The shared merge helper preserves partial-field behavior and unaffected session
-state remains stable.
+state remains stable. The stale-snapshot regression now asserts that neither the
+legacy single-update action nor the production bulk action is called.
 
 Targeted verification passed:
 

--- a/docs/plans/frontend-runtime-cpu/task-03-remove-pinned-scroll-layout-reads.md
+++ b/docs/plans/frontend-runtime-cpu/task-03-remove-pinned-scroll-layout-reads.md
@@ -1,0 +1,111 @@
+---
+id: "03-remove-pinned-scroll-layout-reads"
+title: "Remove pinned-scroll layout reads"
+status: completed
+wave: 3
+depends_on:
+  - "02-batch-message-frame-mutations"
+plan: "plan.md"
+requirements:
+  - REQ-UI-TRANSCRIPT-AUTO-SCROLL-001
+acceptance_criteria:
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.1
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.2
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.5
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.7
+system_design:
+  - ../../specs/ui/system-design/transcript-auto-scroll.md
+---
+
+# Task 03: Remove Pinned-scroll Layout Reads
+
+## Summary
+
+Place a pinned transcript at the native maximum offset with a write-only
+operation. Keep all current auto-scroll guards and responsive behavior.
+
+## Failing regression first
+
+Add a unit test named `pins an appended message without reading content size`.
+Make the transcript `scrollHeight` getter throw, append a message while the
+near-bottom guard is true, and prove that the scroll setter receives the
+maximum-offset request.
+
+## In scope
+
+- Add one write-only native bottom-placement helper.
+- Use it for the work-start and pinned message-update paths.
+- Preserve near-bottom, programmatic-lock, and layout-restore guards.
+- Preserve disabled-state freezing and re-enable catch-up.
+- Extend desktop and mobile auto-scroll browser scenarios.
+- Confirm that the native transcript remains the only scroll owner.
+
+## Out of scope
+
+- Removing geometry reads from user scroll detection, pagination, prepend
+  restoration, or catch-up decisions.
+- Changing smooth navigation to a prompt or message.
+- Changing transcript controls, layout, copy, or touch targets.
+
+## Acceptance
+
+- A pinned message append performs no content-size read in its commit effect.
+- Enabled auto-scroll remains at the bottom after a live message arrives.
+- Disabled auto-scroll retains the same `scrollTop` after content arrives.
+- Desktop and mobile produce the same outcome through shared logic.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/task/chat/message-list-native.test.tsx components/task/chat/transcript-auto-scroll.test.ts
+cd apps && pnpm --filter @kandev/web run typecheck
+cd apps/web && pnpm exec eslint components/task/chat/message-list-native-scroll.ts components/task/chat/message-list-native.test.tsx e2e/tests/chat/auto-scroll-toggle.spec.ts e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
+cd apps/web && pnpm e2e:run --host --project chromium tests/chat/auto-scroll-toggle.spec.ts -- --retries=0
+cd apps/web && pnpm e2e:run --host --no-build --project mobile-chrome tests/chat/mobile-auto-scroll-toggle.spec.ts -- --retries=0
+```
+
+## Files likely touched
+
+- `apps/web/components/task/chat/message-list-native-scroll.ts`
+- `apps/web/components/task/chat/message-list-native.test.tsx`
+- `apps/web/components/task/chat/transcript-auto-scroll.test.ts`
+- `apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts`
+- `apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts`
+
+## Dependencies
+
+- Task 02 completes first so the browser scenario exercises the final store
+  notification cadence.
+
+## Risks
+
+- A large offset can be written while a user-owned scroll is active if a guard
+  is lost.
+- Unit DOM behavior can differ from browser clamping.
+- Sticky prompt geometry can settle after the first bottom placement.
+- Mobile touch scrolling can expose a different lock-release timing.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- Transcript auto-scroll acceptance criteria 1, 2, 5, and 7.
+- The native transcript auto-scroll system design.
+- Existing desktop and mobile auto-scroll tests.
+
+## Results
+
+Implemented the write-only native bottom-placement helper and wired it into
+work-start, pinned message updates, and re-enable catch-up. Initial placement,
+user detection, pagination, prepend restoration, and explicit scroll decisions
+retain their required geometry reads.
+
+Verification passed:
+
+- Native transcript unit suites: 2 files and 57 tests.
+- Desktop auto-scroll browser suite: 9 tests passed.
+- Mobile auto-scroll browser suite: 5 tests passed.
+- The new enabled-live-message scenarios confirm both layouts remain at the
+  bottom after incoming content.

--- a/docs/specs/platform/requirements/bounded-task-status-delivery.md
+++ b/docs/specs/platform/requirements/bounded-task-status-delivery.md
@@ -2,10 +2,11 @@
 status: active
 system: platform
 created: 2026-08-01
-updated: 2026-08-19
+updated: 2026-08-27
 owners:
   - kandev
 ---
+
 # Bounded Task Status Delivery Requirements
 
 ## Overview
@@ -28,6 +29,10 @@ Task rows currently obtain compact status indicators by observing large, session
 - **AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.6:** Correlated WebSocket responses and errors are prioritized over unsolicited notifications and cannot be silently dropped by notification pressure.
 - **AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.7:** One session's streaming text or reasoning cannot monopolize persistence, notification delivery, or browser state work. Intermediate replacement updates are bounded while the final transcript remains lossless.
 - **AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.8:** `message.add` uses a stable client-generated message ID so an uncertain send can be reconciled or retried without creating or dispatching a duplicate.
+- **AC-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001.9:** One frontend animation-frame
+  flush shall apply all accepted `session.message.updated` replacements in one
+  store transaction while preserving semantic barriers and final transcript
+  content.
 
 ## System design
 

--- a/docs/specs/platform/requirements/browser-console-retention.md
+++ b/docs/specs/platform/requirements/browser-console-retention.md
@@ -2,6 +2,7 @@
 status: active
 system: platform
 created: 2026-08-23
+updated: 2026-08-27
 owners:
   - kandev
 ---
@@ -50,6 +51,13 @@ retained history after every log batch.
   diagnostic loss metadata shall remain available.
 - **AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.7:** Clearing browser diagnostic
   history shall also reset its retained count and byte totals.
+- **AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.8:** Entries emitted during one
+  250 ms collection window shall use the fewest committed batches allowed by
+  the 50-entry and 256 KiB batch limits. Browser idle time shall not shorten
+  that collection window.
+- **AC-PLATFORM-BROWSER-CONSOLE-RETENTION-001.9:** An explicit diagnostic
+  snapshot shall bypass an outstanding collection window, flush all staged
+  entries, and wait for the existing serialized drain.
 
 ## Compatibility and persistence
 

--- a/docs/specs/platform/requirements/diagnostic-logging.md
+++ b/docs/specs/platform/requirements/diagnostic-logging.md
@@ -2,9 +2,11 @@
 status: active
 system: platform
 created: 2026-07-30
+updated: 2026-08-27
 owners:
   - tbd
 ---
+
 # Diagnostic logging Requirements
 
 ## Overview
@@ -27,6 +29,10 @@ Users can see frontend failures that leave no backend evidence, and support cann
 - **AC-PLATFORM-DIAGNOSTIC-LOGGING-001.6:** `logging.level` / `KANDEV_LOG_LEVEL` remains the supported override for the file threshold, and `logging.format` remains supported. `logging.outputPath`, `logging.maxSizeMb`, `logging.maxBackups`, `logging.maxAgeDays`, and `logging.compress` are removed; the diagnostic path and daily retention policy are not configurable.
 - **AC-PLATFORM-DIAGNOSTIC-LOGGING-001.7:** `backend-logs.log` represents the current UTC calendar day. At UTC midnight, the backend atomically rolls it to `backend-logs-YYYY-MM-DD.log` and creates a new owner-readable, owner-writable active file.
 - **AC-PLATFORM-DIAGNOSTIC-LOGGING-001.8:** A restart during the same UTC day appends to `backend-logs.log`. On the first startup after a day boundary, the previous active file is rolled to the date it represents before new entries are written.
+- **AC-PLATFORM-DIAGNOSTIC-LOGGING-001.9:** A browser debug diagnostic
+  that scans a growing application collection shall compute and emit at most
+  one latest-state sample per 250 ms while that collection changes
+  continuously.
 
 ## System design
 

--- a/docs/specs/platform/system-design/bounded-task-status-delivery.md
+++ b/docs/specs/platform/system-design/bounded-task-status-delivery.md
@@ -4,10 +4,11 @@ system: platform
 requirements:
   - REQ-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001
 created: 2026-08-01
-updated: 2026-08-19
+updated: 2026-08-27
 owners:
   - kandev
 ---
+
 # Bounded Task Status Delivery System Design
 
 ## Purpose and boundaries
@@ -16,8 +17,8 @@ This design preserves the technical source detail for `REQ-PLATFORM-BOUNDED-TASK
 
 ## Requirement mapping
 
-| Requirement | Design section |
-| --- | --- |
+| Requirement                                     | Design section                                    |
+| ----------------------------------------------- | ------------------------------------------------- |
 | `REQ-PLATFORM-BOUNDED-TASK-STATUS-DELIVERY-001` | [Migrated source detail](#migrated-source-detail) |
 
 ## Migrated source detail
@@ -64,16 +65,16 @@ detail surface.
 The wire field is `status_summary`; the frontend maps it to `statusSummary`.
 The initial contract is:
 
-| Field                                          | Meaning                                                             | Bound                                |
-| ---------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------ |
-| `revision`, `updated_at`                       | Monotonic task-local version and projection time                    | Constant                             |
-| `last_activity_at`                             | Latest durable task, user-prompt, or turn milestone                 | Constant                             |
-| `primary_session`                              | Primary session ID and lifecycle state                              | One session                          |
-| `foreground_activity`, `active_subagent_count` | Existing task-level busy aggregate                                  | Constant                             |
-| `pending_action`                               | `permission`, `clarification`, or absent                            | Constant                             |
+| Field                                          | Meaning                                                                               | Bound                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `revision`, `updated_at`                       | Monotonic task-local version and projection time                                      | Constant                                    |
+| `last_activity_at`                             | Latest durable task, user-prompt, or turn milestone                                   | Constant                                    |
+| `primary_session`                              | Primary session ID and lifecycle state                                                | One session                                 |
+| `foreground_activity`, `active_subagent_count` | Existing task-level busy aggregate                                                    | Constant                                    |
+| `pending_action`                               | `permission`, `clarification`, or absent                                              | Constant                                    |
 | `active_error`                                 | Optional session and task-repository IDs, stamp, time, preview, category, and actions | One preview and at most three known actions |
-| `git`                                          | Aggregate additions, deletions, changed files, ahead, and behind    | Numeric totals only                  |
-| `pull_request`                                 | Count, bounded representative identity, and aggregate display state | Constant regardless of PR count      |
+| `git`                                          | Aggregate additions, deletions, changed files, ahead, and behind                      | Numeric totals only                         |
+| `pull_request`                                 | Count, bounded representative identity, and aggregate display state                   | Constant regardless of PR count             |
 
 `pull_request.aggregate_state` is one of `failure`, `blocked`, `pending`,
 `awaiting_review`, `ready`, `passing`, `draft`, `merged`, `closed`, or
@@ -233,11 +234,17 @@ delivered because the database remains authoritative.
 
 The frontend applies the same defense at the render boundary. It keeps only the
 newest `session.message.updated` payload for each message during one animation
-frame and performs one store update per changed message when the frame flushes.
-Message add/delete and turn-settle events remain ordered barriers. Intentional
-multi-session detail surfaces may subscribe to every session they display, but
-rerendering or refetching equivalent session objects must not tear down and
-recreate unchanged subscription membership.
+frame. The frame flush converts every accepted payload first, then applies all
+message replacements in one Zustand and Immer transaction. The transaction
+preserves first-key insertion order and changes only the affected session
+arrays and message objects. This produces at most one subscriber notification
+for the frame, so derived transcript processing also runs at most once.
+
+Message add/delete and turn-settle events remain ordered barriers. A barrier
+flushes the pending replacement batch before it applies its semantic action.
+Intentional multi-session detail surfaces may subscribe to every session they
+display, but rerendering or refetching equivalent session objects must not tear
+down and recreate unchanged subscription membership.
 
 Overload handling is observable. Structured metrics/logs identify the client,
 session, action, queue class, coalesced chunk count, replacement count, and

--- a/docs/specs/platform/system-design/browser-console-retention.md
+++ b/docs/specs/platform/system-design/browser-console-retention.md
@@ -72,6 +72,24 @@ loop before a diagnostic snapshot. It does not create a parallel writer.
 The console interception path remains synchronous and bounded. It only adds a
 reference-free entry to staging and schedules the loop.
 
+### Burst collection and entry preparation
+
+The first staged entry opens one 250 ms collection window. Browser idle time
+cannot start persistence before that window closes. When the window closes,
+the runtime starts one drain and fills each transaction up to the existing
+50-entry or 256 KiB limit. A diagnostic snapshot cancels the collection wait
+and joins the same drain immediately.
+
+The runtime prepares each accepted entry once after it adds the identity
+scope. This preparation creates the detached entry and its exact encoded byte
+size. The memory buffer, staging queue, and IndexedDB store reuse that prepared
+entry and byte size. They do not repeat `JSON.stringify()` or UTF-8 encoding at
+each layer.
+
+The 500-entry and 2 MiB staging limits remain exact. The collection window
+does not delay the original console call, increase the staging limits, or
+change which log levels a diagnostic bundle contains.
+
 ## Migration and recovery
 
 The version-2 upgrade transaction creates the metadata store and walks the
@@ -97,7 +115,10 @@ real IndexedDB request and transaction behavior without a product dependency.
 
 Runtime tests hold the first append promise while more entries arrive. They
 confirm that append concurrency stays at one and that a snapshot waits for the
-same drain.
+same drain. Fake-time tests also prove that browser idle time cannot split one
+collection window into one-entry transactions, and that a snapshot bypasses
+the wait. Entry-preparation tests prove that the memory and IndexedDB paths use
+the same encoded byte count.
 
 ## Related decisions
 

--- a/docs/specs/platform/system-design/diagnostic-logging-01.md
+++ b/docs/specs/platform/system-design/diagnostic-logging-01.md
@@ -4,9 +4,11 @@ system: platform
 requirements:
   - REQ-PLATFORM-DIAGNOSTIC-LOGGING-001
 created: 2026-07-30
+updated: 2026-08-27
 owners:
   - tbd
 ---
+
 # Diagnostic logging System Design Part 1
 
 ## Purpose and boundaries
@@ -15,8 +17,8 @@ This design preserves the technical source detail for `REQ-PLATFORM-DIAGNOSTIC-L
 
 ## Requirement mapping
 
-| Requirement | Design section |
-| --- | --- |
+| Requirement                           | Design section                                    |
+| ------------------------------------- | ------------------------------------------------- |
 | `REQ-PLATFORM-DIAGNOSTIC-LOGGING-001` | [Migrated source detail](#migrated-source-detail) |
 
 ## Migrated source detail
@@ -161,6 +163,13 @@ paired [system design](../system-design/browser-console-retention.md).
   synchronously in the intercepted console call. A full staging queue drops
   lower-priority `debug`/`info` entries first and records loss metadata; it
   never delays the original console call.
+- A browser debug producer that scans a growing collection coalesces its own
+  derived payload before it calls `console.debug`. The
+  `messages:process` producer keeps the latest inputs and emits one trailing
+  sample at most once per 250 ms. Later updates replace the pending sample.
+  This bounds message counting, grouping summaries, console formatting, and
+  browser-log staging during a stream without removing the final latest-state
+  diagnostic.
 - Bundle collection, JSONL writing, cleanup, and download preparation run
   outside the route handler. An identity owns at most one active job, at most
   eight jobs may collect or wait process-wide, and one archive build runs

--- a/docs/specs/ui/README.md
+++ b/docs/specs/ui/README.md
@@ -11,19 +11,16 @@ owners:
 
 ## Purpose
 
-The UI system owns presentation behavior for the web application, including
-responsive desktop and mobile surfaces.
+The UI system owns web presentation behavior for desktop and mobile surfaces.
 
 ## Ownership
 
-This system owns navigation, settings presentation, boards, task and review
-surfaces, walkthroughs, chat controls, visual feedback, and responsive
-interaction contracts that do not own backend state.
+This system owns navigation, settings, boards, task/review surfaces,
+walkthroughs, chat controls, visual feedback, and responsive interaction
+contracts without backend-state ownership.
 
-A control is not UI-owned only because it appears in the web application. A
-provider or task system keeps ownership when the control configures or displays
-that system's state. The UI system owns only the independent presentation
-contract that other capabilities can reuse.
+Controls that configure or display provider/task state remain owned by that
+system. The UI system owns only independent, reusable presentation contracts.
 
 ## Exclusions
 
@@ -181,8 +178,8 @@ contract that other capabilities can reuse.
 
 ## Migration record
 
-Migration remains in progress while legacy source detail is extracted from the
-canonical requirement and system-design documents above.
+Legacy source detail is still moving to the canonical requirement and
+system-design documents above.
 
 ## Related systems
 

--- a/docs/specs/ui/README.md
+++ b/docs/specs/ui/README.md
@@ -177,6 +177,7 @@ contract that other capabilities can reuse.
 - [Command-panel Sidebar Task Reveal](system-design/command-panel-sidebar-task-reveal.md)
 - [Terminal Rendering](system-design/terminal-rendering.md)
 - [Task Transcript History Visibility](system-design/task-prompt-transcript-visibility.md)
+- [Transcript Auto-scroll Stability](system-design/transcript-auto-scroll.md)
 
 ## Migration record
 

--- a/docs/specs/ui/requirements/transcript-auto-scroll.md
+++ b/docs/specs/ui/requirements/transcript-auto-scroll.md
@@ -2,9 +2,11 @@
 status: active
 system: ui
 created: 2026-07-30
+updated: 2026-08-27
 owners:
   - cfl
 ---
+
 # Transcript Auto-scroll Stability Requirements
 
 ## Overview
@@ -25,6 +27,10 @@ Users who turn off transcript auto-scroll expect the visible conversation to sta
 - **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.4:** **GIVEN** an overflowing native transcript at its bottom with auto-scroll disabled, **WHEN** a new message is appended, **THEN** the transcript's `scrollTop` remains at the pre-append position.
 - **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.5:** **GIVEN** an overflowing native transcript with auto-scroll enabled, **WHEN** new content arrives, **THEN** the transcript remains pinned to the bottom.
 - **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.6:** **GIVEN** clarification recovery has accepted its retry prompt, **WHEN** its asynchronous dispatch is scheduled, **THEN** the recovery call completes before the intentionally blocked prompt is released.
+- **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.7:** **GIVEN** an enabled transcript that is
+  pinned to the bottom, **WHEN** streamed content commits, **THEN** the
+  transcript remains pinned without a synchronous content-size read in the
+  message-commit path.
 
 ## Migrated source detail
 

--- a/docs/specs/ui/system-design/transcript-auto-scroll.md
+++ b/docs/specs/ui/system-design/transcript-auto-scroll.md
@@ -1,0 +1,83 @@
+---
+status: current
+system: ui
+requirements:
+  - REQ-UI-TRANSCRIPT-AUTO-SCROLL-001
+created: 2026-08-27
+owners:
+  - kandev
+---
+
+# Transcript Auto-scroll Stability System Design
+
+## Purpose and boundaries
+
+This design keeps an enabled transcript pinned during streamed updates without
+forcing browser layout during each React commit. It preserves disabled-state
+freezing, explicit navigation, prepend restoration, and catch-up after the user
+enables auto-scroll again.
+
+## Requirement mapping
+
+| Requirement                         | Design section                                                                                                                        |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `REQ-UI-TRANSCRIPT-AUTO-SCROLL-001` | [Bottom placement](#bottom-placement), [Interaction boundaries](#interaction-boundaries), [Responsive behavior](#responsive-behavior) |
+
+## Bottom placement
+
+`message-list-native-scroll.ts` owns one helper that places the native scroll
+container at its maximum vertical offset with a write-only scroll command. The
+common message-update and work-start paths call this helper. They do not read
+`scrollHeight`, `clientHeight`, a bounding rectangle, or computed style before
+the write.
+
+The browser clamps the requested offset to the current maximum. The existing
+near-bottom reference remains the decision input. The helper does not add a
+second animation frame, smooth scrolling, or a resize observer.
+
+Tests instrument the common append path. A `scrollHeight` getter fails the test
+if that path reads it. The scroll setter records the maximum-offset request.
+
+## Interaction boundaries
+
+The optimization does not replace geometry reads that answer a user-action
+question. Scroll events can still read geometry to decide whether the reader
+is near the bottom. Re-enabling auto-scroll can still compare the viewport with
+content to decide whether catch-up is necessary. Pagination and prepend
+restoration retain their existing measurements.
+
+The write-only helper runs only when all existing guards allow automatic
+placement:
+
+- auto-scroll is enabled.
+- The reader is near the bottom.
+- No user programmatic scroll lock is active.
+- No layout restoration is pending.
+
+Disabled auto-scroll continues to restore the captured `scrollTop`. New
+content cannot move that frozen position through application code or browser
+overflow anchoring.
+
+## Responsive behavior
+
+Desktop and mobile use the same native transcript, store state, and bottom
+placement helper. The transcript remains the only vertical scroll owner. No
+control, copy, layout, or touch target changes.
+
+The nearest mobile exemplar is the current task Chat tab in
+`apps/web/components/task/task-layout.tsx`. Existing desktop and mobile
+auto-scroll Playwright scenarios remain the browser contract. Both viewports
+must prove enabled bottom pinning and disabled position freezing after the
+change.
+
+## Failure modes
+
+- If the container is not mounted, the helper performs no work.
+- If a browser clamps a large requested offset, the result is the native
+  maximum scroll position.
+- If a layout restore or explicit navigation owns the scroll, the existing
+  guards suppress bottom placement until that owner releases control.
+
+## Related decisions
+
+- [Isolate Replaceable Session Stream Traffic](../../../decisions/2026-08-02-isolate-replaceable-session-stream-traffic.md)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3093/7a8011e9a3ae.html)
<!-- kandev-pr-walkthrough-end -->

Repeated browser-log encoding, message-store transactions, and transcript layout reads added avoidable main-thread work during active sessions. The runtime now coalesces those paths while preserving diagnostic retention, message ordering, and desktop/mobile scroll behavior.

## Important Changes

- Collect browser diagnostics for one bounded 250 ms window and reuse prepared entries and byte counts through IndexedDB persistence.
- Apply replaceable message updates from one animation frame in one Zustand/Immer transaction while keeping semantic barriers ordered.
- Place enabled native transcripts at the browser-clamped bottom with a write-only scroll command, and add desktop/mobile live-message coverage.

## Validation

- Focused Vitest suites: 167 tests passed across logger, message scheduler/store, and transcript scroll paths.
- `pnpm --filter @kandev/web run typecheck`
- Focused ESLint and `python3 scripts/lint-spec-files.py --all`
- `make build-web`
- Desktop auto-scroll E2E: 9 passed with Chromium.
- Mobile auto-scroll E2E: 5 passed with Pixel 5 emulation.
- Commit hooks: all applicable hooks passed, with no bypass.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop transcript view](https://raw.githubusercontent.com/kdlbs/kandev/3ae551baca4a6fbdd021c028b74674308b3189c5/pr-performance-screenshots--transcript-bottom.png)

![Mobile transcript view](https://raw.githubusercontent.com/kdlbs/kandev/3ae551baca4a6fbdd021c028b74674308b3189c5/mobile-pr-performance-screenshots--transcript-bottom.png)
<!-- kandev-screenshots-end -->