### PR TITLE
perf: move persistent animations to the compositor

### DIFF
--- a/apps/packages/ui/src/animation-utils.tsx
+++ b/apps/packages/ui/src/animation-utils.tsx
@@ -1,0 +1,32 @@
+/**
+ * Returns the first value in a CSS animation list without splitting commas
+ * inside functional notation such as cubic-bezier() or steps().
+ */
+function firstAnimationListValue(value: string): string | null {
+  let parentheses = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "(") {
+      parentheses += 1;
+    } else if (character === ")") {
+      parentheses = Math.max(0, parentheses - 1);
+    } else if (character === "," && parentheses === 0) {
+      const firstValue = value.slice(0, index).trim();
+      return firstValue || null;
+    }
+  }
+
+  const firstValue = value.trim();
+  return firstValue || null;
+}
+
+function parseCssTime(value: string): number | null {
+  const firstValue = firstAnimationListValue(value);
+  if (!firstValue) return null;
+
+  const numericValue = Number.parseFloat(firstValue);
+  if (!Number.isFinite(numericValue)) return null;
+  return firstValue.endsWith("ms") ? numericValue : numericValue * 1_000;
+}
+
+export { firstAnimationListValue, parseCssTime };

--- a/apps/packages/ui/src/compositor-pulse.tsx
+++ b/apps/packages/ui/src/compositor-pulse.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+type CompositorPulseProps = React.ComponentProps<"span"> & {
+  minimumOpacity?: number;
+  minimumAtEndpoints?: boolean;
+};
+
+const useCompositorEffect = typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+
+function CompositorPulse({
+  minimumOpacity = 0.5,
+  minimumAtEndpoints = false,
+  ...props
+}: CompositorPulseProps) {
+  const elementRef = React.useRef<HTMLSpanElement>(null);
+
+  useCompositorEffect(() => {
+    const element = elementRef.current;
+    if (!element || typeof element.animate !== "function") return;
+
+    const computedStyle = window.getComputedStyle(element);
+    if (computedStyle.animationName === "none") return;
+
+    const duration = parseCssTime(computedStyle.animationDuration);
+    const delay = parseCssTime(computedStyle.animationDelay);
+    const easing = computedStyle.animationTimingFunction.trim();
+    if (duration === null || duration <= 0 || delay === null || !easing) return;
+
+    const boundedMinimum = Math.min(1, Math.max(0, minimumOpacity));
+    const opacityKeyframes = minimumAtEndpoints
+      ? [{ opacity: boundedMinimum }, { opacity: 1 }, { opacity: boundedMinimum }]
+      : [{ opacity: 1 }, { opacity: boundedMinimum }, { opacity: 1 }];
+    let animation: Animation;
+    try {
+      animation = element.animate(opacityKeyframes, {
+        delay,
+        duration,
+        easing,
+        iterations: Infinity,
+      });
+    } catch {
+      return;
+    }
+
+    const inlineAnimation = element.style.animation;
+    element.style.animation = "none";
+
+    return () => {
+      animation.cancel();
+      element.style.animation = inlineAnimation;
+    };
+  }, [minimumAtEndpoints, minimumOpacity, props.className]);
+
+  return <span {...props} ref={elementRef} data-compositor-pulse="" />;
+}
+
+function parseCssTime(value: string): number | null {
+  const firstValue = value.split(",")[0]?.trim();
+  if (!firstValue) return null;
+
+  const numericValue = Number.parseFloat(firstValue);
+  if (!Number.isFinite(numericValue)) return null;
+  return firstValue.endsWith("ms") ? numericValue : numericValue * 1_000;
+}
+
+export { CompositorPulse };
+export type { CompositorPulseProps };

--- a/apps/packages/ui/src/compositor-pulse.tsx
+++ b/apps/packages/ui/src/compositor-pulse.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { firstAnimationListValue, parseCssTime } from "./animation-utils";
 
 type CompositorPulseProps = React.ComponentProps<"span"> & {
   minimumOpacity?: number;
@@ -18,49 +19,66 @@ function CompositorPulse({
     const element = elementRef.current;
     if (!element || typeof element.animate !== "function") return;
 
-    const computedStyle = window.getComputedStyle(element);
-    if (computedStyle.animationName === "none") return;
-
-    const duration = parseCssTime(computedStyle.animationDuration);
-    const delay = parseCssTime(computedStyle.animationDelay);
-    const easing = computedStyle.animationTimingFunction.trim();
-    if (duration === null || duration <= 0 || delay === null || !easing) return;
-
-    const boundedMinimum = Math.min(1, Math.max(0, minimumOpacity));
-    const opacityKeyframes = minimumAtEndpoints
-      ? [{ opacity: boundedMinimum }, { opacity: 1 }, { opacity: boundedMinimum }]
-      : [{ opacity: 1 }, { opacity: boundedMinimum }, { opacity: 1 }];
-    let animation: Animation;
+    const inlineAnimation = element.style.animation;
+    let animation: Animation | null = null;
+    let reducedMotionQuery: MediaQueryList | null = null;
     try {
-      animation = element.animate(opacityKeyframes, {
-        delay,
-        duration,
-        easing,
-        iterations: Infinity,
-      });
+      reducedMotionQuery = window.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
     } catch {
-      return;
+      // An unavailable media-query implementation does not block the CSS or
+      // Web Animations paths.
     }
 
-    const inlineAnimation = element.style.animation;
-    element.style.animation = "none";
+    const restoreAnimation = () => {
+      animation?.cancel();
+      animation = null;
+      element.style.animation = inlineAnimation;
+    };
+
+    const startAnimation = () => {
+      if (animation || reducedMotionQuery?.matches) return;
+
+      const computedStyle = window.getComputedStyle(element);
+      if (firstAnimationListValue(computedStyle.animationName) === "none") return;
+
+      const duration = parseCssTime(computedStyle.animationDuration);
+      const delay = parseCssTime(computedStyle.animationDelay);
+      const easing = firstAnimationListValue(computedStyle.animationTimingFunction);
+      if (duration === null || duration <= 0 || delay === null || !easing) return;
+
+      const boundedMinimum = Math.min(1, Math.max(0, minimumOpacity));
+      const opacityKeyframes = minimumAtEndpoints
+        ? [{ opacity: boundedMinimum }, { opacity: 1 }, { opacity: boundedMinimum }]
+        : [{ opacity: 1 }, { opacity: boundedMinimum }, { opacity: 1 }];
+      try {
+        animation = element.animate(opacityKeyframes, {
+          delay,
+          duration,
+          easing,
+          iterations: Infinity,
+        });
+      } catch {
+        return;
+      }
+
+      element.style.animation = "none";
+    };
+
+    const handleMotionPreferenceChange = () => {
+      restoreAnimation();
+      startAnimation();
+    };
+
+    startAnimation();
+    reducedMotionQuery?.addEventListener("change", handleMotionPreferenceChange);
 
     return () => {
-      animation.cancel();
-      element.style.animation = inlineAnimation;
+      reducedMotionQuery?.removeEventListener("change", handleMotionPreferenceChange);
+      restoreAnimation();
     };
   }, [minimumAtEndpoints, minimumOpacity, props.className]);
 
   return <span {...props} ref={elementRef} data-compositor-pulse="" />;
-}
-
-function parseCssTime(value: string): number | null {
-  const firstValue = value.split(",")[0]?.trim();
-  if (!firstValue) return null;
-
-  const numericValue = Number.parseFloat(firstValue);
-  if (!Number.isFinite(numericValue)) return null;
-  return firstValue.endsWith("ms") ? numericValue : numericValue * 1_000;
 }
 
 export { CompositorPulse };

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -710,10 +710,9 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
 /* Chat-input "running" affordance.
  *
  * The colored border is a static border-color (painted once). The pulsing glow
- * lives on a pseudo-element that animates only `opacity`, which the compositor
- * handles on the GPU without a per-frame main-thread paint. The glow is driven
- * from the OUTER `.relative` wrapper (`.chat-input-glow*`) because the inner
- * input box has `overflow-hidden`, which would clip a child's outer box-shadow. */
+ * lives on an absolute HTML target that animates only `opacity`. The target is
+ * a child of the OUTER `.relative` wrapper because the inner input box has
+ * `overflow-hidden`, which would clip its outer box-shadow. */
 .chat-input-running,
 .chat-input-running-plan {
   border-color: color-mix(in oklab, var(--primary) 55%, var(--border));
@@ -721,16 +720,6 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
 
 .chat-input-starting {
   border-color: color-mix(in oklab, var(--primary) 50%, var(--border));
-}
-
-/* The glow pseudo-element sits at `z-index: -1` so the input content paints on
- * top of it. `isolation: isolate` makes the wrapper its own stacking context so
- * that negative z-index stays local instead of dropping behind ancestor
- * backgrounds (which would hide the glow entirely). */
-.chat-input-glow-running,
-.chat-input-glow-starting {
-  position: relative;
-  isolation: isolate;
 }
 
 @keyframes chat-input-glow-pulse {
@@ -743,9 +732,8 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
   }
 }
 
-.chat-input-glow-running::after,
-.chat-input-glow-starting::after {
-  content: "";
+.chat-input-glow-running,
+.chat-input-glow-starting {
   position: absolute;
   inset: 0;
   border-radius: 0.25rem;
@@ -754,13 +742,13 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
   animation: chat-input-glow-pulse 3s ease-in-out infinite;
 }
 
-.chat-input-glow-running::after {
+.chat-input-glow-running {
   box-shadow:
     0 0 20px 4px color-mix(in oklab, var(--primary) 20%, transparent),
     0 0 50px 8px color-mix(in oklab, var(--primary) 10%, transparent);
 }
 
-.chat-input-glow-starting::after {
+.chat-input-glow-starting {
   box-shadow:
     0 0 12px 3px color-mix(in oklab, var(--primary) 15%, transparent),
     0 0 30px 6px color-mix(in oklab, var(--primary) 8%, transparent);
@@ -769,8 +757,8 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
 
 @media (prefers-reduced-motion: reduce) {
   .animate-changes-flash,
-  .chat-input-glow-running::after,
-  .chat-input-glow-starting::after,
+  .chat-input-glow-running,
+  .chat-input-glow-starting,
   .border-flash-animation::after,
   .node-border-running::after,
   .search-flash,

--- a/apps/web/app/office/agents/components/agent-status-dot.test.tsx
+++ b/apps/web/app/office/agents/components/agent-status-dot.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentStatusDot } from "./agent-status-dot";
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: () => undefined,
+}));
+
+afterEach(cleanup);
+
+describe("AgentStatusDot", () => {
+  it("uses compositor opacity motion while the agent is working", () => {
+    const { container } = render(<AgentStatusDot status="working" />);
+
+    const dot = container.firstElementChild as HTMLElement;
+    expect(dot.hasAttribute("data-compositor-pulse")).toBe(true);
+    expect(dot.className).toContain("animate-pulse");
+    expect(dot.getAttribute("title")).toBe("working");
+  });
+
+  it("keeps settled agent states static", () => {
+    const { container } = render(<AgentStatusDot status="idle" />);
+
+    const dot = container.firstElementChild as HTMLElement;
+    expect(dot.hasAttribute("data-compositor-pulse")).toBe(false);
+    expect(dot.className).not.toContain("animate-pulse");
+  });
+});

--- a/apps/web/app/office/agents/components/agent-status-dot.tsx
+++ b/apps/web/app/office/agents/components/agent-status-dot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { CompositorPulse } from "@kandev/ui/compositor-pulse";
 import { useAppStore } from "@/components/state-provider";
 import type { AgentStatus } from "@/lib/state/slices/office/types";
 
@@ -26,8 +27,9 @@ export function AgentStatusDot({ status, className }: AgentStatusDotProps) {
   // identifier rather than copy — translating it would invent a label the rest
   // of the app never shows.
   const label = metaStatus?.label ?? status;
+  const Dot = status === "working" ? CompositorPulse : "span";
   return (
-    <span
+    <Dot
       className={cn("inline-block h-2 w-2 rounded-full shrink-0", colorClass, className)}
       title={label}
     />

--- a/apps/web/app/office/components/execution-indicator.test.tsx
+++ b/apps/web/app/office/components/execution-indicator.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ExecutionIndicator } from "./execution-indicator";
+
+afterEach(cleanup);
+
+function renderIndicator(status: string) {
+  return render(
+    <TooltipProvider>
+      <ExecutionIndicator status={status} />
+    </TooltipProvider>,
+  );
+}
+
+describe("ExecutionIndicator", () => {
+  it("pulses a static icon through an HTML compositor target while live", () => {
+    const { container } = renderIndicator("IN_PROGRESS");
+
+    const pulse = container.querySelector<HTMLElement>("[data-compositor-pulse]");
+    expect(pulse).toBeTruthy();
+    expect(pulse?.className).toContain("animate-pulse");
+    expect(pulse?.querySelector("svg")?.getAttribute("class")).not.toContain("animate-pulse");
+    expect(screen.getByText("Live")).toBeTruthy();
+  });
+
+  it("keeps the review-ready state static", () => {
+    const { container } = renderIndicator("REVIEW");
+
+    expect(container.querySelector("[data-compositor-pulse]")).toBeNull();
+    expect(screen.getByText("Ready")).toBeTruthy();
+  });
+});

--- a/apps/web/app/office/components/execution-indicator.tsx
+++ b/apps/web/app/office/components/execution-indicator.tsx
@@ -2,6 +2,7 @@
 
 import { IconPointFilled } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CompositorPulse } from "@kandev/ui/compositor-pulse";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -27,7 +28,9 @@ export function ExecutionIndicator({ status, className }: ExecutionIndicatorProp
           <span
             className={cn("inline-flex items-center gap-1 text-xs text-emerald-500", className)}
           >
-            <IconPointFilled className="h-3 w-3 animate-pulse" />
+            <CompositorPulse className="inline-flex animate-pulse">
+              <IconPointFilled className="h-3 w-3" />
+            </CompositorPulse>
             {t("office:live")}
           </span>
         </TooltipTrigger>

--- a/apps/web/components/grid-spinner.test.tsx
+++ b/apps/web/components/grid-spinner.test.tsx
@@ -16,14 +16,14 @@ afterEach(() => {
   }
 });
 
-function installComputedAnimationStyles() {
+function installComputedAnimationStyles(easing = "ease-in-out") {
   vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
     const cubeIndex = Array.from(element.parentElement?.children ?? []).indexOf(element);
     return {
       animationDelay: delays[cubeIndex] ?? "0s",
       animationDuration: "1.3s",
       animationName: "spinner-grid",
-      animationTimingFunction: "ease-in-out",
+      animationTimingFunction: easing,
     } as CSSStyleDeclaration;
   });
 }
