### PR TITLE
fix: route passthrough workflow steps by profile (#3110)

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2276,9 +2276,9 @@ func (s *Service) completeAndStopSession(ctx context.Context, taskID string, ses
 }
 
 // prepareWorkflowStepSession resolves the session that must execute a workflow
-// step before any on_enter action runs. Passthrough sessions and steps without
-// an effective profile keep the current session. Profile changes delegate to
-// the existing reuse/create lifecycle helpers.
+// step before any on_enter action runs. Steps without an effective profile keep
+// the current session. Profile changes delegate to the existing reuse/create
+// lifecycle helpers regardless of the source session transport.
 func (s *Service) prepareWorkflowStepSession(
 	ctx context.Context, taskID string, session *models.TaskSession, step *wfmodels.WorkflowStep,
 ) (*models.TaskSession, bool, error) {
@@ -2287,9 +2287,6 @@ func (s *Service) prepareWorkflowStepSession(
 	}
 	if step == nil {
 		return nil, false, fmt.Errorf("workflow step is nil")
-	}
-	if s.agentManager.IsPassthroughSession(ctx, session.ID) {
-		return session, false, nil
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
 	if effectiveProfile == "" || effectiveProfile == session.AgentProfileID {
@@ -2322,7 +2319,7 @@ func (s *Service) preflightWorkflowStepCredentials(
 	currentSession *models.TaskSession,
 	targetStep *wfmodels.WorkflowStep,
 ) error {
-	if currentSession == nil || targetStep == nil || s.agentManager.IsPassthroughSession(ctx, currentSession.ID) {
+	if currentSession == nil || targetStep == nil {
 		return nil
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, targetStep)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
@@ -158,7 +158,10 @@ func TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingSte
 	}
 	log := testLogger()
 	exec := executor.NewExecutor(agentManager, repo, log, executor.ExecutorConfig{})
-	exec.SetGitHubCredentialBroker(fakePassthroughCredentialIssuer{}, "https://kandev.example/api/v1/github/credentials/resolve")
+	// The custom forge host has no persisted provider_host identity, so
+	// preflightWorkflowStepCredentials rejects it before the transition is
+	// committed. The credential broker is not called on this failure path.
+	exec.SetGitHubCredentialBroker(fakeCredentialIssuer{}, "https://kandev.example/api/v1/github/credentials/resolve")
 	svc := &Service{
 		logger: log, repo: repo, workflowStepGetter: steps, taskRepo: taskRepo, agentManager: agentManager,
 		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
@@ -187,9 +190,9 @@ func TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingSte
 	}
 }
 
-type fakePassthroughCredentialIssuer struct{}
+type fakeCredentialIssuer struct{}
 
-func (fakePassthroughCredentialIssuer) Issue(
+func (fakeCredentialIssuer) Issue(
 	context.Context, gitcredentials.Scope,
 ) (gitcredentials.Lease, error) {
 	return gitcredentials.Lease{Token: "opaque-lease"}, nil

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
@@ -1,0 +1,196 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/gitcredentials"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/orchestrator/queue"
+	"github.com/kandev/kandev/internal/orchestrator/scheduler"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/workflow/engine"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// sessionScopedPassthroughAgentManager keeps the source transport distinct
+// from the destination profile in routing tests. A global passthrough flag can
+// otherwise make the newly created destination session look like a TUI session.
+type sessionScopedPassthroughAgentManager struct {
+	*mockAgentManager
+	passthroughSessionID string
+}
+
+func (m *sessionScopedPassthroughAgentManager) IsPassthroughSession(_ context.Context, sessionID string) bool {
+	return sessionID == m.passthroughSessionID
+}
+
+func TestPrepareWorkflowStepSessionSwitchesPassthroughProfile(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step2")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	now := time.Now().UTC()
+	session.AgentProfileID = "profile-a"
+	session.ExecutorID = "exec-local"
+	session.ExecutorProfileID = "executor-profile"
+	session.IsPrimary = true
+	session.TaskEnvironmentID = "env-1"
+	session.State = models.TaskSessionStateRunning
+	session.StartedAt = now
+	session.UpdatedAt = now
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+	if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: "env-1", TaskID: "t1", Status: models.TaskEnvironmentStatusReady,
+	}); err != nil {
+		t.Fatalf("create task environment: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	step := &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", AgentProfileID: "profile-b",
+	}
+	stepGetter.steps[step.ID] = step
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{
+		ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", State: v1.TaskStateInProgress,
+	}
+	baseAgentManager := &mockAgentManager{}
+	agentManager := &sessionScopedPassthroughAgentManager{
+		mockAgentManager:     baseAgentManager,
+		passthroughSessionID: session.ID,
+	}
+	log := testLogger()
+	exec := executor.NewExecutor(agentManager, repo, log, executor.ExecutorConfig{})
+	svc := createTestServiceWithAgent(repo, stepGetter, taskRepo, agentManager)
+	svc.logger = log
+	svc.executor = exec
+	svc.scheduler = scheduler.NewScheduler(queue.NewTaskQueue(10), exec, taskRepo, log, scheduler.SchedulerConfig{})
+
+	effective, switched, err := svc.prepareWorkflowStepSession(ctx, "t1", session, step)
+	if err != nil {
+		t.Fatalf("prepareWorkflowStepSession returned error: %v", err)
+	}
+	if !switched {
+		t.Fatal("passthrough source session should switch to the fixed step profile")
+	}
+	if effective.AgentProfileID != step.AgentProfileID {
+		t.Fatalf("effective profile = %q, want %q", effective.AgentProfileID, step.AgentProfileID)
+	}
+	if effective.TaskEnvironmentID != session.TaskEnvironmentID {
+		t.Fatalf("destination environment = %q, want %q", effective.TaskEnvironmentID, session.TaskEnvironmentID)
+	}
+	persistedEffective, err := repo.GetTaskSession(ctx, effective.ID)
+	if err != nil {
+		t.Fatalf("reload destination session: %v", err)
+	}
+	if !persistedEffective.IsPrimary {
+		t.Fatal("destination session must become primary")
+	}
+
+	old, err := repo.GetTaskSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("reload source session: %v", err)
+	}
+	if old.State != models.TaskSessionStateCompleted {
+		t.Fatalf("source session state = %s, want completed", old.State)
+	}
+}
+
+func TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Test", Description: "Test", State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID: "repo1", WorkspaceID: "ws1", Name: "widgets", SourceType: "local",
+		Provider: "acme-forge", RemoteURL: "https://forge.example/acme/widgets.git",
+	}); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID: "taskrepo1", TaskID: "t1", RepositoryID: "repo1",
+	}); err != nil {
+		t.Fatalf("create task repository: %v", err)
+	}
+	session := &models.TaskSession{
+		ID: "s1", TaskID: "t1", AgentProfileID: "profile-a", ExecutorID: "exec-local",
+		State: models.TaskSessionStateRunning, IsPrimary: true, StartedAt: now, UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, session); err != nil {
+		t.Fatalf("create task session: %v", err)
+	}
+
+	steps := newMockStepGetter()
+	steps.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Position: 1}
+	steps.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Position: 2, AgentProfileID: "profile-b",
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{
+		ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "Test", State: v1.TaskStateInProgress,
+	}
+	baseAgentManager := &mockAgentManager{}
+	agentManager := &sessionScopedPassthroughAgentManager{
+		mockAgentManager:     baseAgentManager,
+		passthroughSessionID: session.ID,
+	}
+	log := testLogger()
+	exec := executor.NewExecutor(agentManager, repo, log, executor.ExecutorConfig{})
+	exec.SetGitHubCredentialBroker(fakePassthroughCredentialIssuer{}, "https://kandev.example/api/v1/github/credentials/resolve")
+	svc := &Service{
+		logger: log, repo: repo, workflowStepGetter: steps, taskRepo: taskRepo, agentManager: agentManager,
+		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
+		workflowStore: newWorkflowStore(repo, steps, agentManager, noopPublisher, log),
+	}
+
+	applied := svc.applyEngineTransition(ctx, "t1", session, engine.HandleResult{
+		Transitioned: true, FromStepID: "step1", ToStepID: "step2",
+	}, engine.TriggerOnTurnStart, "", false)
+	if applied {
+		t.Fatal("applyEngineTransition() = true, want credential admission rejection")
+	}
+	storedTask, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if storedTask.WorkflowStepID != "step1" {
+		t.Fatalf("workflow step = %q, want source step1", storedTask.WorkflowStepID)
+	}
+	storedSession, err := repo.GetTaskSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if storedSession.State != models.TaskSessionStateRunning || !storedSession.IsPrimary {
+		t.Fatalf("session after rejection = %#v, want running primary source session", storedSession)
+	}
+}
+
+type fakePassthroughCredentialIssuer struct{}
+
+func (fakePassthroughCredentialIssuer) Issue(
+	context.Context, gitcredentials.Scope,
+) (gitcredentials.Lease, error) {
+	return gitcredentials.Lease{Token: "opaque-lease"}, nil
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -1511,55 +1511,6 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 		}
 	})
 
