### PR TITLE
fix: settle stale automation runs

### DIFF
--- a/apps/backend/internal/agent/runtime/facade.go
+++ b/apps/backend/internal/agent/runtime/facade.go
@@ -14,6 +14,12 @@ func New(backend Backend) Runtime {
 	return &facade{backend: backend}
 }
 
+// IsNotFound reports whether err identifies runtime execution state that no
+// longer exists, including the lifecycle sentinel behind the runtime facade.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound) || errors.Is(err, lifecycle.ErrExecutionNotFound)
+}
+
 // facade is the default Runtime implementation: a thin adapter over
 // the lifecycle Manager (or any Backend).
 type facade struct {

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -916,6 +916,14 @@ func (s *Service) StopRun(ctx context.Context, automationID, runID string) (*Aut
 		}
 	}
 	if err := s.store.MarkRunTerminal(ctx, run.ID, run.SessionID, run.TurnID, RunStatusFailed, "stopped by user"); err != nil {
+		// The completion path can settle the run after the initial open check but
+		// before this terminal write. Treat that race as an idempotent success.
+		stored, getErr := s.store.GetRun(ctx, run.ID)
+		if getErr == nil && stored != nil && stored.Status != RunStatusTriggered && stored.Status != RunStatusTaskCreated {
+			run.Status = stored.Status
+			run.ErrorMessage = stored.ErrorMessage
+			return run, nil
+		}
 		return nil, err
 	}
 	run.Status = RunStatusFailed

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -62,12 +62,6 @@ var ErrInvalidContinuationPolicy = errors.New("automation: invalid continuation 
 // launch work for this run.
 var ErrAutomationRunNotDispatchable = errors.New("automation: run is not dispatchable")
 
-// ErrAutomationRunNotLive is returned by the orchestrator when an exact run
-// binding is no longer the live turn. The service maps that outcome to the
-// same not-found result as a missing or terminal run, so a stale stop request
-// cannot affect a newer turn in a shared session.
-var ErrAutomationRunNotLive = errors.New("automation: run is not live")
-
 // RunStopper cancels one exact task/session/turn binding. The bool is false
 // when the binding is already terminal or stale; that is not an internal
 // failure and must not cancel a successor turn.
@@ -916,12 +910,9 @@ func (s *Service) StopRun(ctx context.Context, automationID, runID string) (*Aut
 		if s.runStopper == nil {
 			return nil, errors.New("automation run stopper is not configured")
 		}
-		stopped, stopErr := s.runStopper.StopAutomationRun(ctx, run.TaskID, run.SessionID, run.TurnID)
+		_, stopErr := s.runStopper.StopAutomationRun(ctx, run.TaskID, run.SessionID, run.TurnID)
 		if stopErr != nil {
 			return nil, stopErr
-		}
-		if !stopped {
-			return nil, ErrAutomationNotFound
 		}
 	}
 	if err := s.store.MarkRunTerminal(ctx, run.ID, run.SessionID, run.TurnID, RunStatusFailed, "stopped by user"); err != nil {

--- a/apps/backend/internal/automation/service_run_terminal_test.go
+++ b/apps/backend/internal/automation/service_run_terminal_test.go
@@ -1,0 +1,161 @@
+package automation
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type runStopperStub struct {
+	stopped bool
+	err     error
+}
+
+func (s runStopperStub) StopAutomationRun(context.Context, string, string, string) (bool, error) {
+	return s.stopped, s.err
+}
+
+type runLivenessStub struct {
+	live bool
+	err  error
+}
+
+func (s runLivenessStub) AutomationRunLive(context.Context, string, string, string) (bool, error) {
+	return s.live, s.err
+}
+
+// @covers AC-OFFICE-AUTOMATION-CONTINUITY-003.3
+// @covers AC-OFFICE-AUTOMATION-TARGETS-002.4
+func TestStopRun(t *testing.T) {
+	hardErr := errors.New("runtime stop failed")
+	tests := []struct {
+		name               string
+		status             RunStatus
+		stopped            bool
+		stopErr            error
+		missing            bool
+		automationMismatch bool
+		wantErr            error
+		wantStatus         RunStatus
+		wantMessage        string
+	}{
+		{name: "active turn stopped", status: RunStatusTaskCreated, stopped: true, wantStatus: RunStatusFailed, wantMessage: "stopped by user"},
+		{name: "stale open turn settles", status: RunStatusTaskCreated, stopped: false, wantStatus: RunStatusFailed, wantMessage: "stopped by user"},
+		{name: "missing run", missing: true, wantErr: ErrAutomationNotFound},
+		{name: "foreign run", status: RunStatusTaskCreated, automationMismatch: true, wantErr: ErrAutomationNotFound, wantStatus: RunStatusTaskCreated},
+		{name: "terminal run", status: RunStatusSucceeded, wantErr: ErrAutomationNotFound, wantStatus: RunStatusSucceeded},
+		{name: "hard stop error", status: RunStatusTaskCreated, stopErr: hardErr, wantErr: hardErr, wantStatus: RunStatusTaskCreated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(t)
+			ctx := context.Background()
+			requested := &Automation{WorkspaceID: "workspace", Name: "requested", Enabled: true}
+			if err := svc.store.CreateAutomation(ctx, requested); err != nil {
+				t.Fatal(err)
+			}
+			runID := "missing-run"
+			if !tt.missing {
+				owner := requested
+				if tt.automationMismatch {
+					owner = &Automation{WorkspaceID: "workspace", Name: "other", Enabled: true}
+					if err := svc.store.CreateAutomation(ctx, owner); err != nil {
+						t.Fatal(err)
+					}
+				}
+				run := &AutomationRun{
+					AutomationID: owner.ID,
+					TriggerType:  TriggerTypeScheduled,
+					Status:       tt.status,
+					TaskID:       "task",
+					SessionID:    "session",
+					TurnID:       "turn",
+				}
+				if err := svc.store.CreateRun(ctx, run); err != nil {
+					t.Fatal(err)
+				}
+				runID = run.ID
+			}
+			svc.SetRunStopper(runStopperStub{stopped: tt.stopped, err: tt.stopErr})
+
+			got, err := svc.StopRun(ctx, requested.ID, runID)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("StopRun error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if got == nil || got.Status != tt.wantStatus || got.ErrorMessage != tt.wantMessage {
+					t.Fatalf("StopRun result = %+v, want status %q and message %q", got, tt.wantStatus, tt.wantMessage)
+				}
+			}
+			if tt.missing {
+				return
+			}
+			stored, getErr := svc.store.GetRun(ctx, runID)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if stored.Status != tt.wantStatus || stored.ErrorMessage != tt.wantMessage {
+				t.Fatalf("stored run = %+v, want status %q and message %q", stored, tt.wantStatus, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// @covers AC-OFFICE-AUTOMATION-CONTINUITY-003.4
+func TestReconcileOpenRuns(t *testing.T) {
+	transientErr := errors.New("database temporarily unavailable")
+	tests := []struct {
+		name        string
+		bound       bool
+		live        bool
+		livenessErr error
+		wantStatus  RunStatus
+		wantMessage string
+	}{
+		{name: "gone execution normalized to not live", bound: true, wantStatus: RunStatusFailed, wantMessage: "automation turn was stale after backend recovery"},
+		{name: "transient liveness error preserves run", bound: true, livenessErr: transientErr, wantStatus: RunStatusTaskCreated},
+		{name: "not live settles run", bound: true, wantStatus: RunStatusFailed, wantMessage: "automation turn was stale after backend recovery"},
+		{name: "live run stays open", bound: true, live: true, wantStatus: RunStatusTaskCreated},
+		{name: "unbound admitted run settles", wantStatus: RunStatusFailed, wantMessage: "backend stopped before the automation turn was bound"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(t)
+			ctx := context.Background()
+			automation := &Automation{WorkspaceID: "workspace", Name: "reconcile", Enabled: true}
+			if err := svc.store.CreateAutomation(ctx, automation); err != nil {
+				t.Fatal(err)
+			}
+			run := &AutomationRun{
+				AutomationID: automation.ID,
+				TriggerType:  TriggerTypeScheduled,
+				Status:       RunStatusTriggered,
+			}
+			if tt.bound {
+				run.Status = RunStatusTaskCreated
+				run.TaskID = "task"
+				run.SessionID = "session"
+				run.TurnID = "turn"
+			}
+			if err := svc.store.CreateRun(ctx, run); err != nil {
+				t.Fatal(err)
+			}
+			svc.SetRunLivenessChecker(runLivenessStub{live: tt.live, err: tt.livenessErr})
+
+			if err := svc.ReconcileOpenRuns(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			stored, err := svc.store.GetRun(ctx, run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stored.Status != tt.wantStatus || stored.ErrorMessage != tt.wantMessage {
+				t.Fatalf("stored run = %+v, want status %q and message %q", stored, tt.wantStatus, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/automation/service_run_terminal_test.go
+++ b/apps/backend/internal/automation/service_run_terminal_test.go
@@ -9,9 +9,13 @@ import (
 type runStopperStub struct {
 	stopped bool
 	err     error
+	onStop  func()
 }
 
 func (s runStopperStub) StopAutomationRun(context.Context, string, string, string) (bool, error) {
+	if s.onStop != nil {
+		s.onStop()
+	}
 	return s.stopped, s.err
 }
 
@@ -33,6 +37,8 @@ func TestStopRun(t *testing.T) {
 		status             RunStatus
 		stopped            bool
 		stopErr            error
+		settleStatus       RunStatus
+		settleMessage      string
 		missing            bool
 		automationMismatch bool
 		wantErr            error
@@ -41,6 +47,7 @@ func TestStopRun(t *testing.T) {
 	}{
 		{name: "active turn stopped", status: RunStatusTaskCreated, stopped: true, wantStatus: RunStatusFailed, wantMessage: "stopped by user"},
 		{name: "stale open turn settles", status: RunStatusTaskCreated, stopped: false, wantStatus: RunStatusFailed, wantMessage: "stopped by user"},
+		{name: "completion settles concurrently", status: RunStatusTaskCreated, settleStatus: RunStatusSucceeded, settleMessage: "completed", wantStatus: RunStatusSucceeded, wantMessage: "completed"},
 		{name: "missing run", missing: true, wantErr: ErrAutomationNotFound},
 		{name: "foreign run", status: RunStatusTaskCreated, automationMismatch: true, wantErr: ErrAutomationNotFound, wantStatus: RunStatusTaskCreated},
 		{name: "terminal run", status: RunStatusSucceeded, wantErr: ErrAutomationNotFound, wantStatus: RunStatusSucceeded},
@@ -77,7 +84,15 @@ func TestStopRun(t *testing.T) {
 				}
 				runID = run.ID
 			}
-			svc.SetRunStopper(runStopperStub{stopped: tt.stopped, err: tt.stopErr})
+			stopper := runStopperStub{stopped: tt.stopped, err: tt.stopErr}
+			if tt.settleStatus != "" {
+				stopper.onStop = func() {
+					if err := svc.store.MarkRunTerminal(ctx, runID, "session", "turn", tt.settleStatus, tt.settleMessage); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			svc.SetRunStopper(stopper)
 
 			got, err := svc.StopRun(ctx, requested.ID, runID)
 
@@ -114,7 +129,6 @@ func TestReconcileOpenRuns(t *testing.T) {
 		wantStatus  RunStatus
 		wantMessage string
 	}{
-		{name: "gone execution normalized to not live", bound: true, wantStatus: RunStatusFailed, wantMessage: "automation turn was stale after backend recovery"},
 		{name: "transient liveness error preserves run", bound: true, livenessErr: transientErr, wantStatus: RunStatusTaskCreated},
 		{name: "not live settles run", bound: true, wantStatus: RunStatusFailed, wantMessage: "automation turn was stale after backend recovery"},
 		{name: "live run stays open", bound: true, live: true, wantStatus: RunStatusTaskCreated},

--- a/apps/backend/internal/orchestrator/automation_run_liveness_test.go
+++ b/apps/backend/internal/orchestrator/automation_run_liveness_test.go
@@ -1,0 +1,73 @@
+package orchestrator
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	runtimeapi "github.com/kandev/kandev/internal/agent/runtime"
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+type automationRunLivenessTurnService struct {
+	TurnService
+	err error
+}
+
+func (s automationRunLivenessTurnService) GetActiveTurn(context.Context, string) (*models.Turn, error) {
+	return nil, s.err
+}
+
+// @covers AC-OFFICE-AUTOMATION-CONTINUITY-003.4
+func TestAutomationRunLiveNormalizesGoneExecutionErrors(t *testing.T) {
+	transientErr := errors.New("database temporarily unavailable")
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{name: "runtime not found", err: fmt.Errorf("inspect turn: %w", runtimeapi.ErrNotFound)},
+		{name: "executor execution not found", err: fmt.Errorf("inspect turn: %w", executor.ErrExecutionNotFound)},
+		{name: "lifecycle execution not found", err: fmt.Errorf("inspect turn: %w", lifecycle.ErrExecutionNotFound)},
+		{name: "SQL row not found", err: fmt.Errorf("inspect turn: %w", sql.ErrNoRows)},
+		{name: "transient error", err: transientErr, wantErr: transientErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			ctx := context.Background()
+			now := time.Now().UTC()
+			if err := repo.CreateTask(ctx, &models.Task{
+				ID: "task", WorkspaceID: "workspace", Origin: models.TaskOriginAutomationRun,
+				CreatedAt: now, UpdatedAt: now,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+				ID: "session", TaskID: "task", State: models.TaskSessionStateWaitingForInput,
+				StartedAt: now, UpdatedAt: now,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			svc := &Service{
+				repo:        repo,
+				turnService: automationRunLivenessTurnService{err: tt.err},
+			}
+
+			live, err := svc.AutomationRunLive(ctx, "task", "session", "turn")
+
+			if live {
+				t.Fatal("AutomationRunLive returned live for a failed liveness inspection")
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("AutomationRunLive error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/orchestrator/automation_run_liveness_test.go
+++ b/apps/backend/internal/orchestrator/automation_run_liveness_test.go
@@ -71,3 +71,57 @@ func TestAutomationRunLiveNormalizesGoneExecutionErrors(t *testing.T) {
 		})
 	}
 }
+
+// @covers AC-OFFICE-AUTOMATION-CONTINUITY-003.4
+func TestAutomationRunLiveNormalizesMissingTaskAndSession(t *testing.T) {
+	tests := []struct {
+		name          string
+		deleteTask    bool
+		deleteSession bool
+	}{
+		{name: "missing task", deleteTask: true},
+		{name: "deleted session", deleteSession: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			ctx := context.Background()
+			now := time.Now().UTC()
+			task := &models.Task{
+				ID: "task", WorkspaceID: "workspace", Origin: models.TaskOriginAutomationRun,
+				CreatedAt: now, UpdatedAt: now,
+			}
+			if err := repo.CreateTask(ctx, task); err != nil {
+				t.Fatal(err)
+			}
+			session := &models.TaskSession{
+				ID: "session", TaskID: task.ID, State: models.TaskSessionStateWaitingForInput,
+				StartedAt: now, UpdatedAt: now,
+			}
+			if err := repo.CreateTaskSession(ctx, session); err != nil {
+				t.Fatal(err)
+			}
+			if tt.deleteTask {
+				if err := repo.DeleteTask(ctx, task.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.deleteSession {
+				if err := repo.DeleteTaskSession(ctx, session.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			svc := &Service{repo: repo}
+			live, err := svc.AutomationRunLive(ctx, task.ID, session.ID, "turn")
+
+			if live {
+				t.Fatal("AutomationRunLive returned live for a missing task or session")
+			}
+			if err != nil {
+				t.Fatalf("AutomationRunLive error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
+	taskrepo "github.com/kandev/kandev/internal/task/repository"
 	"github.com/kandev/kandev/internal/worktree"
 )
 
@@ -113,7 +114,9 @@ func (s *Service) automationRunLive(ctx context.Context, taskID, sessionID, turn
 func automationRunExecutionGone(err error) bool {
 	return runtimeapi.IsNotFound(err) ||
 		errors.Is(err, executor.ErrExecutionNotFound) ||
-		errors.Is(err, sql.ErrNoRows)
+		errors.Is(err, sql.ErrNoRows) ||
+		errors.Is(err, taskrepo.ErrTaskNotFound) ||
+		errors.Is(err, models.ErrTaskSessionNotFound)
 }
 
 func (s *Service) automationTurnMatches(ctx context.Context, taskID, sessionID, turnID string, requireStoppable bool) (bool, error) {

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,10 +12,12 @@ import (
 
 	"go.uber.org/zap"
 
+	runtimeapi "github.com/kandev/kandev/internal/agent/runtime"
 	"github.com/kandev/kandev/internal/automation"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/worktree"
 )
@@ -76,6 +79,14 @@ func (s *Service) StopAutomationRun(ctx context.Context, taskID, sessionID, turn
 // live permission blocker remains open. Missing runtime state is not enough to
 // keep a parked/stale binding open forever.
 func (s *Service) AutomationRunLive(ctx context.Context, taskID, sessionID, turnID string) (bool, error) {
+	live, err := s.automationRunLive(ctx, taskID, sessionID, turnID)
+	if automationRunExecutionGone(err) {
+		return false, nil
+	}
+	return live, err
+}
+
+func (s *Service) automationRunLive(ctx context.Context, taskID, sessionID, turnID string) (bool, error) {
 	if taskID == "" || sessionID == "" || turnID == "" || s.turnService == nil {
 		return false, nil
 	}
@@ -97,6 +108,12 @@ func (s *Service) AutomationRunLive(ctx context.Context, taskID, sessionID, turn
 		return true, nil
 	}
 	return s.hasPendingCoordinatorPermissions(ctx, sessionID)
+}
+
+func automationRunExecutionGone(err error) bool {
+	return runtimeapi.IsNotFound(err) ||
+		errors.Is(err, executor.ErrExecutionNotFound) ||
+		errors.Is(err, sql.ErrNoRows)
 }
 
 func (s *Service) automationTurnMatches(ctx context.Context, taskID, sessionID, turnID string, requireStoppable bool) (bool, error) {

--- a/docs/plans/automation-run-terminal-recovery/plan.md
+++ b/docs/plans/automation-run-terminal-recovery/plan.md
@@ -1,0 +1,99 @@
+---
+created: 2026-08-27
+status: completed
+requirements:
+  - REQ-OFFICE-AUTOMATION-CONTINUITY-003
+  - REQ-OFFICE-AUTOMATION-TARGETS-002
+system_design:
+  - ../../specs/office/system-design/automation-runs.md
+legacy_specs: []
+---
+
+# Implementation Plan: Automation Run Terminal Recovery
+
+## Overview
+
+Repair exact-run stopping and restart reconciliation. A stale runtime binding must not leave an
+open automation run that consumes its concurrency slot. First add focused service and orchestrator
+regressions. Then make the smallest boundary corrections. Run the requested backend verification
+before the `fix:` Conventional Commit.
+
+## Scope
+
+### In scope
+
+- Terminalize a genuinely open run when its exact-turn stopper reports that no active turn remains.
+- Preserve not-found behavior for a missing, foreign, or already terminal run.
+- Normalize typed gone-execution liveness errors to not live at the orchestrator boundary.
+- Preserve open runs when liveness inspection fails with a transient error.
+- Cover exact stop and recovery outcomes with table-driven Go tests.
+
+### Out of scope
+
+- Changing automation admission, concurrency limits, run statuses, API payloads, or frontend copy.
+- Cancelling a successor turn when a stored exact-turn binding is stale.
+- Treating untyped error strings as missing executions.
+- Repairing or deleting the supplied local database row.
+
+## Technical approach
+
+### Exact-run stop
+
+Update `automation.Service.StopRun` in `apps/backend/internal/automation/service.go`. Keep the loaded
+open row as the authority after automation ownership and status validation. If
+`RunStopper.StopAutomationRun` returns either `true` or `false` without an error, settle that exact
+row. Use `Store.MarkRunTerminal(..., RunStatusFailed, "stopped by user")`, and return success. Return
+`ErrAutomationNotFound` only for a missing row, automation mismatch, or non-open status. Propagate a
+stopper error without settling the row.
+
+Remove or correct the unused `ErrAutomationRunNotLive` documentation because stale exact-turn state
+no longer maps an already-loaded open run to not-found.
+
+### Restart liveness
+
+Update `orchestrator.Service.AutomationRunLive` in
+`apps/backend/internal/orchestrator/event_handlers_automation.go` so its public boundary maps a
+wrapped `runtime.ErrNotFound`, `executor.ErrExecutionNotFound`,
+`lifecycle.ErrExecutionNotFound`, or `sql.ErrNoRows` to `(false, nil)` with `errors.Is`. Keep every
+other error unchanged. The runtime package owns lifecycle-sentinel recognition. The orchestrator
+owns runtime, executor, and SQL classification. `automation.Service.ReconcileOpenRuns` keeps its
+conservative rule. `live=false, err=nil` settles the run. A transient error leaves it open for
+retry. Do not add runtime, executor, lifecycle, or SQL imports to `internal/automation`.
+
+## Tests
+
+- `AC-OFFICE-AUTOMATION-CONTINUITY-003.3` and
+  `AC-OFFICE-AUTOMATION-TARGETS-002.4`: add table-driven `TestStopRun` coverage for a successful
+  active stop and a false-on-open stale stop. Cover real miss, mismatch, non-open state, and a hard
+  stopper error. Assert the stored row and returned error, not only fake calls.
+- `AC-OFFICE-AUTOMATION-CONTINUITY-003.4`: add table-driven `TestReconcileOpenRuns` coverage for a
+  normalized gone execution and a transient liveness error. Cover `live=false`, `live=true`, and an
+  unbound admitted run. Assert terminal or preserved store state.
+- Add orchestrator table coverage that injects each required wrapped sentinel through
+  `AutomationRunLive`, proves `(false, nil)`, and proves a transient error still propagates.
+
+New tests go in new files because the neighboring service and automation-handler test files already
+exceed or approach the backend effective-line limit.
+
+## Work orders
+
+- [x] [Task 01: Repair automation run terminalization](task-01-repair-run-terminalization.md)
+
+## Verification results
+
+- The focused automation test command passed 13 cases.
+- The focused orchestrator test command passed 6 cases.
+- `make test` passed after removal of three task-runtime configuration variables from the test
+  process. The first run exposed only configuration-discovery fixture conflicts.
+- `make lint` passed with zero issues.
+- `golangci-lint run ./... --new-from-rev=c2e2b3a430d0bd865a3d0bc159e9d8543bc1b02d`
+  passed with zero issues.
+- The specification linter and documentation diff validation passed.
+
+## Risks
+
+- Settling before validation of the stored automation ID or open status can hide a real miss or alter
+  another automation's run.
+- Broad error normalization can turn a transient database or runtime error into a false stale
+  result. Classification must use only the four typed sentinels.
+- A stale binding must never cause cancellation of a newer turn in the shared session.

--- a/docs/plans/automation-run-terminal-recovery/plan.md
+++ b/docs/plans/automation-run-terminal-recovery/plan.md
@@ -23,8 +23,10 @@ before the `fix:` Conventional Commit.
 ### In scope
 
 - Terminalize a genuinely open run when its exact-turn stopper reports that no active turn remains.
+- Treat a concurrent normal completion after the open-row check as an idempotent stop success.
 - Preserve not-found behavior for a missing, foreign, or already terminal run.
 - Normalize typed gone-execution liveness errors to not live at the orchestrator boundary.
+- Normalize typed task and session repository disappearance at the same boundary.
 - Preserve open runs when liveness inspection fails with a transient error.
 - Cover exact stop and recovery outcomes with table-driven Go tests.
 
@@ -44,7 +46,9 @@ open row as the authority after automation ownership and status validation. If
 `RunStopper.StopAutomationRun` returns either `true` or `false` without an error, settle that exact
 row. Use `Store.MarkRunTerminal(..., RunStatusFailed, "stopped by user")`, and return success. Return
 `ErrAutomationNotFound` only for a missing row, automation mismatch, or non-open status. Propagate a
-stopper error without settling the row.
+stopper error without settling the row. If the terminal write loses a race to normal completion,
+reload the row and return its terminal state as an idempotent success; propagate the write error only
+when the row is still open or cannot be read.
 
 Remove or correct the unused `ErrAutomationRunNotLive` documentation because stale exact-turn state
 no longer maps an already-loaded open run to not-found.
@@ -54,23 +58,26 @@ no longer maps an already-loaded open run to not-found.
 Update `orchestrator.Service.AutomationRunLive` in
 `apps/backend/internal/orchestrator/event_handlers_automation.go` so its public boundary maps a
 wrapped `runtime.ErrNotFound`, `executor.ErrExecutionNotFound`,
-`lifecycle.ErrExecutionNotFound`, or `sql.ErrNoRows` to `(false, nil)` with `errors.Is`. Keep every
-other error unchanged. The runtime package owns lifecycle-sentinel recognition. The orchestrator
-owns runtime, executor, and SQL classification. `automation.Service.ReconcileOpenRuns` keeps its
-conservative rule. `live=false, err=nil` settles the run. A transient error leaves it open for
-retry. Do not add runtime, executor, lifecycle, or SQL imports to `internal/automation`.
+`lifecycle.ErrExecutionNotFound`, `sql.ErrNoRows`, task-repository task-not-found, or task-session
+not-found to `(false, nil)` with `errors.Is`. Keep every other error unchanged. The runtime package
+owns lifecycle-sentinel recognition. The orchestrator owns runtime, executor, repository, and SQL
+classification. `automation.Service.ReconcileOpenRuns` keeps its conservative rule.
+`live=false, err=nil` settles the run. A transient error leaves it open for retry. Do not add
+runtime, executor, lifecycle, repository, or SQL imports to `internal/automation`.
 
 ## Tests
 
 - `AC-OFFICE-AUTOMATION-CONTINUITY-003.3` and
   `AC-OFFICE-AUTOMATION-TARGETS-002.4`: add table-driven `TestStopRun` coverage for a successful
   active stop and a false-on-open stale stop. Cover real miss, mismatch, non-open state, and a hard
-  stopper error. Assert the stored row and returned error, not only fake calls.
+  stopper error, plus a concurrent completion race. Assert the stored row and returned error, not
+  only fake calls.
 - `AC-OFFICE-AUTOMATION-CONTINUITY-003.4`: add table-driven `TestReconcileOpenRuns` coverage for a
   normalized gone execution and a transient liveness error. Cover `live=false`, `live=true`, and an
   unbound admitted run. Assert terminal or preserved store state.
 - Add orchestrator table coverage that injects each required wrapped sentinel through
-  `AutomationRunLive`, proves `(false, nil)`, and proves a transient error still propagates.
+  `AutomationRunLive`, proves `(false, nil)`, proves task/session deletion is normalized with a real
+  repository, and proves a transient error still propagates.
 
 New tests go in new files because the neighboring service and automation-handler test files already
 exceed or approach the backend effective-line limit.
@@ -89,11 +96,14 @@ exceed or approach the backend effective-line limit.
 - `golangci-lint run ./... --new-from-rev=c2e2b3a430d0bd865a3d0bc159e9d8543bc1b02d`
   passed with zero issues.
 - The specification linter and documentation diff validation passed.
+- PR fixup added idempotent concurrent-stop handling and task/session repository not-found
+  normalization, with focused regressions passing.
 
 ## Risks
 
 - Settling before validation of the stored automation ID or open status can hide a real miss or alter
   another automation's run.
 - Broad error normalization can turn a transient database or runtime error into a false stale
-  result. Classification must use only the four typed sentinels.
+  result. Classification must use only the six typed runtime, executor, SQL, task, and session
+  sentinels.
 - A stale binding must never cause cancellation of a newer turn in the shared session.

--- a/docs/plans/automation-run-terminal-recovery/task-01-repair-run-terminalization.md
+++ b/docs/plans/automation-run-terminal-recovery/task-01-repair-run-terminalization.md
@@ -1,0 +1,110 @@
+---
+id: "01-repair-run-terminalization"
+title: "Repair automation run terminalization"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-OFFICE-AUTOMATION-CONTINUITY-003
+  - REQ-OFFICE-AUTOMATION-TARGETS-002
+acceptance_criteria:
+  - AC-OFFICE-AUTOMATION-CONTINUITY-003.3
+  - AC-OFFICE-AUTOMATION-CONTINUITY-003.4
+  - AC-OFFICE-AUTOMATION-TARGETS-002.4
+system_design:
+  - ../../specs/office/system-design/automation-runs.md
+---
+
+# Task 01: Repair Automation Run Terminalization
+
+## Summary
+
+Make exact-run stop succeed for an already-loaded open run when its bound turn is stale. Make
+restart reconciliation treat typed missing-execution errors as definitive absence. Use strict
+red-green-refactor and keep transient errors retryable.
+
+## In scope
+
+- Add table-driven service regressions for stop and reconciliation state transitions.
+- Add orchestrator boundary regressions for all required typed gone-execution errors.
+- Correct `Service.StopRun` and `Service.AutomationRunLive` with the minimum behavior change.
+- Format changed Go files and run the requested backend test and lint gates.
+- Create a verified `fix:` Conventional Commit without bypassing hooks.
+
+## Out of scope
+
+- Frontend or protocol changes.
+- Database migration or direct repair of existing user data.
+- String matching for missing executions.
+- Changes to automation concurrency policy or run-status vocabulary.
+
+## Acceptance
+
+- A `triggered` or `task_created` run owned by the requested automation becomes failed with the
+  stop reason. The call returns success when the stopper returns either `true` or `false`. A real
+  miss, mismatch, or non-open run remains not-found. A hard error leaves the row open.
+- Wrapped runtime, executor, lifecycle, and SQL not-found sentinels make `AutomationRunLive` return
+  not live without error. Reconciliation then fails the exact run. A transient error preserves it.
+- A live run remains open, an explicit not-live run settles, and an unbound admitted run settles
+  through its existing recovery reason.
+
+## Verification
+
+```bash
+go test -tags fts5 ./internal/automation -run 'Test(StopRun|ReconcileOpenRuns)$'
+go test -tags fts5 ./internal/orchestrator -run '^TestAutomationRunLive'
+make test
+make lint
+golangci-lint run ./... --new-from-rev=c2e2b3a430d0bd865a3d0bc159e9d8543bc1b02d
+git diff --check
+```
+
+Run every command from `apps/backend`. Before the verification, run `gofmt -w` on every changed Go
+file. After the verification passes, use the repository `/commit` workflow with a `fix:` header.
+Do not use `--no-verify`.
+
+## Files likely touched
+
+- `apps/backend/internal/automation/service.go`
+- `apps/backend/internal/automation/service_run_terminal_test.go`
+- `apps/backend/internal/agent/runtime/facade.go`
+- `apps/backend/internal/orchestrator/event_handlers_automation.go`
+- `apps/backend/internal/orchestrator/automation_run_liveness_test.go`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Incorrectly broad missing-execution classification can terminalize a run during a transient
+  outage.
+- Stop must preserve exact-run isolation when a shared session already has a successor turn.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `AC-OFFICE-AUTOMATION-CONTINUITY-003.3` and `.4`.
+- `AC-OFFICE-AUTOMATION-TARGETS-002.4`.
+- `docs/specs/office/system-design/automation-runs.md` API and failure behavior.
+- The reported read-only runtime evidence and current `StopRun`, `ReconcileOpenRuns`,
+  `StopAutomationRun`, and `AutomationRunLive` implementations.
+
+## Results
+
+- RED: `TestStopRun/stale_open_turn_settles` failed because `StopRun` returned
+  `ErrAutomationNotFound`.
+- RED: the runtime, executor, and lifecycle liveness cases failed because
+  `AutomationRunLive` returned each wrapped error.
+- GREEN: `StopRun` now settles an already-loaded open run after both true and false stop results.
+- GREEN: `AutomationRunLive` now maps the four typed gone-execution errors to not live without an
+  error. Other errors remain retryable.
+- The focused automation command passed 13 cases. The focused orchestrator command passed 6 cases.
+- The full backend test target passed with the task-runtime configuration variables removed.
+- Both lint commands passed with zero issues.
+- The architecture hook rejected direct lifecycle imports in the orchestrator layers. The runtime
+  package now owns lifecycle-sentinel recognition.

--- a/docs/plans/automation-run-terminal-recovery/task-01-repair-run-terminalization.md
+++ b/docs/plans/automation-run-terminal-recovery/task-01-repair-run-terminalization.md
@@ -29,6 +29,8 @@ red-green-refactor and keep transient errors retryable.
 - Add table-driven service regressions for stop and reconciliation state transitions.
 - Add orchestrator boundary regressions for all required typed gone-execution errors.
 - Correct `Service.StopRun` and `Service.AutomationRunLive` with the minimum behavior change.
+- Make a completion race after the open-row check idempotent.
+- Normalize deleted task/session repository bindings at the orchestrator boundary.
 - Format changed Go files and run the requested backend test and lint gates.
 - Create a verified `fix:` Conventional Commit without bypassing hooks.
 
@@ -43,9 +45,11 @@ red-green-refactor and keep transient errors retryable.
 
 - A `triggered` or `task_created` run owned by the requested automation becomes failed with the
   stop reason. The call returns success when the stopper returns either `true` or `false`. A real
-  miss, mismatch, or non-open run remains not-found. A hard error leaves the row open.
+  miss, mismatch, or non-open run remains not-found. A hard error leaves the row open. If normal
+  completion wins the terminal-write race, the terminal result is returned as success.
 - Wrapped runtime, executor, lifecycle, and SQL not-found sentinels make `AutomationRunLive` return
-  not live without error. Reconciliation then fails the exact run. A transient error preserves it.
+  not live without error. Deleted task and session repository sentinels have the same result.
+  Reconciliation then fails the exact run. A transient error preserves it.
 - A live run remains open, an explicit not-live run settles, and an unbound admitted run settles
   through its existing recovery reason.
 
@@ -108,3 +112,5 @@ None.
 - Both lint commands passed with zero issues.
 - The architecture hook rejected direct lifecycle imports in the orchestrator layers. The runtime
   package now owns lifecycle-sentinel recognition.
+- PR fixup review remediation added a concurrent completion regression and real-repository deleted
+  task/session normalization coverage. Focused tests and formatting passed after the remediation.

--- a/docs/specs/office/system-design/automation-runs.md
+++ b/docs/specs/office/system-design/automation-runs.md
@@ -3,6 +3,8 @@ status: draft
 system: office
 requirements:
   - REQ-OFFICE-AUTOMATION-RUNS-001
+  - REQ-OFFICE-AUTOMATION-CONTINUITY-003
+  - REQ-OFFICE-AUTOMATION-TARGETS-002
 created: 2026-07-31
 owners:
   - nova28
@@ -18,6 +20,8 @@ This design preserves the technical source detail for `REQ-OFFICE-AUTOMATION-RUN
 | Requirement | Design section |
 | --- | --- |
 | `REQ-OFFICE-AUTOMATION-RUNS-001` | [Migrated source detail](#migrated-source-detail) |
+| `REQ-OFFICE-AUTOMATION-CONTINUITY-003` | [Data model](#data-model), [API surface](#api-surface), [Failure modes](#failure-modes) |
+| `REQ-OFFICE-AUTOMATION-TARGETS-002` | [Data model](#data-model), [API surface](#api-surface), [Failure modes](#failure-modes) |
 
 ## Migrated source detail
 
@@ -208,8 +212,18 @@ automation.run.stop
 ```
 
 `automation.run.stop` loads the stored task/session/turn binding; the client never supplies those
-identities. It succeeds only for an open run owned by `automation_id`. A terminal, missing, or
-foreign run returns the same not-found result and does not cancel any newer turn.
+identities. It succeeds only for an open run owned by `automation_id`. When the orchestrator still
+owns the exact active turn, it cancels that turn before the service marks the run failed. When the
+stored run is open but the exact turn is stale, a false stop result is successful. The service marks
+only the loaded run failed and releases its concurrency slot. It does not touch a successor turn. A
+terminal, missing, or foreign run returns the same not-found result. A hard stop error leaves the
+run open and is returned for retry.
+
+`AutomationRunLive` owns runtime-error normalization for restart recovery. Errors that identify a
+gone execution (`runtime.ErrNotFound`, `executor.ErrExecutionNotFound`,
+`lifecycle.ErrExecutionNotFound`, or `sql.ErrNoRows`, including wrapped errors) become
+`(false, nil)`. The automation service therefore settles the exact open run as stale. Other errors
+remain transient: `ReconcileOpenRuns` logs them and leaves the run open for a later retry.
 
 Both facts are answered in ONE statement. Two queries are two snapshots: a run
 created between them reads as a still-open `last_run` with `open_runs = 0`, so
@@ -264,6 +278,8 @@ The action is workspace-scoped: the caller must be authorized for `workspace_id`
 | A visible run is still reported as open while the health summary says there are no open runs | The detail rail/drawer continues reading until the visible run receives a terminal status, then moves it to Completed without a reload |
 | An open run falls outside the page's own run window | The open count comes from the server, not from the loaded window, so the page still reports work in flight and keeps polling |
 | A user stops a running reused turn | The action addresses its stored run/session/turn identity, cancels that exact turn, and marks only that run failed. |
+| A user stops an open run whose bound turn already ended | The exact open run becomes failed and releases its concurrency slot. The stale stop result does not become not-found. No successor turn is touched. |
+| Restart recovery cannot find the bound execution | Typed gone-execution errors normalize to not live and the exact open run becomes failed. A transient inspection error leaves the run open for a later retry. |
 
 ## Scenarios
 

--- a/docs/specs/office/system-design/automation-runs.md
+++ b/docs/specs/office/system-design/automation-runs.md
@@ -215,15 +215,18 @@ automation.run.stop
 identities. It succeeds only for an open run owned by `automation_id`. When the orchestrator still
 owns the exact active turn, it cancels that turn before the service marks the run failed. When the
 stored run is open but the exact turn is stale, a false stop result is successful. The service marks
-only the loaded run failed and releases its concurrency slot. It does not touch a successor turn. A
-terminal, missing, or foreign run returns the same not-found result. A hard stop error leaves the
-run open and is returned for retry.
+only the loaded run failed and releases its concurrency slot. It does not touch a successor turn. If
+normal completion wins the race after the open-row check, the already-terminal result is returned as
+an idempotent success. A terminal, missing, or foreign run returns the same not-found result. A hard
+stop error, or a terminal-write error while the row remains open, leaves the run open and is returned
+for retry.
 
 `AutomationRunLive` owns runtime-error normalization for restart recovery. Errors that identify a
 gone execution (`runtime.ErrNotFound`, `executor.ErrExecutionNotFound`,
-`lifecycle.ErrExecutionNotFound`, or `sql.ErrNoRows`, including wrapped errors) become
-`(false, nil)`. The automation service therefore settles the exact open run as stale. Other errors
-remain transient: `ReconcileOpenRuns` logs them and leaves the run open for a later retry.
+`lifecycle.ErrExecutionNotFound`, `sql.ErrNoRows`, or the task-repository task and session
+not-found sentinels, including wrapped errors) become `(false, nil)`. The automation service
+therefore settles the exact open run as stale. Other errors remain transient:
+`ReconcileOpenRuns` logs them and leaves the run open for a later retry.
 
 Both facts are answered in ONE statement. Two queries are two snapshots: a run
 created between them reads as a still-open `last_run` with `open_runs = 0`, so
@@ -279,7 +282,7 @@ The action is workspace-scoped: the caller must be authorized for `workspace_id`
 | An open run falls outside the page's own run window | The open count comes from the server, not from the loaded window, so the page still reports work in flight and keeps polling |
 | A user stops a running reused turn | The action addresses its stored run/session/turn identity, cancels that exact turn, and marks only that run failed. |
 | A user stops an open run whose bound turn already ended | The exact open run becomes failed and releases its concurrency slot. The stale stop result does not become not-found. No successor turn is touched. |
-| Restart recovery cannot find the bound execution | Typed gone-execution errors normalize to not live and the exact open run becomes failed. A transient inspection error leaves the run open for a later retry. |
+| Restart recovery cannot find the bound execution, task, or session | Typed runtime, executor, SQL, task, and session not-found errors normalize to not live and the exact open run becomes failed. A transient inspection error leaves the run open for a later retry. |
 
 ## Scenarios
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3096/7a1b6acb7290.html)
<!-- kandev-pr-walkthrough-end -->

Automation runs could remain open after a restart when their bound turn had already completed, blocking future firings. This change terminalizes genuinely open stale runs and treats known gone-execution liveness errors as settled runs during reconciliation.

## Validation

- `env -u KANDEV_INTERNAL_CONFIG_FILE -u KANDEV_INTERNAL_CONFIG_HOME_FILE -u KANDEV_HOME_DIR make test` (from `apps/backend`)
- `make lint` (from `apps/backend`)
- `golangci-lint run ./... --new-from-rev=c2e2b3a430d0bd865a3d0bc159e9d8543bc1b02d` (from `apps/backend`)
- `gofmt -l` on all changed Go files
- `python3 scripts/lint-spec-files.py --all`
- Focused table-driven tests for stale stopping, reconciliation, and gone-execution normalization

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->