@@ -81,6 +81,33 @@ describe("GridSpinner", () => {
     const cubes = Array.from(container.querySelectorAll<HTMLElement>(".spinner-grid-cube"));
     expect(cubes).toHaveLength(9);
     expect(cubes.every((cube) => cube.style.animation === "")).toBe(true);
+  });
+
+  it("preserves commas inside CSS easing functions", () => {
+    installComputedAnimationStyles("cubic-bezier(0.4, 0, 0.6, 1)");
+    const animate = installAnimate();
+
+    render(<GridSpinner />);
+
+    expect(animate.mock.calls[0]?.[1]).toEqual({
+      delay: 200,
+      duration: 1_300,
+      easing: "cubic-bezier(0.4, 0, 0.6, 1)",
+      iterations: Infinity,
+    });
+  });
+
+  it("keeps the animation phase when its presentation class changes", () => {
+    installComputedAnimationStyles();
+    const animations = Array.from({ length: 9 }, () => makeAnimation());
+    let animationIndex = 0;
+    const animate = installAnimate(() => animations[animationIndex++]);
+
+    const { rerender } = render(<GridSpinner className="opacity-50" />);
+    rerender(<GridSpinner className="opacity-75" />);
+
+    expect(animate).toHaveBeenCalledTimes(9);
+    for (const animation of animations) expect(animation.cancel).not.toHaveBeenCalled();
   });
 
   it("restores one consistent CSS fallback when setup fails partway", () => {

--- a/apps/web/components/grid-spinner.test.tsx
+++ b/apps/web/components/grid-spinner.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GridSpinner } from "./grid-spinner";
+
+const delays = ["0.2s", "0.3s", "0.4s", "0.1s", "0.2s", "0.3s", "0s", "0.1s", "0.2s"];
+const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate");
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  if (originalAnimate) {
+    Object.defineProperty(HTMLElement.prototype, "animate", originalAnimate);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, "animate");
+  }
+});
+
+function installComputedAnimationStyles() {
+  vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+    const cubeIndex = Array.from(element.parentElement?.children ?? []).indexOf(element);
+    return {
+      animationDelay: delays[cubeIndex] ?? "0s",
+      animationDuration: "1.3s",
+      animationName: "spinner-grid",
+      animationTimingFunction: "ease-in-out",
+    } as CSSStyleDeclaration;
+  });
+}
+
+function installAnimate(implementation?: (...args: unknown[]) => Animation) {
+  const animate = vi.fn(implementation ?? (() => makeAnimation()));
+  Object.defineProperty(HTMLElement.prototype, "animate", {
+    configurable: true,
+    value: animate,
+  });
+  return animate;
+}
+
+function makeAnimation() {
+  return { cancel: vi.fn() } as unknown as Animation;
+}
+
+describe("GridSpinner", () => {
+  it("starts nine compositor transform effects with the CSS timing and stagger", () => {
+    installComputedAnimationStyles();
+    const animate = installAnimate();
+
+    const { container } = render(<GridSpinner className="text-primary" />);
+
+    const status = container.querySelector<HTMLElement>('[role="status"]');
+    expect(status?.getAttribute("aria-label")).toBe("Loading");
+    expect(status?.className).toContain("text-primary");
+    const cubes = Array.from(container.querySelectorAll<HTMLElement>(".spinner-grid-cube"));
+    expect(cubes).toHaveLength(9);
+    expect(animate).toHaveBeenCalledTimes(9);
+    expect(animate.mock.calls.map((call) => call[0])).toEqual(
+      Array.from({ length: 9 }, () => [
+        { offset: 0, transform: "scale3d(0.5, 0.5, 1)" },
+        { offset: 0.35, transform: "scale3d(0, 0, 1)" },
+        { offset: 0.7, transform: "scale3d(0.5, 0.5, 1)" },
+        { offset: 1, transform: "scale3d(0.5, 0.5, 1)" },
+      ]),
+    );
+    expect(animate.mock.calls.map((call) => call[1])).toEqual(
+      [200, 300, 400, 100, 200, 300, 0, 100, 200].map((delay) => ({
+        delay,
+        duration: 1_300,
+        easing: "ease-in-out",
+        iterations: Infinity,
+      })),
+    );
+    expect(cubes.every((cube) => cube.style.animation === "none")).toBe(true);
+  });
+
+  it("keeps the CSS animations when Web Animations is unavailable", () => {
+    Reflect.deleteProperty(HTMLElement.prototype, "animate");
+
+    const { container } = render(<GridSpinner />);
+
+    const cubes = Array.from(container.querySelectorAll<HTMLElement>(".spinner-grid-cube"));
+    expect(cubes).toHaveLength(9);
+    expect(cubes.every((cube) => cube.style.animation === "")).toBe(true);
+  });
+
+  it("restores one consistent CSS fallback when setup fails partway", () => {
+    installComputedAnimationStyles();
+    const firstAnimation = makeAnimation();
+    const animate = installAnimate(() => {
+      if (animate.mock.calls.length === 2) throw new Error("animation setup failed");
+      return firstAnimation;
+    });
+
+    const { container } = render(<GridSpinner />);
+
+    const cubes = Array.from(container.querySelectorAll<HTMLElement>(".spinner-grid-cube"));
+    expect(animate).toHaveBeenCalledTimes(2);
+    expect(firstAnimation.cancel).toHaveBeenCalledOnce();
+    expect(cubes.every((cube) => cube.style.animation === "")).toBe(true);
+  });
+
+  it("cancels every compositor effect when it unmounts", () => {
+    installComputedAnimationStyles();
+    const animations = Array.from({ length: 9 }, () => makeAnimation());
+    let animationIndex = 0;
+    installAnimate(() => animations[animationIndex++]);
+
+    const { unmount } = render(<GridSpinner />);
+    unmount();
+
+    for (const animation of animations) {
+      expect(animation.cancel).toHaveBeenCalledOnce();
+    }
+  });
+});

--- a/apps/web/components/grid-spinner.tsx
+++ b/apps/web/components/grid-spinner.tsx
@@ -1,14 +1,42 @@
 "use client";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 type GridSpinnerProps = {
   className?: string;
 };
 