-	t.Run("no switch for passthrough sessions", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		now := time.Now().UTC()
-
-		ws := &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}
-		_ = repo.CreateWorkspace(ctx, ws)
-		wf := &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}
-		_ = repo.CreateWorkflow(ctx, wf)
-		task := &models.Task{
-			ID: "t1", WorkflowID: "wf1", WorkflowStepID: "step2",
-			Title: "Test", Description: "desc", State: v1.TaskStateInProgress,
-			CreatedAt: now, UpdatedAt: now,
-		}
-		_ = repo.CreateTask(ctx, task)
-
-		session := &models.TaskSession{
-			ID:             "s1",
-			TaskID:         "t1",
-			AgentProfileID: "profile-a",
-			State:          models.TaskSessionStateRunning,
-			IsPrimary:      true,
-			StartedAt:      now,
-			UpdatedAt:      now,
-		}
-		_ = repo.CreateTaskSession(ctx, session)
-
-		sg := newMockStepGetter()
-		step := &wfmodels.WorkflowStep{
-			ID:             "step2",
-			WorkflowID:     "wf1",
-			Name:           "Review",
-			AgentProfileID: "profile-b",
-		}
-		sg.steps["step2"] = step
-
-		agentMgr := &mockAgentManager{isPassthrough: true}
-		svc := createTestServiceWithAgent(repo, sg, newMockTaskRepo(), agentMgr)
-		svc.processOnEnter(ctx, "t1", session, step, "desc", 0)
-
-		// Session should NOT be completed (passthrough skips profile switch)
-		updatedSession, err := repo.GetTaskSession(ctx, "s1")
-		if err != nil {
-			t.Fatalf("failed to get session: %v", err)
-		}
-		if updatedSession.State == models.TaskSessionStateCompleted {
-			t.Error("passthrough session should not be completed for profile switch")
-		}
-	})
-
 	t.Run("no switch when step has no profile", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		now := time.Now().UTC()

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2150,17 +2150,15 @@ func (s *Service) StartSessionForWorkflowStep(ctx context.Context, taskID, sessi
 	if session.TaskID != taskID {
 		return fmt.Errorf("session does not belong to task")
 	}
-	if !s.agentManager.IsPassthroughSession(ctx, session.ID) {
-		effectiveProfile := s.resolveStepAgentProfile(ctx, step)
-		if effectiveProfile != "" && effectiveProfile != session.AgentProfileID {
-			return fmt.Errorf(
-				"workflow step profile mismatch: step %q resolves to profile %q but session %q uses profile %q; route the session before prompting",
-				workflowStepID,
-				effectiveProfile,
-				session.ID,
-				session.AgentProfileID,
-			)
-		}
+	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
+	if effectiveProfile != "" && effectiveProfile != session.AgentProfileID {
+		return fmt.Errorf(
+			"workflow step profile mismatch: step %q resolves to profile %q but session %q uses profile %q; route the session before prompting",
+			workflowStepID,
+			effectiveProfile,
+			session.ID,
+			session.AgentProfileID,
+		)
 	}
 
 	dbTask, err := s.repo.GetTask(ctx, taskID)

--- a/apps/backend/internal/orchestrator/task_operations_passthrough_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_passthrough_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -63,6 +64,63 @@ func TestResolveIsPassthroughForLaunch_UsesSessionSnapshotOnSuccess(t *testing.T
 
 	if got {
 		t.Fatalf("resolveIsPassthroughForLaunch() = %v, want false (session snapshot IsPassthrough)", got)
+	}
+}
+
+// TestStartSessionForWorkflowStepRejectsPassthroughProfileMismatchBeforePrompt
+// proves that an explicit workflow-step launch cannot advance the task or
+// deliver the step prompt through a passthrough session whose profile does not
+// match the step's fixed profile.
+func TestStartSessionForWorkflowStepRejectsPassthroughProfileMismatchBeforePrompt(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.IsPassthrough = true
+	session.State = models.TaskSessionStateWaitingForInput
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID:             "step2",
+		WorkflowID:     "wf1",
+		AgentProfileID: "profile-b",
+	}
+	agentMgr := &mockAgentManager{
+		isPassthrough:  true,
+		isAgentRunning: true,
+	}
+	svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	err = svc.StartSessionForWorkflowStep(ctx, "task1", "session1", "step2")
+	if err == nil || !strings.Contains(err.Error(), "profile mismatch") {
+		t.Fatalf("StartSessionForWorkflowStep error = %v, want profile mismatch", err)
+	}
+
+	task, err := repo.GetTask(ctx, "task1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task.WorkflowStepID != "step1" {
+		t.Fatalf("task workflow step = %q, want unchanged step1", task.WorkflowStepID)
+	}
+
+	agentMgr.mu.Lock()
+	defer agentMgr.mu.Unlock()
+	if len(agentMgr.passthroughStdinCalls) != 0 {
+		t.Fatalf("passthrough prompt calls = %d, want none", len(agentMgr.passthroughStdinCalls))
+	}
+	if len(agentMgr.capturedPrompts) != 0 {
+		t.Fatalf("ACP prompt calls = %d, want none", len(agentMgr.capturedPrompts))
 	}
 }
 

--- a/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
@@ -150,6 +150,94 @@ test.describe("Terminal agent (TUI passthrough)", () => {
     await expect(session.sidebarSection("Turn Finished")).toBeVisible({ timeout: 15_000 });
   });
 
+  test("switches from a TUI session to the workflow step profile", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
+    const { agents } = await apiClient.listAgents();
+    if (agents.length === 0) throw new Error("no agents available in test fixtures");
+
+    const tuiProfile = await createTUIProfile(apiClient, "TUI Profile Switch");
+    const fixedProfile = await apiClient.createAgentProfile(agents[0].id, "Fixed ACP Profile", {
+      model: "mock-fast",
+    });
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "TUI Profile Routing");
+    const startStep = await apiClient.createWorkflowStep(workflow.id, "TUI Start", 0, {
+      is_start_step: true,
+    });
+    const targetStep = await apiClient.createWorkflowStep(workflow.id, "Fixed Profile", 1);
+
+    await apiClient.updateWorkflowStep(startStep.id, {
+      agent_profile_id: tuiProfile.id,
+      events: { on_enter: [{ type: "auto_start_agent" }] },
+    });
+    await apiClient.updateWorkflowStep(targetStep.id, {
+      agent_profile_id: fixedProfile.id,
+      prompt: 'e2e:message("fixed profile step")',
+      events: { on_enter: [{ type: "auto_start_agent" }] },
+    });
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+      enable_preview_on_click: false,
+    });
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "TUI Profile Routing Task",
+      tuiProfile.id,
+      {
+        workflow_id: workflow.id,
+        workflow_step_id: startStep.id,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("task creation did not return the TUI session");
+
+    const session = await openTaskSession(testPage, "TUI Profile Routing Task");
+    await session.expectPassthroughHasText("Mock Agent");
+    await waitForSessionState(apiClient, {
+      taskId: task.id,
+      sessionId: task.session_id,
+      expectedState: "WAITING_FOR_INPUT",
+      message: "the TUI source session did not become ready before the profile switch",
+      timeout: 60_000,
+    });
+    await waitForSessionAgentctlReady(testPage, task.session_id);
+
+    await apiClient.moveTask(task.id, workflow.id, targetStep.id);
+
+    let destinationSessionId = "";
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          const destination = sessions.find((item) => item.agent_profile_id === fixedProfile.id);
+          destinationSessionId = destination?.id ?? "";
+          return destinationSessionId;
+        },
+        { timeout: 90_000, message: "the fixed-profile destination session was not created" },
+      )
+      .not.toBe("");
+
+    await waitForSessionState(apiClient, {
+      taskId: task.id,
+      sessionId: task.session_id,
+      expectedState: "COMPLETED",
+      message: "the TUI source session did not complete after profile routing",
+      timeout: 60_000,
+    });
+
+    await expect(session.sessionTabBySessionId(destinationSessionId)).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(session.primaryStarInSessionTab(destinationSessionId)).toBeVisible({
+      timeout: 60_000,
+    });
+  });
+
   /**
    * Seeds a 4-step workflow (Backlog → Analyze → Implement → Review).
    * Analyze and Implement both have:

--- a/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
@@ -14,7 +14,11 @@ import { errors, type Page } from "@playwright/test";
 /** Create a passthrough (TUI) agent profile for the mock agent. */
 async function createTUIProfile(apiClient: ApiClient, name: string) {
   const { agents } = await apiClient.listAgents();
-  return apiClient.createAgentProfile(agents[0].id, name, {
+  const agent =
+    agents.find((candidate) => candidate.name === "mock-agent") ??
+    agents.find((candidate) => candidate.id !== "dynamic");
+  if (!agent) throw new Error("no launchable agents available in test fixtures");
+  return apiClient.createAgentProfile(agent.id, name, {
     model: "mock-fast",
     auto_approve: true,
     cli_passthrough: true,
@@ -156,11 +160,13 @@ test.describe("Terminal agent (TUI passthrough)", () => {
     seedData,
   }) => {
     test.setTimeout(180_000);
-    const { agents } = await apiClient.listAgents();
-    if (agents.length === 0) throw new Error("no agents available in test fixtures");
-
     const tuiProfile = await createTUIProfile(apiClient, "TUI Profile Switch");
-    const fixedProfile = await apiClient.createAgentProfile(agents[0].id, "Fixed ACP Profile", {
+    const { agents } = await apiClient.listAgents();
+    const fixedAgent =
+      agents.find((candidate) => candidate.name === "mock-agent") ??
+      agents.find((candidate) => candidate.id !== "dynamic");
+    if (!fixedAgent) throw new Error("no launchable agents available in test fixtures");
+    const fixedProfile = await apiClient.createAgentProfile(fixedAgent.id, "Fixed ACP Profile", {
       model: "mock-fast",
     });
     const workflow = await apiClient.createWorkflow(seedData.workspaceId, "TUI Profile Routing");
@@ -189,6 +195,7 @@ test.describe("Terminal agent (TUI passthrough)", () => {
       "TUI Profile Routing Task",
       tuiProfile.id,
       {
+        description: "switch to the fixed profile",
         workflow_id: workflow.id,
         workflow_step_id: startStep.id,
         repository_ids: [seedData.repositoryId],

--- a/docs/plans/workflow-passthrough-profile-routing/plan.md
+++ b/docs/plans/workflow-passthrough-profile-routing/plan.md
@@ -35,6 +35,7 @@ All diagnostic edits were removed after the test.
 ### In scope
 
 - Resolve and apply fixed step profiles when the active session uses CLI passthrough.
+- Validate the effective profile on explicit workflow-step launches before advancing the task or sending a prompt.
 - Run the existing managed Git credential preflight before persisting such a transition.
 - Preserve the existing session reuse, task-environment inheritance, queue transfer, primary-session promotion, and source-session completion behavior.
 - Add backend and browser regression coverage for a passthrough-to-fixed-profile transition.
@@ -56,6 +57,9 @@ Add focused tests in a new orchestrator test file.
 The current workflow profile test file exceeds the preferred size.
 Cover destination-session creation and pre-transition credential rejection for a passthrough source session.
 
+Keep the explicit `StartSessionForWorkflowStep` launch path transport-neutral.
+Reject a fixed-profile mismatch before task-step advancement or prompt delivery.
+
 Extend the existing TUI passthrough Playwright spec.
 Use a CLI-passthrough source profile and a different fixed destination profile.
 Start the task through the terminal UI, then move the task.
@@ -66,6 +70,7 @@ Use the visible session tab to validate primary ownership.
 
 - `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.2`: add `TestPrepareWorkflowStepSessionSwitchesPassthroughProfile` in `apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go`.
 - `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.3`: add `TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep` in the same file.
+- `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.3`: add `TestStartSessionForWorkflowStepRejectsPassthroughProfileMismatchBeforePrompt` in `apps/backend/internal/orchestrator/task_operations_passthrough_test.go`.
 - Preserve the existing ACP destination-session dispatcher and profile reuse tests.
 
 ## E2E tests
@@ -81,6 +86,7 @@ Use the visible session tab to validate primary ownership.
 ## Verification results
 
 - `cd apps/backend && go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
+- `cd apps/backend && go test ./internal/orchestrator -run '^(TestStartSessionForWorkflowStepRejectsProfileMismatchBeforePrompt|TestStartSessionForWorkflowStepRejectsPassthroughProfileMismatchBeforePrompt)$' -count=1` — passed, 2 tests in 1 package.
 - `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.
 - `python3 scripts/lint-spec-files.py --all` — passed.
 

--- a/docs/plans/workflow-passthrough-profile-routing/plan.md
+++ b/docs/plans/workflow-passthrough-profile-routing/plan.md
@@ -80,7 +80,7 @@ Use the visible session tab to validate primary ownership.
 
 ## Verification results
 
-- `go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
+- `cd apps/backend && go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
 - `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.
 - `python3 scripts/lint-spec-files.py --all` — passed.
 

--- a/docs/plans/workflow-passthrough-profile-routing/plan.md
+++ b/docs/plans/workflow-passthrough-profile-routing/plan.md
@@ -1,0 +1,93 @@
+---
+created: 2026-08-28
+status: done
+requirements:
+  - REQ-TASKS-WORKFLOW-SESSION-SETTINGS-001
+system_design:
+  - ../../specs/tasks/system-design/workflow-step-fixed-profile-routing.md
+legacy_specs: []
+---
+
+# Implementation Plan: Honor Passthrough Workflow Profile Routing
+
+## Overview
+
+Fix GitHub issue #3110 by applying fixed workflow-step profile routing before transport-specific behavior.
+The CLI-passthrough state must not bypass profile resolution, credential admission, or the existing session lifecycle.
+
+## Confirmed root cause
+
+`prepareWorkflowStepSession` returns immediately when `IsPassthroughSession` is true.
+This return occurs before Kandev resolves the destination step profile.
+`preflightWorkflowStepCredentials` has the same early return.
+The workflow commits the move and sends entry behavior to the source passthrough session.
+This error occurs when the step selects another profile.
+
+A focused diagnostic run set the source session of the existing dispatcher scenario to passthrough.
+The unchanged code did not create a destination session.
+The diagnostic patch removed only the two passthrough short-circuits.
+The dispatcher then created and promoted the destination session.
+It preserved the task environment and completed the source session.
+All diagnostic edits were removed after the test.
+
+## Scope
+
+### In scope
+
+- Resolve and apply fixed step profiles when the active session uses CLI passthrough.
+- Run the existing managed Git credential preflight before persisting such a transition.
+- Preserve the existing session reuse, task-environment inheritance, queue transfer, primary-session promotion, and source-session completion behavior.
+- Add backend and browser regression coverage for a passthrough-to-fixed-profile transition.
+
+### Out of scope
+
+- Reconfiguring a running CLI process to impersonate another profile.
+- Changes to profile precedence, conditional session settings, passthrough terminal rendering, or ACP-only entry actions.
+- Frontend controls, localization, schema, migration, runtime flags, or public documentation.
+
+## Technical approach
+
+Update `apps/backend/internal/orchestrator/event_handlers_workflow.go`.
+Remove the source transport exemption from `prepareWorkflowStepSession` and `preflightWorkflowStepCredentials`.
+Keep passthrough guards at transport-specific operation sites.
+
+Replace the existing test that records the incorrect override behavior.
+Add focused tests in a new orchestrator test file.
+The current workflow profile test file exceeds the preferred size.
+Cover destination-session creation and pre-transition credential rejection for a passthrough source session.
+
+Extend the existing TUI passthrough Playwright spec.
+Use a CLI-passthrough source profile and a different fixed destination profile.
+Start the task through the terminal UI, then move the task.
+Use task-session state to validate the destination profile.
+Use the visible session tab to validate primary ownership.
+
+## Tests
+
+- `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.2`: add `TestPrepareWorkflowStepSessionSwitchesPassthroughProfile` in `apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go`.
+- `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.3`: add `TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep` in the same file.
+- Preserve the existing ACP destination-session dispatcher and profile reuse tests.
+
+## E2E tests
+
+- `AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.2`: add `switches from a TUI session to the workflow step profile` to `apps/web/e2e/tests/terminal/terminal-agent.spec.ts`.
+  The test starts a mock TUI process and moves the task to a fixed-profile step.
+  It validates the new primary session through backend state and the visible session tab.
+
+## Work orders
+
+- [x] [Task 01: Honor passthrough step profile routing](task-01-honor-passthrough-step-profile-routing.md)
+
+## Verification results
+
+- `go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
+- `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.
+- `python3 scripts/lint-spec-files.py --all` — passed.
+
+## Risks
+
+- The destination profile can itself be passthrough or ACP. Routing must create the session first and let the destination profile choose its transport.
+- Credential admission must remain before the persisted step transition.
+  A check in `switchSessionForStep` occurs after the task enters the destination step.
+- A test-wide passthrough boolean can misclassify the destination session.
+  Backend coverage must validate routing directly or use session-specific behavior.

--- a/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
+++ b/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
@@ -24,6 +24,7 @@ Make fixed workflow-step profile routing independent of the active session trans
 
 - Remove the passthrough routing exemption from workflow-step session preparation.
 - Remove the passthrough credential-preflight exemption.
+- Apply fixed-profile validation to explicit workflow-step launches before task advancement or prompt delivery.
 - Replace obsolete skip coverage with destination-session and fail-closed regression tests.
 - Add a focused Playwright scenario for TUI-to-fixed-profile routing.
 
@@ -81,6 +82,7 @@ None.
 
 - Removed the passthrough exemptions from workflow-step session preparation and credential preflight.
 - Added backend regressions for destination-session routing and fail-closed credential admission.
+- Added a passthrough regression for explicit workflow-step launches that verifies mismatch rejection before task advancement or prompt delivery.
 - Added a browser regression for TUI-to-fixed-profile routing, destination tab visibility, and primary ownership.
 - `cd apps/backend && go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
 - `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.

--- a/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
+++ b/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
@@ -1,0 +1,87 @@
+---
+id: "01-honor-passthrough-step-profile-routing"
+title: "Honor passthrough step profile routing"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WORKFLOW-SESSION-SETTINGS-001
+acceptance_criteria:
+  - AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.2
+  - AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.3
+system_design:
+  - ../../specs/tasks/system-design/workflow-step-fixed-profile-routing.md
+---
+
+# Task 01: Honor Passthrough Step Profile Routing
+
+## Summary
+
+Make fixed workflow-step profile routing independent of the active session transport. Prove the correction at the orchestrator boundary and in the real mock-TUI browser flow.
+
+## In scope
+
+- Remove the passthrough routing exemption from workflow-step session preparation.
+- Remove the passthrough credential-preflight exemption.
+- Replace obsolete skip coverage with destination-session and fail-closed regression tests.
+- Add a focused Playwright scenario for TUI-to-fixed-profile routing.
+
+## Out of scope
+
+- UI or localization changes.
+- Changes to conditional session settings or transport-specific entry-action support.
+- Schema, migration, runtime-flag, or public API changes.
+
+## Acceptance
+
+- A task enters a differently profiled step from a live passthrough session.
+  Kandev creates or activates the destination profile session before entry behavior runs.
+- The destination session becomes primary, inherits the task environment, and the source passthrough session completes through the existing lifecycle.
+- A credential-preflight failure keeps the task on its source step and leaves the source session running and primary.
+
+## Verification
+
+```bash
+go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1
+cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"
+```
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go`
+- `apps/web/e2e/tests/terminal/terminal-agent.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- The orchestrator test double exposes passthrough as a global boolean.
+  A transport-specific destination action can falsely classify both sessions as passthrough.
+- The E2E flow must wait on session lifecycle state rather than terminal text alone.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/tasks/requirements/workflow-session-settings.md`
+- `docs/specs/tasks/system-design/workflow-step-fixed-profile-routing.md`
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_profile_preflight_test.go`
+- `apps/web/e2e/tests/terminal/terminal-agent.spec.ts`
+
+## Results
+
+- Removed the passthrough exemptions from workflow-step session preparation and credential preflight.
+- Added backend regressions for destination-session routing and fail-closed credential admission.
+- Added a browser regression for TUI-to-fixed-profile routing, destination tab visibility, and primary ownership.
+- `go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
+- `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.
+- `python3 scripts/lint-spec-files.py --all` — passed.

--- a/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
+++ b/docs/plans/workflow-passthrough-profile-routing/task-01-honor-passthrough-step-profile-routing.md
@@ -43,7 +43,7 @@ Make fixed workflow-step profile routing independent of the active session trans
 ## Verification
 
 ```bash
-go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1
+cd apps/backend && go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1
 cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"
 ```
 
@@ -82,6 +82,6 @@ None.
 - Removed the passthrough exemptions from workflow-step session preparation and credential preflight.
 - Added backend regressions for destination-session routing and fail-closed credential admission.
 - Added a browser regression for TUI-to-fixed-profile routing, destination tab visibility, and primary ownership.
-- `go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
+- `cd apps/backend && go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1` — passed, 3 tests in 1 package.
 - `cd apps/web && pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"` — passed, 1 test in 16.3 seconds.
 - `python3 scripts/lint-spec-files.py --all` — passed.

--- a/docs/specs/tasks/README.md
+++ b/docs/specs/tasks/README.md
@@ -128,6 +128,7 @@ signals, and task-scoped scheduling contracts.
 - [Task Launch Failure Recovery](system-design/task-launch-failure-recovery.md)
 - [WIP Limits and Visible Overflow Queues](system-design/wip-limit-pull-system.md)
 - [Workflow quorum decision recording](system-design/workflow-quorum-decision-recording.md)
+- [Workflow Step Fixed-Profile Routing](system-design/workflow-step-fixed-profile-routing.md)
 - [Workflow task-step transition ledger](system-design/workflow-task-step-transition-ledger.md)
 
 ## Migration record

--- a/docs/specs/tasks/requirements/workflow-session-settings.md
+++ b/docs/specs/tasks/requirements/workflow-session-settings.md
@@ -20,6 +20,8 @@ This document is the migrated task-system source for the capability. The source 
 #### Acceptance criteria
 
 - **AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.1:** When a consumer uses this capability, the system shall provide the observable behavior and exclusions documented below.
+- **AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.2:** When a fixed step profile differs from the active session profile, Kandev shall create or activate a session for that profile. Kandev shall route the step entry actions to this session. This rule applies to an active CLI passthrough session.
+- **AC-TASKS-WORKFLOW-SESSION-SETTINGS-001.3:** When Kandev cannot validate or prepare a fixed-profile session, it shall not run the destination step on the previous profile. Kandev shall leave the previous session recoverable.
 
 ## Migrated source detail
 

--- a/docs/specs/tasks/system-design/workflow-step-fixed-profile-routing.md
+++ b/docs/specs/tasks/system-design/workflow-step-fixed-profile-routing.md
@@ -1,0 +1,90 @@
+---
+status: current
+system: tasks
+requirements:
+  - REQ-TASKS-WORKFLOW-SESSION-SETTINGS-001
+---
+
+# Workflow Step Fixed-Profile Routing System Design
+
+## Purpose and boundaries
+
+The task and workflow system selects the task session that executes a workflow step.
+A fixed step profile is a session-routing instruction.
+This instruction does not depend on the ACP or CLI-passthrough transport.
+The agent runtime controls how each selected session starts and stops its process.
+
+Conditional session settings are separate. They modify the original session without changing its profile and do not use this routing flow.
+
+## Requirement mapping
+
+| Requirement | Design section |
+| --- | --- |
+| `REQ-TASKS-WORKFLOW-SESSION-SETTINGS-001` | [Control flow](#control-flow), [Failure and recovery](#failure-and-recovery) |
+
+## Components and responsibilities
+
+- `orchestrator.Service.resolveStepAgentProfile` resolves the pinned step profile before the workflow default.
+- `orchestrator.Service.preflightWorkflowStepCredentials` validates the executor and repository credential boundary before a transition persists.
+- `orchestrator.Service.prepareWorkflowStepSession` selects the session that owns destination-step entry actions.
+- `orchestrator.Service.switchSessionForStep` reuses a nonterminal session for the destination profile or prepares a new session in the task's existing environment.
+- The agent runtime stops the replaced execution and lazily starts or resumes the destination session according to that session's profile and transport.
+
+## Data and contracts
+
+`workflow_steps.agent_profile_id` is the fixed-profile override.
+An empty value uses the workflow profile, then the active session profile.
+A selected profile stays attached to its own `task_sessions.agent_profile_id`.
+Routing never rewrites a live session to impersonate another profile.
+
+The destination session inherits the current task environment and executor profile. Its own agent profile determines ACP or CLI-passthrough launch behavior.
+
+## Control flow
+
+1. Before committing a workflow transition, resolve the destination step's effective profile and preflight its reusable or prospective session against managed Git credential requirements.
+2. After the destination step is selected and before any entry action runs, resolve the effective profile again through the request-scoped workflow metadata cache.
+3. If the effective profile is empty or matches the active session, keep that session and make it primary when needed.
+4. If the profile differs, reuse the newest nonterminal matching session or prepare a new session in the existing task environment.
+5. Promote the destination session, transfer queued messages and pending move state, then complete and stop the replaced session.
+6. Run destination-step entry actions with the destination session ID. Transport-specific action support is evaluated only after routing.
+
+The active session transport does not stop profile resolution, credential preflight, or session switching.
+Passthrough checks remain valid for operations that a CLI session cannot perform.
+ACP-only mode changes are one example.
+
+## Failure and recovery
+
+Credential validation stops the operation before the workflow step changes.
+Session preparation occurs before Kandev completes the current session.
+If either operation fails, Kandev keeps the previous session active.
+Kandev does not execute the destination step with the wrong profile.
+
+If queue transfer fails, Kandev logs the error.
+The queued state stays on the previous session for manual recovery.
+Kandev never revives a terminal matching session.
+Kandev creates a new session instead.
+
+## Persistence
+
+This flow uses existing workflow-step, task-session, task-environment, and session-metadata records.
+It requires no schema change.
+The existing repositories retain profile identity, primary ownership, terminal state, and workflow-switch provenance after a restart.
+
+## Security
+
+The transition keeps existing task authorization.
+Managed Git credential preflight runs for every transport before the destination profile takes ownership.
+Errors identify safe repository IDs and do not identify credential values.
+
+## Observability
+
+Profile changes emit the existing structured switch log.
+The log contains the task, source session, current profile, and destination profile.
+Preflight and preparation errors use the existing workflow transition error paths.
+This change does not require a new metric.
+
+## Related decisions
+
+- [Task model unification](../../../decisions/0004-task-model-unification.md)
+- [Agent model unification](../../../decisions/0005-agent-model-unification.md)
+- [Per-CLI MCP server injection for passthrough mode](../../../decisions/0014-passthrough-mcp-injection-strategies.md)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3117/98029d9af275.html)
<!-- kandev-pr-walkthrough-end -->

Workflow steps with fixed agent profiles were bypassed when the active task session used CLI passthrough, so entry actions could run on the wrong profile and credential failures could be committed too late. This restores transport-neutral profile resolution and fail-closed session routing, with backend and browser regressions covering the TUI transition.

## Important Changes

- Apply fixed-profile resolution and credential preflight for passthrough source sessions.
- Reuse the existing session lifecycle to create or activate the destination profile before entry actions.
- Document the transport-neutral routing contract and add backend plus terminal E2E coverage.

## Validation

- `go test ./internal/orchestrator`
- `go test ./internal/orchestrator -run '^(TestPrepareWorkflowStepSessionSwitchesPassthroughProfile|TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingStep|TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession)$' -count=1`
- `pnpm e2e:run tests/terminal/terminal-agent.spec.ts -- --grep "switches from a TUI session to the workflow step profile"`
- `python3 scripts/lint-spec-files.py --all`
- `git diff --check`

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #3110


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->