### PR TITLE
fix(web): isolate Monaco from Vitest (#3114)

### DIFF
--- a/apps/web/vitest-monaco-editor.test.ts
+++ b/apps/web/vitest-monaco-editor.test.ts
@@ -7,6 +7,27 @@ const monaco = monacoImport as typeof monacoImport & {
 const typeScriptLanguages = monaco.languages.typescript as unknown as {
   javascriptDefaults?: unknown;
   typescriptDefaults?: unknown;
+  JsxEmit?: { ReactJSX?: number };
+  ScriptTarget?: { ESNext?: number };
+  ModuleKind?: { ESNext?: number };
+  ModuleResolutionKind?: { NodeJs?: number };
+};
+const monacoEditor = monaco.editor as unknown as Record<string, unknown>;
+const monacoLanguages = monaco.languages as unknown as {
+  CompletionItemKind?: { File?: number };
+};
+
+type StubModel = {
+  uri: { toString(): string };
+  setValue(value: string): void;
+  getValue(): string;
+  dispose(): void;
+};
+const modelEditor = monaco.editor as unknown as {
+  createModel(value: string, language?: string, uri?: { toString(): string }): StubModel;
+  getModel(uri: { toString(): string }): StubModel | null;
+  setModelMarkers(model: StubModel, owner: string, markers: unknown[]): void;
+  getModelMarkers(filter?: { resource?: { toString(): string } }): unknown[];
 };
 
 describe("Vitest Monaco boundary", () => {
@@ -16,11 +37,48 @@ describe("Vitest Monaco boundary", () => {
       uri: monaco.Uri.parse("file:///workspace/source.ts").toString(),
       hasTypeScriptDefaults: Boolean(typeScriptLanguages.typescriptDefaults),
       hasJavaScriptDefaults: Boolean(typeScriptLanguages.javascriptDefaults),
+      hasIndependentLanguageDefaults:
+        typeScriptLanguages.typescriptDefaults !== typeScriptLanguages.javascriptDefaults,
+      completionItemKindFile: monacoLanguages.CompletionItemKind?.File,
+      jsxEmitReactJSX: typeScriptLanguages.JsxEmit?.ReactJSX,
+      scriptTargetESNext: typeScriptLanguages.ScriptTarget?.ESNext,
+      moduleKindESNext: typeScriptLanguages.ModuleKind?.ESNext,
+      moduleResolutionNodeJs: typeScriptLanguages.ModuleResolutionKind?.NodeJs,
+      hasModelApi: ["createModel", "getModels", "getModel", "setModelMarkers"].every(
+        (method) => typeof monacoEditor[method] === "function",
+      ),
     }).toEqual({
       isStub: true,
       uri: "file:///workspace/source.ts",
       hasTypeScriptDefaults: true,
       hasJavaScriptDefaults: true,
+      hasIndependentLanguageDefaults: true,
+      completionItemKindFile: 20,
+      jsxEmitReactJSX: 4,
+      scriptTargetESNext: 99,
+      moduleKindESNext: 99,
+      moduleResolutionNodeJs: 2,
+      hasModelApi: true,
     });
+  });
+
+  it("supports the model and marker APIs used by LSP consumers", () => {
+    const uri = monaco.Uri.parse("file:///workspace/model.ts");
+    const model = modelEditor.createModel("before", "typescript", uri);
+    const marker = { message: "problem" };
+
+    expect(modelEditor.getModel(uri)).toBe(model);
+    model.setValue("after");
+    modelEditor.setModelMarkers(model, "lsp:test", [marker]);
+    expect({
+      value: model.getValue(),
+      markers: modelEditor.getModelMarkers({ resource: uri }),
+    }).toEqual({
+      value: "after",
+      markers: [marker],
+    });
+
+    model.dispose();
+    expect(modelEditor.getModel(uri)).toBeNull();
   });
 });