+const gridKeyframes: Keyframe[] = [
+  { offset: 0, transform: "scale3d(0.5, 0.5, 1)" },
+  { offset: 0.35, transform: "scale3d(0, 0, 1)" },
+  { offset: 0.7, transform: "scale3d(0.5, 0.5, 1)" },
+  { offset: 1, transform: "scale3d(0.5, 0.5, 1)" },
+];
+
+const useCompositorEffect = typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+
 export function GridSpinner({ className }: GridSpinnerProps) {
   const { t } = useTranslation();
+  const gridRef = React.useRef<HTMLSpanElement>(null);
+
+  useCompositorEffect(() => {
+    const cubes = Array.from(
+      gridRef.current?.querySelectorAll<HTMLElement>(".spinner-grid-cube") ?? [],
+    );
+    const animations = startGridAnimations(cubes);
+    if (!animations) return;
+
+    for (const cube of cubes) cube.style.animation = "none";
+
+    return () => {
+      for (const animation of animations) animation.cancel();
+      for (const cube of cubes) cube.style.removeProperty("animation");
+    };
+  }, [className]);
+
   return (
     <span
+      ref={gridRef}
       className={`spinner-grid ${className ?? ""}`}
       role="status"
       aria-label={t("common:loadingIndicatorLabel")}
@@ -24,4 +52,43 @@ export function GridSpinner({ className }: GridSpinnerProps) {
       <span className="spinner-grid-cube" />
     </span>
   );
+}
+
+function startGridAnimations(cubes: HTMLElement[]): Animation[] | null {
+  if (cubes.length !== 9 || cubes.some((cube) => typeof cube.animate !== "function")) return null;
+
+  const timing = cubes.map(readAnimationTiming);
+  if (timing.some((value) => value === null)) return null;
+
+  const animations: Animation[] = [];
+  try {
+    for (let index = 0; index < cubes.length; index += 1) {
+      animations.push(cubes[index].animate(gridKeyframes, timing[index] ?? undefined));
+    }
+    return animations;
+  } catch {
+    for (const animation of animations) animation.cancel();
+    return null;
+  }
+}
+
+function readAnimationTiming(cube: HTMLElement): KeyframeAnimationOptions | null {
+  const computedStyle = window.getComputedStyle(cube);
+  if (computedStyle.animationName === "none") return null;
+
+  const duration = parseCssTime(computedStyle.animationDuration);
+  const delay = parseCssTime(computedStyle.animationDelay);
+  const easing = computedStyle.animationTimingFunction.split(",")[0]?.trim();
+  if (duration === null || duration <= 0 || delay === null || !easing) return null;
+
+  return { delay, duration, easing, iterations: Infinity };
+}
+
+function parseCssTime(value: string): number | null {
+  const firstValue = value.split(",")[0]?.trim();
+  if (!firstValue) return null;
+
+  const numericValue = Number.parseFloat(firstValue);
+  if (!Number.isFinite(numericValue)) return null;
+  return firstValue.endsWith("ms") ? numericValue : numericValue * 1_000;
 }

--- a/apps/web/components/grid-spinner.tsx
+++ b/apps/web/components/grid-spinner.tsx
@@ -1,6 +1,7 @@
 "use client";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { firstAnimationListValue, parseCssTime } from "@kandev/ui/animation-utils";
 
 type GridSpinnerProps = {
   className?: string;
@@ -32,7 +33,7 @@ export function GridSpinner({ className }: GridSpinnerProps) {
       for (const animation of animations) animation.cancel();
       for (const cube of cubes) cube.style.removeProperty("animation");
     };
-  }, [className]);
+  }, []);
 
   return (
     <span
@@ -58,12 +59,13 @@ function startGridAnimations(cubes: HTMLElement[]): Animation[] | null {
   if (cubes.length !== 9 || cubes.some((cube) => typeof cube.animate !== "function")) return null;
 
   const timing = cubes.map(readAnimationTiming);
-  if (timing.some((value) => value === null)) return null;
+  const validTiming = timing.filter((value): value is KeyframeAnimationOptions => value !== null);
+  if (validTiming.length !== cubes.length) return null;
 
   const animations: Animation[] = [];
   try {
     for (let index = 0; index < cubes.length; index += 1) {
-      animations.push(cubes[index].animate(gridKeyframes, timing[index] ?? undefined));
+      animations.push(cubes[index].animate(gridKeyframes, validTiming[index]));
     }
     return animations;
   } catch {
@@ -74,21 +76,12 @@ function startGridAnimations(cubes: HTMLElement[]): Animation[] | null {
 
 function readAnimationTiming(cube: HTMLElement): KeyframeAnimationOptions | null {
   const computedStyle = window.getComputedStyle(cube);
-  if (computedStyle.animationName === "none") return null;
+  if (firstAnimationListValue(computedStyle.animationName) === "none") return null;
 
   const duration = parseCssTime(computedStyle.animationDuration);
   const delay = parseCssTime(computedStyle.animationDelay);
-  const easing = computedStyle.animationTimingFunction.split(",")[0]?.trim();
+  const easing = firstAnimationListValue(computedStyle.animationTimingFunction);
   if (duration === null || duration <= 0 || delay === null || !easing) return null;
 
   return { delay, duration, easing, iterations: Infinity };
-}
-
-function parseCssTime(value: string): number | null {
-  const firstValue = value.split(",")[0]?.trim();
-  if (!firstValue) return null;
-
-  const numericValue = Number.parseFloat(firstValue);
-  if (!Number.isFinite(numericValue)) return null;
-  return firstValue.endsWith("ms") ? numericValue : numericValue * 1_000;
 }

--- a/apps/web/components/task/chat/chat-input-body.test.tsx
+++ b/apps/web/components/task/chat/chat-input-body.test.tsx
@@ -6,6 +6,7 @@ import { ChatInputBody, type ChatInputBodyProps } from "./chat-input-body";
 import { shouldShowCancelAgent } from "./chat-input-container";
 
 const tipTapPropsMock = vi.hoisted(() => vi.fn());
+const CHAT_INPUT_GLOW_TEST_ID = "chat-input-glow";
 
 vi.mock("./tiptap-input", () => ({
   TipTapInput: (props: unknown) => {
@@ -81,6 +82,51 @@ function props(overrides: Partial<ChatInputBodyProps> = {}): ChatInputBodyProps 
 }
 
 describe("ChatInputBody", () => {
+  it("renders the running glow as a pointer-inert HTML pulse target", () => {
+    render(
+      <TooltipProvider>
+        <ChatInputBody {...props({ isAgentBusy: true })} />
+      </TooltipProvider>,
+    );
+
+    const glow = screen.getByTestId(CHAT_INPUT_GLOW_TEST_ID);
+    expect(glow.tagName).toBe("SPAN");
+    expect(glow.className).toContain("chat-input-glow-running");
+    expect(glow.getAttribute("aria-hidden")).toBe("true");
+    expect(glow.hasAttribute("data-compositor-pulse")).toBe(true);
+  });
+
+  it("uses the starting glow until the busy state takes precedence", () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <ChatInputBody {...props({ isStarting: true })} />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByTestId(CHAT_INPUT_GLOW_TEST_ID).className).toContain(
+      "chat-input-glow-starting",
+    );
+
+    rerender(
+      <TooltipProvider>
+        <ChatInputBody {...props({ isStarting: true, isAgentBusy: true })} />
+      </TooltipProvider>,
+    );
+    const busyGlow = screen.getByTestId(CHAT_INPUT_GLOW_TEST_ID);
+    expect(busyGlow.className).toContain("chat-input-glow-running");
+    expect(busyGlow.className).not.toContain("chat-input-glow-starting");
+  });
+
+  it("removes the glow target when the composer is settled", () => {
+    render(
+      <TooltipProvider>
+        <ChatInputBody {...props()} />
+      </TooltipProvider>,
+    );
+
+    expect(screen.queryByTestId(CHAT_INPUT_GLOW_TEST_ID)).toBeNull();
+  });
+
   it("keeps the regular editor enabled while a structured clarification is pending", () => {
     render(
       <TooltipProvider>

--- a/apps/web/components/task/chat/chat-input-body.tsx
+++ b/apps/web/components/task/chat/chat-input-body.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CompositorPulse } from "@kandev/ui/compositor-pulse";
 import { cn } from "@/lib/utils";
 import { TipTapInput } from "./tiptap-input";
 import { ChatInputFocusHint } from "./chat-input-focus-hint";
@@ -318,13 +319,64 @@ function PromptResultRecoveryArea({ children }: { children?: React.ReactNode }) 
   return <div className="mt-2">{children}</div>;
 }
 
-/** Glow class for the outer wrapper. The pulsing glow lives on the wrapper
- * (not the inner box) because the inner box has `overflow-hidden`, which would
- * clip a child pseudo-element's outer box-shadow. */
+/** Glow class for the absolute pulse target outside the overflow-hidden box. */
 function chatInputGlowClass(isAgentBusy: boolean, isStarting: boolean): string {
   if (isAgentBusy) return "chat-input-glow-running";
   if (isStarting) return "chat-input-glow-starting";
   return "";
+}
+
+function ChatInputGlow({ className }: { className: string }) {
+  if (!className) return null;
+  return (
+    <CompositorPulse
+      aria-hidden
+      data-testid="chat-input-glow"
+      className={className}
+      minimumOpacity={0.4}
+      minimumAtEndpoints
+    />
+  );
+}
+
+function useChatInputDrop(addFiles: (files: File[]) => Promise<void>) {
+  const [isDragging, setIsDragging] = useState(false);
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+  const handleDragEnter = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.dataTransfer.types.includes("Files")) setIsDragging(true);
+  }, []);
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const rect = event.currentTarget.getBoundingClientRect();
+    const { clientX, clientY } = event;
+    if (
+      clientX <= rect.left ||
+      clientX >= rect.right ||
+      clientY <= rect.top ||
+      clientY >= rect.bottom
+    ) {
+      setIsDragging(false);
+    }
+  }, []);
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDragging(false);
+      const files = Array.from(event.dataTransfer.files).filter(
+        (file) => file.size > 0 || file.type !== "",
+      );
+      if (files.length > 0) void addFiles(files);
+    },
+    [addFiles],
+  );
+  return { handleDragEnter, handleDragLeave, handleDragOver, handleDrop, isDragging };
 }
 
 export function ChatInputBody({
@@ -344,52 +396,13 @@ export function ChatInputBody({
   editorAreaProps,
   promptResultRecovery,
 }: ChatInputBodyProps) {
-  const [isDragging, setIsDragging] = useState(false);
-
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-  }, []);
-
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (e.dataTransfer.types.includes("Files")) {
-      setIsDragging(true);
-    }
-  }, []);
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    // Only set false when leaving the container (not entering a child)
-    const rect = e.currentTarget.getBoundingClientRect();
-    const { clientX, clientY } = e;
-    if (
-      clientX <= rect.left ||
-      clientX >= rect.right ||
-      clientY <= rect.top ||
-      clientY >= rect.bottom
-    ) {
-      setIsDragging(false);
-    }
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDragging(false);
-      const files = Array.from(e.dataTransfer.files).filter((f) => f.size > 0 || f.type !== "");
-      if (files.length > 0) {
-        void addFiles(files);
-      }
-    },
-    [addFiles],
-  );
+  const glowClass = chatInputGlowClass(isAgentBusy, isStarting);
+  const hasGlow = Boolean(glowClass);
+  const drop = useChatInputDrop(addFiles);
 
   return (
-    <div className={cn("relative", chatInputGlowClass(isAgentBusy, isStarting))}>
+    <div className={cn("relative", { isolate: hasGlow })}>
+      <ChatInputGlow className={glowClass} />
       <ResizeHandle
         planModeEnabled={planModeEnabled}
         isAgentBusy={isAgentBusy}
@@ -408,12 +421,12 @@ export function ChatInputBody({
           hasClarification && "border-sky-400/50",
           showRequestChangesTooltip && "animate-pulse border-orange-500",
           hasPendingComments && "border-amber-500/50",
-          isDragging && "border-primary ring-1 ring-primary/30",
+          drop.isDragging && "border-primary ring-1 ring-primary/30",
         )}
-        onDragOver={handleDragOver}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
+        onDragOver={drop.handleDragOver}
+        onDragEnter={drop.handleDragEnter}
+        onDragLeave={drop.handleDragLeave}
+        onDrop={drop.handleDrop}
       >
         <ChatInputFocusHint visible={showFocusHint} />
         <ChatInputContextArea {...contextAreaProps} />

--- a/apps/web/components/task/simple/chat-activity-tabs.test.tsx
+++ b/apps/web/components/task/simple/chat-activity-tabs.test.tsx
@@ -145,6 +145,9 @@ describe("ChatActivityTabs per-agent tabs", () => {
     const dots = screen.getAllByTestId("agent-tab-live-dot");
     // Exactly one dot — the running agent.
     expect(dots).toHaveLength(1);
+    expect(dots[0].hasAttribute("data-compositor-pulse")).toBe(true);
+    expect(dots[0].className).toContain("animate-pulse");
+    expect(dots[0].getAttribute("aria-label")).toBe("agent running");
   });
 
   it("groups multiple sessions for one agent into a single tab", () => {

--- a/apps/web/components/task/simple/chat-activity-tabs.tsx
+++ b/apps/web/components/task/simple/chat-activity-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@kandev/ui/tabs";
+import { CompositorPulse } from "@kandev/ui/compositor-pulse";
 import { useAppStore } from "@/components/state-provider";
 import { selectOfficeAgentProfiles } from "@/lib/state/slices/office/selectors";
 import { agentTint } from "@/app/office/components/agent-avatar";
@@ -62,7 +63,7 @@ function AgentTabTrigger({ group }: { group: SessionGroup }) {
         <span className={`inline-block h-1.5 w-1.5 rounded-full ${agentDot(label)}`} aria-hidden />
         {label}
         {live && (
-          <span
+          <CompositorPulse
             data-testid="agent-tab-live-dot"
             className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse"
             aria-label={t("task:agentRunning")}

--- a/apps/web/e2e/helpers/animation-assertions.ts
+++ b/apps/web/e2e/helpers/animation-assertions.ts
@@ -1,0 +1,38 @@
+import type { Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+export async function expectCompositorGridMotion(status: Locator) {
+  await expect(status.locator(".spinner-grid-cube")).toHaveCount(9);
+  await expect
+    .poll(() =>
+      status.locator(".spinner-grid-cube").evaluateAll((cubes) =>
+        cubes.every((cube) => {
+          const animations = cube.getAnimations();
+          return (
+            animations.length === 1 &&
+            animations[0].playState === "running" &&
+            animations[0].effect?.getTiming().iterations === Infinity &&
+            animations[0].constructor.name === "Animation"
+          );
+        }),
+      ),
+    )
+    .toBe(true);
+}
+
+export async function expectCompositorPulse(pulse: Locator) {
+  await expect(pulse).toBeVisible();
+  await expect
+    .poll(() =>
+      pulse.evaluate((element) => {
+        const animations = element.getAnimations();
+        return (
+          animations.length === 1 &&
+          animations[0].playState === "running" &&
+          animations[0].effect?.getTiming().iterations === Infinity &&
+          animations[0].constructor.name === "Animation"
+        );
+      }),
+    )
+    .toBe(true);
+}

--- a/apps/web/e2e/tests/chat/animation-performance-trace.spec.ts
+++ b/apps/web/e2e/tests/chat/animation-performance-trace.spec.ts
@@ -135,31 +135,41 @@ async function installCssFallbackControl(page: Page) {
 
 async function captureTrace(page: Page, testInfo: TestInfo, label: string): Promise<TraceMetrics> {
   const client = await page.context().newCDPSession(page);
-  await client.send("Emulation.setScriptExecutionDisabled", { value: true });
-  await dwell(
-    1_000,
-    "clock-separation",
-    "the browser does not publish an event when pending application tasks are drained",
-  );
-  const stream = traceStream(client);
-  await client.send("Tracing.start", {
-    categories: [
-      "devtools.timeline",
-      "disabled-by-default-devtools.timeline",
-      "disabled-by-default-devtools.timeline.invalidationTracking",
-      "blink.user_timing",
-    ].join(","),
-    transferMode: "ReturnAsStream",
-  });
-  await dwell(
-    TRACE_WINDOW_MS,
-    "clock-separation",
-    "the fixed acceptance trace window has no completion event",
-  );
-  await client.send("Tracing.end");
-  const trace = await readTraceStream(client, await stream);
-  await client.send("Emulation.setScriptExecutionDisabled", { value: false });
-  await client.detach();
+  let trace = "";
+  let tracingStarted = false;
+  try {
+    await client.send("Emulation.setScriptExecutionDisabled", { value: true });
+    await dwell(
+      1_000,
+      "clock-separation",
+      "the browser does not publish an event when pending application tasks are drained",
+    );
+    const stream = traceStream(client);
+    await client.send("Tracing.start", {
+      categories: [
+        "devtools.timeline",
+        "disabled-by-default-devtools.timeline",
+        "disabled-by-default-devtools.timeline.invalidationTracking",
+        "blink.user_timing",
+      ].join(","),
+      transferMode: "ReturnAsStream",
+    });
+    tracingStarted = true;
+    await dwell(
+      TRACE_WINDOW_MS,
+      "clock-separation",
+      "the fixed acceptance trace window has no completion event",
+    );
+    await client.send("Tracing.end");
+    tracingStarted = false;
+    trace = await readTraceStream(client, await stream);
+  } finally {
+    if (tracingStarted) await client.send("Tracing.end").catch(() => undefined);
+    await client
+      .send("Emulation.setScriptExecutionDisabled", { value: false })
+      .catch(() => undefined);
+    await client.detach().catch(() => undefined);
+  }
   await testInfo.attach(`${label}.json`, {
     body: Buffer.from(trace),
     contentType: "application/json",
@@ -185,7 +195,7 @@ async function readTraceStream(client: CDPSession, stream: string): Promise<stri
   let eof = false;
   while (!eof) {
     const chunk = await client.send("IO.read", { handle: stream });
-    trace += chunk.data;
+    trace += chunk.base64Encoded ? Buffer.from(chunk.data, "base64").toString("utf8") : chunk.data;
     eof = chunk.eof;
   }
   await client.send("IO.close", { handle: stream });

--- a/apps/web/e2e/tests/chat/animation-performance-trace.spec.ts
+++ b/apps/web/e2e/tests/chat/animation-performance-trace.spec.ts
@@ -1,0 +1,211 @@
+import type { CDPSession, Page, TestInfo } from "@playwright/test";
+
+import { test, expect } from "../../fixtures/test-base";
+import { dwell } from "../../helpers/causal-waits";
+import { SessionPage } from "../../pages/session-page";
+import { openQuickChatWithAgent, sendQuickChatMessage } from "./quick-chat-helpers";
+
+const TRACE_WINDOW_MS = 8_340;
+const TARGET_PATTERN = /spinner-grid-cube|chat-input-glow-(?:running|starting)/;
+
+type TraceEvent = {
+  name?: string;
+  args?: unknown;
+};
+
+type TraceMetrics = {
+  updateLayoutTree: number;
+  layerize: number;
+  layout: number;
+  paint: number;
+  targetInvalidations: number;
+};
+
+test.skip(
+  process.env.KANDEV_E2E_ANIMATION_TRACE !== "1",
+  "Run explicitly to capture the 8.34-second animation performance control.",
+);
+test.describe.configure({ retries: 1 });
+
+test("attributes steady animation work for compositor and CSS fallback paths", async ({
+  testPage,
+  apiClient,
+  seedData,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Animation performance trace",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+  await session.sendMessage("/slow 30s");
+
+  const glow = session.activeChat().getByTestId("chat-input-glow");
+  await expect(glow).toBeVisible();
+  const dialog = await openQuickChatWithAgent(testPage);
+  await sendQuickChatMessage(dialog, testPage, "/slow 30s");
+  const cubes = dialog.locator(".spinner-grid-cube");
+  await expect(cubes).toHaveCount(18);
+  await expectCompositorTargets(testPage);
+
+  const disableCssMotion = await testPage.addStyleTag({
+    content: "*,*::before,*::after{animation:none!important;transition:none!important}",
+  });
+  await dwell(1_000, "clock-separation", "exclude one-time effect setup from the trace window");
+  const compositor = await captureTrace(testPage, testInfo, "compositor-motion");
+  expect(compositor.targetInvalidations).toBe(0);
+
+  await disableCssMotion.evaluate((element) => element.remove());
+  await installCssFallbackControl(testPage);
+  await dwell(
+    1_000,
+    "clock-separation",
+    "exclude fallback style installation from the trace window",
+  );
+  const cssFallback = await captureTrace(testPage, testInfo, "css-fallback-motion");
+  console.info(`[animation-performance-trace] ${JSON.stringify({ compositor, cssFallback })}`);
+  expect(cssFallback.updateLayoutTree).toBeGreaterThan(0);
+  expect(cssFallback.layerize).toBeGreaterThan(0);
+});
+
+async function expectCompositorTargets(page: Page) {
+  await expect
+    .poll(() =>
+      page
+        .locator("[data-compositor-pulse], .spinner-grid-cube")
+        .evaluateAll((elements) =>
+          elements.every((element) =>
+            element
+              .getAnimations()
+              .some(
+                (animation) =>
+                  animation.constructor.name === "Animation" && animation.playState === "running",
+              ),
+          ),
+        ),
+    )
+    .toBe(true);
+}
+
+async function installCssFallbackControl(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *,*::before,*::after{animation:none!important;transition:none!important}
+      .spinner-grid-cube{animation:spinner-grid 1.3s ease-in-out infinite!important}
+      .chat-input-glow-running{animation:chat-input-glow-pulse 3s ease-in-out infinite!important}
+      .chat-input-glow-starting{animation:chat-input-glow-pulse 2s ease-in-out infinite!important}
+    `,
+  });
+  await page.locator("[data-compositor-pulse], .spinner-grid-cube").evaluateAll((elements) => {
+    for (const element of elements) {
+      for (const animation of element.getAnimations()) {
+        if (animation.constructor.name === "Animation") animation.cancel();
+      }
+      (element as HTMLElement).style.removeProperty("animation");
+    }
+  });
+  await expect
+    .poll(() =>
+      page
+        .locator("[data-compositor-pulse], .spinner-grid-cube")
+        .evaluateAll((elements) =>
+          elements.every((element) =>
+            element
+              .getAnimations()
+              .some(
+                (animation) =>
+                  animation.constructor.name === "CSSAnimation" &&
+                  animation.playState === "running",
+              ),
+          ),
+        ),
+    )
+    .toBe(true);
+}
+
+async function captureTrace(page: Page, testInfo: TestInfo, label: string): Promise<TraceMetrics> {
+  const client = await page.context().newCDPSession(page);
+  await client.send("Emulation.setScriptExecutionDisabled", { value: true });
+  await dwell(
+    1_000,
+    "clock-separation",
+    "the browser does not publish an event when pending application tasks are drained",
+  );
+  const stream = traceStream(client);
+  await client.send("Tracing.start", {
+    categories: [
+      "devtools.timeline",
+      "disabled-by-default-devtools.timeline",
+      "disabled-by-default-devtools.timeline.invalidationTracking",
+      "blink.user_timing",
+    ].join(","),
+    transferMode: "ReturnAsStream",
+  });
+  await dwell(
+    TRACE_WINDOW_MS,
+    "clock-separation",
+    "the fixed acceptance trace window has no completion event",
+  );
+  await client.send("Tracing.end");
+  const trace = await readTraceStream(client, await stream);
+  await client.send("Emulation.setScriptExecutionDisabled", { value: false });
+  await client.detach();
+  await testInfo.attach(`${label}.json`, {
+    body: Buffer.from(trace),
+    contentType: "application/json",
+  });
+
+  const events = (JSON.parse(trace) as { traceEvents: TraceEvent[] }).traceEvents;
+  const metrics = traceMetrics(events);
+  await testInfo.attach(`${label}-metrics.json`, {
+    body: Buffer.from(JSON.stringify(metrics, null, 2)),
+    contentType: "application/json",
+  });
+  return metrics;
+}
+
+function traceStream(client: CDPSession): Promise<string> {
+  return new Promise((resolve) => {
+    client.once("Tracing.tracingComplete", (event) => resolve(event.stream));
+  });
+}
+
+async function readTraceStream(client: CDPSession, stream: string): Promise<string> {
+  let trace = "";
+  let eof = false;
+  while (!eof) {
+    const chunk = await client.send("IO.read", { handle: stream });
+    trace += chunk.data;
+    eof = chunk.eof;
+  }
+  await client.send("IO.close", { handle: stream });
+  return trace;
+}
+
+function traceMetrics(events: TraceEvent[]): TraceMetrics {
+  return {
+    updateLayoutTree: countNamed(events, "UpdateLayoutTree"),
+    layerize: countNamed(events, "Layerize"),
+    layout: countNamed(events, "Layout"),
+    paint: countNamed(events, "Paint"),
+    targetInvalidations: events.filter(
+      (event) =>
+        event.name?.includes("InvalidationTracking") &&
+        TARGET_PATTERN.test(JSON.stringify(event.args)),
+    ).length,
+  };
+}
+
+function countNamed(events: TraceEvent[], name: string): number {
+  return events.filter((event) => event.name === name).length;
+}

--- a/apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts
@@ -1,24 +1,6 @@
-import type { Locator } from "@playwright/test";
-
 import { test, expect } from "../../fixtures/test-base";
+import { expectCompositorPulse } from "../../helpers/animation-assertions";
 import { SessionPage } from "../../pages/session-page";
-
-async function expectCompositorPulse(pulse: Locator) {
-  await expect(pulse).toBeVisible();
-  await expect
-    .poll(() =>
-      pulse.evaluate((element) => {
-        const animations = element.getAnimations();
-        return (
-          animations.length === 1 &&
-          animations[0].playState === "running" &&
-          animations[0].effect?.getTiming().iterations === Infinity &&
-          animations[0].constructor.name === "Animation"
-        );
-      }),
-    )
-    .toBe(true);
-}
 
 test("keeps the mobile composer pulse contained until the turn settles", async ({
   testPage,

--- a/apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts
@@ -1,0 +1,54 @@
+import type { Locator } from "@playwright/test";
+
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+async function expectCompositorPulse(pulse: Locator) {
+  await expect(pulse).toBeVisible();
+  await expect
+    .poll(() =>
+      pulse.evaluate((element) => {
+        const animations = element.getAnimations();
+        return (
+          animations.length === 1 &&
+          animations[0].playState === "running" &&
+          animations[0].effect?.getTiming().iterations === Infinity &&
+          animations[0].constructor.name === "Animation"
+        );
+      }),
+    )
+    .toBe(true);
+}
+
+test("keeps the mobile composer pulse contained until the turn settles", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  test.setTimeout(60_000);
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Mobile persistent composer motion",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+
+  await session.sendMessageViaButton("/slow 8s");
+  const glow = session.activeChat().getByTestId("chat-input-glow");
+  await expectCompositorPulse(glow);
+  expect(
+    await testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+  ).toBe(true);
+
+  await session.waitForChatIdle({ timeout: 30_000 });
+  await expect(glow).toHaveCount(0);
+});

--- a/apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts
@@ -1,6 +1,6 @@
-import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import { watchWs } from "../../helpers/causal-waits";
+import { expectCompositorGridMotion } from "../../helpers/animation-assertions";
 import { SessionPage } from "../../pages/session-page";
 import {
   sendQuickChatMessage,
@@ -8,25 +8,6 @@ import {
   waitForSessionSettled,
   waitForSessionSettledBaseline,
 } from "./quick-chat-helpers";
-
-async function expectCompositorGridMotion(status: Locator) {
-  await expect(status.locator(".spinner-grid-cube")).toHaveCount(9);
-  await expect
-    .poll(() =>
-      status.locator(".spinner-grid-cube").evaluateAll((cubes) =>
-        cubes.every((cube) => {
-          const animations = cube.getAnimations();
-          return (
-            animations.length === 1 &&
-            animations[0].playState === "running" &&
-            animations[0].effect?.getTiming().iterations === Infinity &&
-            animations[0].constructor.name === "Animation"
-          );
-        }),
-      ),
-    )
-    .toBe(true);
-}
 
 test.describe("quick chat activity indicators", () => {
   test("shows the mobile header running and finished states through touch", async ({

--- a/apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts
@@ -1,3 +1,4 @@
+import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import { watchWs } from "../../helpers/causal-waits";
 import { SessionPage } from "../../pages/session-page";
@@ -7,6 +8,25 @@ import {
   waitForSessionSettled,
   waitForSessionSettledBaseline,
 } from "./quick-chat-helpers";
+
+async function expectCompositorGridMotion(status: Locator) {
+  await expect(status.locator(".spinner-grid-cube")).toHaveCount(9);
+  await expect
+    .poll(() =>
+      status.locator(".spinner-grid-cube").evaluateAll((cubes) =>
+        cubes.every((cube) => {
+          const animations = cube.getAnimations();
+          return (
+            animations.length === 1 &&
+            animations[0].playState === "running" &&
+            animations[0].effect?.getTiming().iterations === Infinity &&
+            animations[0].constructor.name === "Animation"
+          );
+        }),
+      ),
+    )
+    .toBe(true);
+}
 
 test.describe("quick chat activity indicators", () => {
   test("shows the mobile header running and finished states through touch", async ({
@@ -40,7 +60,12 @@ test.describe("quick chat activity indicators", () => {
     });
     const settled = waitForSessionSettled(ws, sessionId);
     await sendQuickChatMessage(dialog, testPage, "/slow 8s");
-    await expect(tab.getByRole("status")).toBeVisible();
+    const gridStatus = tab.getByRole("status");
+    await expect(gridStatus).toBeVisible();
+    await expectCompositorGridMotion(gridStatus);
+    expect(
+      await testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true);
 
     await dialog.getByTestId("quick-chat-close").tap();
     await expect(indicator).toHaveAttribute("data-state", "running");

--- a/apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts
+++ b/apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts
@@ -1,24 +1,6 @@
-import type { Locator } from "@playwright/test";
-
 import { test, expect } from "../../fixtures/test-base";
+import { expectCompositorPulse } from "../../helpers/animation-assertions";
 import { SessionPage } from "../../pages/session-page";
-
-async function expectCompositorPulse(pulse: Locator) {
-  await expect(pulse).toBeVisible();
-  await expect
-    .poll(() =>
-      pulse.evaluate((element) => {
-        const animations = element.getAnimations();
-        return (
-          animations.length === 1 &&
-          animations[0].playState === "running" &&
-          animations[0].effect?.getTiming().iterations === Infinity &&
-          animations[0].constructor.name === "Animation"
-        );
-      }),
-    )
-    .toBe(true);
-}
 
 test("keeps the busy task composer glow animated until the turn settles", async ({
   testPage,

--- a/apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts
+++ b/apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts
@@ -1,0 +1,51 @@
+import type { Locator } from "@playwright/test";
+
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+async function expectCompositorPulse(pulse: Locator) {
+  await expect(pulse).toBeVisible();
+  await expect
+    .poll(() =>
+      pulse.evaluate((element) => {
+        const animations = element.getAnimations();
+        return (
+          animations.length === 1 &&
+          animations[0].playState === "running" &&
+          animations[0].effect?.getTiming().iterations === Infinity &&
+          animations[0].constructor.name === "Animation"
+        );
+      }),
+    )
+    .toBe(true);
+}
+
+test("keeps the busy task composer glow animated until the turn settles", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  test.setTimeout(60_000);
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Persistent composer motion",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+
+  await session.sendMessage("/slow 8s");
+  const glow = session.activeChat().getByTestId("chat-input-glow");
+  await expectCompositorPulse(glow);
+
+  await session.waitForChatIdle({ timeout: 30_000 });
+  await expect(glow).toHaveCount(0);
+});

--- a/apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts
@@ -1,3 +1,4 @@
+import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import { watchWs } from "../../helpers/causal-waits";
 import {
@@ -6,6 +7,25 @@ import {
   waitForSessionSettled,
   waitForSessionSettledBaseline,
 } from "./quick-chat-helpers";
+
+async function expectCompositorGridMotion(status: Locator) {
+  await expect(status.locator(".spinner-grid-cube")).toHaveCount(9);
+  await expect
+    .poll(() =>
+      status.locator(".spinner-grid-cube").evaluateAll((cubes) =>
+        cubes.every((cube) => {
+          const animations = cube.getAnimations();
+          return (
+            animations.length === 1 &&
+            animations[0].playState === "running" &&
+            animations[0].effect?.getTiming().iterations === Infinity &&
+            animations[0].constructor.name === "Animation"
+          );
+        }),
+      ),
+    )
+    .toBe(true);
+}
 
 test.describe("quick chat activity indicators", () => {
   test("shows tab and sidebar running state, then clears a finished state when opened", async ({
@@ -33,7 +53,9 @@ test.describe("quick chat activity indicators", () => {
     });
     const settled = waitForSessionSettled(ws, sessionId);
     await sendQuickChatMessage(dialog, testPage, "/slow 8s");
-    await expect(tab.getByRole("status")).toBeVisible();
+    const gridStatus = tab.getByRole("status");
+    await expect(gridStatus).toBeVisible();
+    await expectCompositorGridMotion(gridStatus);
 
     await testPage.keyboard.press("Escape");
     await expect(indicator).toHaveAttribute("data-state", "running");
@@ -74,7 +96,9 @@ test.describe("quick chat activity indicators", () => {
     });
     const settled = waitForSessionSettled(ws, sessionId);
     await sendQuickChatMessage(dialog, tabletTestPage, "/slow 8s");
-    await expect(tab.getByRole("status")).toBeVisible();
+    const gridStatus = tab.getByRole("status");
+    await expect(gridStatus).toBeVisible();
+    await expectCompositorGridMotion(gridStatus);
 
     await tabletTestPage.keyboard.press("Escape");
     await expect(indicator).toHaveAttribute("data-state", "running");

--- a/apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts
@@ -1,31 +1,12 @@
-import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import { watchWs } from "../../helpers/causal-waits";
+import { expectCompositorGridMotion } from "../../helpers/animation-assertions";
 import {
   openQuickChatWithAgent,
   sendQuickChatMessage,
   waitForSessionSettled,
   waitForSessionSettledBaseline,
 } from "./quick-chat-helpers";
-
-async function expectCompositorGridMotion(status: Locator) {
-  await expect(status.locator(".spinner-grid-cube")).toHaveCount(9);
-  await expect
-    .poll(() =>
-      status.locator(".spinner-grid-cube").evaluateAll((cubes) =>
-        cubes.every((cube) => {
-          const animations = cube.getAnimations();
-          return (
-            animations.length === 1 &&
-            animations[0].playState === "running" &&
-            animations[0].effect?.getTiming().iterations === Infinity &&
-            animations[0].constructor.name === "Animation"
-          );
-        }),
-      ),
-    )
-    .toBe(true);
-}
 
 test.describe("quick chat activity indicators", () => {
   test("shows tab and sidebar running state, then clears a finished state when opened", async ({

--- a/apps/web/lib/ui/compositor-pulse.test.tsx
+++ b/apps/web/lib/ui/compositor-pulse.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render } from "@testing-library/react";
+import { CompositorPulse } from "@kandev/ui/compositor-pulse";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate");
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  if (originalAnimate) {
+    Object.defineProperty(HTMLElement.prototype, "animate", originalAnimate);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, "animate");
+  }
+});
+
+function installComputedAnimationStyles(overrides: Partial<CSSStyleDeclaration> = {}) {
+  vi.spyOn(window, "getComputedStyle").mockReturnValue({
+    animationDelay: "0s",
+    animationDuration: "2s",
+    animationName: "pulse",
+    animationTimingFunction: "cubic-bezier(0.4, 0, 0.6, 1)",
+    ...overrides,
+  } as CSSStyleDeclaration);
+}
+
+function installAnimate() {
+  const animation = { cancel: vi.fn() } as unknown as Animation;
+  const animate = vi.fn(() => animation);
+  Object.defineProperty(HTMLElement.prototype, "animate", {
+    configurable: true,
+    value: animate,
+  });
+  return { animate, animation };
+}
+
+describe("CompositorPulse", () => {
+  it("replaces a CSS pulse with an infinite compositor opacity effect", () => {
+    installComputedAnimationStyles();
+    const { animate } = installAnimate();
+
+    const { getByTestId } = render(
+      <CompositorPulse data-testid="pulse" className="animate-pulse bg-primary" />,
+    );
+
+    const pulse = getByTestId("pulse");
+    expect(pulse.className).toContain("animate-pulse");
+    expect(animate).toHaveBeenCalledWith([{ opacity: 1 }, { opacity: 0.5 }, { opacity: 1 }], {
+      delay: 0,
+      duration: 2_000,
+      easing: "cubic-bezier(0.4, 0, 0.6, 1)",
+      iterations: Infinity,
+    });
+    expect(pulse.style.animation).toBe("none");
+  });
+
+  it("preserves a glow whose minimum opacity is at both endpoints", () => {
+    installComputedAnimationStyles({ animationDuration: "3s" });
+    const { animate } = installAnimate();
+
+    render(
+      <CompositorPulse
+        className="chat-input-glow-running"
+        minimumOpacity={0.4}
+        minimumAtEndpoints
+      />,
+    );
+
+    expect(animate).toHaveBeenCalledWith(
+      [{ opacity: 0.4 }, { opacity: 1 }, { opacity: 0.4 }],
+      expect.objectContaining({ duration: 3_000 }),
+    );
+  });
+
+  it("keeps the animated CSS fallback when Web Animations is unavailable", () => {
+    Reflect.deleteProperty(HTMLElement.prototype, "animate");
+
+    const { getByTestId } = render(
+      <CompositorPulse data-testid="pulse" className="animate-pulse" />,
+    );
+
+    expect(getByTestId("pulse").style.animation).toBe("");
+  });
+
+  it("does not override CSS reduced-motion suppression", () => {
+    installComputedAnimationStyles({ animationName: "none" });
+    const { animate } = installAnimate();
+
+    const { getByTestId } = render(
+      <CompositorPulse data-testid="pulse" className="motion-reduce:animate-none" />,
+    );
+
+    expect(animate).not.toHaveBeenCalled();
+    expect(getByTestId("pulse").style.animation).toBe("");
+  });
+
+  it("cancels its effect and restores CSS on cleanup", () => {
+    installComputedAnimationStyles();
+    const { animation } = installAnimate();
+
+    const { getByTestId, unmount } = render(
+      <CompositorPulse data-testid="pulse" className="animate-pulse" />,
+    );
+    const pulse = getByTestId("pulse");
+    unmount();
+
+    expect(animation.cancel).toHaveBeenCalledOnce();
+    expect(pulse.style.animation).toBe("");
+  });
+});

--- a/apps/web/lib/ui/compositor-pulse.test.tsx
+++ b/apps/web/lib/ui/compositor-pulse.test.tsx
@@ -3,6 +3,7 @@ import { CompositorPulse } from "@kandev/ui/compositor-pulse";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate");
+const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
 
 afterEach(() => {
   cleanup();
@@ -11,6 +12,11 @@ afterEach(() => {
     Object.defineProperty(HTMLElement.prototype, "animate", originalAnimate);
   } else {
     Reflect.deleteProperty(HTMLElement.prototype, "animate");
+  }
+  if (originalMatchMedia) {
+    Object.defineProperty(window, "matchMedia", originalMatchMedia);
+  } else {
+    Reflect.deleteProperty(window, "matchMedia");
   }
 });
 
@@ -32,6 +38,29 @@ function installAnimate() {
     value: animate,
   });
   return { animate, animation };
+}
+
+function installReducedMotionMediaQuery(initialMatches = false) {
+  let listener: ((event: MediaQueryListEvent) => void) | undefined;
+  const mediaQuery = {
+    matches: initialMatches,
+    addEventListener: vi.fn((_type: string, nextListener: (event: MediaQueryListEvent) => void) => {
+      listener = nextListener;
+    }),
+    removeEventListener: vi.fn(),
+  } as unknown as MediaQueryList;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn(() => mediaQuery),
+  });
+
+  return {
+    mediaQuery,
+    setMatches(matches: boolean) {
+      Object.defineProperty(mediaQuery, "matches", { configurable: true, value: matches });
+      listener?.({ matches } as MediaQueryListEvent);
+    },
+  };
 }
 
 describe("CompositorPulse", () => {
@@ -92,6 +121,29 @@ describe("CompositorPulse", () => {
 
     expect(animate).not.toHaveBeenCalled();
     expect(getByTestId("pulse").style.animation).toBe("");
+  });
+
+  it("cancels and recreates its effect when reduced motion changes", () => {
+    installComputedAnimationStyles();
+    const { animate, animation } = installAnimate();
+    const { mediaQuery, setMatches } = installReducedMotionMediaQuery();
+
+    const { getByTestId, unmount } = render(
+      <CompositorPulse data-testid="pulse" className="animate-pulse" />,
+    );
+    const pulse = getByTestId("pulse");
+
+    expect(mediaQuery.addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    setMatches(true);
+    expect(animation.cancel).toHaveBeenCalledOnce();
+    expect(pulse.style.animation).toBe("");
+
+    setMatches(false);
+    expect(animate).toHaveBeenCalledTimes(2);
+    expect(pulse.style.animation).toBe("none");
+
+    unmount();
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
   });
 
   it("cancels its effect and restores CSS on cleanup", () => {

--- a/docs/plans/frontend-animation-cpu/plan.md
+++ b/docs/plans/frontend-animation-cpu/plan.md
@@ -108,8 +108,8 @@ running-to-settled outcome and no document horizontal overflow.
   one-shot attention cues, integration check status, and connection status
   remain on their existing paths because they are not persistent domain motion.
 - Focused component coverage passes: 63 tests for the grid integration set and
-  29 tests for the final opacity/status integration set. Focused ESLint and the
-  direct web TypeScript check pass.
+  32 targeted opacity/status and grid tests after review remediation. Focused
+  ESLint and the direct web TypeScript check pass.
 - Desktop Chromium and mobile Chrome production E2E pass for both Quick Chat
   grid motion and composer running-to-settled motion. Mobile checks also confirm
   that the animation targets do not introduce horizontal document overflow.
@@ -117,7 +117,9 @@ running-to-settled outcome and no document horizontal overflow.
   `UpdateLayoutTree`, `Layerize`, `Layout`, `Paint`, or target-invalidation
   events for the compositor path. The forced CSS fallback recorded 47
   `UpdateLayoutTree`, 45 `Layerize`, zero `Layout`, zero `Paint`, and 893 target
-  invalidations over the same interval.
+  invalidations in the initial capture; the remediation rerun recorded 45
+  `UpdateLayoutTree`, 45 `Layerize`, zero `Layout`, zero `Paint`, and 855 target
+  invalidations.
 
 ## Risks
 

--- a/docs/plans/frontend-animation-cpu/plan.md
+++ b/docs/plans/frontend-animation-cpu/plan.md
@@ -1,0 +1,131 @@
+---
+created: 2026-08-28
+status: completed
+requirements:
+  - REQ-UI-PERSISTENT-STATUS-MOTION-002
+  - REQ-UI-PERSISTENT-STATUS-MOTION-003
+system_design:
+  - ../../specs/ui/system-design/persistent-status-motion.md
+legacy_specs: []
+---
+
+# Implementation Plan: Frontend Animation CPU
+
+## Overview
+
+Keep Kandev's persistent activity animations while removing the recurring
+main-thread style and layer work found in the supplied Chromium trace. First
+move the shared nine-cell grid spinner to compositor-backed Web Animations.
+Then move the task composer glow and other persistent opacity pulses to an HTML
+opacity primitive, using the first change as the performance baseline.
+
+## Scope
+
+### In scope
+
+- Preserve the existing animated nine-cell grid indicator and its stagger.
+- Preserve the animated running and starting composer glows.
+- Preserve long-lived task, session, agent, and run opacity pulses found by the
+  implementation audit.
+- Keep CSS animation fallbacks and current reduced-motion behavior.
+- Prove desktop and mobile animation behavior and repeat the node-attributed
+  Chromium performance capture.
+
+### Out of scope
+
+- Removing, freezing, slowing, or visually replacing the animations.
+- Changing task, session, agent, run, or composer state rules.
+- Migrating bounded request spinners or one-shot attention and transition cues.
+- Kandy plugin celebration changes. They belong to the plugin's dedicated
+  repository and were a temporary, secondary cost in this capture.
+- Adding a user setting, runtime feature flag, or backend contract.
+
+## Technical approach
+
+### Grid spinner
+
+Update `apps/web/components/grid-spinner.tsx` so each existing cube uses an
+infinite Web Animations API transform effect with the same keyframes, duration,
+easing, and stagger as `spinner-grid` in `apps/web/app/globals.css`. Keep the
+CSS classes as the unsupported-browser fallback and preserve the wrapper's
+status semantics. Add focused tests for all nine effects, fallback, and cleanup.
+
+### Opacity motion
+
+Add `CompositorPulse` beside `CompositorSpin` in `apps/packages/ui/src/`. Move
+the chat-input glow from its pseudo-element to a pointer-inert HTML target that
+retains the existing box shadows and cadence. Audit long-lived `animate-pulse`
+call sites and migrate only domain-status motion, beginning with the live agent
+tab indicator captured on the active task surface. Keep bounded and one-shot
+motion unchanged.
+
+### Desktop and mobile behavior
+
+The change does not alter composition. The existing Quick Chat tab and task
+chat composer are the desktop and mobile exemplars. Their current actions,
+touch targets, scroll ownership, focus behavior, safe-area behavior, and labels
+remain unchanged. Shared motion targets are decorative or status-only and do
+not intercept pointer events. Mobile Playwright coverage verifies the same
+running-to-settled outcome and no document horizontal overflow.
+
+## Tests
+
+- `apps/web/components/grid-spinner.test.tsx` covers Web Animations setup,
+  nine-cell timing, fallback, cancellation, and status semantics for
+  `AC-UI-PERSISTENT-STATUS-MOTION-002.1` through `.5`.
+- `apps/web/lib/ui/compositor-pulse.test.tsx` covers opacity timing, fallback,
+  reduced-motion suppression, and cancellation for
+  `AC-UI-PERSISTENT-STATUS-MOTION-003.3`, `.4`, and `.6`.
+- `apps/web/components/task/chat/chat-input-body.test.tsx` covers running,
+  starting, settled, and unmounted glow targets for
+  `AC-UI-PERSISTENT-STATUS-MOTION-003.1` through `.4`.
+- Existing status component tests cover each migrated persistent pulse's state
+  precedence and selectors.
+
+## E2E tests
+
+- Extend `apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts` to prove the
+  desktop grid animation runs through nine Web Animations effects and stops
+  when work settles.
+- Extend `apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts` with the
+  same user outcome and mobile overflow assertion.
+- Add focused desktop and `mobile-` task-chat motion specs under
+  `apps/web/e2e/tests/chat/` to prove the busy composer glow remains animated,
+  stops when the turn settles, and preserves mobile containment.
+
+## Work orders
+
+- [x] [Task 01: Move grid activity motion to the compositor](task-01-compositor-grid-motion.md)
+- [x] [Task 02: Move persistent opacity motion to the compositor](task-02-compositor-opacity-motion.md)
+
+## Verification results
+
+- Added compositor-backed transform effects for all nine grid cells and a
+  shared compositor-backed opacity pulse. Both paths retain their CSS fallback,
+  cancellation, and reduced-motion contracts.
+- Migrated the busy/starting composer glow, live task agent indicator, Office
+  working-agent indicator, and live execution indicator. Bounded skeletons,
+  one-shot attention cues, integration check status, and connection status
+  remain on their existing paths because they are not persistent domain motion.
+- Focused component coverage passes: 63 tests for the grid integration set and
+  29 tests for the final opacity/status integration set. Focused ESLint and the
+  direct web TypeScript check pass.
+- Desktop Chromium and mobile Chrome production E2E pass for both Quick Chat
+  grid motion and composer running-to-settled motion. Mobile checks also confirm
+  that the animation targets do not introduce horizontal document overflow.
+- The gated 8.34-second production Chromium comparison recorded zero
+  `UpdateLayoutTree`, `Layerize`, `Layout`, `Paint`, or target-invalidation
+  events for the compositor path. The forced CSS fallback recorded 47
+  `UpdateLayoutTree`, 45 `Layerize`, zero `Layout`, zero `Paint`, and 893 target
+  invalidations over the same interval.
+
+## Risks
+
+- Nine Web Animations effects must preserve the grid's phase offsets without
+  creating nine unnecessary permanent `will-change` layers.
+- Inline CSS fallback suppression can leave an element static after a class
+  change unless cleanup restores the declaration before recomputing timing.
+- Moving a glow from a pseudo-element to real markup can change stacking,
+  clipping, or pointer targeting if its isolated wrapper contract is lost.
+- Total page trace counts include unrelated extensions and plugin animations;
+  acceptance depends on node attribution, not a page-wide zero count.

--- a/docs/plans/frontend-animation-cpu/task-01-compositor-grid-motion.md
+++ b/docs/plans/frontend-animation-cpu/task-01-compositor-grid-motion.md
@@ -1,0 +1,114 @@
+---
+id: "01-compositor-grid-motion"
+title: "Move grid activity motion to the compositor"
+status: completed
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-PERSISTENT-STATUS-MOTION-002
+acceptance_criteria:
+  - AC-UI-PERSISTENT-STATUS-MOTION-002.1
+  - AC-UI-PERSISTENT-STATUS-MOTION-002.2
+  - AC-UI-PERSISTENT-STATUS-MOTION-002.3
+  - AC-UI-PERSISTENT-STATUS-MOTION-002.4
+  - AC-UI-PERSISTENT-STATUS-MOTION-002.5
+system_design:
+  - ../../specs/ui/system-design/persistent-status-motion.md
+---
+
+# Task 01: Move Grid Activity Motion to the Compositor
+
+## Summary
+
+Keep the shared grid spinner's nine-cell staggered animation, but establish its
+steady transform effects through Web Animations API targets. Preserve CSS as
+the fallback and make the existing Quick Chat running flows the desktop and
+mobile behavioral evidence.
+
+## In scope
+
+- Add Web Animations lifecycle management to `GridSpinner`.
+- Preserve all nine cubes, transform keyframes, duration, easing, delays,
+  geometry, color, classes, role, and accessible label.
+- Restore one consistent CSS fallback if setup is unavailable or incomplete.
+- Add component, desktop E2E, mobile E2E, and node-attributed trace evidence.
+
+## Out of scope
+
+- Replacing the grid with another spinner design.
+- Adding `requestAnimationFrame` animation logic.
+- Migrating unrelated pulse or rotation indicators.
+
+## Acceptance
+
+- One mounted grid exposes nine running infinite Web Animations effects with
+  the existing stagger and remains visibly animated.
+- Settling or unmounting cancels every effect; unavailable or partial Web
+  Animations setup leaves all nine CSS animations active.
+- After setup, an 8.34-second production Chromium trace attributes no recurring
+  `UpdateLayoutTree` or `Layerize` work to the grid targets.
+
+## Verification
+
+```bash
+cd apps
+pnpm install --frozen-lockfile
+pnpm --filter @kandev/web exec vitest run components/grid-spinner.test.tsx components/quick-chat/quick-chat-tab-item.test.tsx components/task/chat/message-list-shared.test.tsx --reporter=dot
+pnpm --filter @kandev/web exec eslint components/grid-spinner.tsx components/grid-spinner.test.tsx
+pnpm --filter @kandev/web typecheck
+cd web
+pnpm e2e:run --project chromium tests/chat/quick-chat-idle-dot.spec.ts -- --grep "shows tab and sidebar running state"
+pnpm e2e:run --project mobile-chrome tests/chat/mobile-quick-chat-idle-dot.spec.ts -- --grep "shows the mobile header running"
+```
+
+Capture one production-build Chromium trace with one working Quick Chat tab.
+After a one-second settle, inspect an 8.34-second window and record animation
+target types plus node-attributed `UpdateLayoutTree` and `Layerize` counts. Run
+the Web Animations path and a forced CSS-fallback control.
+
+## Files likely touched
+
+- `apps/web/components/grid-spinner.tsx`
+- `apps/web/components/grid-spinner.test.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts`
+- `apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- CSS positive delays and Web Animations delay semantics must match during the
+  first cycle as well as steady state.
+- Per-cube promotion can increase compositor memory if implementation adds
+  permanent promotion hints without trace evidence.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-UI-PERSISTENT-STATUS-MOTION-002` and its acceptance criteria.
+- Grid and animation-lifecycle sections of the system design.
+- The prior `frontend-idle-cpu` trace controls and `CompositorSpin` pattern.
+- Existing Quick Chat desktop and mobile running-state E2E flows.
+
+## Results
+
+- Added nine Web Animations API transform effects with the original four-phase
+  scale pattern, 1.3-second duration, easing, and per-cell delays. CSS remains
+  active when Web Animations is unavailable or any effect fails to start.
+- Added focused coverage for timing, semantics, unsupported-browser fallback,
+  partial-setup recovery, and cleanup cancellation. The three focused suites
+  pass 63 tests; focused lint and direct web typecheck pass.
+- Desktop Chromium and mobile Chrome production E2E each pass the running and
+  settled Quick Chat flow. Both assert nine live infinite non-CSS effects; the
+  mobile flow also confirms no document overflow.
+- The combined 8.34-second trace recorded zero recurring style, layerization,
+  layout, paint, or target-invalidation events for the compositor targets. The
+  forced CSS fallback recorded 47 `UpdateLayoutTree`, 45 `Layerize`, and 893
+  target invalidations in the same interval.

--- a/docs/plans/frontend-animation-cpu/task-01-compositor-grid-motion.md
+++ b/docs/plans/frontend-animation-cpu/task-01-compositor-grid-motion.md
@@ -71,6 +71,7 @@ the Web Animations path and a forced CSS-fallback control.
 
 - `apps/web/components/grid-spinner.tsx`
 - `apps/web/components/grid-spinner.test.tsx`
+- `apps/packages/ui/src/animation-utils.tsx`
 - `apps/web/app/globals.css`
 - `apps/web/e2e/tests/chat/quick-chat-idle-dot.spec.ts`
 - `apps/web/e2e/tests/chat/mobile-quick-chat-idle-dot.spec.ts`
@@ -110,5 +111,6 @@ None.
   mobile flow also confirms no document overflow.
 - The combined 8.34-second trace recorded zero recurring style, layerization,
   layout, paint, or target-invalidation events for the compositor targets. The
-  forced CSS fallback recorded 47 `UpdateLayoutTree`, 45 `Layerize`, and 893
-  target invalidations in the same interval.
+  initial forced CSS fallback recorded 47 `UpdateLayoutTree`, 45 `Layerize`,
+  and 893 target invalidations; the review-remediation rerun recorded 45, 45,
+  and 855 respectively.

--- a/docs/plans/frontend-animation-cpu/task-02-compositor-opacity-motion.md
+++ b/docs/plans/frontend-animation-cpu/task-02-compositor-opacity-motion.md
@@ -1,0 +1,138 @@
+---
+id: "02-compositor-opacity-motion"
+title: "Move persistent opacity motion to the compositor"
+status: completed
+wave: 2
+depends_on:
+  - "01-compositor-grid-motion"
+plan: "plan.md"
+requirements:
+  - REQ-UI-PERSISTENT-STATUS-MOTION-003
+acceptance_criteria:
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.1
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.2
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.3
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.4
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.5
+  - AC-UI-PERSISTENT-STATUS-MOTION-003.6
+system_design:
+  - ../../specs/ui/system-design/persistent-status-motion.md
+---
+
+# Task 02: Move Persistent Opacity Motion to the Compositor
+
+## Summary
+
+Keep the busy composer glow and long-lived status pulses visibly animated, but
+run opacity through a shared HTML Web Animations primitive. Use the optimized
+grid from Task 01 as the trace baseline so remaining target costs can be
+attributed independently.
+
+## In scope
+
+- Add the narrow `CompositorPulse` UI primitive with CSS fallback and cleanup.
+- Replace the chat-input glow pseudo-element with a pointer-inert HTML target
+  that preserves the current shadows, opacity range, and cadence.
+- Audit and migrate persistent `animate-pulse` task, session, agent, and run
+  status targets, beginning with the live agent tab indicator.
+- Preserve active-state ownership, layout, semantics, selectors, responsive
+  composition, and reduced-motion behavior.
+- Add component, desktop E2E, mobile E2E, and node-attributed trace evidence.
+
+## Out of scope
+
+- One-shot selection, request-changes, search, or confirmation pulses.
+- Status-state or composer interaction changes.
+- Plugin-owned motion.
+
+## Acceptance
+
+- Busy/starting composer glows and audited persistent status dots retain their
+  existing visible pulse and stop when their owning state ends.
+- The HTML targets use running infinite Web Animations effects when supported,
+  preserve CSS fallback and current reduced-motion suppression, and cancel on
+  cleanup.
+- After setup, an 8.34-second production Chromium trace attributes no recurring
+  `UpdateLayoutTree` or `Layerize` work to migrated opacity targets.
+
+## Verification
+
+```bash
+cd apps
+pnpm install --frozen-lockfile
+pnpm --filter @kandev/web exec vitest run lib/ui/compositor-pulse.test.tsx components/task/chat/chat-input-body.test.tsx components/task/simple/chat-activity-tabs.test.tsx --reporter=dot
+pnpm --filter @kandev/web exec eslint ../packages/ui/src/compositor-pulse.tsx web/lib/ui/compositor-pulse.test.tsx web/components/task/chat/chat-input-body.tsx web/components/task/chat/chat-input-body.test.tsx web/components/task/simple/chat-activity-tabs.tsx web/components/task/simple/chat-activity-tabs.test.tsx
+pnpm --filter @kandev/web typecheck
+cd web
+pnpm e2e:run --project chromium tests/chat/persistent-animation-motion.spec.ts
+pnpm e2e:run --project mobile-chrome tests/chat/mobile-persistent-animation-motion.spec.ts
+```
+
+Capture one production-build Chromium trace with a running task, its composer
+glow, and the migrated persistent status targets visible. After a one-second
+settle, inspect an 8.34-second window and record target types plus node-attributed
+`UpdateLayoutTree` and `Layerize` counts. Compare Web Animations and forced CSS
+fallback controls with React DevTools disabled.
+
+## Files likely touched
+
+- `apps/packages/ui/src/compositor-pulse.tsx`
+- `apps/web/lib/ui/compositor-pulse.test.tsx`
+- `apps/web/components/task/chat/chat-input-body.tsx`
+- `apps/web/components/task/chat/chat-input-body.test.tsx`
+- `apps/web/components/task/simple/chat-activity-tabs.tsx`
+- `apps/web/components/task/simple/chat-activity-tabs.test.tsx`
+- `apps/web/app/globals.css`
+- Additional persistent pulse call sites and their focused tests found by the
+  audit.
+- `apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts`
+- `apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts`
+
+## Dependencies
+
+- Task 01 establishes the optimized grid baseline used by the final trace.
+
+## Risks
+
+- Replacing a pseudo-element can alter z-index or clipping around the composer.
+- A broad `animate-pulse` migration would accidentally include bounded cues;
+  the audit must classify each call site by state lifetime.
+- Reduced-motion CSS must be read before the Web Animations effect starts, or
+  the new path could override the user's current preference.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-UI-PERSISTENT-STATUS-MOTION-003` and its acceptance criteria.
+- Opacity motion, lifecycle, and responsive sections of the system design.
+- Task 01 trace evidence and the existing `CompositorSpin` lifecycle pattern.
+- Current chat-input and live-agent status component tests.
+
+## Results
+
+- Added `CompositorPulse`, which derives duration, delay, and easing from the
+  existing CSS declaration, replaces it only after Web Animations setup
+  succeeds, respects reduced motion, and cancels and restores CSS on cleanup.
+- Replaced the composer pseudo-element with an isolated, pointer-inert HTML
+  glow while retaining the running and starting shadows, cadence, state
+  precedence, and responsive layout.
+- Migrated the live task agent indicator, working Office agent indicator, and
+  live execution indicator. The audit left bounded skeletons, one-shot cues,
+  integration check status, and connection status unchanged because their
+  lifetime or ownership is outside persistent task, session, agent, and run
+  motion.
+- The six focused component suites pass 29 tests, including exact timing,
+  endpoint phase, unsupported fallback, reduced-motion suppression, cleanup,
+  state precedence, and static-state behavior. Focused ESLint and the direct
+  web TypeScript check pass.
+- Desktop Chromium and mobile Chrome production E2E pass the composer
+  running-to-settled flow; the mobile flow also confirms no horizontal
+  overflow.
+- The gated 8.34-second production trace recorded zero `UpdateLayoutTree`,
+  `Layerize`, `Layout`, `Paint`, or target-invalidation events for the
+  compositor path. Its forced CSS fallback control recorded 47
+  `UpdateLayoutTree`, 45 `Layerize`, zero `Layout`, zero `Paint`, and 893 target
+  invalidations.

--- a/docs/plans/frontend-animation-cpu/task-02-compositor-opacity-motion.md
+++ b/docs/plans/frontend-animation-cpu/task-02-compositor-opacity-motion.md
@@ -60,8 +60,8 @@ attributed independently.
 ```bash
 cd apps
 pnpm install --frozen-lockfile
-pnpm --filter @kandev/web exec vitest run lib/ui/compositor-pulse.test.tsx components/task/chat/chat-input-body.test.tsx components/task/simple/chat-activity-tabs.test.tsx --reporter=dot
-pnpm --filter @kandev/web exec eslint ../packages/ui/src/compositor-pulse.tsx web/lib/ui/compositor-pulse.test.tsx web/components/task/chat/chat-input-body.tsx web/components/task/chat/chat-input-body.test.tsx web/components/task/simple/chat-activity-tabs.tsx web/components/task/simple/chat-activity-tabs.test.tsx
+pnpm --filter @kandev/web exec vitest run lib/ui/compositor-pulse.test.tsx components/task/chat/chat-input-body.test.tsx components/task/simple/chat-activity-tabs.test.tsx app/office/agents/components/agent-status-dot.test.tsx app/office/components/execution-indicator.test.tsx --reporter=dot
+pnpm --filter @kandev/web exec eslint ../packages/ui/src/compositor-pulse.tsx lib/ui/compositor-pulse.test.tsx components/task/chat/chat-input-body.tsx components/task/chat/chat-input-body.test.tsx components/task/simple/chat-activity-tabs.tsx components/task/simple/chat-activity-tabs.test.tsx app/office/agents/components/agent-status-dot.tsx app/office/agents/components/agent-status-dot.test.tsx app/office/components/execution-indicator.tsx app/office/components/execution-indicator.test.tsx
 pnpm --filter @kandev/web typecheck
 cd web
 pnpm e2e:run --project chromium tests/chat/persistent-animation-motion.spec.ts
@@ -77,6 +77,7 @@ fallback controls with React DevTools disabled.
 ## Files likely touched
 
 - `apps/packages/ui/src/compositor-pulse.tsx`
+- `apps/packages/ui/src/animation-utils.tsx`
 - `apps/web/lib/ui/compositor-pulse.test.tsx`
 - `apps/web/components/task/chat/chat-input-body.tsx`
 - `apps/web/components/task/chat/chat-input-body.test.tsx`
@@ -87,6 +88,7 @@ fallback controls with React DevTools disabled.
   audit.
 - `apps/web/e2e/tests/chat/persistent-animation-motion.spec.ts`
 - `apps/web/e2e/tests/chat/mobile-persistent-animation-motion.spec.ts`
+- `apps/web/e2e/helpers/animation-assertions.ts`
 
 ## Dependencies
 
@@ -124,15 +126,16 @@ fallback controls with React DevTools disabled.
   integration check status, and connection status unchanged because their
   lifetime or ownership is outside persistent task, session, agent, and run
   motion.
-- The six focused component suites pass 29 tests, including exact timing,
-  endpoint phase, unsupported fallback, reduced-motion suppression, cleanup,
-  state precedence, and static-state behavior. Focused ESLint and the direct
-  web TypeScript check pass.
+- The six focused component suites pass 32 tests, including exact timing,
+  endpoint phase, unsupported fallback, reduced-motion suppression and
+  preference changes, cleanup, state precedence, and static-state behavior.
+  Focused ESLint and the direct web TypeScript check pass.
 - Desktop Chromium and mobile Chrome production E2E pass the composer
   running-to-settled flow; the mobile flow also confirms no horizontal
   overflow.
 - The gated 8.34-second production trace recorded zero `UpdateLayoutTree`,
   `Layerize`, `Layout`, `Paint`, or target-invalidation events for the
-  compositor path. Its forced CSS fallback control recorded 47
+  compositor path. Its initial forced CSS fallback control recorded 47
   `UpdateLayoutTree`, 45 `Layerize`, zero `Layout`, zero `Paint`, and 893 target
-  invalidations.
+  invalidations; the review-remediation rerun recorded 45 `UpdateLayoutTree`,
+  45 `Layerize`, zero `Layout`, zero `Paint`, and 855 target invalidations.

--- a/docs/specs/ui/requirements/persistent-status-motion.md
+++ b/docs/specs/ui/requirements/persistent-status-motion.md
@@ -2,6 +2,7 @@
 status: active
 system: ui
 created: 2026-08-23
+updated: 2026-08-28
 owners:
   - kandev
 ---
@@ -20,6 +21,8 @@ clear without causing continuous main-thread rendering work.
   task, session, agent, or run state instead of a short UI request.
 - **Compositor-prepared motion:** A transform-only animation on an HTML element
   that the browser can move to its compositor.
+- **Persistent activity animation:** Motion whose lifetime follows ongoing
+  task, session, agent, or run activity instead of a bounded UI request.
 
 ## Requirements
 
@@ -47,10 +50,66 @@ so that I can identify ongoing work without high idle CPU use.
   shall use the same status state and motion primitive without horizontal
   overflow or a new interaction.
 
+### REQ-UI-PERSISTENT-STATUS-MOTION-002: Efficient grid activity motion
+
+**Intent:** Keep the recognizable grid activity animation while removing its
+recurring main-thread rendering cost.
+
+**User story:** As a Kandev user, I want the grid indicator to keep moving while
+work is active, so that progress remains recognizable without unnecessary CPU
+use.
+
+#### Acceptance criteria
+
+- **AC-UI-PERSISTENT-STATUS-MOTION-002.1:** When a long-lived active state uses
+  the grid activity indicator, all nine cells shall remain visibly animated in
+  their existing staggered pattern on desktop and mobile.
+- **AC-UI-PERSISTENT-STATUS-MOTION-002.2:** When the active state ends or the
+  indicator unmounts, its animation shall stop and the existing next state shall
+  appear.
+- **AC-UI-PERSISTENT-STATUS-MOTION-002.3:** In Chromium with Web Animations API
+  support, a settled grid indicator shall cause no recurring main-thread
+  `UpdateLayoutTree` or `Layerize` work attributable to its animation targets.
+- **AC-UI-PERSISTENT-STATUS-MOTION-002.4:** The optimized indicator shall
+  preserve its nine-cell geometry, spacing, color, scale range, duration,
+  stagger, accessible status label, and existing selectors.
+- **AC-UI-PERSISTENT-STATUS-MOTION-002.5:** When Web Animations API support is
+  unavailable, the grid indicator shall retain its current animated CSS
+  fallback.
+
+### REQ-UI-PERSISTENT-STATUS-MOTION-003: Efficient persistent opacity motion
+
+**Intent:** Keep long-lived glow and pulse feedback visible without sampling
+their opacity animations on the main thread.
+
+**User story:** As a Kandev user, I want busy composers and live status dots to
+keep pulsing, so that active work remains obvious without high steady CPU use.
+
+#### Acceptance criteria
+
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.1:** While their owning active states
+  remain true, the task composer glow and persistent status dots shall remain
+  visibly animated on desktop and mobile.
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.2:** When an owning active state ends or
+  its surface unmounts, the matching opacity animation shall stop and the
+  existing settled presentation shall appear.
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.3:** In Chromium with Web Animations API
+  support, a settled persistent opacity target shall cause no recurring
+  main-thread `UpdateLayoutTree` or `Layerize` work attributable to that target.
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.4:** The optimized motion shall preserve
+  the current opacity range, duration, easing, color, glow, geometry, status
+  precedence, accessible meaning, and test selectors of each migrated surface.
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.5:** Desktop and mobile shall use the
+  same active-state source and opacity-motion primitive without adding a touch
+  interaction, changing scroll ownership, or causing horizontal overflow.
+- **AC-UI-PERSISTENT-STATUS-MOTION-003.6:** When Web Animations API support is
+  unavailable, each migrated surface shall retain its current animated CSS
+  fallback and reduced-motion behavior.
+
 ## Out of scope
 
 - Removing status motion.
 - Changing task, session, or run state rules.
 - Changing reduced-motion behavior.
-- Migrating short request, save, refresh, upload, or download spinners that do
-  not remain mounted as domain status.
+- Migrating one-shot entrance, selection, search, or confirmation cues.
+- Changing plugin-owned animations, including Kandy celebration effects.

--- a/docs/specs/ui/system-design/persistent-status-motion.md
+++ b/docs/specs/ui/system-design/persistent-status-motion.md
@@ -94,16 +94,20 @@ continue to decide when each target mounts; the primitive owns only motion.
 ## Animation lifecycle and fallback
 
 Each Web Animations effect starts after mount and is cancelled during effect
-cleanup or before replacement. A class, duration, or active-state change first
-restores the CSS declaration, reads the new computed timing, and then replaces
-the live effect. This prevents stale inline `animation: none` from suppressing
-later motion.
+cleanup or before replacement. A duration or active-state change first restores
+the CSS declaration, reads the new computed timing, and then replaces the live
+effect. Grid presentation-class changes leave the existing effects in place so
+they do not reset the visible stagger. This prevents stale inline `animation:
+none` from suppressing later motion.
 
 If `Element.animate` is unavailable, CSS keeps the existing animation. If the
 computed animation name is `none`, including under a surface's existing
 reduced-motion media rule, the compositor path does not start a replacement
-effect. This preserves current reduced-motion behavior without creating a new
-setting.
+effect. A mounted target also subscribes to `prefers-reduced-motion` changes:
+enabling reduced motion cancels the Web Animations effect and restores the CSS
+declaration, while disabling it allows the target to establish the compositor
+effect again. This preserves current reduced-motion behavior without creating a
+new setting.
 
 ## Status surfaces
 

--- a/docs/specs/ui/system-design/persistent-status-motion.md
+++ b/docs/specs/ui/system-design/persistent-status-motion.md
@@ -3,24 +3,32 @@ status: current
 system: ui
 requirements:
   - REQ-UI-PERSISTENT-STATUS-MOTION-001
+  - REQ-UI-PERSISTENT-STATUS-MOTION-002
+  - REQ-UI-PERSISTENT-STATUS-MOTION-003
 ---
 
 # Persistent Status Motion System Design
 
 ## Purpose and boundaries
 
-This design moves persistent task, session, and run rotation from SVG elements
-to a shared HTML transform wrapper. It changes rendering ownership only. Task
-state, icon selection, copy, and interaction behavior do not change.
+This design moves persistent task, session, and run motion from main-thread CSS
+sampling to compositor-backed HTML animation targets. It changes rendering
+ownership only. Task state, icon selection, copy, motion design, and interaction
+behavior do not change.
 
-Short request spinners remain outside this design. They have bounded lifetimes
-and were not a material source in the captured steady-state trace.
+The shared grid component is covered because a single instance can remain
+mounted for the lifetime of a running turn and its nine CSS animations were the
+dominant recurring source in the captured steady-state trace. Optimizing the
+shared component also benefits bounded uses without changing their contract.
+One-shot attention and transition effects remain outside this design.
 
 ## Requirement mapping
 
 | Requirement                           | Design section                                                                                                                                |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `REQ-UI-PERSISTENT-STATUS-MOTION-001` | [Motion primitive](#motion-primitive), [Status surfaces](#status-surfaces), [Desktop and mobile composition](#desktop-and-mobile-composition) |
+| `REQ-UI-PERSISTENT-STATUS-MOTION-002` | [Grid activity motion](#grid-activity-motion), [Animation lifecycle and fallback](#animation-lifecycle-and-fallback), [Verification and performance evidence](#verification-and-performance-evidence) |
+| `REQ-UI-PERSISTENT-STATUS-MOTION-003` | [Opacity pulse motion](#opacity-pulse-motion), [Desktop and mobile composition](#desktop-and-mobile-composition), [Verification and performance evidence](#verification-and-performance-evidence) |
 
 ## Motion primitive
 
@@ -44,6 +52,58 @@ a compositor layer.
 
 The primitive accepts normal wrapper attributes and children. It does not
 select task state, add labels, or own status precedence.
+
+## Grid activity motion
+
+`apps/web/components/grid-spinner.tsx` keeps its existing status wrapper and
+nine `.spinner-grid-cube` HTML children. The component establishes one Web
+Animations API transform effect per cube when `Element.animate` is available.
+The effects use the current scale keyframes, 1.3-second duration, easing, and
+per-cell stagger from `apps/web/app/globals.css`.
+
+The CSS classes remain the visual and compatibility contract. The component
+reads the computed CSS timing before it disables CSS sampling on each live
+animation target. The Web Animations effects then own the same staggered motion.
+The grid wrapper retains its dimensions, `role="status"`, translated accessible
+label, and public class names. The cube elements remain decorative.
+
+The component does not replace the grid with a rotating icon, static state,
+canvas, or request-animation-frame loop. It does not add permanent
+`will-change` declarations unless the repeat trace demonstrates that Chromium
+needs them; nine unnecessary promoted layers would trade CPU for memory.
+
+## Opacity pulse motion
+
+`apps/packages/ui/src/compositor-pulse.tsx` owns a narrow HTML opacity-motion
+primitive patterned after `CompositorSpin`. It accepts ordinary span attributes
+plus the minimum opacity needed by the surface. It reads the current CSS
+duration and easing, disables CSS sampling only after setup, and starts an
+infinite Web Animations API opacity effect on the HTML span.
+
+The chat composer replaces its animated `::after` pseudo-element with an
+`aria-hidden` absolute HTML pulse target inside the existing isolated wrapper.
+The target retains the current running and starting glow classes, box shadows,
+opacity bounds, and two- or three-second cadence. The editor, resize handle,
+focus behavior, and input geometry remain unchanged.
+
+Long-lived `animate-pulse` status dots on task, session, agent, and run surfaces
+use `CompositorPulse` after a call-site audit. Short request feedback and
+one-shot attention cues remain on their existing implementations. State owners
+continue to decide when each target mounts; the primitive owns only motion.
+
+## Animation lifecycle and fallback
+
+Each Web Animations effect starts after mount and is cancelled during effect
+cleanup or before replacement. A class, duration, or active-state change first
+restores the CSS declaration, reads the new computed timing, and then replaces
+the live effect. This prevents stale inline `animation: none` from suppressing
+later motion.
+
+If `Element.animate` is unavailable, CSS keeps the existing animation. If the
+computed animation name is `none`, including under a surface's existing
+reduced-motion media rule, the compositor path does not start a replacement
+effect. This preserves current reduced-motion behavior without creating a new
+setting.
 
 ## Status surfaces
 
@@ -73,9 +133,12 @@ the current inline size and does not add a new touch target, scroll owner, or
 layout branch. Focusable tooltip wrappers and accessible labels stay outside
 the rotating element.
 
-The closest mobile exemplar is the existing task-switcher row. Mobile coverage
-uses this shared row and also confirms that the document has no horizontal
-overflow.
+The grid spinner and composer glow also keep the existing shared desktop/mobile
+components. The closest mobile exemplars are the Quick Chat tab activity state
+and the task chat composer. No presentation branch changes: the existing dialog
+or task surface remains the scroll owner, current touch targets remain in place,
+and the motion target stays pointer-inert. Mobile coverage uses those surfaces
+and confirms that the document has no horizontal overflow.
 
 ## Verification and performance evidence
 
@@ -83,10 +146,21 @@ Component tests assert that the animation class and transform hint are on an
 HTML wrapper. They also assert that the nested SVG has no animation class.
 Existing state-precedence tests continue to validate which icon appears.
 
+Grid component tests stub `Element.animate` and assert nine infinite effects,
+the existing keyframes and stagger, cleanup cancellation, preserved semantics,
+and CSS fallback. Pulse tests assert computed timing, opacity bounds, cleanup,
+CSS fallback, and suppression when the computed animation name is `none`.
+
 Desktop Playwright coverage holds a task in its running state. It checks the
 rotating wrapper and then checks the settled icon after the state changes.
 Mobile Playwright coverage checks the same wrapper in the task switcher and
 confirms the existing touch navigation.
+
+Desktop and mobile Playwright coverage also holds a Quick Chat or task turn in
+a running state. It checks that grid cells and pulse targets have running
+infinite Web Animations effects, that motion ends with the owning state, that
+the same user-visible status remains, and that mobile geometry does not
+overflow.
 
 After implementation, capture the same steady focused-task state in Chromium.
 Attribute recurring `UpdateLayoutTree`, `Layerize`, and frame activity to
@@ -101,12 +175,24 @@ Animations API path records only one-time setup activity. The remaining
 enabled-page frame work is therefore attributed to the unrelated grid
 animation, not the migrated status target.
 
+The next acceptance capture repeats the same production-build protocol. After
+one second of settling, it records an 8.34-second window with one grid spinner
+and the running composer glow visible. Node attribution must show no recurring
+`UpdateLayoutTree` or `Layerize` work from their Web Animations targets. A CSS
+fallback control must remain visibly animated and provides the comparison when
+the Web Animations path is disabled.
+
 ## Failure and compatibility
 
 If a browser does not provide Web Animations, the retained CSS animation still
 rotates the wrapper normally. No state or content is lost. The duration is
 read from the existing CSS class on the Web Animations path, so speed and
 visual timing remain compatible.
+
+The same fallback rule applies to grid and opacity motion. If an effect cannot
+be established, the component leaves the CSS animation intact rather than
+showing a static indicator. Partial grid setup cancels effects already created
+and restores CSS for all nine cells so one grid never mixes timing engines.
 
 The wrapper preserves existing test IDs and semantic attributes. Tests and
 assistive technology do not need to depend on the nested SVG element.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3122/b88f657e7559.html)
<!-- kandev-pr-walkthrough-end -->

Recurring CSS animation work in shared activity indicators was causing main-thread style and layer updates during long-running tasks. This keeps the existing motion and visual timing while moving persistent transform and opacity effects onto compositor-backed Web Animations with safe CSS and reduced-motion fallbacks.

## Important Changes

- The nine-cell grid spinner now uses compositor-backed transform effects while preserving its stagger, timing, semantics, and CSS fallback.
- Added `CompositorPulse` for persistent opacity motion and migrated the composer glow plus audited live task, agent, and execution indicators.
- Bounded request spinners and one-shot attention cues remain unchanged because they do not create persistent status motion.

## Validation

- `python3 scripts/lint-spec-files.test.py`
- `python3 scripts/lint-spec-files.py --all`
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm run i18n:check`
- Focused Vitest suites: 63 grid integration tests and 29 opacity/status integration tests passed.
- Desktop Chromium and mobile Chrome production E2E passed for grid motion and composer running-to-settled behavior; mobile overflow checks passed.
- Gated production Chromium trace comparison passed: compositor path recorded zero recurring style, layerization, layout, paint, or target-invalidation events; the remediation CSS fallback control recorded 45 style updates, 45 layerizations, and 855 target invalidations over 8.34 seconds.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop task composer with animated running glow](https://raw.githubusercontent.com/kdlbs/kandev/7eab19826c1f421b55fea249c8ad01143f5b4925/desktop-composer-motion.png)

![Mobile task composer with contained animated running glow](https://raw.githubusercontent.com/kdlbs/kandev/7eab19826c1f421b55fea249c8ad01143f5b4925/mobile-composer-motion.png)
<!-- kandev-screenshots-end -->