--- a/apps/web/vitest-monaco-editor.test.ts
+++ b/apps/web/vitest-monaco-editor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import * as monacoImport from "monaco-editor";
+
+const monaco = monacoImport as typeof monacoImport & {
+  __KANDEV_VITEST_STUB__?: boolean;
+};
+const typeScriptLanguages = monaco.languages.typescript as unknown as {
+  javascriptDefaults?: unknown;
+  typescriptDefaults?: unknown;
+};
+
+describe("Vitest Monaco boundary", () => {
+  it("uses the unit-test stub with the required runtime contract", () => {
+    expect({
+      isStub: monaco.__KANDEV_VITEST_STUB__,
+      uri: monaco.Uri.parse("file:///workspace/source.ts").toString(),
+      hasTypeScriptDefaults: Boolean(typeScriptLanguages.typescriptDefaults),
+      hasJavaScriptDefaults: Boolean(typeScriptLanguages.javascriptDefaults),
+    }).toEqual({
+      isStub: true,
+      uri: "file:///workspace/source.ts",
+      hasTypeScriptDefaults: true,
+      hasJavaScriptDefaults: true,
+    });
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig, mergeConfig } from "vitest/config";
 
 import viteConfig from "./vite.config";
@@ -13,6 +14,14 @@ const maxWorkers = resolveMaxWorkers(configuredMaxWorkers, Boolean(process.env.C
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    resolve: {
+      alias: [
+        {
+          find: /^monaco-editor$/,
+          replacement: path.resolve(__dirname, "vitest.monaco-editor.ts"),
+        },
+      ],
+    },
     test: {
       environment: "happy-dom",
       environmentOptions: {

--- a/apps/web/vitest.monaco-editor.ts
+++ b/apps/web/vitest.monaco-editor.ts
@@ -5,11 +5,143 @@ import type { Uri as MonacoUri } from "monaco-editor";
 
 export const __KANDEV_VITEST_STUB__ = true;
 
-const noop = () => undefined;
-const disposable = () => ({ dispose: noop });
-const languageDefaults = {
+type StubUri = { toString(): string };
+type StubPosition = { lineNumber: number; column: number };
+type StubRange = {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+};
+type StubModel = {
+  uri: StubUri;
+  setValue(value: string): void;
+  getValue(): string;
+  getLineContent(lineNumber: number): string;
+  getWordUntilPosition(position: StubPosition): {
+    startColumn: number;
+    endColumn: number;
+    word: string;
+  };
+  getValueInRange(range: StubRange): string;
+  onDidChangeContent(listener: () => void): { dispose(): void };
+  dispose(): void;
+};
+
+const noop = (..._args: unknown[]) => undefined;
+const disposable = (..._args: unknown[]) => ({ dispose: noop });
+const createLanguageDefaults = () => ({
   setCompilerOptions: noop,
   setDiagnosticsOptions: noop,
+});
+
+const models = new Map<string, StubModel>();
+const modelMarkers = new Map<string, unknown[]>();
+let nextModelId = 0;
+
+function modelKey(uri: StubUri): string {
+  return uri.toString();
+}
+
+function nextModelUri(): StubUri {
+  nextModelId += 1;
+  return URI.parse(`inmemory://vitest/model-${nextModelId}`) as StubUri;
+}
+
+function createModel(value = "", _language?: string, uri = nextModelUri()): StubModel {
+  let currentValue = value;
+  const listeners = new Set<() => void>();
+  const key = modelKey(uri);
+  const model: StubModel = {
+    uri,
+    setValue(nextValue) {
+      currentValue = nextValue;
+      for (const listener of listeners) listener();
+    },
+    getValue() {
+      return currentValue;
+    },
+    getLineContent(lineNumber) {
+      return currentValue.split(/\r?\n/)[lineNumber - 1] ?? "";
+    },
+    getWordUntilPosition({ lineNumber, column }) {
+      const line = currentValue.split(/\r?\n/)[lineNumber - 1] ?? "";
+      const beforeCursor = line.slice(0, column - 1);
+      const match = beforeCursor.match(/[\w$]+$/);
+      const word = match?.[0] ?? "";
+      return { startColumn: column - word.length, endColumn: column, word };
+    },
+    getValueInRange(range) {
+      const lines = currentValue
+        .split(/\r?\n/)
+        .slice(range.startLineNumber - 1, range.endLineNumber);
+      if (lines.length === 0) return "";
+      lines[0] = lines[0].slice(range.startColumn - 1);
+      const lastLine = lines.length - 1;
+      lines[lastLine] = lines[lastLine].slice(0, range.endColumn - 1);
+      return lines.join("\n");
+    },
+    onDidChangeContent(listener) {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+    dispose() {
+      models.delete(key);
+      for (const markerKey of modelMarkers.keys()) {
+        if (markerKey.startsWith(`${key}:`)) modelMarkers.delete(markerKey);
+      }
+    },
+  };
+  models.set(key, model);
+  return model;
+}
+
+function getModel(uri: StubUri): StubModel | null {
+  return models.get(modelKey(uri)) ?? null;
+}
+
+function setModelMarkers(model: StubModel, owner: string, markers: unknown[]): void {
+  const key = `${modelKey(model.uri)}:${owner}`;
+  if (markers.length === 0) {
+    modelMarkers.delete(key);
+    return;
+  }
+  modelMarkers.set(key, [...markers]);
+}
+
+function getModelMarkers(filter: { resource?: StubUri } = {}): unknown[] {
+  const resourceKey = filter.resource ? `${modelKey(filter.resource)}:` : null;
+  return [...modelMarkers.entries()]
+    .filter(([key]) => resourceKey === null || key.startsWith(resourceKey))
+    .flatMap(([, markers]) => markers);
+}
+
+const completionItemKind = {
+  Method: 0,
+  Function: 1,
+  Constructor: 2,
+  Field: 3,
+  Variable: 4,
+  Class: 5,
+  Struct: 6,
+  Interface: 7,
+  Module: 8,
+  Property: 9,
+  Event: 10,
+  Operator: 11,
+  Unit: 12,
+  Value: 13,
+  Constant: 14,
+  Enum: 15,
+  EnumMember: 16,
+  Keyword: 17,
+  Text: 18,
+  Color: 19,
+  File: 20,
+  Reference: 21,
+  Folder: 23,
+  TypeParameter: 24,
+  Snippet: 28,
 };
 
 export const Uri = URI as typeof MonacoUri;
@@ -17,17 +149,23 @@ export const Uri = URI as typeof MonacoUri;
 export const editor = {
   defineTheme: noop,
   registerEditorOpener: disposable,
+  createModel,
+  getModels: () => [...models.values()],
+  getModel,
+  setModelMarkers,
+  getModelMarkers,
 };
 
 export const languages = {
+  CompletionItemKind: completionItemKind,
   registerCompletionItemProvider: disposable,
   registerDefinitionProvider: disposable,
   registerHoverProvider: disposable,
   registerReferenceProvider: disposable,
   registerSignatureHelpProvider: disposable,
   typescript: {
-    javascriptDefaults: languageDefaults,
-    typescriptDefaults: languageDefaults,
+    javascriptDefaults: createLanguageDefaults(),
+    typescriptDefaults: createLanguageDefaults(),
     JsxEmit: { ReactJSX: 4 },
     ModuleKind: { ESNext: 99 },
     ModuleResolutionKind: { NodeJs: 2 },

--- a/apps/web/vitest.monaco-editor.ts
+++ b/apps/web/vitest.monaco-editor.ts
@@ -1,0 +1,36 @@
+// @ts-expect-error -- Monaco does not publish declarations for its internal URI module.
+import { URI } from "monaco-editor/esm/vs/base/common/uri.js";
+
+import type { Uri as MonacoUri } from "monaco-editor";
+
+export const __KANDEV_VITEST_STUB__ = true;
+
+const noop = () => undefined;
+const disposable = () => ({ dispose: noop });
+const languageDefaults = {
+  setCompilerOptions: noop,
+  setDiagnosticsOptions: noop,
+};
+
+export const Uri = URI as typeof MonacoUri;
+
+export const editor = {
+  defineTheme: noop,
+  registerEditorOpener: disposable,
+};
+
+export const languages = {
+  registerCompletionItemProvider: disposable,
+  registerDefinitionProvider: disposable,
+  registerHoverProvider: disposable,
+  registerReferenceProvider: disposable,
+  registerSignatureHelpProvider: disposable,
+  typescript: {
+    javascriptDefaults: languageDefaults,
+    typescriptDefaults: languageDefaults,
+    JsxEmit: { ReactJSX: 4 },
+    ModuleKind: { ESNext: 99 },
+    ModuleResolutionKind: { NodeJs: 2 },
+    ScriptTarget: { ESNext: 99 },
+  },
+};

--- a/docs/decisions/0037-resource-aware-frontend-unit-tests.md
+++ b/docs/decisions/0037-resource-aware-frontend-unit-tests.md
@@ -1,8 +1,30 @@
 # 0037: Resource-Aware Frontend Unit Tests
 
-**Status:** accepted
+**Status:** accepted (amended 2026-08-28)
 **Date:** 2026-07-14
 **Area:** frontend, infra
+
+## Amendment (2026-08-28)
+
+Vitest aliases only the bare `monaco-editor` specifier to a small unit-test
+stub. The stub supplies the runtime values that unit tests use. These values
+include `Uri`, editor registration methods, and TypeScript language defaults.
+Deep Monaco imports stay unaliased.
+
+Production builds and Playwright tests continue to load the real Monaco
+package. Unit tests do not load Monaco's side-effectful editor contribution
+graph. This boundary keeps per-file isolation enabled. It also prevents
+duplicate command registration inside one Vitest worker.
+
+The stub must expose an explicit test marker. A focused regression test must
+check the marker, URI behavior, and the language-default shape. When a unit
+test needs another Monaco runtime value, the stub and regression test must
+change together.
+
+Simple dependency deduplication and an alias to `editor.api.js` do not meet the
+contract. Deduplication does not merge distinct module evaluations. The
+API-only entry also omits language contributions that application code uses.
+Native Node externalization is not valid because Monaco imports CSS files.
 
 ## Context
 
@@ -18,6 +40,9 @@ The unit-test environment disables Happy DOM child-frame navigation and intercep
 
 Targeted test-file runs remain the normal development loop. Full frontend suites run during final verification and CI rather than after every edit. Per-file isolation remains enabled because the suite relies on module and DOM isolation.
 
+The unit-test environment uses a narrow Monaco stub. The browser build and
+browser tests use the real editor package.
+
 ## Consequences
 
 - Concurrent Kandev tasks leave CPU capacity for the backend, agents, editor, and other test suites.
@@ -25,6 +50,9 @@ Targeted test-file runs remain the normal development loop. Full frontend suites
 - CI performance is unchanged unless the CI environment explicitly sets `VITEST_MAX_WORKERS`.
 - Vitest and Vite share a supported dependency generation instead of loading a second legacy Vite toolchain.
 - Unit tests do not load iframe content, access the network through Happy DOM, or inherit the host's generic debug verbosity.
+- Unit tests do not evaluate Monaco editor contributions or workers.
+- The stub can drift when application code adds a Monaco runtime dependency. One focused test owns its required shape.
+- Production builds and browser tests remain the evidence for real Monaco integration.
 - The percentage limit scales across developer machines without hard-coding a workstation-specific core count.
 - Vite updates require a production-build smoke check until the Rolldown re-export regression is fixed upstream.
 
@@ -37,6 +65,21 @@ Rejected because the fastest isolated run becomes slower and less predictable wh
 ### Disable test-file isolation
 
 Rejected because a trial produced widespread cross-file mock and DOM failures. The suite depends on isolation for correctness.
+
+### Load the real Monaco package in every unit-test context
+
+Rejected because Monaco registers global editor actions during module
+evaluation. Separate Vitest module evaluations can register the same action
+twice inside one worker.
+
+### Externalize Monaco to native Node
+
+Rejected because native Node does not transform Monaco's CSS imports.
+
+### Alias Monaco to `editor.api.js`
+
+Rejected because the API-only entry omits language contributions that Kandev
+uses, including TypeScript defaults.
 
 ### Migrate to Rstest
 

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -42,7 +42,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0034 | [Agent Client Protocol Codex ACP Bridge](0034-agentclientprotocol-codex-acp.md)                                                     | accepted (amended 2026-07-25) | backend, protocol | 2026-07-10 |
 | 0035 | [Version AgentReady events by prompt generation](0035-version-agent-ready-events-by-prompt-generation.md)                          | accepted   | backend                     | 2026-07-14 |
 | 0036 | [Normalize ACP shell output at the adapter boundary](0036-normalize-acp-shell-output-at-adapter-boundary.md)                        | accepted   | backend, frontend, protocol | 2026-07-14 |
-| 0037 | [Resource-aware frontend unit tests](0037-resource-aware-frontend-unit-tests.md)                                                     | accepted   | frontend, infra             | 2026-07-14 |
+| 0037 | [Resource-aware frontend unit tests](0037-resource-aware-frontend-unit-tests.md)                                                     | accepted (amended 2026-08-28) | frontend, infra             | 2026-07-14 |
 | 0038 | [Quick Chat Repository Isolation](0038-quick-chat-repository-isolation.md)                                                           | accepted   | backend, frontend           | 2026-07-14 |
 | 0039 | [Native desktop integration boundary](0039-native-desktop-integration-boundary.md)                                                  | accepted (amended 2026-07-24) | desktop, frontend, backend, infra | 2026-07-15 |
 | 0040 | [Separate updater integrity from OS publisher identity](0040-separate-updater-integrity-from-os-publisher-identity.md)              | accepted   | desktop, infra, workflow    | 2026-07-15 |

--- a/docs/plans/monaco-vitest-isolation/plan.md
+++ b/docs/plans/monaco-vitest-isolation/plan.md
@@ -1,0 +1,78 @@
+---
+created: 2026-08-28
+status: implemented
+requirements: []
+system_design: []
+legacy_specs: []
+---
+
+# Implementation Plan: Monaco Vitest Isolation
+
+## Overview
+
+Frontend unit tests must not evaluate Monaco's editor contribution graph.
+Vitest will alias the bare package import to a small test stub. Production and
+browser tests will continue to use the real package.
+
+The full suite on PR #3112 reproduced issue #3114. All 1,657 test files passed,
+but one duplicate Monaco command registration made Vitest exit with code 1. The
+same suite passed with the stub prototype.
+
+This internal harness change has no product requirement or system design. It
+follows [ADR 0037](../../decisions/0037-resource-aware-frontend-unit-tests.md).
+
+## Scope
+
+### In scope
+
+- Alias only the bare `monaco-editor` specifier in Vitest.
+- Supply the Monaco runtime values that current unit tests use.
+- Add a focused regression test for the test-only contract.
+- Keep real Monaco behavior in production builds and browser tests.
+
+### Out of scope
+
+- Changes to Monaco initialization in production code.
+- Changes to Monaco workers or language providers.
+- Disabling Vitest per-file isolation.
+- Changes to PR #3112.
+
+## Technical approach
+
+Update `apps/web/vitest.config.ts` with an exact regular-expression alias. The
+alias must not match worker paths or other Monaco subpaths.
+
+Add `apps/web/vitest.monaco-editor.ts`. The stub will export `Uri`, editor
+registration methods, language registration methods, TypeScript defaults, and
+the enum values that `monaco-init.ts` uses.
+
+Add `apps/web/vitest-monaco-editor.test.ts`. The test will check a stub marker,
+URI round trips, and the TypeScript defaults. The marker makes the test fail
+when the alias is absent.
+
+## Tests
+
+- The focused stub test must fail before the alias exists.
+- The Monaco initialization, URI, plugin, and task-listing tests must pass with
+  the stub.
+- The full frontend unit suite must pass without an unhandled Monaco rejection.
+
+## Work orders
+
+- [x] [Task 01: Isolate Monaco from Vitest](task-01-isolate-monaco-from-vitest.md)
+
+## Verification results
+
+- The regression test failed before the alias because the stub marker was absent.
+- The focused compatibility set passed 32 files and 249 tests.
+- ESLint and TypeScript passed.
+- The full frontend unit suite passed 1,652 files. It passed 14,182 tests,
+  skipped 4 tests, and exited with code 0.
+- The full suite did not report a duplicate Monaco command registration.
+
+## Risks
+
+- The stub can drift when production code imports another Monaco runtime value.
+- An alias without an exact match can intercept worker and deep API imports.
+- Unit tests cannot prove the real Monaco browser integration. Existing browser
+  tests and production builds retain that responsibility.

--- a/docs/plans/monaco-vitest-isolation/task-01-isolate-monaco-from-vitest.md
+++ b/docs/plans/monaco-vitest-isolation/task-01-isolate-monaco-from-vitest.md
@@ -1,0 +1,94 @@
+---
+id: "01-isolate-monaco-from-vitest"
+title: "Isolate Monaco from Vitest"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements: []
+acceptance_criteria: []
+system_design: []
+---
+
+# Task 01: Isolate Monaco from Vitest
+
+## Summary
+
+Replace the real Monaco package with a narrow stub during unit tests. Keep the
+real package unchanged for production builds and browser tests.
+
+## In scope
+
+- Add the exact bare-package alias to `vitest.config.ts`.
+- Add the minimal Monaco unit-test stub.
+- Add a regression test for the stub contract.
+- Record the targeted and full-suite results.
+
+## Out of scope
+
+- Production Monaco initialization changes.
+- Monaco dependency upgrades.
+- Vitest pool, worker, or isolation changes.
+- New browser tests.
+
+## Acceptance
+
+- The regression test fails when Vitest resolves the real package.
+- The stub supplies URI behavior and the language defaults that current tests use.
+- Deep Monaco paths remain available to Vite and production code.
+- The full PR #3112 frontend suite exits with code 0 and has no Monaco rejection.
+
+## Verification
+
+```bash
+pnpm exec vitest run vitest-monaco-editor.test.ts
+pnpm exec vitest run vitest-monaco-editor.test.ts components/editors/monaco/monaco-init.test.ts lib/lsp/file-uri.test.ts lib/plugins lib/task-listing
+pnpm exec eslint --max-warnings 0 vitest.config.ts vitest.monaco-editor.ts vitest-monaco-editor.test.ts
+pnpm run typecheck
+pnpm test
+```
+
+Run these commands from `apps/web`. In a fresh worktree, first run
+`pnpm install --frozen-lockfile` from `apps`.
+
+## Files likely touched
+
+- `apps/web/vitest.config.ts`
+- `apps/web/vitest.monaco-editor.ts`
+- `apps/web/vitest-monaco-editor.test.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- A missing stub export can hide a new unit-test dependency until the focused
+  contract test changes.
+- A broad alias can replace worker modules and break production-like tests.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- [ADR 0037](../../decisions/0037-resource-aware-frontend-unit-tests.md)
+- GitHub issue #3114.
+- The full-suite failure on PR #3112.
+- `apps/web/components/editors/monaco/monaco-loader.ts`.
+- `apps/web/components/editors/monaco/monaco-init.ts`.
+- `apps/web/lib/lsp/file-uri.test.ts`.
+
+## Results
+
+- RED: `pnpm exec vitest run vitest-monaco-editor.test.ts` failed because
+  `__KANDEV_VITEST_STUB__` was absent from the real package.
+- GREEN: The same command passed one test after the exact alias and stub were added.
+- The focused compatibility command passed 32 files and 249 tests.
+- The focused ESLint command exited with code 0.
+- `pnpm run typecheck` exited with code 0.
+- `pnpm test` passed 1,652 files. It passed 14,182 tests, skipped 4 tests,
+  and exited with code 0. It did not report a duplicate Monaco command registration.
+- The investigation prototype also passed the PR #3112 suite. That run passed
+  1,657 files and 14,258 tests with the same stub design.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3121/ef3a2dd3b4ef.html)
<!-- kandev-pr-walkthrough-end -->

Vitest could evaluate Monaco's side-effectful contribution graph more than once in one worker. The unit suite now uses a narrow Monaco stub, so the full run exits successfully without duplicate command registration.

## Important Changes

- Alias only the bare `monaco-editor` import in Vitest.
- Keep deep Monaco imports, production builds, and Playwright tests on the real package.
- Add a regression test for the stub marker, URI behavior, and TypeScript defaults.

## Validation

- `pnpm exec vitest run vitest-monaco-editor.test.ts`
- `pnpm exec vitest run vitest-monaco-editor.test.ts components/editors/monaco/monaco-init.test.ts lib/lsp/file-uri.test.ts lib/plugins lib/task-listing`
- `pnpm exec eslint --max-warnings 0 vitest.config.ts vitest.monaco-editor.ts vitest-monaco-editor.test.ts`
- `pnpm run typecheck`
- `pnpm test` (1,652 files, 14,182 passed, 4 skipped)
- `python3 scripts/lint-spec-files.py --all`
- `git diff --check`

## Possible Improvements

Low risk: update the stub and its regression test when unit tests use another Monaco runtime value.

Closes #3114

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->