### PR TITLE
fix(plugins): route plugin task moves through the shared step-transition path

### DIFF
--- a/apps/backend/cmd/plugin-fixture/main_test.go
+++ b/apps/backend/cmd/plugin-fixture/main_test.go
@@ -388,6 +388,9 @@ func (fakeHostTaskReader) Get(context.Context, string) (*pluginsdk.Task, error) 
 func (fakeHostTaskReader) Update(context.Context, pluginsdk.UpdateTaskInput) (*pluginsdk.Task, error) {
 	return nil, nil
 }
+func (fakeHostTaskReader) Move(context.Context, pluginsdk.MoveTaskInput) (*pluginsdk.MoveTaskOutcome, error) {
+	return nil, nil
+}
 
 func (r fakeHostTaskReader) Create(_ context.Context, in pluginsdk.CreateTaskInput) (*pluginsdk.Task, error) {
 	r.h.lastCreateInput = in

--- a/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
@@ -160,6 +160,25 @@ func TestPluginsTaskWriter_MoveGetTaskNotFoundDuringResolution(t *testing.T) {
 	require.Equal(t, 0, svc.moveCalls, "MoveTaskWithOptions must not be reached when the task can't be loaded")
 }
 
+// TestPluginsTaskWriter_MoveUnexpectedWorkflowReadErrorIsSanitized pins the
+// plugin boundary contract for inherited-workflow resolution: an unexpected
+// repository failure must not expose storage details or task identifiers to a
+// plugin caller.
+func TestPluginsTaskWriter_MoveUnexpectedWorkflowReadErrorIsSanitized(t *testing.T) {
+	internalErr := errors.New("database is locked while reading task task-secret")
+	svc := &fakePluginTaskWriteService{getTaskErr: internalErr}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-secret", WorkflowStepID: "step-2",
+	})
+
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Equal(t, "failed to move task", status.Convert(err).Message())
+	require.NotContains(t, status.Convert(err).Message(), internalErr.Error())
+	require.Equal(t, 0, svc.moveCalls, "MoveTaskWithOptions must not run after workflow resolution fails")
+}
+
 // TestPluginsTaskWriter_MovePositionCastAndResultMapping pins that Position
 // is forwarded as int and the response's Transitioned/FromStepID come
 // straight from MoveTaskResult (not re-derived).
@@ -211,6 +230,8 @@ func TestClassifyPluginMoveError(t *testing.T) {
 		{"different workspace, AC-001.6", errors.New("target workflow is in a different workspace"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
 		{"step not in workflow, AC-001.6", errors.New("target workflow step does not belong to target workflow"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
 		{"task not found sentinel, AC-005.6", fmt.Errorf("%w: task-1", repoerrors.ErrTaskNotFound), codes.NotFound, "task not found"},
+		{"context canceled", fmt.Errorf("read task: %w", context.Canceled), codes.Canceled, "move task canceled"},
+		{"context deadline", fmt.Errorf("read task: %w", context.DeadlineExceeded), codes.DeadlineExceeded, "move task deadline exceeded"},
 		{"workflow resolution conflict, SEC-001", fmt.Errorf("%w: resolved %q, task is now in %q", taskservice.ErrWorkflowResolutionConflict, "wf-home", "wf-away"), codes.Aborted, "task workflow changed concurrently, retry the move"},
 		{"unmapped error falls back to Internal", errors.New("something unexpected"), codes.Internal, "failed to move task"},
 	}

--- a/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
@@ -187,21 +187,32 @@ func TestPluginsTaskWriter_MovePositionCastAndResultMapping(t *testing.T) {
 // table this classifier is responsible for (the rows reachable from
 // MoveTaskWithOptions' bare validation errors; capability/request-shape rows
 // are classified earlier, in internal/plugins/host_write.go).
+//
+// SEC-002 (Review round 2): the classifier's whole job is to strip the real
+// validator's internal text off the gRPC boundary. Pinning only the status
+// code (as this table did before) lets a future change keep the code right
+// while silently re-forwarding err.Error() into the message — reopening the
+// exact info-disclosure surface SEC-002 closed. Every case therefore also
+// asserts the exact fixed message, and every input error below embeds an
+// internal-only fragment (an id, a raw validator sentence) that must NOT
+// appear in the output message.
 func TestClassifyPluginMoveError(t *testing.T) {
 	cases := []struct {
-		name string
-		err  error
-		want codes.Code
+		name    string
+		err     error
+		want    codes.Code
+		wantMsg string
 	}{
-		{"nil is nil", nil, codes.OK},
-		{"archived task, AC-001.7", errors.New("archived tasks cannot be moved"), codes.FailedPrecondition},
-		{"active session, AC-001.8", errors.New("task has an active session (starting)"), codes.FailedPrecondition},
-		{"unknown workflow, AC-001.6", errors.New("failed to get target workflow: workflow not found: wf-x"), codes.InvalidArgument},
-		{"unknown step, AC-001.6", errors.New("failed to get target workflow step: workflow step not found: step-x"), codes.InvalidArgument},
-		{"different workspace, AC-001.6", errors.New("target workflow is in a different workspace"), codes.InvalidArgument},
-		{"step not in workflow, AC-001.6", errors.New("target workflow step does not belong to target workflow"), codes.InvalidArgument},
-		{"task not found sentinel, AC-005.6", fmt.Errorf("%w: task-1", repoerrors.ErrTaskNotFound), codes.NotFound},
-		{"unmapped error falls back to Internal", errors.New("something unexpected"), codes.Internal},
+		{"nil is nil", nil, codes.OK, ""},
+		{"archived task, AC-001.7", errors.New("archived tasks cannot be moved"), codes.FailedPrecondition, "task is archived and cannot be moved"},
+		{"active session, AC-001.8", errors.New("task has an active session (starting)"), codes.FailedPrecondition, "task has an active session and cannot be moved"},
+		{"unknown workflow, AC-001.6", errors.New("failed to get target workflow: workflow not found: wf-x"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
+		{"unknown step, AC-001.6", errors.New("failed to get target workflow step: workflow step not found: step-x"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
+		{"different workspace, AC-001.6", errors.New("target workflow is in a different workspace"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
+		{"step not in workflow, AC-001.6", errors.New("target workflow step does not belong to target workflow"), codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace"},
+		{"task not found sentinel, AC-005.6", fmt.Errorf("%w: task-1", repoerrors.ErrTaskNotFound), codes.NotFound, "task not found"},
+		{"workflow resolution conflict, SEC-001", fmt.Errorf("%w: resolved %q, task is now in %q", taskservice.ErrWorkflowResolutionConflict, "wf-home", "wf-away"), codes.Aborted, "task workflow changed concurrently, retry the move"},
+		{"unmapped error falls back to Internal", errors.New("something unexpected"), codes.Internal, "failed to move task"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -210,7 +221,14 @@ func TestClassifyPluginMoveError(t *testing.T) {
 				require.NoError(t, got)
 				return
 			}
-			require.Equal(t, tc.want, status.Code(got))
+			st := status.Convert(got)
+			require.Equal(t, tc.want, st.Code())
+			require.Equal(t, tc.wantMsg, st.Message())
+			require.NotContains(t, st.Message(), "wf-x", "message must not leak the internal error's workflow/step id")
+			require.NotContains(t, st.Message(), "step-x", "message must not leak the internal error's workflow/step id")
+			require.NotContains(t, st.Message(), "task-1", "message must not leak the internal error's task id")
+			require.NotContains(t, st.Message(), "wf-home", "message must not leak the internal error's workflow id")
+			require.NotContains(t, st.Message(), "wf-away", "message must not leak the internal error's workflow id")
 		})
 	}
 }

--- a/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
@@ -1,0 +1,184 @@
+package backendapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kandev/kandev/internal/plugins"
+	"github.com/kandev/kandev/internal/steptelemetry"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	taskservice "github.com/kandev/kandev/internal/task/service"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+// TestPluginsTaskWriter_MoveAttributesToPluginIntegrationActor pins AC-003.1
+// and AC-003.3: a plugin move is recorded under the integration actor kind
+// with the plugin's own "plugin:<id>" provenance, under the dedicated
+// plugin_move trigger — never Human, never the bulk/manual/mcp triggers.
+func TestPluginsTaskWriter_MoveAttributesToPluginIntegrationActor(t *testing.T) {
+	svc := &fakePluginTaskWriteService{}
+	a := pluginsTaskWriterAdapter{svc: svc}
+	wf := "wf-1"
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &wf, Source: "plugin:acme",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc.lastMoveCtx)
+	attr := steptelemetry.FromContext(svc.lastMoveCtx)
+	require.Equal(t, steptelemetry.TriggerPluginMove, attr.Trigger)
+	require.Equal(t, steptelemetry.ActorIntegration, attr.ActorKind)
+	require.Equal(t, "plugin:acme", attr.ActorID)
+}
+
+// TestPluginsTaskWriter_MoveStepHistoryOptions pins that the session-level
+// history is written under plugin_move too (AC-003.2) and never under the
+// Human actor (AC-003.3's "must not be Human" — see design's rationale that
+// Human is what stamps an authenticated user id onto an unattended move).
+func TestPluginsTaskWriter_MoveStepHistoryOptions(t *testing.T) {
+	svc := &fakePluginTaskWriteService{}
+	a := pluginsTaskWriterAdapter{svc: svc}
+	wf := "wf-1"
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &wf,
+	})
+	require.NoError(t, err)
+	require.Equal(t, wfmodels.StepTransitionTriggerPluginMove, svc.lastMoveOpts.StepHistoryTrigger)
+	require.NotEqual(t, wfmodels.StepTransitionActorHuman, svc.lastMoveOpts.StepHistoryActor)
+	require.False(t, svc.lastMoveOpts.AllowActivePrimarySession,
+		"a plugin move must take the agent-shaped option and reject a live session (AC-001.8), not the board's AllowActivePrimarySession")
+}
+
+// TestPluginsTaskWriter_MoveExplicitWorkflowIDPassesThrough pins that a
+// caller-supplied workflow_id is used as-is and never overridden by the
+// task's current workflow.
+func TestPluginsTaskWriter_MoveExplicitWorkflowIDPassesThrough(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: "wf-current"}}
+	a := pluginsTaskWriterAdapter{svc: svc}
+	wf := "wf-explicit"
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &wf})
+	require.NoError(t, err)
+	require.Equal(t, "wf-explicit", svc.lastMoveWfID)
+	require.Equal(t, "", svc.lastGetTaskID, "an explicit workflow_id needs no task read to resolve it")
+}
+
+// TestPluginsTaskWriter_MoveNilWorkflowIDInheritsCurrent pins AC-005.4: an
+// omitted workflow_id uses the task's current workflow.
+func TestPluginsTaskWriter_MoveNilWorkflowIDInheritsCurrent(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: "wf-current"}}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.NoError(t, err)
+	require.Equal(t, "task-1", svc.lastGetTaskID)
+	require.Equal(t, "wf-current", svc.lastMoveWfID)
+}
+
+// TestPluginsTaskWriter_MoveNoWorkflowNoneNamedDefersToSharedPath pins the
+// AC-005.11/precedence-ladder fix: when the task has no current workflow and
+// none was named, resolution must NOT short-circuit with its own
+// InvalidArgument before MoveTaskWithOptions' archived/active-session checks
+// (AC-001.7/001.8) get a chance to run. The empty workflow id is passed
+// through so the shared path's own destination check (which the ladder places
+// AFTER the task-state checks) is what ultimately answers InvalidArgument —
+// see resolvePluginMoveWorkflowID's doc for why a local short-circuit here
+// would answer the wrong code for an archived task with no workflow.
+func TestPluginsTaskWriter_MoveNoWorkflowNoneNamedDefersToSharedPath(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: ""}}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.NoError(t, err, "the fake's MoveTaskWithOptions succeeds unconditionally; this test only pins that resolution reached it")
+	require.Equal(t, "", svc.lastMoveWfID, "empty workflow id must reach MoveTaskWithOptions, not be rejected before it")
+}
+
+// TestPluginsTaskWriter_MoveNoWorkflowNoneNamedRejectsAfterSharedValidation
+// pins the InvalidArgument end state for AC-005.11 once the shared path's own
+// "workflow not found" (from GetWorkflow("")) surfaces, going through
+// classifyPluginMoveError like every other destination-classification case.
+func TestPluginsTaskWriter_MoveNoWorkflowNoneNamedRejectsAfterSharedValidation(t *testing.T) {
+	svc := &fakePluginTaskWriteService{
+		getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: ""},
+		moveErr:       fmt.Errorf("failed to get target workflow: workflow not found: "),
+	}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestPluginsTaskWriter_MoveGetTaskNotFoundDuringResolution pins that a
+// missing task surfaces NotFound (AC-005.6) even when discovered during
+// workflow-inheritance resolution, before MoveTaskWithOptions is ever called.
+func TestPluginsTaskWriter_MoveGetTaskNotFoundDuringResolution(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskErr: fmt.Errorf("%w: task-missing", repoerrors.ErrTaskNotFound)}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-missing", WorkflowStepID: "step-2"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+	require.Equal(t, 0, svc.moveCalls, "MoveTaskWithOptions must not be reached when the task can't be loaded")
+}
+
+// TestPluginsTaskWriter_MovePositionCastAndResultMapping pins that Position
+// is forwarded as int and the response's Transitioned/FromStepID come
+// straight from MoveTaskResult (not re-derived).
+func TestPluginsTaskWriter_MovePositionCastAndResultMapping(t *testing.T) {
+	svc := &fakePluginTaskWriteService{
+		moveResult: &taskservice.MoveTaskResult{
+			Task:         &taskmodels.Task{ID: "task-1"},
+			Transitioned: true,
+			FromStepID:   "step-origin",
+		},
+	}
+	a := pluginsTaskWriterAdapter{svc: svc}
+	wf := "wf-1"
+
+	result, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &wf, Position: 7,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 7, svc.lastMovePos)
+	require.True(t, result.Transitioned)
+	require.Equal(t, "step-origin", result.FromStepID)
+}
+
+// TestClassifyPluginMoveError pins every row of the binding error-mapping
+// table this classifier is responsible for (the rows reachable from
+// MoveTaskWithOptions' bare validation errors; capability/request-shape rows
+// are classified earlier, in internal/plugins/host_write.go).
+func TestClassifyPluginMoveError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"nil is nil", nil, codes.OK},
+		{"archived task, AC-001.7", errors.New("archived tasks cannot be moved"), codes.FailedPrecondition},
+		{"active session, AC-001.8", errors.New("task has an active session (starting)"), codes.FailedPrecondition},
+		{"unknown workflow, AC-001.6", errors.New("failed to get target workflow: workflow not found: wf-x"), codes.InvalidArgument},
+		{"unknown step, AC-001.6", errors.New("failed to get target workflow step: workflow step not found: step-x"), codes.InvalidArgument},
+		{"different workspace, AC-001.6", errors.New("target workflow is in a different workspace"), codes.InvalidArgument},
+		{"step not in workflow, AC-001.6", errors.New("target workflow step does not belong to target workflow"), codes.InvalidArgument},
+		{"task not found sentinel, AC-005.6", fmt.Errorf("%w: task-1", repoerrors.ErrTaskNotFound), codes.NotFound},
+		{"unmapped error falls back to Internal", errors.New("something unexpected"), codes.Internal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyPluginMoveError(tc.err)
+			if tc.err == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.Equal(t, tc.want, status.Code(got))
+		})
+	}
+}

--- a/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_mover_test.go
@@ -83,6 +83,38 @@ func TestPluginsTaskWriter_MoveNilWorkflowIDInheritsCurrent(t *testing.T) {
 	require.Equal(t, "wf-current", svc.lastMoveWfID)
 }
 
+// TestPluginsTaskWriter_MoveNilWorkflowIDSetsExpectedWorkflowIDForCAS pins the
+// SEC-001 fix (Review round 2): when workflow_id is inherited via the
+// resolvePluginMoveWorkflowID pre-read rather than named explicitly, MoveTask
+// must pass that resolved value as MoveTaskOptions.ExpectedWorkflowID so
+// MoveTaskWithOptions can reject the write if a concurrent reassignment lands
+// before it — see TestConcurrentReassignmentSurvivesMatchingStepStaleMove for
+// the mechanism itself.
+func TestPluginsTaskWriter_MoveNilWorkflowIDSetsExpectedWorkflowIDForCAS(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: "wf-current"}}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.NoError(t, err)
+	require.NotNil(t, svc.lastMoveOpts.ExpectedWorkflowID, "an inherited workflow id must be CAS-guarded against a concurrent reassignment")
+	require.Equal(t, "wf-current", *svc.lastMoveOpts.ExpectedWorkflowID)
+}
+
+// TestPluginsTaskWriter_MoveExplicitWorkflowIDSkipsExpectedWorkflowID pins the
+// other half of the SEC-001 fix: a plugin that explicitly names a target
+// workflow_id is intentionally requesting a cross-workflow move, so that
+// request must never be CAS-guarded against the task's current workflow —
+// doing so would reject every legitimate explicit reassignment.
+func TestPluginsTaskWriter_MoveExplicitWorkflowIDSkipsExpectedWorkflowID(t *testing.T) {
+	svc := &fakePluginTaskWriteService{getTaskResult: &taskmodels.Task{ID: "task-1", WorkflowID: "wf-current"}}
+	a := pluginsTaskWriterAdapter{svc: svc}
+	wf := "wf-explicit"
+
+	_, err := a.MoveTask(context.Background(), plugins.TaskMoveInput{TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &wf})
+	require.NoError(t, err)
+	require.Nil(t, svc.lastMoveOpts.ExpectedWorkflowID, "an explicit workflow_id is an intentional target and must not be CAS-guarded")
+}
+
 // TestPluginsTaskWriter_MoveNoWorkflowNoneNamedDefersToSharedPath pins the
 // AC-005.11/precedence-ladder fix: when the task has no current workflow and
 // none was named, resolution must NOT short-circuit with its own

--- a/apps/backend/internal/backendapp/adapters_plugin_writer_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_writer_test.go
@@ -20,6 +20,20 @@ type fakePluginTaskWriteService struct {
 	lastUpdate *taskservice.UpdateTaskRequest
 	lastID     string
 	deletedID  string
+
+	getTaskResult *taskmodels.Task
+	getTaskErr    error
+	lastGetTaskID string
+
+	moveResult   *taskservice.MoveTaskResult
+	moveErr      error
+	moveCalls    int
+	lastMoveID   string
+	lastMoveWfID string
+	lastMoveStep string
+	lastMovePos  int
+	lastMoveOpts taskservice.MoveTaskOptions
+	lastMoveCtx  context.Context
 }
 
 func (f *fakePluginTaskWriteService) CreateTask(_ context.Context, req *taskservice.CreateTaskRequest) (taskservice.CreateTaskResult, error) {
@@ -37,6 +51,38 @@ func (f *fakePluginTaskWriteService) UpdateTask(_ context.Context, id string, re
 func (f *fakePluginTaskWriteService) DeleteTask(_ context.Context, id string) error {
 	f.deletedID = id
 	return nil
+}
+
+func (f *fakePluginTaskWriteService) GetTask(_ context.Context, id string) (*taskmodels.Task, error) {
+	f.lastGetTaskID = id
+	if f.getTaskErr != nil {
+		return nil, f.getTaskErr
+	}
+	if f.getTaskResult != nil {
+		return f.getTaskResult, nil
+	}
+	return &taskmodels.Task{ID: id}, nil
+}
+
+func (f *fakePluginTaskWriteService) MoveTaskWithOptions(ctx context.Context, id, workflowID, workflowStepID string, position int, opts taskservice.MoveTaskOptions) (*taskservice.MoveTaskResult, error) {
+	f.moveCalls++
+	f.lastMoveCtx = ctx
+	f.lastMoveID = id
+	f.lastMoveWfID = workflowID
+	f.lastMoveStep = workflowStepID
+	f.lastMovePos = position
+	f.lastMoveOpts = opts
+	if f.moveErr != nil {
+		return nil, f.moveErr
+	}
+	if f.moveResult != nil {
+		return f.moveResult, nil
+	}
+	return &taskservice.MoveTaskResult{
+		Task:         &taskmodels.Task{ID: id, WorkflowID: workflowID, WorkflowStepID: workflowStepID},
+		Transitioned: true,
+		FromStepID:   "step-from",
+	}, nil
 }
 
 func TestPluginsTaskWriter_CreateMapsSourceToMetadata(t *testing.T) {
@@ -108,15 +154,40 @@ func TestPluginsTaskWriter_UpdateMapsFieldMask(t *testing.T) {
 
 	title := "Renamed"
 	state := "IN_PROGRESS"
-	step := "step-2"
-	_, err := a.UpdateTask(context.Background(), plugins.TaskUpdateInput{ID: "task-1", Title: &title, State: &state, WorkflowStepID: &step})
+	_, err := a.UpdateTask(context.Background(), plugins.TaskUpdateInput{ID: "task-1", Title: &title, State: &state})
 	require.NoError(t, err)
 	require.Equal(t, "task-1", svc.lastID)
 	require.Equal(t, "Renamed", *svc.lastUpdate.Title)
 	require.NotNil(t, svc.lastUpdate.State)
 	require.Equal(t, v1.TaskStateInProgress, *svc.lastUpdate.State)
-	require.Equal(t, "step-2", *svc.lastUpdate.WorkflowStepID)
 	require.Nil(t, svc.lastUpdate.Description, "an unset field stays nil")
+}
+
+// TestPluginsTaskWriter_UpdateRejectsWorkflowStepID pins AC-004.3: UpdateTask
+// never calls publishTaskMovedEvent, so writing workflow_step_id directly
+// through it would move the card without firing on_enter actions like
+// auto-start. A plugin must use MoveTask instead.
+func TestPluginsTaskWriter_UpdateRejectsWorkflowStepID(t *testing.T) {
+	svc := &fakePluginTaskWriteService{}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	step := "step-2"
+	_, err := a.UpdateTask(context.Background(), plugins.TaskUpdateInput{ID: "task-1", WorkflowStepID: &step})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Nil(t, svc.lastUpdate, "the service is never called when workflow_step_id is present")
+}
+
+// TestPluginsTaskWriter_UpdateRejectsEmptyWorkflowStepID pins that the
+// rejection fires on presence, not on a non-empty value — a plugin cannot
+// smuggle a move through by clearing the field to "".
+func TestPluginsTaskWriter_UpdateRejectsEmptyWorkflowStepID(t *testing.T) {
+	svc := &fakePluginTaskWriteService{}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	empty := ""
+	_, err := a.UpdateTask(context.Background(), plugins.TaskUpdateInput{ID: "task-1", WorkflowStepID: &empty})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Nil(t, svc.lastUpdate)
 }
 
 func TestPluginsTaskWriter_UpdateRejectsUnknownState(t *testing.T) {

--- a/apps/backend/internal/backendapp/adapters_plugin_writer_test.go
+++ b/apps/backend/internal/backendapp/adapters_plugin_writer_test.go
@@ -190,6 +190,33 @@ func TestPluginsTaskWriter_UpdateRejectsEmptyWorkflowStepID(t *testing.T) {
 	require.Nil(t, svc.lastUpdate)
 }
 
+// TestPluginsTaskWriter_UpdateWorkflowStepIDGuardRunsBeforeStateValidation
+// pins AC-004.3's guard ordering: the workflow_step_id-presence rejection
+// must be the first check in UpdateTask, before state validation, so a
+// request carrying both an invalid state AND workflow_step_id is named as a
+// rejected move (not a state error) — per the doc comment on that check. Both
+// TestPluginsTaskWriter_UpdateRejectsWorkflowStepID and
+// TestPluginsTaskWriter_UpdateRejectsUnknownState alone only pin
+// codes.InvalidArgument, which either check alone satisfies — this test
+// combines both invalid fields in one request and asserts on the message to
+// prove which check actually fired, so a future reorder that runs state
+// validation first would fail this test even though the status code is
+// unchanged.
+func TestPluginsTaskWriter_UpdateWorkflowStepIDGuardRunsBeforeStateValidation(t *testing.T) {
+	svc := &fakePluginTaskWriteService{}
+	a := pluginsTaskWriterAdapter{svc: svc}
+
+	step := "step-2"
+	badState := "NOT_A_STATE"
+	_, err := a.UpdateTask(context.Background(), plugins.TaskUpdateInput{
+		ID: "task-1", WorkflowStepID: &step, State: &badState,
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, status.Convert(err).Message(), "workflow_step_id",
+		"the workflow_step_id guard must fire first, not the state-validation error")
+	require.Nil(t, svc.lastUpdate, "the service is never called when workflow_step_id is present")
+}
+
 func TestPluginsTaskWriter_UpdateRejectsUnknownState(t *testing.T) {
 	svc := &fakePluginTaskWriteService{}
 	a := pluginsTaskWriterAdapter{svc: svc}

--- a/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
+++ b/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
@@ -32,8 +32,10 @@ import (
 // so the error text classifyPluginMoveError matches against is whatever the
 // real validators produce today, not a hand-written stand-in.
 type pluginMoveErrorBindingHarness struct {
-	adapter pluginsTaskWriterAdapter
-	repo    *sqliterepo.Repository
+	adapter     pluginsTaskWriterAdapter
+	repo        *sqliterepo.Repository
+	workflowSvc *workflowservice.Service
+	db          *sqlx.DB
 }
 
 func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarness {
@@ -75,6 +77,12 @@ func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarne
 	}, bus.NewMemoryEventBus(log), log, taskservice.RepositoryDiscoveryConfig{})
 	workflowSvc := workflowservice.NewService(workflowRepo, log)
 	taskSvc.SetWorkflowStepGetter(&workflowStepGetterAdapter{svc: workflowSvc})
+	// Matches production wiring (backendapp.wireServices calls
+	// taskSvc.SetStepHistoryRecorder(workflowSvc)) so a plugin move against a
+	// task with a live session writes the ADR 0015 session_step_history audit
+	// row the same way it does at runtime.
+	taskSvc.SetStepHistoryRecorder(workflowSvc)
+	t.Cleanup(func() { _ = workflowSvc.Close() })
 
 	ctx := context.Background()
 	require.NoError(t, taskRepo.CreateWorkspace(ctx, &taskmodels.Workspace{ID: "ws-1", Name: "Workspace 1"}))
@@ -86,8 +94,10 @@ func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarne
 	require.NoError(t, workflowSvc.CreateStep(ctx, &wfmodels.WorkflowStep{ID: "step-home", WorkflowID: "wf-home", Name: "Home", Position: 0}))
 
 	return &pluginMoveErrorBindingHarness{
-		adapter: pluginsTaskWriterAdapter{svc: taskSvc},
-		repo:    taskRepo,
+		adapter:     pluginsTaskWriterAdapter{svc: taskSvc},
+		repo:        taskRepo,
+		workflowSvc: workflowSvc,
+		db:          database,
 	}
 }
 
@@ -105,6 +115,31 @@ func (h *pluginMoveErrorBindingHarness) createTask(t *testing.T, id string, arch
 	if archived {
 		require.NoError(t, h.repo.ArchiveTask(ctx, id))
 	}
+}
+
+// createSession attaches a primary task session in the given state, letting
+// tests exercise MoveTaskWithOptions' session-resolution and ADR 0015
+// session_step_history recording paths.
+func (h *pluginMoveErrorBindingHarness) createSession(t *testing.T, id, taskID string, state taskmodels.TaskSessionState) {
+	t.Helper()
+	require.NoError(t, h.repo.CreateTaskSession(context.Background(), &taskmodels.TaskSession{
+		ID: id, TaskID: taskID, State: state, IsPrimary: true,
+	}))
+}
+
+// lastSessionStepHistoryTrigger reads back the most recently written ADR 0015
+// session_step_history.trigger for a session, flushing the workflow
+// service's async history-writer queue first (EnqueueStepTransition is
+// fire-and-forget; Close drains it and waits for the writer goroutine to
+// exit before returning).
+func (h *pluginMoveErrorBindingHarness) lastSessionStepHistoryTrigger(t *testing.T, sessionID string) string {
+	t.Helper()
+	require.NoError(t, h.workflowSvc.Close())
+	var trigger string
+	err := h.db.Get(&trigger,
+		`SELECT trigger FROM session_step_history WHERE session_id = ? ORDER BY id DESC LIMIT 1`, sessionID)
+	require.NoError(t, err, "expected a session_step_history row for session %q", sessionID)
+	return trigger
 }
 
 // TestClassifyPluginMoveError_BindsToRealValidatorStrings pins AC-004.6: the
@@ -219,4 +254,71 @@ func TestResolvePluginMoveWorkflowID_StaleReadFailsSafeNotSilentlyWrong(t *testi
 	require.NoError(t, getErr)
 	require.Equal(t, "step-target", final.WorkflowStepID, "the failed stale move must not have changed the step set by the interceding real move")
 	require.Equal(t, "wf-target", final.WorkflowID)
+}
+
+// TestConcurrentReassignmentSurvivesMatchingStepStaleMove pins the SEC-001 fix
+// (Review round 2): the sibling gap in
+// TestResolvePluginMoveWorkflowID_StaleReadFailsSafeNotSilentlyWrong, which
+// only covers a stale workflow id whose requested step does NOT belong to it
+// (caught for free by validateTaskMove's own targetStep.WorkflowID check).
+// Here the requested step DOES belong to the stale, pre-read workflow — so
+// without a write-time CAS check, the stale move would pass validateTaskMove
+// outright and silently revert the concurrent, legitimate reassignment with
+// no error at all. MoveTaskOptions.ExpectedWorkflowID must catch this.
+func TestConcurrentReassignmentSurvivesMatchingStepStaleMove(t *testing.T) {
+	h := newPluginMoveErrorBindingHarness(t)
+	h.createTask(t, "task-race-2", false)
+
+	staleWorkflowID, err := h.adapter.resolvePluginMoveWorkflowID(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-race-2",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "wf-home", staleWorkflowID)
+
+	// Simulate the race: another caller reassigns the task to a different
+	// workflow before the plugin's own move (using the now-stale pre-read)
+	// commits.
+	_, err = h.adapter.svc.MoveTaskWithOptions(context.Background(), "task-race-2", "wf-target", "step-target", 0, taskservice.MoveTaskOptions{})
+	require.NoError(t, err)
+
+	// The plugin's stale move now targets step-home, which DOES belong to the
+	// stale wf-home — the exploit case. Without the CAS guard this would pass
+	// validateTaskMove and silently move the task back to wf-home/step-home.
+	_, err = h.adapter.svc.MoveTaskWithOptions(context.Background(), "task-race-2", staleWorkflowID, "step-home", 0, taskservice.MoveTaskOptions{
+		ExpectedWorkflowID: &staleWorkflowID,
+	})
+	require.ErrorIs(t, err, taskservice.ErrWorkflowResolutionConflict)
+	require.Equal(t, codes.Aborted, status.Code(classifyPluginMoveError(err)))
+
+	final, getErr := h.repo.GetTask(context.Background(), "task-race-2")
+	require.NoError(t, getErr)
+	require.Equal(t, "wf-target", final.WorkflowID, "the concurrent reassignment must survive the rejected stale move")
+	require.Equal(t, "step-target", final.WorkflowStepID)
+}
+
+// TestPluginMoveWithLiveNonBlockingSessionRecordsPluginMoveTrigger pins the
+// AC-003.2/AC-003.5 test-rigor gap (Review round 2): every existing plugin
+// move test either has no session at all, or a Starting/Running session that
+// validateMoveSessions rejects outright (isSessionMoveBlocked) before
+// MoveTaskWithOptions ever reaches recordManualStepTransition. None of them
+// prove what happens for a session that is live (resolvePrimaryOrActiveSession
+// picks it up via isSessionActive, so it becomes the ADR 0015 audit row's
+// session_id) but not move-blocking — WaitingForInput is exactly that gap.
+// Without the plugin adapter's opts.StepHistoryTrigger reaching the recorder,
+// recordManualStepTransition's zero-value fallback would silently default the
+// row to StepTransitionTriggerManual instead of plugin_move.
+func TestPluginMoveWithLiveNonBlockingSessionRecordsPluginMoveTrigger(t *testing.T) {
+	h := newPluginMoveErrorBindingHarness(t)
+	h.createTask(t, "task-live-waiting", false)
+	h.createSession(t, "session-waiting", "task-live-waiting", taskmodels.TaskSessionStateWaitingForInput)
+	wf := "wf-target"
+
+	_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-live-waiting", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
+	})
+	require.NoError(t, err, "a WaitingForInput session is live but not move-blocking (isSessionMoveBlocked covers only Starting/Running)")
+
+	trigger := h.lastSessionStepHistoryTrigger(t, "session-waiting")
+	require.Equal(t, string(wfmodels.StepTransitionTriggerPluginMove), trigger,
+		"a plugin move against a task with a live session must record plugin_move, not fall back to manual")
 }

--- a/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
+++ b/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
@@ -150,8 +150,15 @@ func (h *pluginMoveErrorBindingHarness) lastSessionStepHistoryTrigger(t *testing
 // test, per Review round 1's must-fix finding (test-supervisor proved by
 // mutation that TestClassifyPluginMoveError's stand-in literals do not
 // notice such a change).
+// SEC-002 (Review round 2): each subtest below also asserts the exact fixed
+// message and the absence of the real, identity-bearing fragment this
+// specific move actually produced internally (a workflow/step/task id, or
+// the raw validator sentence) — status.Code alone would still pass if the
+// classifier regressed to forwarding err.Error() verbatim, since the status
+// code discrimination is unaffected by that regression.
 func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 	wf := "wf-target"
+	const invalidArgMsg = "invalid move_task request: unknown or mismatched workflow, step, or workspace"
 
 	t.Run("archived task, AC-001.7", func(t *testing.T) {
 		h := newPluginMoveErrorBindingHarness(t)
@@ -159,7 +166,9 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-archived", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+		require.Equal(t, "task is archived and cannot be moved", st.Message())
 	})
 
 	t.Run("active session, AC-001.8", func(t *testing.T) {
@@ -171,7 +180,10 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-live-session", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+		require.Equal(t, "task has an active session and cannot be moved", st.Message())
+		require.NotContains(t, st.Message(), "RUNNING", "message must not leak the session's internal state value")
 	})
 
 	t.Run("unknown workflow, AC-001.6", func(t *testing.T) {
@@ -181,7 +193,10 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-unknown-wf", WorkflowStepID: "step-target", WorkflowID: &missing, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Equal(t, invalidArgMsg, st.Message())
+		require.NotContains(t, st.Message(), missing, "message must not leak the requested workflow id")
 	})
 
 	t.Run("different workspace, AC-001.6", func(t *testing.T) {
@@ -191,16 +206,23 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-cross-workspace", WorkflowStepID: "step-target", WorkflowID: &other, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Equal(t, invalidArgMsg, st.Message())
+		require.NotContains(t, st.Message(), other, "message must not leak the target workflow id")
 	})
 
 	t.Run("unknown step, AC-001.6", func(t *testing.T) {
 		h := newPluginMoveErrorBindingHarness(t)
 		h.createTask(t, "task-unknown-step", false)
+		missingStep := "step-does-not-exist"
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
-			TaskID: "task-unknown-step", WorkflowStepID: "step-does-not-exist", WorkflowID: &wf, Source: "plugin:acme",
+			TaskID: "task-unknown-step", WorkflowStepID: missingStep, WorkflowID: &wf, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Equal(t, invalidArgMsg, st.Message())
+		require.NotContains(t, st.Message(), missingStep, "message must not leak the requested step id")
 	})
 
 	t.Run("step not in workflow, AC-001.6", func(t *testing.T) {
@@ -210,7 +232,11 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-step-wrong-workflow", WorkflowStepID: "step-home", WorkflowID: &wf, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.InvalidArgument, st.Code())
+		require.Equal(t, invalidArgMsg, st.Message())
+		require.NotContains(t, st.Message(), "step-home", "message must not leak the requested step id")
+		require.NotContains(t, st.Message(), "wf-home", "message must not leak the task's actual workflow id")
 	})
 
 	t.Run("task not found, AC-005.6", func(t *testing.T) {
@@ -218,7 +244,10 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
 			TaskID: "task-missing", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
 		})
-		require.Equal(t, codes.NotFound, status.Code(err))
+		st := status.Convert(err)
+		require.Equal(t, codes.NotFound, st.Code())
+		require.Equal(t, "task not found", st.Message())
+		require.NotContains(t, st.Message(), "task-missing", "message must not leak the requested task id")
 	})
 }
 

--- a/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
+++ b/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
@@ -1,0 +1,222 @@
+package backendapp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/plugins"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	taskservice "github.com/kandev/kandev/internal/task/service"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	workflowrepository "github.com/kandev/kandev/internal/workflow/repository"
+	workflowservice "github.com/kandev/kandev/internal/workflow/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// pluginMoveErrorBindingHarness wires the same two repositories and services
+// production boots (internal/task's own workflow table for
+// validateTaskMove's GetWorkflow/workspace checks, plus the separate
+// internal/workflow package for step lookups via workflowStepGetterAdapter),
+// so the error text classifyPluginMoveError matches against is whatever the
+// real validators produce today, not a hand-written stand-in.
+type pluginMoveErrorBindingHarness struct {
+	adapter pluginsTaskWriterAdapter
+	repo    *sqliterepo.Repository
+}
+
+func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarness {
+	t.Helper()
+	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "plugin-move-error-binding.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	database := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = database.Close() })
+	taskRepo, cleanup, err := repository.Provide(database, database, nil)
+	if err != nil {
+		t.Fatalf("task repository: %v", err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+	workflowRepo, err := workflowrepository.NewWithDB(database, database, nil)
+	if err != nil {
+		t.Fatalf("workflow repository: %v", err)
+	}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	taskSvc := taskservice.NewService(taskservice.Repos{
+		Workspaces:       taskRepo,
+		Tasks:            taskRepo,
+		TaskRepos:        taskRepo,
+		Workflows:        taskRepo,
+		Messages:         taskRepo,
+		Turns:            taskRepo,
+		Sessions:         taskRepo,
+		GitSnapshots:     taskRepo,
+		RepoEntities:     taskRepo,
+		Executors:        taskRepo,
+		Environments:     taskRepo,
+		TaskEnvironments: taskRepo,
+		Reviews:          taskRepo,
+		ResourceCleanups: taskRepo,
+	}, bus.NewMemoryEventBus(log), log, taskservice.RepositoryDiscoveryConfig{})
+	workflowSvc := workflowservice.NewService(workflowRepo, log)
+	taskSvc.SetWorkflowStepGetter(&workflowStepGetterAdapter{svc: workflowSvc})
+
+	ctx := context.Background()
+	require.NoError(t, taskRepo.CreateWorkspace(ctx, &taskmodels.Workspace{ID: "ws-1", Name: "Workspace 1"}))
+	require.NoError(t, taskRepo.CreateWorkspace(ctx, &taskmodels.Workspace{ID: "ws-2", Name: "Workspace 2"}))
+	require.NoError(t, taskRepo.CreateWorkflow(ctx, &taskmodels.Workflow{ID: "wf-home", WorkspaceID: "ws-1", Name: "Home"}))
+	require.NoError(t, taskRepo.CreateWorkflow(ctx, &taskmodels.Workflow{ID: "wf-target", WorkspaceID: "ws-1", Name: "Target"}))
+	require.NoError(t, taskRepo.CreateWorkflow(ctx, &taskmodels.Workflow{ID: "wf-other-workspace", WorkspaceID: "ws-2", Name: "Other"}))
+	require.NoError(t, workflowSvc.CreateStep(ctx, &wfmodels.WorkflowStep{ID: "step-target", WorkflowID: "wf-target", Name: "Target", Position: 0}))
+	require.NoError(t, workflowSvc.CreateStep(ctx, &wfmodels.WorkflowStep{ID: "step-home", WorkflowID: "wf-home", Name: "Home", Position: 0}))
+
+	return &pluginMoveErrorBindingHarness{
+		adapter: pluginsTaskWriterAdapter{svc: taskSvc},
+		repo:    taskRepo,
+	}
+}
+
+func (h *pluginMoveErrorBindingHarness) createTask(t *testing.T, id string, archived bool) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, h.repo.CreateTask(ctx, &taskmodels.Task{
+		ID:             id,
+		WorkspaceID:    "ws-1",
+		WorkflowID:     "wf-home",
+		WorkflowStepID: "step-home",
+		Title:          id,
+		State:          v1.TaskStateTODO,
+	}))
+	if archived {
+		require.NoError(t, h.repo.ArchiveTask(ctx, id))
+	}
+}
+
+// TestClassifyPluginMoveError_BindsToRealValidatorStrings pins AC-004.6: the
+// binding error-mapping table in classifyPluginMoveError must be exercised
+// against errors the real validateTaskMove/GetWorkflow/GetStep code paths
+// actually produce, not hand-written stand-in strings — so a validator
+// wording change that breaks the classifier's substring match fails this
+// test, per Review round 1's must-fix finding (test-supervisor proved by
+// mutation that TestClassifyPluginMoveError's stand-in literals do not
+// notice such a change).
+func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
+	wf := "wf-target"
+
+	t.Run("archived task, AC-001.7", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-archived", true)
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-archived", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	})
+
+	t.Run("active session, AC-001.8", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-live-session", false)
+		require.NoError(t, h.repo.CreateTaskSession(context.Background(), &taskmodels.TaskSession{
+			ID: "session-live", TaskID: "task-live-session", State: taskmodels.TaskSessionStateRunning, IsPrimary: true,
+		}))
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-live-session", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	})
+
+	t.Run("unknown workflow, AC-001.6", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-unknown-wf", false)
+		missing := "wf-does-not-exist"
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-unknown-wf", WorkflowStepID: "step-target", WorkflowID: &missing, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("different workspace, AC-001.6", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-cross-workspace", false)
+		other := "wf-other-workspace"
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-cross-workspace", WorkflowStepID: "step-target", WorkflowID: &other, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("unknown step, AC-001.6", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-unknown-step", false)
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-unknown-step", WorkflowStepID: "step-does-not-exist", WorkflowID: &wf, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("step not in workflow, AC-001.6", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		h.createTask(t, "task-step-wrong-workflow", false)
+		// step-home is a real step, but it belongs to wf-home, not wf-target.
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-step-wrong-workflow", WorkflowStepID: "step-home", WorkflowID: &wf, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("task not found, AC-005.6", func(t *testing.T) {
+		h := newPluginMoveErrorBindingHarness(t)
+		_, err := h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+			TaskID: "task-missing", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
+		})
+		require.Equal(t, codes.NotFound, status.Code(err))
+	})
+}
+
+// TestResolvePluginMoveWorkflowID_StaleReadFailsSafeNotSilentlyWrong pins
+// TEST-003 (Review round 1, LOW/non-blocking, converges with Spec Review
+// round 5's Q-001): an omitted WorkflowID is resolved by a separate GetTask
+// pre-read (resolvePluginMoveWorkflowID) rather than atomically with the move
+// itself. If the task's workflow changes between that pre-read and the move
+// commit — the accepted race — the stale workflow id must never let the move
+// silently land somewhere it shouldn't; validateTaskMove's
+// targetStep.WorkflowID != workflowID check must reject it as
+// InvalidArgument instead.
+func TestResolvePluginMoveWorkflowID_StaleReadFailsSafeNotSilentlyWrong(t *testing.T) {
+	h := newPluginMoveErrorBindingHarness(t)
+	h.createTask(t, "task-race", false)
+
+	staleWorkflowID, err := h.adapter.resolvePluginMoveWorkflowID(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-race",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "wf-home", staleWorkflowID, "pre-read should observe the task's workflow at that moment")
+
+	// Simulate the race: another caller moves the task to a different
+	// workflow before the plugin's own move (using the now-stale pre-read)
+	// commits.
+	_, err = h.adapter.svc.MoveTaskWithOptions(context.Background(), "task-race", "wf-target", "step-target", 0, taskservice.MoveTaskOptions{})
+	require.NoError(t, err)
+
+	_, err = h.adapter.svc.MoveTaskWithOptions(context.Background(), "task-race", staleWorkflowID, "step-target", 0, taskservice.MoveTaskOptions{})
+	require.Equal(t, codes.InvalidArgument, status.Code(classifyPluginMoveError(err)), "a stale workflow id must fail safe, never silently move the task")
+
+	final, getErr := h.repo.GetTask(context.Background(), "task-race")
+	require.NoError(t, getErr)
+	require.Equal(t, "step-target", final.WorkflowStepID, "the failed stale move must not have changed the step set by the interceding real move")
+	require.Equal(t, "wf-target", final.WorkflowID)
+}

--- a/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
+++ b/apps/backend/internal/backendapp/plugin_move_error_binding_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/plugins"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
@@ -36,6 +37,7 @@ type pluginMoveErrorBindingHarness struct {
 	repo        *sqliterepo.Repository
 	workflowSvc *workflowservice.Service
 	db          *sqlx.DB
+	eventBus    *bus.MemoryEventBus
 }
 
 func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarness {
@@ -59,6 +61,7 @@ func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarne
 	if err != nil {
 		t.Fatalf("logger: %v", err)
 	}
+	eventBus := bus.NewMemoryEventBus(log)
 	taskSvc := taskservice.NewService(taskservice.Repos{
 		Workspaces:       taskRepo,
 		Tasks:            taskRepo,
@@ -74,7 +77,7 @@ func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarne
 		TaskEnvironments: taskRepo,
 		Reviews:          taskRepo,
 		ResourceCleanups: taskRepo,
-	}, bus.NewMemoryEventBus(log), log, taskservice.RepositoryDiscoveryConfig{})
+	}, eventBus, log, taskservice.RepositoryDiscoveryConfig{})
 	workflowSvc := workflowservice.NewService(workflowRepo, log)
 	taskSvc.SetWorkflowStepGetter(&workflowStepGetterAdapter{svc: workflowSvc})
 	// Matches production wiring (backendapp.wireServices calls
@@ -98,6 +101,7 @@ func newPluginMoveErrorBindingHarness(t *testing.T) *pluginMoveErrorBindingHarne
 		repo:        taskRepo,
 		workflowSvc: workflowSvc,
 		db:          database,
+		eventBus:    eventBus,
 	}
 }
 
@@ -142,6 +146,22 @@ func (h *pluginMoveErrorBindingHarness) lastSessionStepHistoryTrigger(t *testing
 	return trigger
 }
 
+// requireTaskUnmoved reads taskID back from the real repository and asserts
+// its workflow/step are still exactly h.createTask's defaults (wf-home /
+// step-home). Every rejected-move subtest below drives a real task through
+// h.adapter.MoveTask and only ever asserts the returned error — never that
+// the DB row was left untouched. A regression that validates then writes
+// unconditionally (or writes before validating) would still pass every
+// existing assertion in this file; this closes that gap by proving a
+// rejection has zero persisted side effects, not just a non-nil error.
+func requireTaskUnmoved(t *testing.T, h *pluginMoveErrorBindingHarness, taskID string) {
+	t.Helper()
+	task, err := h.repo.GetTask(context.Background(), taskID)
+	require.NoError(t, err)
+	require.Equal(t, "wf-home", task.WorkflowID, "a rejected move must not persist a workflow change")
+	require.Equal(t, "step-home", task.WorkflowStepID, "a rejected move must not persist a step change")
+}
+
 // TestClassifyPluginMoveError_BindsToRealValidatorStrings pins AC-004.6: the
 // binding error-mapping table in classifyPluginMoveError must be exercised
 // against errors the real validateTaskMove/GetWorkflow/GetStep code paths
@@ -169,6 +189,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		st := status.Convert(err)
 		require.Equal(t, codes.FailedPrecondition, st.Code())
 		require.Equal(t, "task is archived and cannot be moved", st.Message())
+		requireTaskUnmoved(t, h, "task-archived")
 	})
 
 	t.Run("active session, AC-001.8", func(t *testing.T) {
@@ -184,6 +205,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		require.Equal(t, codes.FailedPrecondition, st.Code())
 		require.Equal(t, "task has an active session and cannot be moved", st.Message())
 		require.NotContains(t, st.Message(), "RUNNING", "message must not leak the session's internal state value")
+		requireTaskUnmoved(t, h, "task-live-session")
 	})
 
 	t.Run("unknown workflow, AC-001.6", func(t *testing.T) {
@@ -197,6 +219,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		require.Equal(t, codes.InvalidArgument, st.Code())
 		require.Equal(t, invalidArgMsg, st.Message())
 		require.NotContains(t, st.Message(), missing, "message must not leak the requested workflow id")
+		requireTaskUnmoved(t, h, "task-unknown-wf")
 	})
 
 	t.Run("different workspace, AC-001.6", func(t *testing.T) {
@@ -210,6 +233,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		require.Equal(t, codes.InvalidArgument, st.Code())
 		require.Equal(t, invalidArgMsg, st.Message())
 		require.NotContains(t, st.Message(), other, "message must not leak the target workflow id")
+		requireTaskUnmoved(t, h, "task-cross-workspace")
 	})
 
 	t.Run("unknown step, AC-001.6", func(t *testing.T) {
@@ -223,6 +247,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		require.Equal(t, codes.InvalidArgument, st.Code())
 		require.Equal(t, invalidArgMsg, st.Message())
 		require.NotContains(t, st.Message(), missingStep, "message must not leak the requested step id")
+		requireTaskUnmoved(t, h, "task-unknown-step")
 	})
 
 	t.Run("step not in workflow, AC-001.6", func(t *testing.T) {
@@ -237,6 +262,7 @@ func TestClassifyPluginMoveError_BindsToRealValidatorStrings(t *testing.T) {
 		require.Equal(t, invalidArgMsg, st.Message())
 		require.NotContains(t, st.Message(), "step-home", "message must not leak the requested step id")
 		require.NotContains(t, st.Message(), "wf-home", "message must not leak the task's actual workflow id")
+		requireTaskUnmoved(t, h, "task-step-wrong-workflow")
 	})
 
 	t.Run("task not found, AC-005.6", func(t *testing.T) {
@@ -350,4 +376,43 @@ func TestPluginMoveWithLiveNonBlockingSessionRecordsPluginMoveTrigger(t *testing
 	trigger := h.lastSessionStepHistoryTrigger(t, "session-waiting")
 	require.Equal(t, string(wfmodels.StepTransitionTriggerPluginMove), trigger,
 		"a plugin move against a task with a live session must record plugin_move, not fall back to manual")
+}
+
+// TestPluginMovePublishesTaskMovedEvent closes the test-rigor gap flagged
+// alongside the round-5 CAS fix: the whole point of routing plugin moves
+// through MoveTaskWithOptions (rather than the old UpdateTask WorkflowStepID
+// path) is that a move publishes task.moved so the orchestrator runs
+// on_enter/on_exit step actions. No existing test subscribes to the event
+// bus to prove a plugin-initiated move actually publishes it — every other
+// test in this file only asserts the DB row or the audit trigger. This
+// subscribes before the move and asserts the handler observed the event
+// synchronously (MemoryEventBus.Publish dispatches subscribers inline) with
+// the expected task/step identifiers.
+func TestPluginMovePublishesTaskMovedEvent(t *testing.T) {
+	h := newPluginMoveErrorBindingHarness(t)
+	h.createTask(t, "task-publishes-move", false)
+	wf := "wf-target"
+
+	var received *bus.Event
+	sub, err := h.eventBus.Subscribe(events.TaskMoved, func(_ context.Context, event *bus.Event) error {
+		received = event
+		return nil
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	_, err = h.adapter.MoveTask(context.Background(), plugins.TaskMoveInput{
+		TaskID: "task-publishes-move", WorkflowStepID: "step-target", WorkflowID: &wf, Source: "plugin:acme",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, received, "a plugin move must publish task.moved so on_enter/on_exit step actions fire")
+	require.Equal(t, events.TaskMoved, received.Type)
+	data, ok := received.Data.(map[string]interface{})
+	require.True(t, ok, "task.moved event data must be a map")
+	require.Equal(t, "task-publishes-move", data["task_id"])
+	require.Equal(t, "wf-home", data["from_workflow_id"])
+	require.Equal(t, "wf-target", data["to_workflow_id"])
+	require.Equal(t, "step-home", data["from_step_id"])
+	require.Equal(t, "step-target", data["to_step_id"])
 }

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -1392,7 +1392,10 @@ func (a pluginsTaskWriterAdapter) resolvePluginMoveWorkflowID(ctx context.Contex
 			// that never runs for this branch.
 			return "", classifyPluginMoveError(err)
 		}
-		return "", err
+		// Do not forward repository or driver details across the plugin gRPC
+		// boundary. The classifier preserves cancellation codes and maps every
+		// other unexpected lookup failure to a fixed Internal status.
+		return "", classifyPluginMoveError(err)
 	}
 	return task.WorkflowID, nil
 }
@@ -1413,6 +1416,12 @@ func (a pluginsTaskWriterAdapter) resolvePluginMoveWorkflowID(ctx context.Contex
 func classifyPluginMoveError(err error) error {
 	if err == nil {
 		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, "move task canceled")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, "move task deadline exceeded")
 	}
 	if errors.Is(err, repoerrors.ErrTaskNotFound) {
 		return status.Error(codes.NotFound, "task not found")

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -1384,7 +1384,13 @@ func (a pluginsTaskWriterAdapter) resolvePluginMoveWorkflowID(ctx context.Contex
 	task, err := a.svc.GetTask(ctx, in.TaskID)
 	if err != nil {
 		if errors.Is(err, repoerrors.ErrTaskNotFound) {
-			return "", status.Errorf(codes.NotFound, "task %q not found", in.TaskID)
+			// classifyPluginMoveError's fixed "task not found" message, not a
+			// %q-interpolated one: MoveTask returns this error directly to the
+			// plugin without routing it through that classifier (see the
+			// caller), so building the status here has to match its no-leaked-
+			// identifiers convention itself rather than relying on a wrapper
+			// that never runs for this branch.
+			return "", classifyPluginMoveError(err)
 		}
 		return "", err
 	}

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -40,8 +40,10 @@ import (
 	"github.com/kandev/kandev/internal/repoclone"
 	"github.com/kandev/kandev/internal/secrets"
 	"github.com/kandev/kandev/internal/sentry"
+	"github.com/kandev/kandev/internal/steptelemetry"
 	systemsettings "github.com/kandev/kandev/internal/system/settings"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 	taskservice "github.com/kandev/kandev/internal/task/service"
 	"github.com/kandev/kandev/internal/task/share"
 	userservice "github.com/kandev/kandev/internal/user/service"
@@ -1154,6 +1156,8 @@ type pluginTaskWriteService interface {
 	CreateTask(ctx context.Context, req *taskservice.CreateTaskRequest) (taskservice.CreateTaskResult, error)
 	UpdateTask(ctx context.Context, id string, req *taskservice.UpdateTaskRequest) (*taskmodels.Task, error)
 	DeleteTask(ctx context.Context, id string) error
+	GetTask(ctx context.Context, id string) (*taskmodels.Task, error)
+	MoveTaskWithOptions(ctx context.Context, id, workflowID, workflowStepID string, position int, opts taskservice.MoveTaskOptions) (*taskservice.MoveTaskResult, error)
 }
 
 type pluginsTaskWriterAdapter struct {
@@ -1287,10 +1291,20 @@ func firstPluginPRNumber(values ...*int64) int {
 }
 
 func (a pluginsTaskWriterAdapter) UpdateTask(ctx context.Context, in plugins.TaskUpdateInput) (*taskmodels.Task, error) {
+	// workflow_step_id is rejected on this path regardless of value (including
+	// a present but empty string) — Update never calls publishTaskMovedEvent,
+	// so writing the column directly would move the card without firing
+	// on_enter actions like auto-start. Use Move instead, which routes through
+	// MoveTaskWithOptions. Checked before the state validation below so a
+	// request that also carries an invalid state is still named as a
+	// rejected move, not a state error.
+	if in.WorkflowStepID != nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"workflow_step_id cannot be set via UpdateTask: use MoveTask to transition a task between workflow steps")
+	}
 	req := &taskservice.UpdateTaskRequest{
-		Title:          in.Title,
-		Description:    in.Description,
-		WorkflowStepID: in.WorkflowStepID,
+		Title:       in.Title,
+		Description: in.Description,
 	}
 	if in.State != nil {
 		// v1.TaskState is a string type, so the cast can't fail — validate the
@@ -1304,6 +1318,95 @@ func (a pluginsTaskWriterAdapter) UpdateTask(ctx context.Context, in plugins.Tas
 		req.State = &state
 	}
 	return a.svc.UpdateTask(ctx, in.ID, req)
+}
+
+func (a pluginsTaskWriterAdapter) MoveTask(ctx context.Context, in plugins.TaskMoveInput) (*plugins.TaskMoveResult, error) {
+	workflowID, err := a.resolvePluginMoveWorkflowID(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attach attribution before calling MoveTaskWithOptions: that method only
+	// falls back to its own default attribution when none is already present
+	// on the context (steptelemetry.HasTrigger), so setting it here — exactly
+	// like BulkMoveTasks does — survives untouched into the recorded ledger row.
+	ctx = steptelemetry.WithAttribution(ctx, steptelemetry.Attribution{
+		Trigger:   steptelemetry.TriggerPluginMove,
+		ActorKind: steptelemetry.ActorIntegration,
+		ActorID:   in.Source,
+	})
+
+	result, err := a.svc.MoveTaskWithOptions(ctx, in.TaskID, workflowID, in.WorkflowStepID, int(in.Position), taskservice.MoveTaskOptions{
+		StepHistoryTrigger: wfmodels.StepTransitionTriggerPluginMove,
+		StepHistoryActor:   wfmodels.StepTransitionActorSystem,
+	})
+	if err != nil {
+		return nil, classifyPluginMoveError(err)
+	}
+	return &plugins.TaskMoveResult{
+		Task:         result.Task,
+		Transitioned: result.Transitioned,
+		FromStepID:   result.FromStepID,
+	}, nil
+}
+
+// resolvePluginMoveWorkflowID resolves the effective workflow id for a plugin
+// move: an explicit WorkflowID is used as-is; a nil WorkflowID inherits the
+// task's current workflow, requiring a lookup MoveTaskWithOptions doesn't do
+// on its own (it takes a plain workflow id with no "inherit current" case).
+//
+// A task with no current workflow resolves to "", passed through rather than
+// rejected here (AC-005.11 still ends in InvalidArgument, just not from this
+// function) — the binding precedence ladder requires the task's own state
+// (archived/active-session, AC-001.7/001.8) to be checked before its
+// destination (AC-001.6/005.11) is judged. Those state checks live inside
+// MoveTaskWithOptions' validateTaskMove, called after this function returns,
+// so failing fast here on an empty workflow id would answer InvalidArgument
+// for an archived task instead of FailedPrecondition. Passing "" through
+// instead lets validateTaskMove's GetWorkflow("") fail naturally — after the
+// state gates — with a "workflow not found" error classifyPluginMoveError
+// already maps to InvalidArgument.
+func (a pluginsTaskWriterAdapter) resolvePluginMoveWorkflowID(ctx context.Context, in plugins.TaskMoveInput) (string, error) {
+	if in.WorkflowID != nil {
+		return *in.WorkflowID, nil
+	}
+	task, err := a.svc.GetTask(ctx, in.TaskID)
+	if err != nil {
+		if errors.Is(err, repoerrors.ErrTaskNotFound) {
+			return "", status.Errorf(codes.NotFound, "task %q not found", in.TaskID)
+		}
+		return "", err
+	}
+	return task.WorkflowID, nil
+}
+
+// classifyPluginMoveError maps MoveTaskWithOptions' bare validation errors to
+// the plugin MoveTask RPC's binding error-mapping table. It intentionally does
+// NOT reuse mcp/handlers.classifyMoveTaskError: that classifier lowercases and
+// buckets archived/active-session/different-workspace/step-not-in-workflow
+// into a single Conflict code, but this table requires FailedPrecondition for
+// the first two and InvalidArgument for the latter two.
+func classifyPluginMoveError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, repoerrors.ErrTaskNotFound) {
+		return status.Error(codes.NotFound, err.Error())
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "archived tasks cannot be moved"):
+		return status.Error(codes.FailedPrecondition, msg)
+	case strings.Contains(msg, "task has an active session"):
+		return status.Error(codes.FailedPrecondition, msg)
+	case strings.Contains(msg, "workflow not found"),
+		strings.Contains(msg, "workflow step not found"),
+		strings.Contains(msg, "target workflow is in a different workspace"),
+		strings.Contains(msg, "target workflow step does not belong to target workflow"):
+		return status.Error(codes.InvalidArgument, msg)
+	default:
+		return status.Error(codes.Internal, msg)
+	}
 }
 
 // validPluginTaskState reports whether state is a state a plugin may set via

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -1326,6 +1326,20 @@ func (a pluginsTaskWriterAdapter) MoveTask(ctx context.Context, in plugins.TaskM
 		return nil, err
 	}
 
+	opts := taskservice.MoveTaskOptions{
+		StepHistoryTrigger: wfmodels.StepTransitionTriggerPluginMove,
+		StepHistoryActor:   wfmodels.StepTransitionActorSystem,
+	}
+	if in.WorkflowID == nil {
+		// workflowID above was inherited from a separate GetTask pre-read
+		// (resolvePluginMoveWorkflowID), not named explicitly by the plugin.
+		// Guard against a concurrent reassignment landing between that read
+		// and the write below: MoveTaskWithOptions re-checks this against the
+		// task's WorkflowID from its own fresh GetTask and fails the move
+		// instead of silently reverting the concurrent change.
+		opts.ExpectedWorkflowID = &workflowID
+	}
+
 	// Attach attribution before calling MoveTaskWithOptions: that method only
 	// falls back to its own default attribution when none is already present
 	// on the context (steptelemetry.HasTrigger), so setting it here — exactly
@@ -1336,10 +1350,7 @@ func (a pluginsTaskWriterAdapter) MoveTask(ctx context.Context, in plugins.TaskM
 		ActorID:   in.Source,
 	})
 
-	result, err := a.svc.MoveTaskWithOptions(ctx, in.TaskID, workflowID, in.WorkflowStepID, int(in.Position), taskservice.MoveTaskOptions{
-		StepHistoryTrigger: wfmodels.StepTransitionTriggerPluginMove,
-		StepHistoryActor:   wfmodels.StepTransitionActorSystem,
-	})
+	result, err := a.svc.MoveTaskWithOptions(ctx, in.TaskID, workflowID, in.WorkflowStepID, int(in.Position), opts)
 	if err != nil {
 		return nil, classifyPluginMoveError(err)
 	}
@@ -1386,26 +1397,36 @@ func (a pluginsTaskWriterAdapter) resolvePluginMoveWorkflowID(ctx context.Contex
 // buckets archived/active-session/different-workspace/step-not-in-workflow
 // into a single Conflict code, but this table requires FailedPrecondition for
 // the first two and InvalidArgument for the latter two.
+//
+// Every branch returns a fixed, generic message rather than the underlying
+// err.Error() text: validateTaskMove's messages are meant for trusted
+// board/MCP callers and can name internal identifiers, so forwarding them
+// verbatim to a plugin (an external, less-trusted caller) over the gRPC
+// status would leak implementation detail the plugin has no legitimate need
+// for. This mirrors classifyMoveTaskError's own fixed-message convention.
 func classifyPluginMoveError(err error) error {
 	if err == nil {
 		return nil
 	}
 	if errors.Is(err, repoerrors.ErrTaskNotFound) {
-		return status.Error(codes.NotFound, err.Error())
+		return status.Error(codes.NotFound, "task not found")
+	}
+	if errors.Is(err, taskservice.ErrWorkflowResolutionConflict) {
+		return status.Error(codes.Aborted, "task workflow changed concurrently, retry the move")
 	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "archived tasks cannot be moved"):
-		return status.Error(codes.FailedPrecondition, msg)
+		return status.Error(codes.FailedPrecondition, "task is archived and cannot be moved")
 	case strings.Contains(msg, "task has an active session"):
-		return status.Error(codes.FailedPrecondition, msg)
+		return status.Error(codes.FailedPrecondition, "task has an active session and cannot be moved")
 	case strings.Contains(msg, "workflow not found"),
 		strings.Contains(msg, "workflow step not found"),
 		strings.Contains(msg, "target workflow is in a different workspace"),
 		strings.Contains(msg, "target workflow step does not belong to target workflow"):
-		return status.Error(codes.InvalidArgument, msg)
+		return status.Error(codes.InvalidArgument, "invalid move_task request: unknown or mismatched workflow, step, or workspace")
 	default:
-		return status.Error(codes.Internal, msg)
+		return status.Error(codes.Internal, "failed to move task")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_supersession_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_supersession_test.go
@@ -1,0 +1,85 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestHandleTaskMoved_SupersededMoveSkipsStaleDestinationLifecycle pins
+// AC-005.3 (pin): handleTaskMoved's supersession guard
+// (event_handlers_workflow.go, "} else if task.WorkflowStepID !=
+// data.ToStepID {"). task.moved events are published after each write and
+// can be delivered out of order or delayed; if two moves race (task A:
+// step1 -> step2, then step2 -> step3) and the first event is processed
+// after the second move already committed, the handler must recognize the
+// task has since moved on and skip step2's on_enter/auto-start lifecycle
+// entirely — otherwise a superseded destination's auto_start_agent launches
+// an agent on a step the task has already left, precisely the defect class
+// this whole card exists to prevent. Replacing the guard's condition with
+// "false" (never firing) passes the rest of this package's suite untouched
+// — this is the only test that pins it.
+func TestHandleTaskMoved_SupersededMoveSkipsStaleDestinationLifecycle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		repo := setupTestRepo(t)
+		now := time.Now().UTC()
+		requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+		requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+		// The task's persisted step is step3 — a later move has already landed
+		// it there — while the event handled below still names step2 as its own
+		// destination, simulating delayed/out-of-order delivery of the earlier
+		// move's task.moved event.
+		requireNoError(t, repo.CreateTask(ctx, &models.Task{
+			ID:             "t-superseded",
+			WorkspaceID:    "ws1",
+			WorkflowID:     "wf1",
+			WorkflowStepID: "step3",
+			Title:          "Task",
+			Description:    "prompt",
+			State:          v1.TaskStateCreated,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}))
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Superseded destination", Position: 1,
+			Events: wfmodels.StepEvents{
+				OnEnter: []wfmodels.OnEnterAction{
+					{Type: wfmodels.OnEnterAutoStartAgent},
+				},
+			},
+		}
+
+		svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), failIfLaunched(t))
+
+		svc.handleTaskMoved(ctx, watcher.TaskMovedEventData{
+			TaskID:     "t-superseded",
+			FromStepID: "step1",
+			ToStepID:   "step2",
+			SessionID:  "",
+		})
+
+		// Settle any goroutine the (correctly guarded) call did not spawn, and
+		// any the guard failed to prevent under mutation — synctest.Wait
+		// blocks until every goroutine in the bubble is durably idle, so
+		// failIfLaunched's t.Error would already have fired by the time this
+		// returns.
+		synctest.Wait()
+
+		task, err := repo.GetTask(ctx, "t-superseded")
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		if task.WorkflowStepID != "step3" {
+			t.Fatalf("WorkflowStepID = %q, want step3 unchanged — the guard must return before touching the task", task.WorkflowStepID)
+		}
+	})
+}

--- a/apps/backend/internal/plugins/host_data_test.go
+++ b/apps/backend/internal/plugins/host_data_test.go
@@ -187,6 +187,10 @@ type fakeTaskWriter struct {
 	updateErr   error
 	deletedIDs  []string
 	deleteErr   error
+	lastMove    TaskMoveInput
+	moveCalls   int
+	moveResult  *TaskMoveResult
+	moveErr     error
 }
 
 func (f *fakeTaskWriter) CreateTask(_ context.Context, in TaskCreateInput) (*taskmodels.Task, error) {
@@ -211,6 +215,22 @@ func (f *fakeTaskWriter) UpdateTask(_ context.Context, in TaskUpdateInput) (*tas
 		return f.updated, nil
 	}
 	return &taskmodels.Task{ID: in.ID, Title: "updated"}, nil
+}
+
+func (f *fakeTaskWriter) MoveTask(_ context.Context, in TaskMoveInput) (*TaskMoveResult, error) {
+	f.moveCalls++
+	f.lastMove = in
+	if f.moveErr != nil {
+		return nil, f.moveErr
+	}
+	if f.moveResult != nil {
+		return f.moveResult, nil
+	}
+	return &TaskMoveResult{
+		Task:         &taskmodels.Task{ID: in.TaskID, WorkflowStepID: in.WorkflowStepID},
+		Transitioned: true,
+		FromStepID:   "step-from",
+	}, nil
 }
 
 func (f *fakeTaskWriter) DeleteTask(_ context.Context, id string) error {

--- a/apps/backend/internal/plugins/host_write.go
+++ b/apps/backend/internal/plugins/host_write.go
@@ -77,6 +77,35 @@ type TaskUpdateInput struct {
 	WorkflowStepID *string
 }
 
+// TaskMoveInput is the plugins-local task-move request a taskWriter adapter
+// translates into internal/task/service.MoveTaskWithOptions. Unlike
+// TaskUpdateInput's WorkflowStepID (rejected on the plugin path), Move
+// transitions a task through the same path the board's own move uses.
+// WorkflowID nil means inherit the task's current workflow; a pointer to ""
+// is rejected before reaching the adapter (see taskReader.Move). Source is
+// the "plugin:<id>" provenance the host stamps as the ADR 0015 actor id (a
+// plugin cannot set it).
+type TaskMoveInput struct {
+	TaskID         string
+	WorkflowStepID string
+	WorkflowID     *string
+	Position       int32
+	Source         string
+}
+
+// TaskMoveResult is the outcome of a plugin-initiated move. Transitioned and
+// FromStepID mirror internal/task/service.MoveTaskResult's write-transaction
+// sourced fields — they must come from the result, not be re-derived from
+// Task, because a step-changing move's post-commit refresh replaces Task with
+// a plain read that carries neither transient field (see
+// taskmodels.Task.FromStepID's doc). QueuedForStepID is read directly off the
+// returned Task since it is a persisted field, unaffected by that refresh.
+type TaskMoveResult struct {
+	Task         *taskmodels.Task
+	Transitioned bool
+	FromStepID   string
+}
+
 // PluginMessageResult is the outcome of delivering a message to a task session,
 // returned by a taskMessenger adapter. Status is "queued" | "sent" | "started".
 type PluginMessageResult struct {
@@ -84,14 +113,16 @@ type PluginMessageResult struct {
 	Status    string
 }
 
-// taskWriter is the narrow slice of the task service the CreateTask/UpdateTask
-// RPCs need, adapted by backendapp to avoid an internal/task/service import
-// cycle. Both methods return the persisted *taskmodels.Task so the reader can
-// map it to the wire DTO.
+// taskWriter is the narrow slice of the task service the
+// CreateTask/UpdateTask/MoveTask RPCs need, adapted by backendapp to avoid an
+// internal/task/service import cycle. Create/Update return the persisted
+// *taskmodels.Task so the reader can map it to the wire DTO; Move returns the
+// richer TaskMoveResult (see its doc for why).
 type taskWriter interface {
 	CreateTask(ctx context.Context, in TaskCreateInput) (*taskmodels.Task, error)
 	UpdateTask(ctx context.Context, in TaskUpdateInput) (*taskmodels.Task, error)
 	DeleteTask(ctx context.Context, id string) error
+	MoveTask(ctx context.Context, in TaskMoveInput) (*TaskMoveResult, error)
 }
 
 // taskMessenger delivers a prompt to a task session through the orchestrator's
@@ -216,6 +247,52 @@ func (r taskReader) Update(ctx context.Context, in pluginsdk.UpdateTaskInput) (*
 	items := []pluginsdk.Task{taskModelToDTO(updated)}
 	r.host.attachPullRequests(ctx, items)
 	return &items[0], nil
+}
+
+func (r taskReader) Move(ctx context.Context, in pluginsdk.MoveTaskInput) (*pluginsdk.MoveTaskOutcome, error) {
+	if !r.host.capabilities.CanWrite(resourceTasks) {
+		return nil, permissionDenied(apiWriteCapability(resourceTasks))
+	}
+	if r.host.taskWriter == nil {
+		return r.host.UnimplementedHostData.Tasks().Move(ctx, in)
+	}
+	if in.TaskID == "" {
+		return nil, invalidArgument("task_id is required")
+	}
+	if in.WorkflowStepID == "" {
+		return nil, invalidArgument("workflow_step_id is required")
+	}
+	if in.WorkflowID != nil && *in.WorkflowID == "" {
+		return nil, invalidArgument("workflow_id must not be empty when present")
+	}
+	if in.Position < 0 {
+		return nil, invalidArgument("position must not be negative")
+	}
+	result, err := r.host.taskWriter.MoveTask(ctx, TaskMoveInput{
+		TaskID:         in.TaskID,
+		WorkflowStepID: in.WorkflowStepID,
+		WorkflowID:     in.WorkflowID,
+		Position:       in.Position,
+		Source:         r.host.pluginSource(),
+	})
+	if err != nil {
+		if errors.Is(err, repoerrors.ErrTaskNotFound) {
+			return nil, taskNotFound(in.TaskID)
+		}
+		return nil, err
+	}
+	var queuedForStepID *string
+	if result.Task.QueuedForStepID != "" {
+		q := result.Task.QueuedForStepID
+		queuedForStepID = &q
+	}
+	dto := taskModelToDTO(result.Task)
+	return &pluginsdk.MoveTaskOutcome{
+		Task:            &dto,
+		Transitioned:    result.Transitioned,
+		QueuedForStepID: queuedForStepID,
+		FromStepID:      result.FromStepID,
+	}, nil
 }
 
 // resolveCreatePlacement fills the workspace and workflow a created task lands

--- a/apps/backend/internal/plugins/host_write.go
+++ b/apps/backend/internal/plugins/host_write.go
@@ -286,9 +286,10 @@ func (r taskReader) Move(ctx context.Context, in pluginsdk.MoveTaskInput) (*plug
 		q := result.Task.QueuedForStepID
 		queuedForStepID = &q
 	}
-	dto := taskModelToDTO(result.Task)
+	items := []pluginsdk.Task{taskModelToDTO(result.Task)}
+	r.host.attachPullRequests(ctx, items)
 	return &pluginsdk.MoveTaskOutcome{
-		Task:            &dto,
+		Task:            &items[0],
 		Transitioned:    result.Transitioned,
 		QueuedForStepID: queuedForStepID,
 		FromStepID:      result.FromStepID,

--- a/apps/backend/internal/plugins/host_write_test.go
+++ b/apps/backend/internal/plugins/host_write_test.go
@@ -486,6 +486,151 @@ func TestPluginHost_Tasks_UpdateNotFoundMapsToGRPCNotFound(t *testing.T) {
 	}
 }
 
+// ── Task move ───────────────────────────────────────────────────────────
+
+func TestPluginHost_Tasks_MoveDeniedWithoutWriteCapability(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"tasks"}})
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	assertPermissionDenied(t, err, "api_write:tasks")
+	if d.taskWriter.moveCalls != 0 {
+		t.Fatalf("task writer called despite missing api_write:tasks")
+	}
+}
+
+func TestPluginHost_Tasks_MoveRequiresTaskID(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{WorkflowStepID: "step-2"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Move() without task_id error = %v, want InvalidArgument", err)
+	}
+	if d.taskWriter.moveCalls != 0 {
+		t.Fatalf("task writer called despite empty task_id")
+	}
+}
+
+func TestPluginHost_Tasks_MoveRequiresWorkflowStepID(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Move() without workflow_step_id error = %v, want InvalidArgument", err)
+	}
+	if d.taskWriter.moveCalls != 0 {
+		t.Fatalf("task writer called despite empty workflow_step_id")
+	}
+}
+
+// TestPluginHost_Tasks_MoveRejectsPresentButEmptyWorkflowID pins AC-005.5: a
+// present-but-empty workflow_id is rejected outright, not treated the same
+// as an omitted (nil) one — those two have different meanings (explicit
+// empty vs. inherit-current-workflow) and only nil may pass through.
+func TestPluginHost_Tasks_MoveRejectsPresentButEmptyWorkflowID(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	empty := ""
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &empty})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Move() with empty workflow_id error = %v, want InvalidArgument", err)
+	}
+	if d.taskWriter.moveCalls != 0 {
+		t.Fatalf("task writer called despite empty workflow_id")
+	}
+}
+
+// TestPluginHost_Tasks_MoveRejectsNegativePosition pins AC-005.4's negative
+// half: omitted position and position=0 are the same request, but a negative
+// position is invalid input rather than a natural default.
+func TestPluginHost_Tasks_MoveRejectsNegativePosition(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2", Position: -1})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Move() with negative position error = %v, want InvalidArgument", err)
+	}
+	if d.taskWriter.moveCalls != 0 {
+		t.Fatalf("task writer called despite negative position")
+	}
+}
+
+func TestPluginHost_Tasks_MoveSucceedsAndStampsSource(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	d.taskWriter.moveResult = &TaskMoveResult{
+		Task:         &taskmodels.Task{ID: "task-1", WorkflowStepID: "step-2"},
+		Transitioned: true,
+		FromStepID:   "step-1",
+	}
+
+	outcome, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	if err != nil {
+		t.Fatalf("Move() unexpected error: %v", err)
+	}
+	if outcome == nil || !outcome.Transitioned || outcome.FromStepID != "step-1" {
+		t.Fatalf("Move() = %+v, want transitioned from step-1", outcome)
+	}
+	if outcome.Task == nil || outcome.Task.ID != "task-1" {
+		t.Fatalf("Move() task = %+v, want task-1", outcome.Task)
+	}
+	if d.taskWriter.moveCalls != 1 {
+		t.Fatalf("task writer move calls = %d, want 1", d.taskWriter.moveCalls)
+	}
+	if d.taskWriter.lastMove.Source != "plugin:p1" {
+		t.Fatalf("move source = %q, want plugin:p1 (server-stamped provenance)", d.taskWriter.lastMove.Source)
+	}
+}
+
+// TestPluginHost_Tasks_MoveReportsQueuedForStepIDOnlyWhenSet pins AC-002.2:
+// the admission discriminator is QueuedForStepID's presence alone, never a
+// separate admitted/queued boolean the reader would have to derive.
+func TestPluginHost_Tasks_MoveReportsQueuedForStepIDOnlyWhenSet(t *testing.T) {
+	t.Run("queued", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+		d.taskWriter.moveResult = &TaskMoveResult{
+			Task: &taskmodels.Task{ID: "task-1", WorkflowStepID: "step-2", QueuedForStepID: "step-2"},
+		}
+		outcome, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+		if err != nil {
+			t.Fatalf("Move() unexpected error: %v", err)
+		}
+		if outcome.QueuedForStepID == nil || *outcome.QueuedForStepID != "step-2" {
+			t.Fatalf("QueuedForStepID = %v, want step-2", outcome.QueuedForStepID)
+		}
+	})
+	t.Run("admitted", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+		d.taskWriter.moveResult = &TaskMoveResult{
+			Task: &taskmodels.Task{ID: "task-1", WorkflowStepID: "step-2", QueuedForStepID: ""},
+		}
+		outcome, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+		if err != nil {
+			t.Fatalf("Move() unexpected error: %v", err)
+		}
+		if outcome.QueuedForStepID != nil {
+			t.Fatalf("QueuedForStepID = %v, want nil for an admitted task", outcome.QueuedForStepID)
+		}
+	})
+}
+
+func TestPluginHost_Tasks_MoveNotFoundMapsToGRPCNotFound(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	d.taskWriter.moveErr = repoerrors.ErrTaskNotFound
+
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "no-such-task", WorkflowStepID: "step-2"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("Move() of missing task error = %v, want NotFound", err)
+	}
+}
+
+// TestPluginHost_Tasks_MovePropagatesClassifiedError proves an error the
+// writer already classified (e.g. FailedPrecondition for an active session,
+// AC-001.8) passes straight through rather than being reclassified here —
+// classification is owned by the backendapp adapter layer, one level down.
+func TestPluginHost_Tasks_MovePropagatesClassifiedError(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+	d.taskWriter.moveErr = status.Error(codes.FailedPrecondition, "task has an active session (session-1)")
+
+	_, err := d.host.Tasks().Move(context.Background(), pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("Move() error = %v, want FailedPrecondition passed through unchanged", err)
+	}
+}
+
 // ── Message send ────────────────────────────────────────────────────────
 
 func TestPluginHost_Messages_SendSucceedsAndStampsSource(t *testing.T) {

--- a/apps/backend/internal/plugins/host_write_test.go
+++ b/apps/backend/internal/plugins/host_write_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	agentsettingsdto "github.com/kandev/kandev/internal/agent/settings/dto"
@@ -546,6 +547,59 @@ func TestPluginHost_Tasks_MoveRejectsNegativePosition(t *testing.T) {
 	}
 	if d.taskWriter.moveCalls != 0 {
 		t.Fatalf("task writer called despite negative position")
+	}
+}
+
+// TestPluginHost_Tasks_MoveInvalidFieldPrecedenceOrder pins AC-004.3 (TEST-002):
+// when two fields are simultaneously invalid, the ladder in Move (task_id ->
+// workflow_step_id -> present-but-empty workflow_id -> negative position)
+// must report the FIRST offending field, not whichever the implementation
+// happens to check last. Each case names two invalid fields and asserts the
+// error text matches the earlier one in the ladder, not the later one.
+func TestPluginHost_Tasks_MoveInvalidFieldPrecedenceOrder(t *testing.T) {
+	empty := ""
+	cases := []struct {
+		name      string
+		in        pluginsdk.MoveTaskInput
+		wantFirst string
+		notLater  string
+	}{
+		{
+			name:      "empty task_id beats empty workflow_step_id",
+			in:        pluginsdk.MoveTaskInput{TaskID: "", WorkflowStepID: "", Position: -1},
+			wantFirst: "task_id is required",
+			notLater:  "workflow_step_id is required",
+		},
+		{
+			name:      "empty workflow_step_id beats present-but-empty workflow_id",
+			in:        pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "", WorkflowID: &empty, Position: -1},
+			wantFirst: "workflow_step_id is required",
+			notLater:  "workflow_id must not be empty",
+		},
+		{
+			name:      "present-but-empty workflow_id beats negative position",
+			in:        pluginsdk.MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &empty, Position: -1},
+			wantFirst: "workflow_id must not be empty",
+			notLater:  "position must not be negative",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDataHost(manifest.Capabilities{APIWrite: []string{"tasks"}})
+			_, err := d.host.Tasks().Move(context.Background(), tc.in)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("Move() error = %v, want InvalidArgument", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantFirst) {
+				t.Fatalf("Move() error = %q, want it to name the earlier ladder field %q", err.Error(), tc.wantFirst)
+			}
+			if strings.Contains(err.Error(), tc.notLater) {
+				t.Fatalf("Move() error = %q, must not report the later ladder field %q ahead of %q", err.Error(), tc.notLater, tc.wantFirst)
+			}
+			if d.taskWriter.moveCalls != 0 {
+				t.Fatalf("task writer called despite invalid input")
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/plugins/runtime/manager_test.go
+++ b/apps/backend/internal/plugins/runtime/manager_test.go
@@ -62,6 +62,9 @@ func (fakeHostTaskReader) Get(context.Context, string) (*pluginsdk.Task, error) 
 func (fakeHostTaskReader) Update(context.Context, pluginsdk.UpdateTaskInput) (*pluginsdk.Task, error) {
 	return nil, nil
 }
+func (fakeHostTaskReader) Move(context.Context, pluginsdk.MoveTaskInput) (*pluginsdk.MoveTaskOutcome, error) {
+	return nil, nil
+}
 
 func (r fakeHostTaskReader) Create(_ context.Context, in pluginsdk.CreateTaskInput) (*pluginsdk.Task, error) {
 	r.h.mu.Lock()

--- a/apps/backend/internal/steptelemetry/steptelemetry.go
+++ b/apps/backend/internal/steptelemetry/steptelemetry.go
@@ -37,6 +37,7 @@ const (
 	TriggerUnarchiveRestore Trigger = "unarchive_restore"
 	TriggerWorkflowAttached Trigger = "workflow_attached"
 	TriggerWorkflowDetached Trigger = "workflow_detached"
+	TriggerPluginMove       Trigger = "plugin_move"
 	TriggerUnknown          Trigger = "unknown"
 )
 

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -853,6 +853,12 @@ type Task struct {
 	// latest workflow-step write. Repositories populate it after a transition;
 	// it is transient and is not stored in the tasks table.
 	WorkflowStepTransitionID int64 `json:"-"`
+	// FromStepID is the workflow_step_id the task left on the same write that
+	// set WorkflowStepTransitionID, read inside that write's own transaction
+	// (readTaskStepInTx) rather than from any earlier snapshot. Empty when no
+	// transition occurred (WorkflowStepTransitionID == 0) or on task creation.
+	// Transient and is not stored in the tasks table.
+	FromStepID string `json:"-"`
 
 	// Office extensions.
 	//

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -859,6 +859,10 @@ type Task struct {
 	// transition occurred (WorkflowStepTransitionID == 0) or on task creation.
 	// Transient and is not stored in the tasks table.
 	FromStepID string `json:"-"`
+	// FromWorkflowID is the workflow_id the task left on the same write that
+	// set WorkflowStepTransitionID, read inside that write's own transaction.
+	// It is transient and is not stored in the tasks table.
+	FromWorkflowID string `json:"-"`
 
 	// Office extensions.
 	//

--- a/apps/backend/internal/task/repository/repoerrors/errors.go
+++ b/apps/backend/internal/task/repository/repoerrors/errors.go
@@ -47,3 +47,12 @@ var ErrExternalIDConflict = errors.New("external_id already claimed by another t
 // task. Creation races resolve by rejecting the late comer; the cleanup
 // inventory was captured under the same barrier.
 var ErrTaskCleanupInProgress = errors.New("task cleanup in progress")
+
+// ErrWorkflowResolutionConflict reports that a caller's expected current
+// workflow (passed to guard a write against a concurrent reassignment) no
+// longer matches the task's persisted workflow_id, checked atomically inside
+// the write transaction immediately before the row is updated. The write is
+// rejected rather than silently reverting whatever the concurrent move just
+// did. See task/service.MoveTaskOptions.ExpectedWorkflowID for the caller
+// contract.
+var ErrWorkflowResolutionConflict = errors.New("task workflow changed since resolution")

--- a/apps/backend/internal/task/repository/sqlite/errors.go
+++ b/apps/backend/internal/task/repository/sqlite/errors.go
@@ -42,3 +42,9 @@ var ErrExternalIDConflict = repoerrors.ErrExternalIDConflict
 // (task_id, agent_profile_id) pair. Callers should re-read and reuse the
 // winning row rather than treating this as a hard failure.
 var ErrOfficeSessionRaceConflict = errors.New("office task session race conflict")
+
+// ErrWorkflowResolutionConflict is returned by UpdateTaskIfWorkflowMatches and
+// the workflow-step admission writers when a caller-supplied expected
+// workflow id no longer matches the row's persisted workflow_id, checked
+// atomically inside the write transaction. See repoerrors.ErrWorkflowResolutionConflict.
+var ErrWorkflowResolutionConflict = repoerrors.ErrWorkflowResolutionConflict

--- a/apps/backend/internal/task/repository/sqlite/next_queued_task_ordering_pin_test.go
+++ b/apps/backend/internal/task/repository/sqlite/next_queued_task_ordering_pin_test.go
@@ -1,0 +1,133 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// TestNextQueuedTaskForStepExcluding_FullPromotionOrderLadder pins
+// AC-PLUGINS-STEP-MOVE-005.2: queued-task promotion (the query a plugin
+// move's vacate-and-reconcile step relies on, same as the board's own move)
+// orders candidates by position, then priority tier, then queued_at falling
+// back to created_at, then created_at, then task id — exactly the ladder the
+// design file names for NextQueuedTaskForStepExcluding. Each candidate below
+// differs from the next by exactly one key so the whole ladder is exercised
+// in one pass rather than only its first tiebreaker.
+func TestNextQueuedTaskForStepExcluding_FullPromotionOrderLadder(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, "workspace-order")
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "workflow-order", WorkspaceID: "workspace-order", Name: "Workflow"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.April, 5, 6, 7, 8, 0, time.UTC)
+	for _, stepID := range []string{"step-feeder", "step-destination"} {
+		if _, err := repo.db.Exec(repo.db.Rebind(`INSERT INTO workflow_steps
+			(id, workflow_id, name, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`),
+			stepID, "workflow-order", stepID, 0, now, now); err != nil {
+			t.Fatalf("insert step %s: %v", stepID, err)
+		}
+	}
+
+	// Rank 0 (best): position 0 beats every other candidate regardless of
+	// its own priority/time fields.
+	mustCreateOrderedTask(t, ctx, repo, "task-position-wins", "step-feeder", 0, "low", now.Add(time.Hour))
+	// Among position 1 candidates, priority tier is the next key: critical
+	// beats medium beats none, independent of timestamps.
+	mustCreateOrderedTask(t, ctx, repo, "task-priority-critical", "step-feeder", 1, "critical", now.Add(2*time.Hour))
+	mustCreateOrderedTask(t, ctx, repo, "task-priority-medium-early", "step-feeder", 1, "medium", now.Add(3*time.Hour))
+	mustCreateOrderedTask(t, ctx, repo, "task-priority-none", "step-feeder", 1, "none", now)
+	// Among position 1 / priority medium candidates, queued_at (falling back
+	// to created_at) is the next key: an explicit earlier queued_at wins over
+	// a later one even though this task's row was created later.
+	mustCreateOrderedTask(t, ctx, repo, "task-priority-medium-late", "step-feeder", 1, "medium", now.Add(4*time.Hour))
+	setQueuedAt(t, ctx, repo, "task-priority-medium-early", "step-destination", now.Add(90*time.Minute))
+	setQueuedAt(t, ctx, repo, "task-priority-medium-late", "step-destination", now.Add(150*time.Minute))
+	// Among position 1 / priority medium / equal queued_at candidates,
+	// created_at is the next key.
+	sameQueuedAt := now.Add(5 * time.Hour)
+	mustCreateOrderedTaskWithCreatedAt(t, ctx, repo, "task-created-later", "step-feeder", 1, "medium", now.Add(6*time.Hour))
+	mustCreateOrderedTaskWithCreatedAt(t, ctx, repo, "task-created-earlier", "step-feeder", 1, "medium", now.Add(5*time.Hour))
+	setQueuedAt(t, ctx, repo, "task-created-later", "step-destination", sameQueuedAt)
+	setQueuedAt(t, ctx, repo, "task-created-earlier", "step-destination", sameQueuedAt)
+	// Among position 1 / priority medium / equal queued_at / equal created_at
+	// candidates, task id is the final tiebreaker (lexical ASC).
+	sameCreatedAt := now.Add(7 * time.Hour)
+	mustCreateOrderedTaskWithCreatedAt(t, ctx, repo, "task-id-z", "step-feeder", 1, "medium", sameCreatedAt)
+	mustCreateOrderedTaskWithCreatedAt(t, ctx, repo, "task-id-a", "step-feeder", 1, "medium", sameCreatedAt)
+	setQueuedAt(t, ctx, repo, "task-id-z", "step-destination", sameQueuedAt.Add(time.Hour))
+	setQueuedAt(t, ctx, repo, "task-id-a", "step-destination", sameQueuedAt.Add(time.Hour))
+
+	want := []string{
+		"task-position-wins",
+		"task-priority-critical",
+		"task-priority-medium-early",
+		"task-priority-medium-late",
+		"task-created-earlier",
+		"task-created-later",
+		"task-id-a",
+		"task-id-z",
+		"task-priority-none",
+	}
+	var got []string
+	excluded := []string{}
+	for range want {
+		candidate, err := repo.NextQueuedTaskForStepExcluding(ctx, "step-feeder", "step-destination", excluded)
+		if err != nil {
+			t.Fatalf("NextQueuedTaskForStepExcluding: %v", err)
+		}
+		if candidate == nil {
+			t.Fatalf("NextQueuedTaskForStepExcluding returned nil after %v", got)
+		}
+		got = append(got, candidate.ID)
+		excluded = append(excluded, candidate.ID)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("promotion order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("promotion order = %v, want %v (mismatch at index %d)", got, want, i)
+		}
+	}
+}
+
+func mustCreateOrderedTask(t *testing.T, ctx context.Context, repo *Repository, id, stepID string, position int, priority string, createdAt time.Time) {
+	t.Helper()
+	mustCreateOrderedTaskWithCreatedAt(t, ctx, repo, id, stepID, position, priority, createdAt)
+}
+
+func mustCreateOrderedTaskWithCreatedAt(t *testing.T, ctx context.Context, repo *Repository, id, stepID string, position int, priority string, createdAt time.Time) {
+	t.Helper()
+	task := &models.Task{
+		ID:             id,
+		WorkspaceID:    "workspace-order",
+		WorkflowID:     "workflow-order",
+		WorkflowStepID: stepID,
+		Title:          id,
+		Priority:       priority,
+		Position:       position,
+	}
+	if err := repo.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask(%s): %v", id, err)
+	}
+	if _, err := repo.db.Exec(repo.db.Rebind(`UPDATE tasks SET created_at = ? WHERE id = ?`), createdAt, id); err != nil {
+		t.Fatalf("backdate created_at(%s): %v", id, err)
+	}
+}
+
+// setQueuedAt marks a task as queued for destinationStepID with an explicit
+// queued_at, mirroring the state UpdateTaskIfWorkflowStepHasCapacity leaves
+// an overflowed move in.
+func setQueuedAt(t *testing.T, ctx context.Context, repo *Repository, id, destinationStepID string, queuedAt time.Time) {
+	t.Helper()
+	if _, err := repo.db.Exec(repo.db.Rebind(
+		`UPDATE tasks SET queued_for_step_id = ?, queued_at = ?, wip_admitted = 0 WHERE id = ?`),
+		destinationStepID, queuedAt, id); err != nil {
+		t.Fatalf("setQueuedAt(%s): %v", id, err)
+	}
+	_ = ctx
+}

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -530,7 +530,7 @@ func (r *Repository) UpdateTask(ctx context.Context, task *models.Task) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	entryID, err := r.updateTaskTx(ctx, tx, task, metadata)
+	entryID, err := r.updateTaskTx(ctx, tx, task, metadata, "")
 	if err != nil {
 		return err
 	}
@@ -542,10 +542,54 @@ func (r *Repository) UpdateTask(ctx context.Context, task *models.Task) error {
 	return nil
 }
 
-func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.Task, metadata []byte) (entryID string, err error) {
+// UpdateTaskIfWorkflowMatches is the same-step counterpart of the
+// expectedWorkflowID guard threaded through updateTaskWithWorkflowStepAdmission:
+// it performs the same write as UpdateTask, but first rechecks — inside the
+// same write transaction, via the readTaskStepInTx row lock — that the task's
+// persisted workflow_id still equals expectedWorkflowID. This closes the
+// same-step half of the plugin-move TOCTOU window: a caller that resolved
+// "the task's current workflow" via a separate pre-read (see
+// service.MoveTaskOptions.ExpectedWorkflowID) can otherwise silently overwrite
+// a concurrent legitimate reassignment landing between that pre-read and this
+// write. A mismatch returns repoerrors.ErrWorkflowResolutionConflict and the
+// transaction rolls back untouched.
+func (r *Repository) UpdateTaskIfWorkflowMatches(ctx context.Context, task *models.Task, expectedWorkflowID string) error {
+	metadata, err := json.Marshal(task.Metadata)
+	if err != nil {
+		metadata = []byte("{}")
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	entryID, err := r.updateTaskTx(ctx, tx, task, metadata, expectedWorkflowID)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	r.dispatchStepEntry(ctx, task.ID, task.WorkflowID, task.WorkflowStepID, entryID)
+	return nil
+}
+
+func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.Task, metadata []byte, expectedWorkflowID string) (entryID string, err error) {
 	fromWorkflowID, fromStepID, _, err := r.readTaskStepInTx(ctx, tx, task.ID)
 	if err != nil {
 		return "", err
+	}
+	if expectedWorkflowID != "" && fromWorkflowID != expectedWorkflowID {
+		// Checked here, immediately before the UPDATE below and using the
+		// same in-transaction, lock-protected read the ledger's "from" value
+		// already comes from — this is the narrowest possible point to close
+		// the race a caller-side pre-read (GetTask, well before this write)
+		// cannot rule out on its own. See ErrWorkflowResolutionConflict (errors.go).
+		return "", fmt.Errorf("%w: expected %q, task is now in %q",
+			ErrWorkflowResolutionConflict, expectedWorkflowID, fromWorkflowID)
 	}
 	// Stamped after the transactional read/lock above, not before BeginTx: on
 	// Postgres, readTaskStepInTx's FOR UPDATE blocks until this transaction's
@@ -625,7 +669,7 @@ func (r *Repository) UpdateTaskWithWorkflowStepAdmission(
 	targetStepID string,
 	limit int,
 ) (bool, error) {
-	admitted, _, err := r.updateTaskWithWorkflowStepAdmission(ctx, task, targetStepID, limit, nil, false, "")
+	admitted, _, err := r.updateTaskWithWorkflowStepAdmission(ctx, task, targetStepID, limit, nil, false, "", "")
 	return admitted, err
 }
 
@@ -633,6 +677,12 @@ func (r *Repository) UpdateTaskWithWorkflowStepAdmission(
 // UpdateTaskWithWorkflowStepAdmission. It keeps the destination admission,
 // the state that applies after admission, and the queued source-exit marker
 // in one transaction so a later full-row update cannot strand the move.
+//
+// expectedWorkflowID, when non-empty, is rechecked atomically inside this
+// transaction (see updateTaskTx) immediately before the row is written,
+// closing the step-changed half of the plugin-move TOCTOU window — see
+// UpdateTaskIfWorkflowMatches for the same-step half. Pass "" for callers that
+// do not carry a pre-resolved expected workflow (e.g. queue promotion/pull).
 func (r *Repository) UpdateTaskWithWorkflowStepAdmissionAndState(
 	ctx context.Context,
 	task *models.Task,
@@ -640,9 +690,10 @@ func (r *Repository) UpdateTaskWithWorkflowStepAdmissionAndState(
 	limit int,
 	admittedState *v1.TaskState,
 	queueExitPending bool,
+	expectedWorkflowID string,
 ) (bool, error) {
 	admitted, _, err := r.updateTaskWithWorkflowStepAdmission(
-		ctx, task, targetStepID, limit, admittedState, queueExitPending, "",
+		ctx, task, targetStepID, limit, admittedState, queueExitPending, "", expectedWorkflowID,
 	)
 	return admitted, err
 }
@@ -663,7 +714,7 @@ func (r *Repository) UpdateTaskWithWorkflowStepAdmissionIfAtStep(
 	targetStepID string,
 	limit int,
 ) (applied bool, err error) {
-	_, applied, err = r.updateTaskWithWorkflowStepAdmission(ctx, task, targetStepID, limit, nil, false, expectedStepID)
+	_, applied, err = r.updateTaskWithWorkflowStepAdmission(ctx, task, targetStepID, limit, nil, false, expectedStepID, "")
 	return applied, err
 }
 
@@ -761,6 +812,7 @@ func (r *Repository) updateTaskWithWorkflowStepAdmission(
 	admittedState *v1.TaskState,
 	queueExitPending bool,
 	expectedStepID string,
+	expectedWorkflowID string,
 ) (admitted bool, applied bool, err error) {
 	now := time.Now().UTC()
 	task.UpdatedAt = now
@@ -842,7 +894,7 @@ func (r *Repository) updateTaskWithWorkflowStepAdmission(
 	if err != nil {
 		metadata = []byte("{}")
 	}
-	entryID, err := r.updateTaskTx(ctx, tx, task, metadata)
+	entryID, err := r.updateTaskTx(ctx, tx, task, metadata, expectedWorkflowID)
 	if err != nil {
 		return false, false, err
 	}

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -596,7 +596,11 @@ func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID = formatEntryID(transitionID)
-	task.FromStepID = fromStepID
+	if transitionID != 0 {
+		task.FromStepID = fromStepID
+	} else {
+		task.FromStepID = ""
+	}
 
 	// Both sides kept. pr-2907's allocateStepEntryIfPending is a write with its
 	// own concern; #3043's entryID is a pure format of transitionID (line above),
@@ -1294,7 +1298,11 @@ func (r *Repository) UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, ta
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
-	task.FromStepID = fromStepID
+	if transitionID != 0 {
+		task.FromStepID = fromStepID
+	} else {
+		task.FromStepID = ""
+	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return err
 	}
@@ -1398,7 +1406,11 @@ func (r *Repository) PromoteQueuedTaskIfWorkflowStepHasCapacity(
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
-	task.FromStepID = fromStepID
+	if transitionID != 0 {
+		task.FromStepID = fromStepID
+	} else {
+		task.FromStepID = ""
+	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}
@@ -2699,7 +2711,11 @@ func (r *Repository) RestoreTaskMessageRollbackIfSessionState(
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
-	task.FromStepID = fromStepID
+	if transitionID != 0 {
+		task.FromStepID = fromStepID
+	} else {
+		task.FromStepID = ""
+	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -596,6 +596,7 @@ func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID = formatEntryID(transitionID)
+	task.FromStepID = fromStepID
 
 	// Both sides kept. pr-2907's allocateStepEntryIfPending is a write with its
 	// own concern; #3043's entryID is a pure format of transitionID (line above),
@@ -1293,6 +1294,7 @@ func (r *Repository) UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, ta
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
+	task.FromStepID = fromStepID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return err
 	}
@@ -1396,6 +1398,7 @@ func (r *Repository) PromoteQueuedTaskIfWorkflowStepHasCapacity(
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
+	task.FromStepID = fromStepID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}
@@ -2696,6 +2699,7 @@ func (r *Repository) RestoreTaskMessageRollbackIfSessionState(
 	}
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
+	task.FromStepID = fromStepID
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
 		return false, err
 	}

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -578,9 +578,18 @@ func (r *Repository) UpdateTaskIfWorkflowMatches(ctx context.Context, task *mode
 }
 
 func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.Task, metadata []byte, expectedWorkflowID string) (entryID string, err error) {
-	fromWorkflowID, fromStepID, _, err := r.readTaskStepInTx(ctx, tx, task.ID)
+	fromWorkflowID, fromStepID, found, err := r.readTaskStepInTx(ctx, tx, task.ID)
 	if err != nil {
 		return "", err
+	}
+	if !found {
+		// A concurrently deleted task must surface as ErrTaskNotFound, not
+		// fall through to the CAS comparison below: with fromWorkflowID=""
+		// (never equal to a non-empty expectedWorkflowID) that branch would
+		// misreport the deletion as a workflow-resolution conflict. NotFound
+		// is reserved for the addressed resource and wins the precedence
+		// ladder over every other case (design's error-mapping table).
+		return "", fmt.Errorf("%w: %s", ErrTaskNotFound, task.ID)
 	}
 	if expectedWorkflowID != "" && fromWorkflowID != expectedWorkflowID {
 		// Checked here, immediately before the UPDATE below and using the

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -650,8 +650,10 @@ func (r *Repository) updateTaskTx(ctx context.Context, tx *sql.Tx, task *models.
 	task.WorkflowStepTransitionID = transitionID
 	entryID = formatEntryID(transitionID)
 	if transitionID != 0 {
+		task.FromWorkflowID = fromWorkflowID
 		task.FromStepID = fromStepID
 	} else {
+		task.FromWorkflowID = ""
 		task.FromStepID = ""
 	}
 
@@ -1360,8 +1362,10 @@ func (r *Repository) UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, ta
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
 	if transitionID != 0 {
+		task.FromWorkflowID = fromWorkflowID
 		task.FromStepID = fromStepID
 	} else {
+		task.FromWorkflowID = ""
 		task.FromStepID = ""
 	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
@@ -1468,8 +1472,10 @@ func (r *Repository) PromoteQueuedTaskIfWorkflowStepHasCapacity(
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
 	if transitionID != 0 {
+		task.FromWorkflowID = fromWorkflowID
 		task.FromStepID = fromStepID
 	} else {
+		task.FromWorkflowID = ""
 		task.FromStepID = ""
 	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
@@ -2773,8 +2779,10 @@ func (r *Repository) RestoreTaskMessageRollbackIfSessionState(
 	task.WorkflowStepTransitionID = transitionID
 	entryID := formatEntryID(transitionID)
 	if transitionID != 0 {
+		task.FromWorkflowID = fromWorkflowID
 		task.FromStepID = fromStepID
 	} else {
+		task.FromWorkflowID = ""
 		task.FromStepID = ""
 	}
 	if err := syncRunnerInTx(ctx, tx, r.db.Rebind, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {

--- a/apps/backend/internal/task/repository/sqlite/task_update_if_workflow_matches_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_update_if_workflow_matches_postgres_test.go
@@ -1,0 +1,186 @@
+package sqlite
+
+// Postgres proof that UpdateTaskIfWorkflowMatches's CAS check is genuinely
+// serialized against a concurrent reassignment, not merely usually-correct.
+// Skips unless KANDEV_TEST_POSTGRES_DSN is set; CI runs this in postgres-boot.
+//
+// task_update_if_workflow_matches_test.go injects its race sequentially (move
+// the task, then call UpdateTaskIfWorkflowMatches) against the SQLite
+// repository, which only proves the comparison logic once fromWorkflowID is
+// known — it never exercises readTaskStepInTx's real PostgreSQL "FOR UPDATE"
+// lock, so it can't tell a genuinely serialized CAS apart from one that reads
+// stale data between two racing writers. This test mirrors the pattern in
+// step_transitions_writer_postgres_test.go's
+// TestPostgresReadTaskStepInTxBlocksOnConcurrentRowLock: one goroutine holds
+// the row's FOR UPDATE lock open on an independent connection while
+// reassigning the task to a different workflow, and a second, independent
+// connection calls the real UpdateTaskIfWorkflowMatches with the task's
+// pre-reassignment workflow id as expectedWorkflowID. The test observes the
+// mover enter a genuine PostgreSQL lock wait before releasing the holder, so
+// a scheduler delay can't masquerade as contention, then asserts the mover
+// gets ErrWorkflowResolutionConflict and the holder's reassignment survives
+// untouched.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+func TestPostgresUpdateTaskIfWorkflowMatchesBlocksOnConcurrentReassignment(t *testing.T) {
+	dsn := testutil.PostgresDSNFromEnv(t)
+	db := testutil.OpenIsolatedPostgres(t, dsn)
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	// Independent connections, not repo's single isolated connection: see
+	// openSecondPostgresConnection's doc comment for why a shared connection
+	// would serialize the calls at Go's pool rather than at the Postgres
+	// server, proving nothing about the FOR UPDATE clause itself.
+	holderDB := openSecondPostgresConnection(t, dsn, db)
+	moverDB := openSecondPostgresConnection(t, dsn, db)
+	observerDB := openSecondPostgresConnection(t, dsn, db)
+	moverRepo, err := NewWithDB(moverDB, moverDB, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema on second connection: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-pg-cas", Name: "PG CAS Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	task := &models.Task{
+		ID: "task-pg-cas", WorkspaceID: "ws-pg-cas", WorkflowID: "workflow-a",
+		WorkflowStepID: "step-source", Title: "PG CAS Task", Priority: "medium",
+	}
+	if err := repo.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	// The holder plays the concurrent legitimate reassignment: it acquires
+	// the row's FOR UPDATE lock via readTaskStepInTx (on its own connection),
+	// reassigns the task to workflow-b, and holds the transaction open —
+	// uncommitted — until this test explicitly releases it.
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLock) }) }
+	holderFinished := make(chan struct{})
+	var holderErr error
+	go func() {
+		defer close(holderFinished)
+		tx, err := holderDB.BeginTx(ctx, nil)
+		if err != nil {
+			holderErr = err
+			return
+		}
+		if _, _, _, err := repo.readTaskStepInTx(ctx, tx, task.ID); err != nil {
+			_ = tx.Rollback()
+			holderErr = err
+			return
+		}
+		if _, err := tx.ExecContext(ctx, holderDB.Rebind(
+			`UPDATE tasks SET workflow_id = ?, workflow_step_id = ? WHERE id = ?`),
+			"workflow-b", "step-destination", task.ID); err != nil {
+			_ = tx.Rollback()
+			holderErr = err
+			return
+		}
+		close(lockHeld)
+		<-releaseLock
+		holderErr = tx.Commit()
+	}()
+	t.Cleanup(func() {
+		release()
+		select {
+		case <-holderFinished:
+			if holderErr != nil {
+				t.Errorf("holder goroutine during cleanup: %v", holderErr)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out waiting for holder goroutine during cleanup")
+		}
+	})
+
+	select {
+	case <-lockHeld:
+	case <-holderFinished:
+		t.Fatalf("holder goroutine failed before acquiring the row lock: %v", holderErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the holder goroutine to acquire the row lock")
+	}
+
+	var moverPID int
+	if err := moverDB.Get(&moverPID, "SELECT pg_backend_pid()"); err != nil {
+		t.Fatalf("read mover backend pid: %v", err)
+	}
+
+	// The mover runs on moverRepo/moverDB, the SECOND connection — genuinely
+	// independent of holderDB, so its call below contends for the real
+	// PostgreSQL row lock rather than for Go's connection pool. It is the
+	// unmodified production UpdateTaskIfWorkflowMatches path, called with the
+	// task's pre-reassignment workflow id, exactly as a plugin move's
+	// same-step CAS guard does.
+	moved := *task
+	moved.WorkflowStepID = "step-source-mover"
+	moverDone := make(chan error, 1)
+	moverFinished := make(chan struct{})
+	go func() {
+		defer close(moverFinished)
+		moverDone <- moverRepo.UpdateTaskIfWorkflowMatches(ctx, &moved, "workflow-a")
+	}()
+	t.Cleanup(func() {
+		release()
+		select {
+		case <-moverFinished:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out waiting for mover goroutine during cleanup")
+		}
+	})
+
+	if err := waitForPostgresLock(ctx, observerDB, moverPID, moverFinished); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-moverDone:
+		t.Fatal("moverRepo.UpdateTaskIfWorkflowMatches returned while the holder's reassignment still held the row's FOR UPDATE lock — the CAS check is not serialized against a concurrent PostgreSQL writer")
+	default:
+	}
+
+	release()
+	select {
+	case <-holderFinished:
+		if holderErr != nil {
+			t.Fatalf("holder goroutine: %v", holderErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for holder goroutine after releasing the row lock")
+	}
+
+	select {
+	case err := <-moverDone:
+		if err == nil {
+			t.Fatal("moverRepo.UpdateTaskIfWorkflowMatches: got nil error, want ErrWorkflowResolutionConflict (the holder reassigned the task to workflow-b while this call's expectedWorkflowID was workflow-a)")
+		}
+		if !errors.Is(err, ErrWorkflowResolutionConflict) {
+			t.Fatalf("moverRepo.UpdateTaskIfWorkflowMatches: err = %v, want errors.Is(err, ErrWorkflowResolutionConflict)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for moverRepo.UpdateTaskIfWorkflowMatches to proceed after the lock was released")
+	}
+
+	final, err := repo.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if final.WorkflowID != "workflow-b" || final.WorkflowStepID != "step-destination" {
+		t.Fatalf("final task = {workflow_id: %q, workflow_step_id: %q}, want {workflow-b, step-destination} (the holder's committed reassignment must survive the mover's rejected CAS)",
+			final.WorkflowID, final.WorkflowStepID)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/task_update_if_workflow_matches_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_update_if_workflow_matches_test.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// TestUpdateTaskIfWorkflowMatches_ReturnsNotFoundWhenTaskDeletedConcurrently
+// pins the design's binding error-mapping table (AC-004.6: "NotFound is
+// reserved for the addressed resource" and wins the precedence ladder over
+// every other case). updateTaskTx discarded readTaskStepInTx's found bool, so
+// a task deleted between a plugin's GetTask pre-read and this CAS write
+// surfaced as fromWorkflowID="" — which never equals a non-empty
+// expectedWorkflowID — firing the CAS-conflict branch
+// (ErrWorkflowResolutionConflict, mapped to codes.Aborted) before the
+// rows==0 check further down ever ran. Simulates the race directly: delete
+// the task, then call UpdateTaskIfWorkflowMatches against the now-deleted
+// row exactly as updateMovedTaskSameStep does.
+func TestUpdateTaskIfWorkflowMatches_ReturnsNotFoundWhenTaskDeletedConcurrently(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, "workspace-cas-notfound")
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "workflow-cas-notfound", WorkspaceID: "workspace-cas-notfound", Name: "Workflow"}); err != nil {
+		t.Fatal(err)
+	}
+	seedCASWorkflowStep(t, repo, "workflow-cas-notfound", "step-source", 0)
+
+	task := &models.Task{
+		ID: "task-cas-deleted", WorkspaceID: "workspace-cas-notfound", WorkflowID: "workflow-cas-notfound",
+		WorkflowStepID: "step-source", Title: "Deleted mid-flight",
+	}
+	if err := repo.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, task.ID); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+
+	err := repo.UpdateTaskIfWorkflowMatches(ctx, task, "workflow-cas-notfound")
+	if err == nil {
+		t.Fatal("UpdateTaskIfWorkflowMatches on a deleted task: got nil error, want ErrTaskNotFound")
+	}
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("UpdateTaskIfWorkflowMatches on a deleted task: err = %v, want errors.Is(err, ErrTaskNotFound) (NotFound is reserved for the addressed resource and wins the precedence ladder)", err)
+	}
+	if errors.Is(err, ErrWorkflowResolutionConflict) {
+		t.Fatalf("UpdateTaskIfWorkflowMatches on a deleted task: err = %v also matches ErrWorkflowResolutionConflict — the CAS-conflict branch must not fire before the not-found check", err)
+	}
+}

--- a/apps/backend/internal/task/repository/task_wip_test.go
+++ b/apps/backend/internal/task/repository/task_wip_test.go
@@ -27,7 +27,7 @@ type workflowStepMoveAdmissionRepository interface {
 }
 
 type workflowStepMoveAdmissionWithStateRepository interface {
-	UpdateTaskWithWorkflowStepAdmissionAndState(context.Context, *models.Task, string, int, *v1.TaskState, bool) (bool, error)
+	UpdateTaskWithWorkflowStepAdmissionAndState(context.Context, *models.Task, string, int, *v1.TaskState, bool, string) (bool, error)
 }
 
 type queuedTaskPromoter interface {
@@ -288,7 +288,7 @@ func TestUpdateTaskWithWorkflowStepAdmissionAndState_PersistsMoveLifecycleAtomic
 		t.Fatalf("seed candidate: %v", err)
 	}
 	admittedState := v1.TaskStateCompleted
-	admitted, err := mover.UpdateTaskWithWorkflowStepAdmissionAndState(ctx, candidate, targetStepID, 1, &admittedState, true)
+	admitted, err := mover.UpdateTaskWithWorkflowStepAdmissionAndState(ctx, candidate, targetStepID, 1, &admittedState, true, "")
 	if err != nil {
 		t.Fatalf("move candidate: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestUpdateTaskWithWorkflowStepAdmissionAndState_PersistsMoveLifecycleAtomic
 	if err != nil {
 		t.Fatalf("load unlimited candidate: %v", err)
 	}
-	admitted, err = mover.UpdateTaskWithWorkflowStepAdmissionAndState(ctx, admittedCandidate, "atomic-unlimited-target", 0, &admittedState, true)
+	admitted, err = mover.UpdateTaskWithWorkflowStepAdmissionAndState(ctx, admittedCandidate, "atomic-unlimited-target", 0, &admittedState, true, "")
 	if err != nil || !admitted {
 		t.Fatalf("unlimited move admitted=%t err=%v", admitted, err)
 	}

--- a/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
+++ b/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
 
@@ -229,6 +230,96 @@ func TestSharedMovePath_ConcurrentDifferentStepMovesRecordDistinctTransitions(t 
 		if trigger != string(steptelemetry.TriggerPluginMove) {
 			t.Fatalf("ledger trigger = %q, want %s for each committed move row", trigger, steptelemetry.TriggerPluginMove)
 		}
+	}
+}
+
+// TestSharedMovePath_SameStepMoveReportsNoTransitionAndEmptyFromStepID pins
+// AC-PLUGINS-STEP-MOVE-002.6 and AC-PLUGINS-STEP-MOVE-005.1: a plugin move
+// that names the step the task already occupies is a no-op write through the
+// real shared path (updateMovedTask's early oldStepID == targetStep.ID
+// branch, which calls the plain repository UpdateTask/updateTaskTx — not one
+// of the WIP-admission call sites). System-design.md's "Both outcome fields
+// come from the write transaction" requires FromStepID be empty whenever
+// Transitioned is false; models.Task.FromStepID's own doc says the same
+// ("Empty when no transition occurred"). This drives the real repository,
+// not a mock, so a regression in updateTaskTx's FromStepID assignment fails
+// here rather than only in a hand-constructed MoveTaskResult fixture.
+func TestSharedMovePath_SameStepMoveReportsNoTransitionAndEmptyFromStepID(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-stationary", "wf-source", "step-source", nil)
+
+	result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-stationary", "wf-source", "step-source", 0, pluginMoveOptions())
+	if err != nil {
+		t.Fatalf("MoveTaskWithOptions: %v", err)
+	}
+	if result.Transitioned {
+		t.Fatalf("Transitioned = true, want false for a same-step move (no ledger row)")
+	}
+	if result.FromStepID != "" {
+		t.Fatalf("FromStepID = %q, want empty when Transitioned is false (design: both outcome fields come from the write transaction)", result.FromStepID)
+	}
+
+	// The genesis task_created row is the only ledger row — the no-op move
+	// must not have appended a second one.
+	triggers := stepTransitionTriggers(t, repo, "task-stationary")
+	if len(triggers) != 1 {
+		t.Fatalf("ledger rows for task-stationary = %d (%v), want exactly 1 (genesis only, no row for the no-op move)", len(triggers), triggers)
+	}
+}
+
+// lastStepTransitionActor reads back the actor_kind/actor_id columns of the
+// most recent task_step_transitions row for taskID, mirroring
+// stepTransitionTriggers' direct-SQL approach since the ledger has no
+// application-layer reader.
+func lastStepTransitionActor(t *testing.T, repo *sqliterepo.Repository, taskID string) (actorKind, actorID string) {
+	t.Helper()
+	var kind sql.NullString
+	var id sql.NullString
+	err := repo.DB().QueryRow(
+		`SELECT actor_kind, actor_id FROM task_step_transitions WHERE task_id = ? ORDER BY id DESC LIMIT 1`, taskID,
+	).Scan(&kind, &id)
+	if err != nil {
+		t.Fatalf("query last task_step_transitions row for %s: %v", taskID, err)
+	}
+	return kind.String, id.String
+}
+
+// TestSharedMovePath_PluginMoveRecordsIntegrationActorOnLedgerRow pins
+// AC-003.1: a plugin-initiated move must land its actor_kind/actor_id on the
+// committed task_step_transitions row exactly as
+// backendapp.pluginsTaskWriterAdapter.MoveTask attaches them
+// (steptelemetry.ActorIntegration + the plugin's source string), not merely
+// pass them through in-memory — this drives the real repository write, so a
+// regression in how recordStepTransition persists the attribution fails here.
+func TestSharedMovePath_PluginMoveRecordsIntegrationActorOnLedgerRow(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-target": {ID: "step-target", WorkflowID: "wf-source", Name: "Target", Position: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-attributed", "wf-source", "step-source", nil)
+
+	result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-attributed", "wf-source", "step-target", 0, pluginMoveOptions())
+	if err != nil {
+		t.Fatalf("MoveTaskWithOptions: %v", err)
+	}
+	if !result.Transitioned {
+		t.Fatalf("Transitioned = false, want true for a cross-step move")
+	}
+
+	actorKind, actorID := lastStepTransitionActor(t, repo, "task-attributed")
+	if actorKind != string(steptelemetry.ActorIntegration) {
+		t.Fatalf("ledger actor_kind = %q, want %q", actorKind, steptelemetry.ActorIntegration)
+	}
+	if actorID != "plugin:acme" {
+		t.Fatalf("ledger actor_id = %q, want %q", actorID, "plugin:acme")
 	}
 }
 

--- a/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
+++ b/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
@@ -1,0 +1,292 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/kandev/kandev/internal/steptelemetry"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// This file pins REQ-PLUGINS-STEP-MOVE-005's (pin)-labelled acceptance
+// criteria: behavior the shared move path already has, that plugin moves now
+// also exercise. Each test drives MoveTaskWithOptions with exactly the
+// options and context attribution (backendapp.pluginsTaskWriterAdapter).
+// MoveTask sets — see internal/backendapp/services.go — so a regression in
+// the shared path plugin moves depend on fails here, not silently.
+
+// pluginMoveOptions mirrors what the plugin adapter passes as
+// taskservice.MoveTaskOptions.
+func pluginMoveOptions() MoveTaskOptions {
+	return MoveTaskOptions{
+		StepHistoryTrigger: wfmodels.StepTransitionTriggerPluginMove,
+		StepHistoryActor:   wfmodels.StepTransitionActorSystem,
+	}
+}
+
+// pluginMoveContext mirrors the steptelemetry.Attribution the plugin adapter
+// attaches to the context before calling MoveTaskWithOptions.
+func pluginMoveContext(source string) context.Context {
+	return steptelemetry.WithAttribution(context.Background(), steptelemetry.Attribution{
+		Trigger:   steptelemetry.TriggerPluginMove,
+		ActorKind: steptelemetry.ActorIntegration,
+		ActorID:   source,
+	})
+}
+
+// stepTransitionTriggers reads back every task_step_transitions.trigger row
+// for taskID, oldest first, using the exported Repository.DB() accessor. The
+// ledger has no application-layer reader — internal/telemetrycontract's raw
+// SQL is the only other consumer — so a direct query is the only way to pin
+// what was actually committed, not merely what a caller requested.
+func stepTransitionTriggers(t *testing.T, repo *sqliterepo.Repository, taskID string) []string {
+	t.Helper()
+	rows, err := repo.DB().Query(
+		`SELECT trigger FROM task_step_transitions WHERE task_id = ? ORDER BY id ASC`, taskID)
+	if err != nil {
+		t.Fatalf("query task_step_transitions: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var triggers []string
+	for rows.Next() {
+		var trigger string
+		if err := rows.Scan(&trigger); err != nil {
+			t.Fatalf("scan trigger: %v", err)
+		}
+		triggers = append(triggers, trigger)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate task_step_transitions: %v", err)
+	}
+	return triggers
+}
+
+// createEphemeralMoveTask creates an is_ephemeral task attached to a
+// workflow step, the shape AC-005.14 exercises: an ephemeral task that is
+// nonetheless placed on a workflow step (e.g. a quick-chat task moved onto a
+// board) and must admit without consuming that step's WIP capacity.
+func createEphemeralMoveTask(t *testing.T, ctx context.Context, repo interface {
+	CreateTask(context.Context, *models.Task) error
+}, id, workflowID, stepID string) {
+	t.Helper()
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:             id,
+		WorkspaceID:    "ws-1",
+		WorkflowID:     workflowID,
+		WorkflowStepID: stepID,
+		Title:          id,
+		State:          v1.TaskStateTODO,
+		Priority:       "medium",
+		IsEphemeral:    true,
+	}); err != nil {
+		t.Fatalf("CreateTask(ephemeral %s): %v", id, err)
+	}
+}
+
+// TestSharedMovePath_PluginAttributedVacatePromotesUnderWIPPullTrigger pins
+// AC-PLUGINS-STEP-MOVE-005.8: vacating a step that has tasks queued for it
+// runs the same reconciliation the board's move runs, and the resulting
+// promotion is recorded under the promotion's own trigger
+// (wip_pull) rather than the vacating caller's (plugin_move) — even though
+// the vacating move itself was driven with plugin attribution end to end.
+func TestSharedMovePath_PluginAttributedVacatePromotesUnderWIPPullTrigger(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-limited": {
+			ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 0,
+			WIPLimit: 1, PullFromStepID: "step-feeder",
+		},
+		"step-feeder": {ID: "step-feeder", WorkflowID: "wf-source", Name: "Feeder", Position: 1},
+		"step-target": {ID: "step-target", WorkflowID: "wf-target", Name: "Target", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-vacating", "wf-source", "step-limited", nil)
+	createMoveTask(t, ctx, repo, "task-waiting", "wf-source", "step-feeder", nil)
+
+	moveCtx := pluginMoveContext("plugin:acme")
+	if _, err := svc.MoveTaskWithOptions(moveCtx, "task-vacating", "wf-target", "step-target", 0, pluginMoveOptions()); err != nil {
+		t.Fatalf("MoveTaskWithOptions: %v", err)
+	}
+
+	promoted, err := repo.GetTask(ctx, "task-waiting")
+	if err != nil {
+		t.Fatalf("GetTask(task-waiting): %v", err)
+	}
+	if promoted.WorkflowStepID != "step-limited" {
+		t.Fatalf("feeder task step = %s, want promoted into step-limited", promoted.WorkflowStepID)
+	}
+
+	// Every CreateTask call writes its own task_created genesis row (see
+	// genesisAttribution in step_transitions.go), so each task's ledger
+	// carries that row before the move-driven row this test cares about —
+	// assert the LAST row rather than the full history.
+	vacatingTriggers := stepTransitionTriggers(t, repo, "task-vacating")
+	if len(vacatingTriggers) == 0 || vacatingTriggers[len(vacatingTriggers)-1] != string(steptelemetry.TriggerPluginMove) {
+		t.Fatalf("task-vacating ledger triggers = %v, want the last row to be %s", vacatingTriggers, steptelemetry.TriggerPluginMove)
+	}
+	promotedTriggers := stepTransitionTriggers(t, repo, "task-waiting")
+	if len(promotedTriggers) == 0 || promotedTriggers[len(promotedTriggers)-1] != string(steptelemetry.TriggerWIPPull) {
+		t.Fatalf("task-waiting ledger triggers = %v, want the last row to be %s (never the vacating move's plugin_move)",
+			promotedTriggers, steptelemetry.TriggerWIPPull)
+	}
+}
+
+// TestSharedMovePath_ConcurrentSameTaskSameStepNeverExceedsWIPLimit pins
+// AC-PLUGINS-STEP-MOVE-005.2's serialization half: two callers moving
+// different tasks onto the same WIP-limited step concurrently must never
+// admit more than the step's limit, regardless of write interleaving.
+func TestSharedMovePath_ConcurrentSameTaskSameStepNeverExceedsWIPLimit(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-full":   {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 1, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-a", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-b", "wf-source", "step-source", nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for _, taskID := range []string{"task-a", "task-b"} {
+		go func(id string) {
+			defer wg.Done()
+			_, _ = svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), id, "wf-source", "step-full", 0, pluginMoveOptions())
+		}(taskID)
+	}
+	wg.Wait()
+
+	admitted := 0
+	for _, taskID := range []string{"task-a", "task-b"} {
+		task, err := repo.GetTask(ctx, taskID)
+		if err != nil {
+			t.Fatalf("GetTask(%s): %v", taskID, err)
+		}
+		if task.WorkflowStepID != "step-full" {
+			t.Fatalf("task %s step = %s, want step-full", taskID, task.WorkflowStepID)
+		}
+		if task.WIPAdmitted {
+			admitted++
+			if task.QueuedForStepID != "" {
+				t.Fatalf("admitted task %s still carries queued_for_step_id = %q", taskID, task.QueuedForStepID)
+			}
+		} else if task.QueuedForStepID != "step-full" {
+			t.Fatalf("non-admitted task %s queued_for_step_id = %q, want step-full", taskID, task.QueuedForStepID)
+		}
+	}
+	if admitted != 1 {
+		t.Fatalf("admitted count = %d, want exactly 1 (WIP limit is 1)", admitted)
+	}
+}
+
+// TestSharedMovePath_ConcurrentDifferentStepMovesRecordDistinctTransitions
+// pins AC-PLUGINS-STEP-MOVE-005.10: two callers moving the same task to
+// different steps concurrently must serialize on the task write, commit both,
+// and record one ledger row per committed change — the writer never
+// collapses two committed step changes into a single row.
+func TestSharedMovePath_ConcurrentDifferentStepMovesRecordDistinctTransitions(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-a":      {ID: "step-a", WorkflowID: "wf-source", Name: "A", Position: 1},
+		"step-b":      {ID: "step-b", WorkflowID: "wf-source", Name: "B", Position: 2},
+	}})
+	createMoveTask(t, ctx, repo, "task-racing", "wf-source", "step-source", nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for _, dest := range []string{"step-a", "step-b"} {
+		go func(step string) {
+			defer wg.Done()
+			_, _ = svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-racing", "wf-source", step, 0, pluginMoveOptions())
+		}(dest)
+	}
+	wg.Wait()
+
+	final, err := repo.GetTask(ctx, "task-racing")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if final.WorkflowStepID != "step-a" && final.WorkflowStepID != "step-b" {
+		t.Fatalf("final step = %s, want step-a or step-b", final.WorkflowStepID)
+	}
+
+	// The genesis task_created row (see genesisAttribution in
+	// step_transitions.go) precedes the two move-driven rows this test
+	// cares about — assert the trailing two, not the full history.
+	triggers := stepTransitionTriggers(t, repo, "task-racing")
+	if len(triggers) != 3 {
+		t.Fatalf("ledger rows for task-racing = %d (%v), want exactly 3 (1 genesis + one per committed move, not collapsed)", len(triggers), triggers)
+	}
+	for _, trigger := range triggers[1:] {
+		if trigger != string(steptelemetry.TriggerPluginMove) {
+			t.Fatalf("ledger trigger = %q, want %s for each committed move row", trigger, steptelemetry.TriggerPluginMove)
+		}
+	}
+}
+
+// TestSharedMovePath_NonPositiveWIPLimitAdmitsImmediately pins
+// AC-PLUGINS-STEP-MOVE-005.12: an absent, zero, or negative WIP limit is
+// treated as unlimited, so the move admits rather than queues, and reports
+// admission via QueuedForStepID being empty (never via WIPAdmitted alone —
+// AC-002.2).
+func TestSharedMovePath_NonPositiveWIPLimitAdmitsImmediately(t *testing.T) {
+	for name, limit := range map[string]int{"absent (zero value)": 0, "explicit zero": 0, "negative": -1} {
+		t.Run(name, func(t *testing.T) {
+			svc, _, repo := createTestService(t)
+			ctx := context.Background()
+			seedMoveWorkflows(t, ctx, repo)
+			svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+				"step-source":    {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+				"step-unlimited": {ID: "step-unlimited", WorkflowID: "wf-source", Name: "Unlimited", Position: 1, WIPLimit: limit},
+			}})
+			createMoveTask(t, ctx, repo, "task-moving", "wf-source", "step-source", nil)
+			createMoveTask(t, ctx, repo, "task-occupant", "wf-source", "step-unlimited", nil)
+
+			result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-moving", "wf-source", "step-unlimited", 0, pluginMoveOptions())
+			if err != nil {
+				t.Fatalf("MoveTaskWithOptions: %v", err)
+			}
+			if result.Task.QueuedForStepID != "" {
+				t.Fatalf("QueuedForStepID = %q, want empty (admitted) under a non-positive WIP limit", result.Task.QueuedForStepID)
+			}
+			if !result.Task.WIPAdmitted {
+				t.Fatal("WIPAdmitted = false, want true under a non-positive WIP limit")
+			}
+		})
+	}
+}
+
+// TestSharedMovePath_EphemeralTaskAdmitsWithoutConsumingCapacity pins
+// AC-PLUGINS-STEP-MOVE-005.14: moving an ephemeral task always admits and
+// reports admission (QueuedForStepID empty) even onto a step already at its
+// WIP limit, because an ephemeral task is queued for no step.
+func TestSharedMovePath_EphemeralTaskAdmitsWithoutConsumingCapacity(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-full":   {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 1, WIPLimit: 1},
+	}})
+	createEphemeralMoveTask(t, ctx, repo, "task-ephemeral", "wf-source", "step-source")
+	createMoveTask(t, ctx, repo, "task-occupant", "wf-source", "step-full", nil)
+
+	result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-ephemeral", "wf-source", "step-full", 0, pluginMoveOptions())
+	if err != nil {
+		t.Fatalf("MoveTaskWithOptions: %v", err)
+	}
+	if result.Task.QueuedForStepID != "" {
+		t.Fatalf("QueuedForStepID = %q, want empty (admitted) for an ephemeral task", result.Task.QueuedForStepID)
+	}
+	if result.Task.WorkflowStepID != "step-full" {
+		t.Fatalf("WorkflowStepID = %s, want step-full", result.Task.WorkflowStepID)
+	}
+}

--- a/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
+++ b/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
@@ -457,3 +457,89 @@ func TestSharedMovePath_EphemeralTaskAdmitsWithoutConsumingCapacity(t *testing.T
 		t.Fatalf("WorkflowStepID = %s, want step-full", result.Task.WorkflowStepID)
 	}
 }
+
+// TestSharedMovePath_CASGuardedSameStepMoveSucceeds pins the
+// UpdateTaskIfWorkflowMatches happy path: AC-005.1's headline scenario, a
+// plugin repeating an identical move (no explicit workflow_id — the caller
+// resolved "the task's current workflow" from its own pre-read and sets
+// MoveTaskOptions.ExpectedWorkflowID, exactly as
+// pluginsTaskWriterAdapter.MoveTask does when in.WorkflowID is nil, see
+// backendapp/services.go) after the task already sits on the named step.
+// Every other same-step test in this file leaves ExpectedWorkflowID nil, so
+// none of them reach updateMovedTaskSameStep's CAS branch
+// (UpdateTaskIfWorkflowMatches) at all — this is the only one that does.
+func TestSharedMovePath_CASGuardedSameStepMoveSucceeds(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-stationary", "wf-source", "step-source", nil)
+
+	expectedWorkflowID := "wf-source"
+	opts := pluginMoveOptions()
+	opts.ExpectedWorkflowID = &expectedWorkflowID
+
+	result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-stationary", "wf-source", "step-source", 0, opts)
+	if err != nil {
+		t.Fatalf("MoveTaskWithOptions (CAS-guarded same-step move): %v", err)
+	}
+	if result.Transitioned {
+		t.Fatalf("Transitioned = true, want false for a same-step move (no ledger row)")
+	}
+	if result.FromStepID != "" {
+		t.Fatalf("FromStepID = %q, want empty when Transitioned is false", result.FromStepID)
+	}
+
+	// The genesis task_created row is the only ledger row — the no-op move
+	// must not have appended a second one.
+	triggers := stepTransitionTriggers(t, repo, "task-stationary")
+	if len(triggers) != 1 {
+		t.Fatalf("ledger rows for task-stationary = %d (%v), want exactly 1 (genesis only)", len(triggers), triggers)
+	}
+
+	task, err := repo.GetTask(ctx, "task-stationary")
+	if err != nil {
+		t.Fatalf("GetTask(task-stationary): %v", err)
+	}
+	if task.WorkflowID != "wf-source" || task.WorkflowStepID != "step-source" {
+		t.Fatalf("task-stationary after CAS-guarded same-step move: workflow=%q step=%q, want wf-source/step-source unchanged",
+			task.WorkflowID, task.WorkflowStepID)
+	}
+}
+
+// TestSharedMovePath_CrossStepMoveReportsActualOriginStepNotDestination pins
+// MoveTaskResult.FromStepID's positive value against a real write
+// transaction: system-design.md's "both outcome fields come from the write
+// transaction" requires FromStepID name the step the task actually left, not
+// the step it landed on. Every other test in this file either only asserts
+// the negative/empty case (SameStepMoveReportsNoTransitionAndEmptyFromStepID)
+// or a cross-step move's Transitioned flag without ever reading FromStepID's
+// value (PluginMoveRecordsIntegrationActorOnLedgerRow) — so a mutation
+// swapping the assignment from the origin step to the destination step (e.g.
+// task.FromStepID = task.WorkflowStepID) would still pass every existing
+// package. Source and destination step IDs are deliberately distinguishable
+// strings so that mutation cannot pass by coincidence.
+func TestSharedMovePath_CrossStepMoveReportsActualOriginStepNotDestination(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-target": {ID: "step-target", WorkflowID: "wf-source", Name: "Target", Position: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-crossing", "wf-source", "step-source", nil)
+
+	result, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-crossing", "wf-source", "step-target", 0, pluginMoveOptions())
+	if err != nil {
+		t.Fatalf("MoveTaskWithOptions: %v", err)
+	}
+	if !result.Transitioned {
+		t.Fatalf("Transitioned = false, want true for a cross-step move")
+	}
+	if result.FromStepID != "step-source" {
+		t.Fatalf("FromStepID = %q, want %q (the step actually left, not the destination %q)",
+			result.FromStepID, "step-source", "step-target")
+	}
+}

--- a/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
+++ b/apps/backend/internal/task/service/plugin_move_shared_path_pins_test.go
@@ -272,6 +272,82 @@ func TestSharedMovePath_SameStepMoveReportsNoTransitionAndEmptyFromStepID(t *tes
 	}
 }
 
+// TestSharedMovePath_SameStepMovePreservesWIPAdmissionFieldsAgainstRealDB
+// closes the test-rigor gap alongside the round-5 CAS fix: updateMovedTask's
+// same-step branch (service_workflow.go, oldStepID == targetStep.ID) returns
+// task.WIPAdmitted straight from the in-memory struct it was handed and never
+// touches WIPAdmitted/QueuedForStepID itself, so every existing assertion of
+// "the field survives" was really just asserting Go's zero-mutation
+// semantics on a struct field — never proving the plain s.tasks.UpdateTask
+// write this branch performs actually persists (rather than clobbers) those
+// two columns. This drives real admission (a WIP-limited step, one task
+// admitted, one queued) through the real sqlite repository, performs a
+// same-step reorder on each via the shared move path, and re-reads both rows
+// from the real DB — not a hand-constructed models.Task fixture — to prove
+// the write round-trips the admission state unchanged.
+func TestSharedMovePath_SameStepMovePreservesWIPAdmissionFieldsAgainstRealDB(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source":  {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-limited": {ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 1, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-admitted", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-overflow", "wf-source", "step-source", nil)
+
+	// Drive real admission through the shared move path: the first arrival
+	// at the WIP-limited step is admitted, the second overflows and queues.
+	if _, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-admitted", "wf-source", "step-limited", 0, pluginMoveOptions()); err != nil {
+		t.Fatalf("MoveTaskWithOptions(task-admitted): %v", err)
+	}
+	if _, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-overflow", "wf-source", "step-limited", 1, pluginMoveOptions()); err != nil {
+		t.Fatalf("MoveTaskWithOptions(task-overflow): %v", err)
+	}
+
+	admittedBefore, err := repo.GetTask(ctx, "task-admitted")
+	if err != nil {
+		t.Fatalf("GetTask(task-admitted) before reorder: %v", err)
+	}
+	if !admittedBefore.WIPAdmitted || admittedBefore.QueuedForStepID != "" {
+		t.Fatalf("task-admitted before reorder: admitted=%v queued_for=%q, want admitted with no queue target",
+			admittedBefore.WIPAdmitted, admittedBefore.QueuedForStepID)
+	}
+	overflowBefore, err := repo.GetTask(ctx, "task-overflow")
+	if err != nil {
+		t.Fatalf("GetTask(task-overflow) before reorder: %v", err)
+	}
+	if overflowBefore.WIPAdmitted || overflowBefore.QueuedForStepID != "step-limited" {
+		t.Fatalf("task-overflow before reorder: admitted=%v queued_for=%q, want queued for step-limited",
+			overflowBefore.WIPAdmitted, overflowBefore.QueuedForStepID)
+	}
+
+	// Same-step reorders (position change only) must not disturb admission.
+	if _, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-admitted", "wf-source", "step-limited", 1, pluginMoveOptions()); err != nil {
+		t.Fatalf("MoveTaskWithOptions same-step reorder(task-admitted): %v", err)
+	}
+	if _, err := svc.MoveTaskWithOptions(pluginMoveContext("plugin:acme"), "task-overflow", "wf-source", "step-limited", 0, pluginMoveOptions()); err != nil {
+		t.Fatalf("MoveTaskWithOptions same-step reorder(task-overflow): %v", err)
+	}
+
+	admittedAfter, err := repo.GetTask(ctx, "task-admitted")
+	if err != nil {
+		t.Fatalf("GetTask(task-admitted) after reorder: %v", err)
+	}
+	if !admittedAfter.WIPAdmitted || admittedAfter.QueuedForStepID != "" {
+		t.Fatalf("task-admitted after same-step reorder: admitted=%v queued_for=%q, want the pre-reorder admission state unchanged",
+			admittedAfter.WIPAdmitted, admittedAfter.QueuedForStepID)
+	}
+	overflowAfter, err := repo.GetTask(ctx, "task-overflow")
+	if err != nil {
+		t.Fatalf("GetTask(task-overflow) after reorder: %v", err)
+	}
+	if overflowAfter.WIPAdmitted || overflowAfter.QueuedForStepID != "step-limited" {
+		t.Fatalf("task-overflow after same-step reorder: admitted=%v queued_for=%q, want the pre-reorder queued state unchanged (a reorder must not silently admit it)",
+			overflowAfter.WIPAdmitted, overflowAfter.QueuedForStepID)
+	}
+}
+
 // lastStepTransitionActor reads back the actor_kind/actor_id columns of the
 // most recent task_step_transitions row for taskID, mirroring
 // stepTransitionTriggers' direct-SQL approach since the ledger has no

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/steptelemetry"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
@@ -432,10 +433,17 @@ type MoveTaskOptions struct {
 
 // ErrWorkflowResolutionConflict indicates a caller's pre-resolved "current
 // workflow" (see MoveTaskOptions.ExpectedWorkflowID) no longer matches the
-// task's actual workflow by the time the move is applied — a concurrent
-// reassignment won the race. The move is rejected rather than silently
-// reverting that reassignment.
-var ErrWorkflowResolutionConflict = errors.New("task workflow changed since resolution")
+// task's actual workflow — a concurrent reassignment won the race. The move
+// is rejected rather than silently reverting that reassignment.
+//
+// This is an alias for repoerrors.ErrWorkflowResolutionConflict, not a
+// separate sentinel: the same check now also runs atomically inside the
+// repository's write transaction (UpdateTaskIfWorkflowMatches,
+// UpdateTaskWithWorkflowStepAdmissionAndState), which returns the repoerrors
+// value directly. Keeping one sentinel means callers using errors.Is against
+// either name catch both the pre-write fast-fail below and the write-time
+// guard that actually closes the race.
+var ErrWorkflowResolutionConflict = repoerrors.ErrWorkflowResolutionConflict
 
 type workflowMoveLimitsRepository interface {
 	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
@@ -461,7 +469,19 @@ type workflowMoveAdmissionWithStateRepository interface {
 		limit int,
 		admittedState *v1.TaskState,
 		queueExitPending bool,
+		expectedWorkflowID string,
 	) (bool, error)
+}
+
+// workflowMoveConflictRepository is the same-step counterpart of
+// workflowMoveAdmissionWithStateRepository's expectedWorkflowID guard: when a
+// move does not change workflow step, updateMovedTask writes through plain
+// UpdateTask, which has no expected-workflow parameter (it is called from
+// many unrelated, non-move sites). A caller that set
+// MoveTaskOptions.ExpectedWorkflowID must instead route through this
+// narrower method so the atomic in-transaction recheck still applies.
+type workflowMoveConflictRepository interface {
+	UpdateTaskIfWorkflowMatches(ctx context.Context, task *models.Task, expectedWorkflowID string) error
 }
 
 type workflowQueuedTaskPromoter interface {
@@ -503,6 +523,13 @@ func (s *Service) MoveTaskWithOptions(
 		return nil, err
 	}
 	if opts.ExpectedWorkflowID != nil && task.WorkflowID != *opts.ExpectedWorkflowID {
+		// Cheap fast-fail only: this GetTask is not inside a lock, so it
+		// cannot by itself rule out a race landing between this read and the
+		// eventual write below. That race is closed by the atomic,
+		// in-transaction recheck updateMovedTask now performs at write time
+		// (UpdateTaskIfWorkflowMatches / UpdateTaskWithWorkflowStepAdmissionAndState).
+		// This early check only spares validateTaskMove and the session/state
+		// lookups below when the mismatch is already visible from a plain read.
 		return nil, fmt.Errorf("%w: resolved %q, task is now in %q",
 			ErrWorkflowResolutionConflict, *opts.ExpectedWorkflowID, task.WorkflowID)
 	}
@@ -587,7 +614,7 @@ func (s *Service) MoveTaskWithOptions(
 		})
 	}
 
-	_, err = s.updateMovedTask(moveCtx, task, oldStepID, targetStep, admittedState)
+	_, err = s.updateMovedTask(moveCtx, task, oldStepID, targetStep, admittedState, opts)
 	if err != nil {
 		s.logger.Error("failed to move task", zap.String("task_id", id), zap.Error(err))
 		return nil, err
@@ -1097,21 +1124,79 @@ func skippedTaskIDs(skipped map[string]struct{}) []string {
 	return ids
 }
 
-func (s *Service) updateMovedTask(ctx context.Context, task *models.Task, oldStepID string, targetStep *wfmodels.WorkflowStep, admittedState *v1.TaskState) (bool, error) {
+func (s *Service) updateMovedTask(
+	ctx context.Context,
+	task *models.Task,
+	oldStepID string,
+	targetStep *wfmodels.WorkflowStep,
+	admittedState *v1.TaskState,
+	opts MoveTaskOptions,
+) (bool, error) {
 	if targetStep == nil || oldStepID == targetStep.ID {
-		if err := s.tasks.UpdateTask(ctx, task); err != nil {
+		return s.updateMovedTaskSameStep(ctx, task, opts)
+	}
+	return s.updateMovedTaskCrossStep(ctx, task, targetStep, admittedState, opts)
+}
+
+// updateMovedTaskSameStep handles the no-step-change branch of updateMovedTask
+// (a reorder, or a plugin move that names the task's current step): it writes
+// through the plain repository UpdateTask, not one of the WIP-admission call
+// sites, since there is no admission decision to make when the step is
+// unchanged.
+func (s *Service) updateMovedTaskSameStep(ctx context.Context, task *models.Task, opts MoveTaskOptions) (bool, error) {
+	if opts.ExpectedWorkflowID != nil {
+		// Same-step writes go through plain UpdateTask, which has no
+		// expected-workflow parameter (it is the general-purpose writer
+		// used by many unrelated call sites). A caller carrying a CAS
+		// guard must route through the narrower method instead, or the
+		// guard would silently stop applying for the same-step case —
+		// see workflowMoveConflictRepository's doc.
+		conflictRepo, ok := s.tasks.(workflowMoveConflictRepository)
+		if !ok {
+			return false, fmt.Errorf("workflow conflict guard repository unavailable for task %s", task.ID)
+		}
+		if err := conflictRepo.UpdateTaskIfWorkflowMatches(ctx, task, *opts.ExpectedWorkflowID); err != nil {
 			return false, err
 		}
 		return task.WIPAdmitted, nil
 	}
+	if err := s.tasks.UpdateTask(ctx, task); err != nil {
+		return false, err
+	}
+	return task.WIPAdmitted, nil
+}
+
+// updateMovedTaskCrossStep handles the step-changing branch of
+// updateMovedTask: it runs the target step's WIP admission decision (queuing
+// the task instead of moving it when the step is at capacity) and persists
+// the result.
+func (s *Service) updateMovedTaskCrossStep(
+	ctx context.Context,
+	task *models.Task,
+	targetStep *wfmodels.WorkflowStep,
+	admittedState *v1.TaskState,
+	opts MoveTaskOptions,
+) (bool, error) {
 	admissionRepo, ok := s.tasks.(workflowMoveAdmissionRepository)
 	if !ok {
 		return false, fmt.Errorf("workflow step admission repository unavailable for step %s", targetStep.ID)
 	}
+	expectedWorkflowID := ""
+	if opts.ExpectedWorkflowID != nil {
+		expectedWorkflowID = *opts.ExpectedWorkflowID
+	}
 	if admissionWithState, ok := s.tasks.(workflowMoveAdmissionWithStateRepository); ok {
 		return admissionWithState.UpdateTaskWithWorkflowStepAdmissionAndState(
-			ctx, task, targetStep.ID, targetStep.WIPLimit, admittedState, true,
+			ctx, task, targetStep.ID, targetStep.WIPLimit, admittedState, true, expectedWorkflowID,
 		)
+	}
+	if expectedWorkflowID != "" {
+		// The CAS-guarded caller (plugin moves) always runs against a
+		// production repository, which implements the atomic variant above.
+		// A repository that only exposes the legacy admission method has no
+		// way to honor the guard, so fail closed instead of silently
+		// dropping it.
+		return false, fmt.Errorf("workflow conflict guard unavailable on legacy admission repository for step %s", targetStep.ID)
 	}
 
 	// Keep compatibility with narrow test/dry-run repositories that expose

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -632,15 +632,26 @@ func (s *Service) MoveTaskWithOptions(
 	resultFromStepID := task.FromStepID
 	resultTransitioned := task.WorkflowStepTransitionID != 0
 
-	// Publish task.moved event so the orchestrator can process on_exit/on_enter actions
-	if stepChanged {
-		s.publishTaskMovedEvent(ctx, task, oldWorkflowID, oldStepID, workflowStepID, sessionID)
+	// Publish task.moved event so the orchestrator can process on_exit/on_enter
+	// actions. Gated on resultTransitioned (the write transaction's own
+	// outcome), not the pre-write stepChanged: a concurrent same-workflow move
+	// can land between this call's read and its write, so stepChanged/oldStepID
+	// can name a step the task never actually left (stepChanged=true but the
+	// commit was a no-op transition) or miss one it did leave (stepChanged=false
+	// because this call's read already matched its own target, but the commit's
+	// in-transaction read found a different actual "from" step). Every write
+	// path reachable here (UpdateTask, UpdateTaskIfWorkflowMatches, and the
+	// admission-with-state variant) sets WorkflowStepTransitionID/FromStepID
+	// off the same in-transaction read, so resultFromStepID is always the
+	// step the task actually left on this commit.
+	if resultTransitioned {
+		s.publishTaskMovedEvent(ctx, task, oldWorkflowID, resultFromStepID, workflowStepID, sessionID)
 		historySessionID := opts.StepHistorySessionID
 		if historySessionID == "" {
 			historySessionID = sessionID
 		}
-		s.recordManualStepTransition(ctx, historySessionID, oldStepID, workflowStepID, opts.StepHistoryTrigger, opts.StepHistoryActor)
-		s.pullNextTaskOnVacate(ctx, oldStepID, task.ID)
+		s.recordManualStepTransition(ctx, historySessionID, resultFromStepID, workflowStepID, opts.StepHistoryTrigger, opts.StepHistoryActor)
+		s.pullNextTaskOnVacate(ctx, resultFromStepID, task.ID)
 		s.pullTasksFromNewFeederWork(ctx, workflowID, workflowStepID)
 		refreshed, err := s.tasks.GetTask(ctx, task.ID)
 		if err != nil {

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -420,7 +420,22 @@ type MoveTaskOptions struct {
 	// StepHistoryActor identifies the caller. Agent moves must not inherit the
 	// owner identity that MCP uses for authorization.
 	StepHistoryActor wfmodels.StepTransitionActor
+	// ExpectedWorkflowID guards a caller that resolved "the task's current
+	// workflow" via a separate pre-read (rather than passing an explicit,
+	// intentional target workflow) against a concurrent reassignment landing
+	// between that read and this call. When set, MoveTaskWithOptions compares
+	// it to the task's WorkflowID from the fresh GetTask this method already
+	// performs and fails with ErrWorkflowResolutionConflict on a mismatch,
+	// instead of silently reverting whatever the concurrent move just did.
+	ExpectedWorkflowID *string
 }
+
+// ErrWorkflowResolutionConflict indicates a caller's pre-resolved "current
+// workflow" (see MoveTaskOptions.ExpectedWorkflowID) no longer matches the
+// task's actual workflow by the time the move is applied — a concurrent
+// reassignment won the race. The move is rejected rather than silently
+// reverting that reassignment.
+var ErrWorkflowResolutionConflict = errors.New("task workflow changed since resolution")
 
 type workflowMoveLimitsRepository interface {
 	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
@@ -486,6 +501,10 @@ func (s *Service) MoveTaskWithOptions(
 	task, err := s.tasks.GetTask(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+	if opts.ExpectedWorkflowID != nil && task.WorkflowID != *opts.ExpectedWorkflowID {
+		return nil, fmt.Errorf("%w: resolved %q, task is now in %q",
+			ErrWorkflowResolutionConflict, *opts.ExpectedWorkflowID, task.WorkflowID)
 	}
 
 	targetStep, err := s.validateTaskMove(ctx, task, workflowID, workflowStepID, opts)

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -620,17 +620,25 @@ func (s *Service) MoveTaskWithOptions(
 		return nil, err
 	}
 
-	s.publishTaskEvent(ctx, events.TaskUpdated, task, nil, oldWorkflowID)
+	// Captured now, before the post-commit GetTask refresh below replaces
+	// task with a plain read that carries neither transient field (see
+	// models.Task.FromStepID and FromWorkflowID) — these are the write
+	// transaction's own result, not the pre-move snapshot computed above.
+	resultFromWorkflowID := task.FromWorkflowID
+	resultFromStepID := task.FromStepID
+	resultTransitioned := task.WorkflowStepTransitionID != 0
+	if resultTransitioned && resultFromWorkflowID == "" {
+		// Keep compatibility with repository implementations that predate the
+		// transient source-workflow field. SQLite populates it from the write
+		// transaction; this fallback preserves the previous event value for any
+		// external test or adapter implementation that does not.
+		resultFromWorkflowID = oldWorkflowID
+	}
+
+	s.publishTaskEvent(ctx, events.TaskUpdated, task, nil, resultFromWorkflowID)
 	if oldState != task.State {
 		s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
 	}
-
-	// Captured now, before the post-commit GetTask refresh below replaces
-	// task with a plain read that carries neither transient field (see
-	// models.Task.FromStepID's doc) — these are the write transaction's own
-	// result, not the pre-move oldStepID/stepChanged computed above.
-	resultFromStepID := task.FromStepID
-	resultTransitioned := task.WorkflowStepTransitionID != 0
 
 	// Publish task.moved event so the orchestrator can process on_exit/on_enter
 	// actions. Gated on resultTransitioned (the write transaction's own
@@ -641,11 +649,12 @@ func (s *Service) MoveTaskWithOptions(
 	// because this call's read already matched its own target, but the commit's
 	// in-transaction read found a different actual "from" step). Every write
 	// path reachable here (UpdateTask, UpdateTaskIfWorkflowMatches, and the
-	// admission-with-state variant) sets WorkflowStepTransitionID/FromStepID
-	// off the same in-transaction read, so resultFromStepID is always the
-	// step the task actually left on this commit.
+	// admission-with-state variant) sets WorkflowStepTransitionID, FromStepID,
+	// and FromWorkflowID off the same in-transaction read, so the result fields
+	// are always the source step and workflow the task actually left on this
+	// commit.
 	if resultTransitioned {
-		s.publishTaskMovedEvent(ctx, task, oldWorkflowID, resultFromStepID, workflowStepID, sessionID)
+		s.publishTaskMovedEvent(ctx, task, resultFromWorkflowID, resultFromStepID, workflowStepID, sessionID)
 		historySessionID := opts.StepHistorySessionID
 		if historySessionID == "" {
 			historySessionID = sessionID

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -388,6 +388,11 @@ func (s *Service) UpdateTaskMetadata(ctx context.Context, id string, metadata ma
 type MoveTaskResult struct {
 	Task         *models.Task
 	WorkflowStep *wfmodels.WorkflowStep
+	// FromStepID and Transitioned are read off Task's own write-transaction
+	// result (Task.FromStepID / Task.WorkflowStepTransitionID != 0), not from
+	// this call's earlier pre-move snapshot — see Task.FromStepID's doc.
+	FromStepID   string
+	Transitioned bool
 }
 
 // MoveTaskOptions controls non-default move behavior for trusted callers.
@@ -574,6 +579,13 @@ func (s *Service) MoveTaskWithOptions(
 		s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
 	}
 
+	// Captured now, before the post-commit GetTask refresh below replaces
+	// task with a plain read that carries neither transient field (see
+	// models.Task.FromStepID's doc) — these are the write transaction's own
+	// result, not the pre-move oldStepID/stepChanged computed above.
+	resultFromStepID := task.FromStepID
+	resultTransitioned := task.WorkflowStepTransitionID != 0
+
 	// Publish task.moved event so the orchestrator can process on_exit/on_enter actions
 	if stepChanged {
 		s.publishTaskMovedEvent(ctx, task, oldWorkflowID, oldStepID, workflowStepID, sessionID)
@@ -601,7 +613,7 @@ func (s *Service) MoveTaskWithOptions(
 		zap.String("workflow_step_id", workflowStepID),
 		zap.Int("position", position))
 
-	result := &MoveTaskResult{Task: task}
+	result := &MoveTaskResult{Task: task, FromStepID: resultFromStepID, Transitioned: resultTransitioned}
 
 	// Fetch the workflow step info if getter is available
 	if s.workflowStepGetter != nil {

--- a/apps/backend/internal/task/service/service_workflow_event_source_test.go
+++ b/apps/backend/internal/task/service/service_workflow_event_source_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+)
+
+type moveTaskUpdateHookRepository struct {
+	*sqliterepo.Repository
+	beforeUpdate func()
+	updateOnce   sync.Once
+}
+
+func (r *moveTaskUpdateHookRepository) UpdateTask(ctx context.Context, task *models.Task) error {
+	r.updateOnce.Do(func() {
+		if r.beforeUpdate != nil {
+			r.beforeUpdate()
+		}
+	})
+	return r.Repository.UpdateTask(ctx, task)
+}
+
+// TestService_MoveTaskEventsUseTransactionalSourceWorkflow covers a stale
+// pre-read that turns a same-step request into a real cross-workflow write.
+// The event payload must use the source workflow read by that write
+// transaction, not the workflow from the earlier service snapshot.
+func TestService_MoveTaskEventsUseTransactionalSourceWorkflow(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	createMoveTask(t, ctx, repo, "task-event-race", "wf-source", "step-source", nil)
+	eventBus.ClearEvents()
+
+	var injectedErr error
+	svc.tasks = &moveTaskUpdateHookRepository{
+		Repository: repo,
+		beforeUpdate: func() {
+			_, injectedErr = svc.MoveTaskWithOptions(
+				ctx, "task-event-race", "wf-target", "step-target", 0, MoveTaskOptions{},
+			)
+		},
+	}
+
+	_, err := svc.MoveTaskWithOptions(
+		pluginMoveContext("plugin:acme"), "task-event-race", "wf-source", "step-source", 0,
+		pluginMoveOptions(),
+	)
+	require.NoError(t, injectedErr)
+	require.NoError(t, err)
+
+	var updatedData map[string]interface{}
+	var movedData map[string]interface{}
+	for _, event := range eventBus.GetPublishedEvents() {
+		if event.Type == events.TaskUpdated {
+			updatedData, _ = event.Data.(map[string]interface{})
+		}
+		if event.Type == events.TaskMoved {
+			movedData, _ = event.Data.(map[string]interface{})
+		}
+	}
+	require.Equal(t, "wf-target", updatedData["old_workflow_id"],
+		"task.updated must identify the workflow observed by the committing write")
+	require.Equal(t, "wf-target", movedData["from_workflow_id"],
+		"task.moved must identify the workflow observed by the committing write")
+}

--- a/apps/backend/internal/task/service/service_workflow_feeder_move_test.go
+++ b/apps/backend/internal/task/service/service_workflow_feeder_move_test.go
@@ -226,9 +226,10 @@ func (r *failAfterMoveRefreshTaskRepository) UpdateTaskWithWorkflowStepAdmission
 	limit int,
 	admittedState *v1.TaskState,
 	queueExitPending bool,
+	expectedWorkflowID string,
 ) (bool, error) {
 	admitted, err := r.Repository.UpdateTaskWithWorkflowStepAdmissionAndState(
-		ctx, task, targetStepID, limit, admittedState, queueExitPending,
+		ctx, task, targetStepID, limit, admittedState, queueExitPending, expectedWorkflowID,
 	)
 	if err == nil {
 		r.failRefresh.Store(true)

--- a/apps/backend/internal/task/service/service_workflow_race_test.go
+++ b/apps/backend/internal/task/service/service_workflow_race_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// workflowMoveRaceRepo wraps the real sqlite repository and, on the first
+// call to UpdateTaskWithWorkflowStepAdmissionAndState, runs an injected
+// callback before delegating to the real implementation. This simulates a
+// concurrent, legitimate reassignment landing between MoveTaskWithOptions'
+// own GetTask (service_workflow.go's pre-write fast-fail check) and its own
+// write — a race landing INSIDE a single MoveTaskWithOptions call, as
+// distinct from TestConcurrentReassignmentSurvivesMatchingStepStaleMove
+// (backendapp package), which only covers a race landing entirely before the
+// call starts. The injected callback runs on the same wrapped repository
+// (guarded by injected, so its own recursive write goes straight to the real
+// embedded method rather than re-triggering the injection).
+type workflowMoveRaceRepo struct {
+	*sqliterepo.Repository
+	inject   func()
+	injected bool
+}
+
+func (r *workflowMoveRaceRepo) UpdateTaskWithWorkflowStepAdmissionAndState(
+	ctx context.Context,
+	task *models.Task,
+	targetStepID string,
+	limit int,
+	admittedState *v1.TaskState,
+	queueExitPending bool,
+	expectedWorkflowID string,
+) (bool, error) {
+	if !r.injected {
+		r.injected = true
+		r.inject()
+	}
+	return r.Repository.UpdateTaskWithWorkflowStepAdmissionAndState(
+		ctx, task, targetStepID, limit, admittedState, queueExitPending, expectedWorkflowID,
+	)
+}
+
+// TestMoveTaskWithOptions_RaceLandingInsideCallIsRejectedByWriteTimeGuard
+// closes the gap Review round 3 flagged: every existing CAS test (including
+// TestConcurrentReassignmentSurvivesMatchingStepStaleMove) only proves a
+// stale ExpectedWorkflowID is caught when the concurrent reassignment lands
+// BEFORE MoveTaskWithOptions starts. None of them prove that MoveTaskWithOptions'
+// own unlocked pre-write check (service_workflow.go, comparing
+// opts.ExpectedWorkflowID against a plain GetTask) cannot itself close: a
+// reassignment landing AFTER that check has already passed but BEFORE this
+// call's own write commits.
+//
+// Here the concurrent, legitimate move is injected via workflowMoveRaceRepo
+// at the exact point MoveTaskWithOptions reaches the repository write —
+// strictly after its own pre-write check already passed (the check compares
+// against wf-source, which is still true when it runs) and strictly before
+// its own write executes. Only the atomic in-transaction recheck inside
+// UpdateTaskWithWorkflowStepAdmissionAndState (updateTaskTx's
+// expectedWorkflowID comparison, sqlite/task.go) can catch this — proving
+// that check, not the outer fast-fail, is what closes the race.
+func TestMoveTaskWithOptions_RaceLandingInsideCallIsRejectedByWriteTimeGuard(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	createMoveTask(t, ctx, repo, "task-race-in-call", "wf-source", "step-source", nil)
+
+	raceRepo := &workflowMoveRaceRepo{Repository: repo}
+	raceRepo.inject = func() {
+		if _, err := svc.MoveTaskWithOptions(ctx, "task-race-in-call", "wf-target", "step-target", 0, MoveTaskOptions{}); err != nil {
+			t.Fatalf("concurrent legitimate reassignment (injected mid-call) failed: %v", err)
+		}
+	}
+	svc.tasks = raceRepo
+
+	staleWorkflowID := "wf-source"
+	_, err := svc.MoveTaskWithOptions(ctx, "task-race-in-call", "wf-source", "step-review-target", 0, MoveTaskOptions{
+		ExpectedWorkflowID: &staleWorkflowID,
+	})
+	if !errors.Is(err, ErrWorkflowResolutionConflict) {
+		t.Fatalf("stale move: got err %v, want ErrWorkflowResolutionConflict", err)
+	}
+
+	final, err := repo.GetTask(ctx, "task-race-in-call")
+	if err != nil {
+		t.Fatalf("GetTask after race: %v", err)
+	}
+	if final.WorkflowID != "wf-target" || final.WorkflowStepID != "step-target" {
+		t.Fatalf("concurrent reassignment must survive the rejected stale move: got (%s, %s), want (wf-target, step-target)",
+			final.WorkflowID, final.WorkflowStepID)
+	}
+}

--- a/apps/backend/internal/workflow/models/models.go
+++ b/apps/backend/internal/workflow/models/models.go
@@ -330,6 +330,9 @@ const (
 	StepTransitionTriggerChildrenCompleted StepTransitionTrigger = "on_children_completed"
 	StepTransitionTriggerTaskUpdate        StepTransitionTrigger = "task_update"
 	StepTransitionTriggerQueuePromotion    StepTransitionTrigger = "queue_promotion"
+	// StepTransitionTriggerPluginMove identifies a transition caused by a
+	// plugin's MoveTask RPC call.
+	StepTransitionTriggerPluginMove StepTransitionTrigger = "plugin_move"
 )
 
 // StepTransitionActor identifies the source of a move. Human identity is

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -1198,8 +1198,13 @@ func pluginTaskLaunchOptionsFromProto(p *pluginv1.PluginTaskLaunchOptions) *Plug
 // UpdateTaskInput is the Go-native mirror of
 // kandev.plugin.v1.UpdateTaskRequest. Every field except ID is optional: a nil
 // pointer leaves that field untouched, a non-nil pointer overwrites it. The
-// conservative field surface (title/description/state/workflow_step_id) is the
-// documented plugin-writable mask.
+// conservative field surface (title/description/state) is the documented
+// plugin-writable mask. WorkflowStepID is rejected when non-nil — it exists
+// on this struct only for wire-shape symmetry with UpdateTaskRequest; use
+// TaskReader.Move (see host.go) to transition a task between workflow steps,
+// which routes through the same validation, WIP admission, task.moved
+// publication, auto-start gates, and queue reconciliation the board's own
+// move uses.
 type UpdateTaskInput struct {
 	ID             string
 	Title          *string

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -1231,6 +1231,88 @@ func updateTaskInputFromProto(p *pluginv1.UpdateTaskRequest) UpdateTaskInput {
 	}
 }
 
+// MoveTaskInput is the Go-native mirror of kandev.plugin.v1.MoveTaskRequest.
+// Unlike Update, Move transitions the task through the same path the board's
+// own move uses, so on_enter actions (auto-start included) actually fire.
+// WorkflowID is optional: nil inherits the task's current workflow; a
+// pointer to "" is rejected rather than treated as inherit. Position is not
+// optional: an omitted position and a position of zero are the same
+// request, both placing the task at the top of the target step.
+type MoveTaskInput struct {
+	TaskID         string
+	WorkflowStepID string
+	WorkflowID     *string
+	Position       int32
+}
+
+func (in MoveTaskInput) toProto() *pluginv1.MoveTaskRequest {
+	return &pluginv1.MoveTaskRequest{
+		TaskId:         in.TaskID,
+		WorkflowStepId: in.WorkflowStepID,
+		WorkflowId:     in.WorkflowID,
+		Position:       in.Position,
+	}
+}
+
+func moveTaskInputFromProto(p *pluginv1.MoveTaskRequest) MoveTaskInput {
+	if p == nil {
+		return MoveTaskInput{}
+	}
+	return MoveTaskInput{
+		TaskID:         p.GetTaskId(),
+		WorkflowStepID: p.GetWorkflowStepId(),
+		WorkflowID:     p.WorkflowId,
+		Position:       p.GetPosition(),
+	}
+}
+
+// MoveTaskOutcome is the Go-native mirror of kandev.plugin.v1.MoveTaskResponse.
+// Transitioned reports whether a ledger row was written for this move (false
+// when the task was already on the target step). QueuedForStepID is the sole
+// admission discriminator, reported on both values of Transitioned: nil means
+// admitted (when Transitioned) or not applicable (when not); non-nil means
+// queued for that step holding no WIP slot. FromStepID is the step the task
+// left; empty when Transitioned is false.
+type MoveTaskOutcome struct {
+	Task            *Task
+	Transitioned    bool
+	QueuedForStepID *string
+	FromStepID      string
+}
+
+func (o MoveTaskOutcome) toProto() (*pluginv1.MoveTaskResponse, error) {
+	var protoTask *pluginv1.Task
+	if o.Task != nil {
+		var err error
+		protoTask, err = o.Task.toProto()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &pluginv1.MoveTaskResponse{
+		Task:            protoTask,
+		Transitioned:    o.Transitioned,
+		QueuedForStepId: o.QueuedForStepID,
+		FromStepId:      o.FromStepID,
+	}, nil
+}
+
+func moveTaskOutcomeFromProto(p *pluginv1.MoveTaskResponse) (*MoveTaskOutcome, error) {
+	if p == nil {
+		return nil, nil
+	}
+	task, err := taskFromProto(p.GetTask())
+	if err != nil {
+		return nil, err
+	}
+	return &MoveTaskOutcome{
+		Task:            &task,
+		Transitioned:    p.GetTransitioned(),
+		QueuedForStepID: p.QueuedForStepId,
+		FromStepID:      p.GetFromStepId(),
+	}, nil
+}
+
 // MessageDispatch is the Go-native mirror of
 // kandev.plugin.v1.SendMessageResponse — the result of delivering a prompt to a
 // task session. Status is "queued" (the session was running and the message

--- a/apps/backend/pkg/pluginsdk/host.go
+++ b/apps/backend/pkg/pluginsdk/host.go
@@ -138,9 +138,16 @@ type TaskReader interface {
 	Create(ctx context.Context, in CreateTaskInput) (*Task, error)
 
 	// Update mutates a conservative field surface of an existing task
-	// (title/description/state/workflow_step_id) and returns the updated task.
-	// Requires api_write:tasks.
+	// (title/description/state) and returns the updated task. Requires
+	// api_write:tasks. WorkflowStepID is rejected when present — use Move to
+	// transition a task between workflow steps.
 	Update(ctx context.Context, in UpdateTaskInput) (*Task, error)
+
+	// Move transitions a task to a workflow step through the same path the
+	// board's own move uses (validation, WIP admission, task.moved
+	// publication, auto-start gates, queue reconciliation) — unlike Update,
+	// which rejects a workflow step change. Requires api_write:tasks.
+	Move(ctx context.Context, in MoveTaskInput) (*MoveTaskOutcome, error)
 }
 
 // SessionReader is the read-only accessor behind Host.Sessions(), mirroring
@@ -440,6 +447,14 @@ func (r grpcTaskReader) Update(ctx context.Context, in UpdateTaskInput) (*Task, 
 		return nil, err
 	}
 	return &task, nil
+}
+
+func (r grpcTaskReader) Move(ctx context.Context, in MoveTaskInput) (*MoveTaskOutcome, error) {
+	resp, err := r.client.MoveTask(ctx, in.toProto())
+	if err != nil {
+		return nil, err
+	}
+	return moveTaskOutcomeFromProto(resp)
 }
 
 // grpcSessionReader implements SessionReader on the plugin side.
@@ -884,6 +899,17 @@ func (s *grpcHostServer) UpdateTask(ctx context.Context, req *pluginv1.UpdateTas
 	return &pluginv1.UpdateTaskResponse{Task: protoTask}, nil
 }
 
+func (s *grpcHostServer) MoveTask(ctx context.Context, req *pluginv1.MoveTaskRequest) (*pluginv1.MoveTaskResponse, error) {
+	outcome, err := s.impl.Tasks().Move(ctx, moveTaskInputFromProto(req))
+	if err != nil {
+		return nil, err
+	}
+	if outcome == nil {
+		return nil, status.Error(codes.Internal, "MoveTask returned nil outcome")
+	}
+	return outcome.toProto()
+}
+
 func (s *grpcHostServer) SendMessage(ctx context.Context, req *pluginv1.SendMessageRequest) (*pluginv1.SendMessageResponse, error) {
 	dispatch, err := s.impl.Messages().Send(ctx, req.GetTaskId(), req.GetSessionId(), req.GetText())
 	if err != nil {
@@ -992,6 +1018,10 @@ func (unimplementedTaskReader) Create(context.Context, CreateTaskInput) (*Task, 
 }
 
 func (unimplementedTaskReader) Update(context.Context, UpdateTaskInput) (*Task, error) {
+	return nil, errUnimplementedHostData("tasks")
+}
+
+func (unimplementedTaskReader) Move(context.Context, MoveTaskInput) (*MoveTaskOutcome, error) {
 	return nil, errUnimplementedHostData("tasks")
 }
 

--- a/apps/backend/pkg/pluginsdk/host_data_test.go
+++ b/apps/backend/pkg/pluginsdk/host_data_test.go
@@ -44,6 +44,8 @@ type dataRecordingHost struct {
 	lastCreateInput CreateTaskInput
 	updatedTask     Task
 	lastUpdateInput UpdateTaskInput
+	movedOutcome    MoveTaskOutcome
+	lastMoveInput   MoveTaskInput
 	messageDispatch MessageDispatch
 	lastSendTask    string
 	lastSendSession string
@@ -112,6 +114,12 @@ func (r dataRecordingTaskReader) Update(_ context.Context, in UpdateTaskInput) (
 	r.h.lastUpdateInput = in
 	task := r.h.updatedTask
 	return &task, nil
+}
+
+func (r dataRecordingTaskReader) Move(_ context.Context, in MoveTaskInput) (*MoveTaskOutcome, error) {
+	r.h.lastMoveInput = in
+	outcome := r.h.movedOutcome
+	return &outcome, nil
 }
 
 type dataRecordingSessionReader struct{ h *dataRecordingHost }
@@ -245,6 +253,71 @@ func TestHostData_TaskWritesAndMessage(t *testing.T) {
 	require.Equal(t, "task-1", impl.lastSendTask)
 	require.Equal(t, "session-1", impl.lastSendSession)
 	require.Equal(t, "rerun the tests", impl.lastSendText)
+}
+
+// TestHostData_TaskMove proves MoveTask round-trips through
+// grpcHostClient -> proto -> grpcHostServer, including the optional
+// workflow_id pointer, the position field, and the outcome's
+// queued_for_step_id/transitioned/from_step_id fields.
+func TestHostData_TaskMove(t *testing.T) {
+	impl := &dataRecordingHost{
+		movedOutcome: MoveTaskOutcome{
+			Task:            &Task{ID: "task-1", State: "IN_PROGRESS"},
+			Transitioned:    true,
+			QueuedForStepID: nil,
+			FromStepID:      "step-1",
+		},
+	}
+	host := dialHostOverBufconn(t, impl)
+
+	workflowID := "wf-1"
+	outcome, err := host.Tasks().Move(context.Background(), MoveTaskInput{
+		TaskID: "task-1", WorkflowStepID: "step-2", WorkflowID: &workflowID, Position: 3,
+	})
+	require.NoError(t, err)
+	require.True(t, outcome.Transitioned)
+	require.Nil(t, outcome.QueuedForStepID)
+	require.Equal(t, "step-1", outcome.FromStepID)
+	require.Equal(t, "task-1", outcome.Task.ID)
+
+	require.Equal(t, "task-1", impl.lastMoveInput.TaskID)
+	require.Equal(t, "step-2", impl.lastMoveInput.WorkflowStepID)
+	require.NotNil(t, impl.lastMoveInput.WorkflowID)
+	require.Equal(t, "wf-1", *impl.lastMoveInput.WorkflowID)
+	require.Equal(t, int32(3), impl.lastMoveInput.Position)
+}
+
+// TestHostData_TaskMove_OmittedWorkflowIDStaysNilAcrossWire proves an
+// omitted workflow_id (nil, meaning "inherit the task's current workflow",
+// AC-005.4) survives the proto round-trip as nil rather than being coerced
+// to an empty string, which would be indistinguishable from an explicit
+// present-but-empty rejection (AC-005.5).
+func TestHostData_TaskMove_OmittedWorkflowIDStaysNilAcrossWire(t *testing.T) {
+	impl := &dataRecordingHost{movedOutcome: MoveTaskOutcome{Task: &Task{ID: "task-1"}}}
+	host := dialHostOverBufconn(t, impl)
+
+	_, err := host.Tasks().Move(context.Background(), MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.NoError(t, err)
+	require.Nil(t, impl.lastMoveInput.WorkflowID)
+}
+
+// TestHostData_TaskMove_ReportsQueuedForStepID proves a non-nil
+// QueuedForStepID (AC-002.1/002.2: landing on a step at its WIP limit) also
+// survives the wire round-trip.
+func TestHostData_TaskMove_ReportsQueuedForStepID(t *testing.T) {
+	impl := &dataRecordingHost{movedOutcome: MoveTaskOutcome{
+		Task:            &Task{ID: "task-1"},
+		Transitioned:    false,
+		QueuedForStepID: strPtr("step-2"),
+		FromStepID:      "step-2",
+	}}
+	host := dialHostOverBufconn(t, impl)
+
+	outcome, err := host.Tasks().Move(context.Background(), MoveTaskInput{TaskID: "task-1", WorkflowStepID: "step-2"})
+	require.NoError(t, err)
+	require.False(t, outcome.Transitioned)
+	require.NotNil(t, outcome.QueuedForStepID)
+	require.Equal(t, "step-2", *outcome.QueuedForStepID)
 }
 
 func TestHostData_SessionsListAndCodeStats(t *testing.T) {

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -6739,6 +6739,152 @@ func (x *UpdateTaskResponse) GetTask() *Task {
 	return nil
 }
 
+// MoveTask transitions a task to a workflow step. workflow_id is optional:
+// omitted inherits the task's current workflow, present-empty is rejected.
+// position is not optional: an omitted position and a position of zero are
+// the same request, both placing the task at the top of the target step.
+type MoveTaskRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	TaskId         string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	WorkflowStepId string                 `protobuf:"bytes,2,opt,name=workflow_step_id,json=workflowStepId,proto3" json:"workflow_step_id,omitempty"`
+	WorkflowId     *string                `protobuf:"bytes,3,opt,name=workflow_id,json=workflowId,proto3,oneof" json:"workflow_id,omitempty"`
+	Position       int32                  `protobuf:"varint,4,opt,name=position,proto3" json:"position,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *MoveTaskRequest) Reset() {
+	*x = MoveTaskRequest{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[103]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MoveTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MoveTaskRequest) ProtoMessage() {}
+
+func (x *MoveTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[103]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MoveTaskRequest.ProtoReflect.Descriptor instead.
+func (*MoveTaskRequest) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{103}
+}
+
+func (x *MoveTaskRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *MoveTaskRequest) GetWorkflowStepId() string {
+	if x != nil {
+		return x.WorkflowStepId
+	}
+	return ""
+}
+
+func (x *MoveTaskRequest) GetWorkflowId() string {
+	if x != nil && x.WorkflowId != nil {
+		return *x.WorkflowId
+	}
+	return ""
+}
+
+func (x *MoveTaskRequest) GetPosition() int32 {
+	if x != nil {
+		return x.Position
+	}
+	return 0
+}
+
+// transitioned reports whether a ledger row was written for this move
+// (false when the task was already on the target step). queued_for_step_id
+// is the sole admission discriminator, reported on both values of
+// transitioned: absent means admitted (when transitioned) or not applicable
+// (when not), present means queued for that step holding no WIP slot.
+// from_step_id is the step the task left; empty when transitioned is false.
+type MoveTaskResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Task            *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
+	Transitioned    bool                   `protobuf:"varint,2,opt,name=transitioned,proto3" json:"transitioned,omitempty"`
+	QueuedForStepId *string                `protobuf:"bytes,3,opt,name=queued_for_step_id,json=queuedForStepId,proto3,oneof" json:"queued_for_step_id,omitempty"`
+	FromStepId      string                 `protobuf:"bytes,4,opt,name=from_step_id,json=fromStepId,proto3" json:"from_step_id,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *MoveTaskResponse) Reset() {
+	*x = MoveTaskResponse{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[104]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MoveTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MoveTaskResponse) ProtoMessage() {}
+
+func (x *MoveTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[104]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MoveTaskResponse.ProtoReflect.Descriptor instead.
+func (*MoveTaskResponse) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{104}
+}
+
+func (x *MoveTaskResponse) GetTask() *Task {
+	if x != nil {
+		return x.Task
+	}
+	return nil
+}
+
+func (x *MoveTaskResponse) GetTransitioned() bool {
+	if x != nil {
+		return x.Transitioned
+	}
+	return false
+}
+
+func (x *MoveTaskResponse) GetQueuedForStepId() string {
+	if x != nil && x.QueuedForStepId != nil {
+		return *x.QueuedForStepId
+	}
+	return ""
+}
+
+func (x *MoveTaskResponse) GetFromStepId() string {
+	if x != nil {
+		return x.FromStepId
+	}
+	return ""
+}
+
 // SendMessage delivers a prompt to a task session (api_write:messages). The
 // server records a user message stamped source = "plugin:<id>" and dispatches
 // it through the orchestrator, resolving session_id (empty → the task's primary
@@ -6756,7 +6902,7 @@ type SendMessageRequest struct {
 
 func (x *SendMessageRequest) Reset() {
 	*x = SendMessageRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[103]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6768,7 +6914,7 @@ func (x *SendMessageRequest) String() string {
 func (*SendMessageRequest) ProtoMessage() {}
 
 func (x *SendMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[103]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6781,7 +6927,7 @@ func (x *SendMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendMessageRequest.ProtoReflect.Descriptor instead.
 func (*SendMessageRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{103}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *SendMessageRequest) GetTaskId() string {
@@ -6815,7 +6961,7 @@ type SendMessageResponse struct {
 
 func (x *SendMessageResponse) Reset() {
 	*x = SendMessageResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[104]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6827,7 +6973,7 @@ func (x *SendMessageResponse) String() string {
 func (*SendMessageResponse) ProtoMessage() {}
 
 func (x *SendMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[104]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6840,7 +6986,7 @@ func (x *SendMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendMessageResponse.ProtoReflect.Descriptor instead.
 func (*SendMessageResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{104}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *SendMessageResponse) GetSessionId() string {
@@ -6866,7 +7012,7 @@ type PreviewPluginOwnedTaskTreeRequest struct {
 
 func (x *PreviewPluginOwnedTaskTreeRequest) Reset() {
 	*x = PreviewPluginOwnedTaskTreeRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[105]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6878,7 +7024,7 @@ func (x *PreviewPluginOwnedTaskTreeRequest) String() string {
 func (*PreviewPluginOwnedTaskTreeRequest) ProtoMessage() {}
 
 func (x *PreviewPluginOwnedTaskTreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[105]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6891,7 +7037,7 @@ func (x *PreviewPluginOwnedTaskTreeRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PreviewPluginOwnedTaskTreeRequest.ProtoReflect.Descriptor instead.
 func (*PreviewPluginOwnedTaskTreeRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{105}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *PreviewPluginOwnedTaskTreeRequest) GetRootTaskId() string {
@@ -6910,7 +7056,7 @@ type PreviewPluginOwnedTaskTreeResponse struct {
 
 func (x *PreviewPluginOwnedTaskTreeResponse) Reset() {
 	*x = PreviewPluginOwnedTaskTreeResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[106]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6922,7 +7068,7 @@ func (x *PreviewPluginOwnedTaskTreeResponse) String() string {
 func (*PreviewPluginOwnedTaskTreeResponse) ProtoMessage() {}
 
 func (x *PreviewPluginOwnedTaskTreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[106]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6935,7 +7081,7 @@ func (x *PreviewPluginOwnedTaskTreeResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PreviewPluginOwnedTaskTreeResponse.ProtoReflect.Descriptor instead.
 func (*PreviewPluginOwnedTaskTreeResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{106}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *PreviewPluginOwnedTaskTreeResponse) GetTasks() []*Task {
@@ -6954,7 +7100,7 @@ type DeletePluginOwnedTaskTreeRequest struct {
 
 func (x *DeletePluginOwnedTaskTreeRequest) Reset() {
 	*x = DeletePluginOwnedTaskTreeRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[107]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6966,7 +7112,7 @@ func (x *DeletePluginOwnedTaskTreeRequest) String() string {
 func (*DeletePluginOwnedTaskTreeRequest) ProtoMessage() {}
 
 func (x *DeletePluginOwnedTaskTreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[107]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6979,7 +7125,7 @@ func (x *DeletePluginOwnedTaskTreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePluginOwnedTaskTreeRequest.ProtoReflect.Descriptor instead.
 func (*DeletePluginOwnedTaskTreeRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{107}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *DeletePluginOwnedTaskTreeRequest) GetRootTaskId() string {
@@ -6998,7 +7144,7 @@ type DeletePluginOwnedTaskTreeResponse struct {
 
 func (x *DeletePluginOwnedTaskTreeResponse) Reset() {
 	*x = DeletePluginOwnedTaskTreeResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[108]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7010,7 +7156,7 @@ func (x *DeletePluginOwnedTaskTreeResponse) String() string {
 func (*DeletePluginOwnedTaskTreeResponse) ProtoMessage() {}
 
 func (x *DeletePluginOwnedTaskTreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[108]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7023,7 +7169,7 @@ func (x *DeletePluginOwnedTaskTreeResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use DeletePluginOwnedTaskTreeResponse.ProtoReflect.Descriptor instead.
 func (*DeletePluginOwnedTaskTreeResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{108}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *DeletePluginOwnedTaskTreeResponse) GetDeletedTaskIds() []string {
@@ -7045,7 +7191,7 @@ type DeletePluginOwnedTaskTreeProgress struct {
 
 func (x *DeletePluginOwnedTaskTreeProgress) Reset() {
 	*x = DeletePluginOwnedTaskTreeProgress{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[109]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7057,7 +7203,7 @@ func (x *DeletePluginOwnedTaskTreeProgress) String() string {
 func (*DeletePluginOwnedTaskTreeProgress) ProtoMessage() {}
 
 func (x *DeletePluginOwnedTaskTreeProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[109]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7070,7 +7216,7 @@ func (x *DeletePluginOwnedTaskTreeProgress) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use DeletePluginOwnedTaskTreeProgress.ProtoReflect.Descriptor instead.
 func (*DeletePluginOwnedTaskTreeProgress) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{109}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *DeletePluginOwnedTaskTreeProgress) GetDeletedTaskIds() []string {
@@ -7676,7 +7822,21 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x06_stateB\x13\n" +
 	"\x11_workflow_step_id\"@\n" +
 	"\x12UpdateTaskResponse\x12*\n" +
-	"\x04task\x18\x01 \x01(\v2\x16.kandev.plugin.v1.TaskR\x04task\"`\n" +
+	"\x04task\x18\x01 \x01(\v2\x16.kandev.plugin.v1.TaskR\x04task\"\xa6\x01\n" +
+	"\x0fMoveTaskRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12(\n" +
+	"\x10workflow_step_id\x18\x02 \x01(\tR\x0eworkflowStepId\x12$\n" +
+	"\vworkflow_id\x18\x03 \x01(\tH\x00R\n" +
+	"workflowId\x88\x01\x01\x12\x1a\n" +
+	"\bposition\x18\x04 \x01(\x05R\bpositionB\x0e\n" +
+	"\f_workflow_id\"\xcd\x01\n" +
+	"\x10MoveTaskResponse\x12*\n" +
+	"\x04task\x18\x01 \x01(\v2\x16.kandev.plugin.v1.TaskR\x04task\x12\"\n" +
+	"\ftransitioned\x18\x02 \x01(\bR\ftransitioned\x120\n" +
+	"\x12queued_for_step_id\x18\x03 \x01(\tH\x00R\x0fqueuedForStepId\x88\x01\x01\x12 \n" +
+	"\ffrom_step_id\x18\x04 \x01(\tR\n" +
+	"fromStepIdB\x15\n" +
+	"\x13_queued_for_step_id\"`\n" +
 	"\x12SendMessageRequest\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1d\n" +
 	"\n" +
@@ -7706,7 +7866,7 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x18AuthorizeEntityReference\x121.kandev.plugin.v1.AuthorizeEntityReferenceRequest\x1a2.kandev.plugin.v1.AuthorizeEntityReferenceResponse\x12u\n" +
 	"\x14ResolveGitCredential\x12-.kandev.plugin.v1.ResolveGitCredentialRequest\x1a..kandev.plugin.v1.ResolveGitCredentialResponse\x12x\n" +
 	"\x17GetGitCredentialBinding\x12-.kandev.plugin.v1.GitCredentialBindingRequest\x1a..kandev.plugin.v1.GitCredentialBindingResponse\x12Z\n" +
-	"\x0fInvokeAgentTool\x12\".kandev.plugin.v1.AgentToolRequest\x1a#.kandev.plugin.v1.AgentToolResponse2\xa5\x19\n" +
+	"\x0fInvokeAgentTool\x12\".kandev.plugin.v1.AgentToolRequest\x1a#.kandev.plugin.v1.AgentToolResponse2\xf8\x19\n" +
 	"\x04Host\x12Q\n" +
 	"\bGetState\x12!.kandev.plugin.v1.GetStateRequest\x1a\".kandev.plugin.v1.GetStateResponse\x12Q\n" +
 	"\bSetState\x12!.kandev.plugin.v1.SetStateRequest\x1a\".kandev.plugin.v1.SetStateResponse\x12Z\n" +
@@ -7735,7 +7895,8 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\n" +
 	"CreateTask\x12#.kandev.plugin.v1.CreateTaskRequest\x1a$.kandev.plugin.v1.CreateTaskResponse\x12W\n" +
 	"\n" +
-	"UpdateTask\x12#.kandev.plugin.v1.UpdateTaskRequest\x1a$.kandev.plugin.v1.UpdateTaskResponse\x12Z\n" +
+	"UpdateTask\x12#.kandev.plugin.v1.UpdateTaskRequest\x1a$.kandev.plugin.v1.UpdateTaskResponse\x12Q\n" +
+	"\bMoveTask\x12!.kandev.plugin.v1.MoveTaskRequest\x1a\".kandev.plugin.v1.MoveTaskResponse\x12Z\n" +
 	"\vSendMessage\x12$.kandev.plugin.v1.SendMessageRequest\x1a%.kandev.plugin.v1.SendMessageResponse\x12\x87\x01\n" +
 	"\x1aPreviewPluginOwnedTaskTree\x123.kandev.plugin.v1.PreviewPluginOwnedTaskTreeRequest\x1a4.kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse\x12\x84\x01\n" +
 	"\x19DeletePluginOwnedTaskTree\x122.kandev.plugin.v1.DeletePluginOwnedTaskTreeRequest\x1a3.kandev.plugin.v1.DeletePluginOwnedTaskTreeResponse\x12r\n" +
@@ -7755,7 +7916,7 @@ func file_kandev_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_kandev_plugin_v1_plugin_proto_rawDescData
 }
 
-var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 113)
+var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 115)
 var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*Event)(nil),                              // 0: kandev.plugin.v1.Event
 	(*EventAck)(nil),                           // 1: kandev.plugin.v1.EventAck
@@ -7860,38 +8021,40 @@ var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*CreateTaskResponse)(nil),                 // 100: kandev.plugin.v1.CreateTaskResponse
 	(*UpdateTaskRequest)(nil),                  // 101: kandev.plugin.v1.UpdateTaskRequest
 	(*UpdateTaskResponse)(nil),                 // 102: kandev.plugin.v1.UpdateTaskResponse
-	(*SendMessageRequest)(nil),                 // 103: kandev.plugin.v1.SendMessageRequest
-	(*SendMessageResponse)(nil),                // 104: kandev.plugin.v1.SendMessageResponse
-	(*PreviewPluginOwnedTaskTreeRequest)(nil),  // 105: kandev.plugin.v1.PreviewPluginOwnedTaskTreeRequest
-	(*PreviewPluginOwnedTaskTreeResponse)(nil), // 106: kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse
-	(*DeletePluginOwnedTaskTreeRequest)(nil),   // 107: kandev.plugin.v1.DeletePluginOwnedTaskTreeRequest
-	(*DeletePluginOwnedTaskTreeResponse)(nil),  // 108: kandev.plugin.v1.DeletePluginOwnedTaskTreeResponse
-	(*DeletePluginOwnedTaskTreeProgress)(nil),  // 109: kandev.plugin.v1.DeletePluginOwnedTaskTreeProgress
-	nil,                     // 110: kandev.plugin.v1.WebhookRequest.HeadersEntry
-	nil,                     // 111: kandev.plugin.v1.WebhookResponse.HeadersEntry
-	nil,                     // 112: kandev.plugin.v1.PluginActionResponse.HeadersEntry
-	(*structpb.Struct)(nil), // 113: google.protobuf.Struct
+	(*MoveTaskRequest)(nil),                    // 103: kandev.plugin.v1.MoveTaskRequest
+	(*MoveTaskResponse)(nil),                   // 104: kandev.plugin.v1.MoveTaskResponse
+	(*SendMessageRequest)(nil),                 // 105: kandev.plugin.v1.SendMessageRequest
+	(*SendMessageResponse)(nil),                // 106: kandev.plugin.v1.SendMessageResponse
+	(*PreviewPluginOwnedTaskTreeRequest)(nil),  // 107: kandev.plugin.v1.PreviewPluginOwnedTaskTreeRequest
+	(*PreviewPluginOwnedTaskTreeResponse)(nil), // 108: kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse
+	(*DeletePluginOwnedTaskTreeRequest)(nil),   // 109: kandev.plugin.v1.DeletePluginOwnedTaskTreeRequest
+	(*DeletePluginOwnedTaskTreeResponse)(nil),  // 110: kandev.plugin.v1.DeletePluginOwnedTaskTreeResponse
+	(*DeletePluginOwnedTaskTreeProgress)(nil),  // 111: kandev.plugin.v1.DeletePluginOwnedTaskTreeProgress
+	nil,                     // 112: kandev.plugin.v1.WebhookRequest.HeadersEntry
+	nil,                     // 113: kandev.plugin.v1.WebhookResponse.HeadersEntry
+	nil,                     // 114: kandev.plugin.v1.PluginActionResponse.HeadersEntry
+	(*structpb.Struct)(nil), // 115: google.protobuf.Struct
 }
 var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
-	113, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
-	113, // 1: kandev.plugin.v1.AgentToolRequest.arguments:type_name -> google.protobuf.Struct
+	115, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
+	115, // 1: kandev.plugin.v1.AgentToolRequest.arguments:type_name -> google.protobuf.Struct
 	3,   // 2: kandev.plugin.v1.AgentToolRequest.context:type_name -> kandev.plugin.v1.AgentToolContext
-	113, // 3: kandev.plugin.v1.AgentToolResponse.structured_content:type_name -> google.protobuf.Struct
-	110, // 4: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
-	111, // 5: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
+	115, // 3: kandev.plugin.v1.AgentToolResponse.structured_content:type_name -> google.protobuf.Struct
+	112, // 4: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
+	113, // 5: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
 	8,   // 6: kandev.plugin.v1.PluginActionRequest.context:type_name -> kandev.plugin.v1.VerifiedActionContext
-	112, // 7: kandev.plugin.v1.PluginActionResponse.headers:type_name -> kandev.plugin.v1.PluginActionResponse.HeadersEntry
+	114, // 7: kandev.plugin.v1.PluginActionResponse.headers:type_name -> kandev.plugin.v1.PluginActionResponse.HeadersEntry
 	12,  // 8: kandev.plugin.v1.SearchEntityReferencesResponse.candidates:type_name -> kandev.plugin.v1.EntityReferenceCandidate
-	113, // 9: kandev.plugin.v1.EntityReferenceCandidate.attributes:type_name -> google.protobuf.Struct
-	113, // 10: kandev.plugin.v1.AuthorizeEntityReferenceRequest.reference:type_name -> google.protobuf.Struct
-	113, // 11: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
-	113, // 12: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
+	115, // 9: kandev.plugin.v1.EntityReferenceCandidate.attributes:type_name -> google.protobuf.Struct
+	115, // 10: kandev.plugin.v1.AuthorizeEntityReferenceRequest.reference:type_name -> google.protobuf.Struct
+	115, // 11: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
+	115, // 12: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
 	27,  // 13: kandev.plugin.v1.ListStateResponse.entries:type_name -> kandev.plugin.v1.StateEntry
-	113, // 14: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
-	113, // 15: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
-	113, // 16: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
+	115, // 14: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
+	115, // 15: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
+	115, // 16: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
 	43,  // 17: kandev.plugin.v1.Task.repositories:type_name -> kandev.plugin.v1.TaskRepository
-	113, // 18: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
+	115, // 18: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
 	44,  // 19: kandev.plugin.v1.Task.pull_requests:type_name -> kandev.plugin.v1.TaskPullRequest
 	45,  // 20: kandev.plugin.v1.ListTasksRequest.filter:type_name -> kandev.plugin.v1.TaskFilter
 	40,  // 21: kandev.plugin.v1.ListTasksRequest.page:type_name -> kandev.plugin.v1.Page
@@ -7940,96 +8103,99 @@ var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
 	81,  // 64: kandev.plugin.v1.CancelClarificationResponse.interaction:type_name -> kandev.plugin.v1.Interaction
 	97,  // 65: kandev.plugin.v1.CreateTaskRequest.repositories:type_name -> kandev.plugin.v1.PluginTaskRepository
 	99,  // 66: kandev.plugin.v1.CreateTaskRequest.launch:type_name -> kandev.plugin.v1.PluginTaskLaunchOptions
-	113, // 67: kandev.plugin.v1.CreateTaskRequest.metadata:type_name -> google.protobuf.Struct
+	115, // 67: kandev.plugin.v1.CreateTaskRequest.metadata:type_name -> google.protobuf.Struct
 	98,  // 68: kandev.plugin.v1.PluginTaskRepository.remote:type_name -> kandev.plugin.v1.RemoteRepositoryDescriptor
 	42,  // 69: kandev.plugin.v1.CreateTaskResponse.task:type_name -> kandev.plugin.v1.Task
 	42,  // 70: kandev.plugin.v1.UpdateTaskResponse.task:type_name -> kandev.plugin.v1.Task
-	42,  // 71: kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse.tasks:type_name -> kandev.plugin.v1.Task
-	0,   // 72: kandev.plugin.v1.Plugin.DeliverEvent:input_type -> kandev.plugin.v1.Event
-	5,   // 73: kandev.plugin.v1.Plugin.HandleWebhook:input_type -> kandev.plugin.v1.WebhookRequest
-	7,   // 74: kandev.plugin.v1.Plugin.HandleAction:input_type -> kandev.plugin.v1.PluginActionRequest
-	10,  // 75: kandev.plugin.v1.Plugin.SearchEntityReferences:input_type -> kandev.plugin.v1.SearchEntityReferencesRequest
-	13,  // 76: kandev.plugin.v1.Plugin.AuthorizeEntityReference:input_type -> kandev.plugin.v1.AuthorizeEntityReferenceRequest
-	15,  // 77: kandev.plugin.v1.Plugin.ResolveGitCredential:input_type -> kandev.plugin.v1.ResolveGitCredentialRequest
-	17,  // 78: kandev.plugin.v1.Plugin.GetGitCredentialBinding:input_type -> kandev.plugin.v1.GitCredentialBindingRequest
-	2,   // 79: kandev.plugin.v1.Plugin.InvokeAgentTool:input_type -> kandev.plugin.v1.AgentToolRequest
-	19,  // 80: kandev.plugin.v1.Host.GetState:input_type -> kandev.plugin.v1.GetStateRequest
-	21,  // 81: kandev.plugin.v1.Host.SetState:input_type -> kandev.plugin.v1.SetStateRequest
-	23,  // 82: kandev.plugin.v1.Host.DeleteState:input_type -> kandev.plugin.v1.DeleteStateRequest
-	25,  // 83: kandev.plugin.v1.Host.ListState:input_type -> kandev.plugin.v1.ListStateRequest
-	36,  // 84: kandev.plugin.v1.Host.RevealSecret:input_type -> kandev.plugin.v1.RevealSecretRequest
-	38,  // 85: kandev.plugin.v1.Host.EmitEvent:input_type -> kandev.plugin.v1.EmitEventRequest
-	30,  // 86: kandev.plugin.v1.Host.GetSecret:input_type -> kandev.plugin.v1.GetSecretRequest
-	32,  // 87: kandev.plugin.v1.Host.SetSecret:input_type -> kandev.plugin.v1.SetSecretRequest
-	34,  // 88: kandev.plugin.v1.Host.DeleteSecret:input_type -> kandev.plugin.v1.DeleteSecretRequest
-	28,  // 89: kandev.plugin.v1.Host.GetConfig:input_type -> kandev.plugin.v1.GetConfigRequest
-	46,  // 90: kandev.plugin.v1.Host.ListTasks:input_type -> kandev.plugin.v1.ListTasksRequest
-	48,  // 91: kandev.plugin.v1.Host.GetTask:input_type -> kandev.plugin.v1.GetTaskRequest
-	51,  // 92: kandev.plugin.v1.Host.ListWorkspaces:input_type -> kandev.plugin.v1.ListWorkspacesRequest
-	54,  // 93: kandev.plugin.v1.Host.ListWorkflows:input_type -> kandev.plugin.v1.ListWorkflowsRequest
-	57,  // 94: kandev.plugin.v1.Host.ListWorkflowSteps:input_type -> kandev.plugin.v1.ListWorkflowStepsRequest
-	60,  // 95: kandev.plugin.v1.Host.ListAgentProfiles:input_type -> kandev.plugin.v1.ListAgentProfilesRequest
-	63,  // 96: kandev.plugin.v1.Host.ListExecutorProfiles:input_type -> kandev.plugin.v1.ListExecutorProfilesRequest
-	66,  // 97: kandev.plugin.v1.Host.ListRepositories:input_type -> kandev.plugin.v1.ListRepositoriesRequest
-	70,  // 98: kandev.plugin.v1.Host.ListSessions:input_type -> kandev.plugin.v1.ListSessionsRequest
-	73,  // 99: kandev.plugin.v1.Host.ListSessionCodeStats:input_type -> kandev.plugin.v1.ListSessionCodeStatsRequest
-	77,  // 100: kandev.plugin.v1.Host.ListMessages:input_type -> kandev.plugin.v1.ListMessagesRequest
-	83,  // 101: kandev.plugin.v1.Host.ListPendingInteractions:input_type -> kandev.plugin.v1.ListPendingInteractionsRequest
-	85,  // 102: kandev.plugin.v1.Host.GetInteraction:input_type -> kandev.plugin.v1.GetInteractionRequest
-	94,  // 103: kandev.plugin.v1.Host.InvokeUtilityAgent:input_type -> kandev.plugin.v1.InvokeUtilityAgentRequest
-	96,  // 104: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
-	101, // 105: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
-	103, // 106: kandev.plugin.v1.Host.SendMessage:input_type -> kandev.plugin.v1.SendMessageRequest
-	105, // 107: kandev.plugin.v1.Host.PreviewPluginOwnedTaskTree:input_type -> kandev.plugin.v1.PreviewPluginOwnedTaskTreeRequest
-	107, // 108: kandev.plugin.v1.Host.DeletePluginOwnedTaskTree:input_type -> kandev.plugin.v1.DeletePluginOwnedTaskTreeRequest
-	87,  // 109: kandev.plugin.v1.Host.RespondToPermission:input_type -> kandev.plugin.v1.RespondToPermissionRequest
-	90,  // 110: kandev.plugin.v1.Host.AnswerClarification:input_type -> kandev.plugin.v1.AnswerClarificationRequest
-	92,  // 111: kandev.plugin.v1.Host.CancelClarification:input_type -> kandev.plugin.v1.CancelClarificationRequest
-	1,   // 112: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
-	6,   // 113: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
-	9,   // 114: kandev.plugin.v1.Plugin.HandleAction:output_type -> kandev.plugin.v1.PluginActionResponse
-	11,  // 115: kandev.plugin.v1.Plugin.SearchEntityReferences:output_type -> kandev.plugin.v1.SearchEntityReferencesResponse
-	14,  // 116: kandev.plugin.v1.Plugin.AuthorizeEntityReference:output_type -> kandev.plugin.v1.AuthorizeEntityReferenceResponse
-	16,  // 117: kandev.plugin.v1.Plugin.ResolveGitCredential:output_type -> kandev.plugin.v1.ResolveGitCredentialResponse
-	18,  // 118: kandev.plugin.v1.Plugin.GetGitCredentialBinding:output_type -> kandev.plugin.v1.GitCredentialBindingResponse
-	4,   // 119: kandev.plugin.v1.Plugin.InvokeAgentTool:output_type -> kandev.plugin.v1.AgentToolResponse
-	20,  // 120: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
-	22,  // 121: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
-	24,  // 122: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
-	26,  // 123: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
-	37,  // 124: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
-	39,  // 125: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
-	31,  // 126: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
-	33,  // 127: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
-	35,  // 128: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
-	29,  // 129: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
-	47,  // 130: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
-	49,  // 131: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
-	52,  // 132: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
-	55,  // 133: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
-	58,  // 134: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
-	61,  // 135: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
-	64,  // 136: kandev.plugin.v1.Host.ListExecutorProfiles:output_type -> kandev.plugin.v1.ListExecutorProfilesResponse
-	67,  // 137: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
-	71,  // 138: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
-	74,  // 139: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
-	78,  // 140: kandev.plugin.v1.Host.ListMessages:output_type -> kandev.plugin.v1.ListMessagesResponse
-	84,  // 141: kandev.plugin.v1.Host.ListPendingInteractions:output_type -> kandev.plugin.v1.ListPendingInteractionsResponse
-	86,  // 142: kandev.plugin.v1.Host.GetInteraction:output_type -> kandev.plugin.v1.GetInteractionResponse
-	95,  // 143: kandev.plugin.v1.Host.InvokeUtilityAgent:output_type -> kandev.plugin.v1.InvokeUtilityAgentResponse
-	100, // 144: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
-	102, // 145: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
-	104, // 146: kandev.plugin.v1.Host.SendMessage:output_type -> kandev.plugin.v1.SendMessageResponse
-	106, // 147: kandev.plugin.v1.Host.PreviewPluginOwnedTaskTree:output_type -> kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse
-	108, // 148: kandev.plugin.v1.Host.DeletePluginOwnedTaskTree:output_type -> kandev.plugin.v1.DeletePluginOwnedTaskTreeResponse
-	88,  // 149: kandev.plugin.v1.Host.RespondToPermission:output_type -> kandev.plugin.v1.RespondToPermissionResponse
-	91,  // 150: kandev.plugin.v1.Host.AnswerClarification:output_type -> kandev.plugin.v1.AnswerClarificationResponse
-	93,  // 151: kandev.plugin.v1.Host.CancelClarification:output_type -> kandev.plugin.v1.CancelClarificationResponse
-	112, // [112:152] is the sub-list for method output_type
-	72,  // [72:112] is the sub-list for method input_type
-	72,  // [72:72] is the sub-list for extension type_name
-	72,  // [72:72] is the sub-list for extension extendee
-	0,   // [0:72] is the sub-list for field type_name
+	42,  // 71: kandev.plugin.v1.MoveTaskResponse.task:type_name -> kandev.plugin.v1.Task
+	42,  // 72: kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse.tasks:type_name -> kandev.plugin.v1.Task
+	0,   // 73: kandev.plugin.v1.Plugin.DeliverEvent:input_type -> kandev.plugin.v1.Event
+	5,   // 74: kandev.plugin.v1.Plugin.HandleWebhook:input_type -> kandev.plugin.v1.WebhookRequest
+	7,   // 75: kandev.plugin.v1.Plugin.HandleAction:input_type -> kandev.plugin.v1.PluginActionRequest
+	10,  // 76: kandev.plugin.v1.Plugin.SearchEntityReferences:input_type -> kandev.plugin.v1.SearchEntityReferencesRequest
+	13,  // 77: kandev.plugin.v1.Plugin.AuthorizeEntityReference:input_type -> kandev.plugin.v1.AuthorizeEntityReferenceRequest
+	15,  // 78: kandev.plugin.v1.Plugin.ResolveGitCredential:input_type -> kandev.plugin.v1.ResolveGitCredentialRequest
+	17,  // 79: kandev.plugin.v1.Plugin.GetGitCredentialBinding:input_type -> kandev.plugin.v1.GitCredentialBindingRequest
+	2,   // 80: kandev.plugin.v1.Plugin.InvokeAgentTool:input_type -> kandev.plugin.v1.AgentToolRequest
+	19,  // 81: kandev.plugin.v1.Host.GetState:input_type -> kandev.plugin.v1.GetStateRequest
+	21,  // 82: kandev.plugin.v1.Host.SetState:input_type -> kandev.plugin.v1.SetStateRequest
+	23,  // 83: kandev.plugin.v1.Host.DeleteState:input_type -> kandev.plugin.v1.DeleteStateRequest
+	25,  // 84: kandev.plugin.v1.Host.ListState:input_type -> kandev.plugin.v1.ListStateRequest
+	36,  // 85: kandev.plugin.v1.Host.RevealSecret:input_type -> kandev.plugin.v1.RevealSecretRequest
+	38,  // 86: kandev.plugin.v1.Host.EmitEvent:input_type -> kandev.plugin.v1.EmitEventRequest
+	30,  // 87: kandev.plugin.v1.Host.GetSecret:input_type -> kandev.plugin.v1.GetSecretRequest
+	32,  // 88: kandev.plugin.v1.Host.SetSecret:input_type -> kandev.plugin.v1.SetSecretRequest
+	34,  // 89: kandev.plugin.v1.Host.DeleteSecret:input_type -> kandev.plugin.v1.DeleteSecretRequest
+	28,  // 90: kandev.plugin.v1.Host.GetConfig:input_type -> kandev.plugin.v1.GetConfigRequest
+	46,  // 91: kandev.plugin.v1.Host.ListTasks:input_type -> kandev.plugin.v1.ListTasksRequest
+	48,  // 92: kandev.plugin.v1.Host.GetTask:input_type -> kandev.plugin.v1.GetTaskRequest
+	51,  // 93: kandev.plugin.v1.Host.ListWorkspaces:input_type -> kandev.plugin.v1.ListWorkspacesRequest
+	54,  // 94: kandev.plugin.v1.Host.ListWorkflows:input_type -> kandev.plugin.v1.ListWorkflowsRequest
+	57,  // 95: kandev.plugin.v1.Host.ListWorkflowSteps:input_type -> kandev.plugin.v1.ListWorkflowStepsRequest
+	60,  // 96: kandev.plugin.v1.Host.ListAgentProfiles:input_type -> kandev.plugin.v1.ListAgentProfilesRequest
+	63,  // 97: kandev.plugin.v1.Host.ListExecutorProfiles:input_type -> kandev.plugin.v1.ListExecutorProfilesRequest
+	66,  // 98: kandev.plugin.v1.Host.ListRepositories:input_type -> kandev.plugin.v1.ListRepositoriesRequest
+	70,  // 99: kandev.plugin.v1.Host.ListSessions:input_type -> kandev.plugin.v1.ListSessionsRequest
+	73,  // 100: kandev.plugin.v1.Host.ListSessionCodeStats:input_type -> kandev.plugin.v1.ListSessionCodeStatsRequest
+	77,  // 101: kandev.plugin.v1.Host.ListMessages:input_type -> kandev.plugin.v1.ListMessagesRequest
+	83,  // 102: kandev.plugin.v1.Host.ListPendingInteractions:input_type -> kandev.plugin.v1.ListPendingInteractionsRequest
+	85,  // 103: kandev.plugin.v1.Host.GetInteraction:input_type -> kandev.plugin.v1.GetInteractionRequest
+	94,  // 104: kandev.plugin.v1.Host.InvokeUtilityAgent:input_type -> kandev.plugin.v1.InvokeUtilityAgentRequest
+	96,  // 105: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
+	101, // 106: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
+	103, // 107: kandev.plugin.v1.Host.MoveTask:input_type -> kandev.plugin.v1.MoveTaskRequest
+	105, // 108: kandev.plugin.v1.Host.SendMessage:input_type -> kandev.plugin.v1.SendMessageRequest
+	107, // 109: kandev.plugin.v1.Host.PreviewPluginOwnedTaskTree:input_type -> kandev.plugin.v1.PreviewPluginOwnedTaskTreeRequest
+	109, // 110: kandev.plugin.v1.Host.DeletePluginOwnedTaskTree:input_type -> kandev.plugin.v1.DeletePluginOwnedTaskTreeRequest
+	87,  // 111: kandev.plugin.v1.Host.RespondToPermission:input_type -> kandev.plugin.v1.RespondToPermissionRequest
+	90,  // 112: kandev.plugin.v1.Host.AnswerClarification:input_type -> kandev.plugin.v1.AnswerClarificationRequest
+	92,  // 113: kandev.plugin.v1.Host.CancelClarification:input_type -> kandev.plugin.v1.CancelClarificationRequest
+	1,   // 114: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
+	6,   // 115: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
+	9,   // 116: kandev.plugin.v1.Plugin.HandleAction:output_type -> kandev.plugin.v1.PluginActionResponse
+	11,  // 117: kandev.plugin.v1.Plugin.SearchEntityReferences:output_type -> kandev.plugin.v1.SearchEntityReferencesResponse
+	14,  // 118: kandev.plugin.v1.Plugin.AuthorizeEntityReference:output_type -> kandev.plugin.v1.AuthorizeEntityReferenceResponse
+	16,  // 119: kandev.plugin.v1.Plugin.ResolveGitCredential:output_type -> kandev.plugin.v1.ResolveGitCredentialResponse
+	18,  // 120: kandev.plugin.v1.Plugin.GetGitCredentialBinding:output_type -> kandev.plugin.v1.GitCredentialBindingResponse
+	4,   // 121: kandev.plugin.v1.Plugin.InvokeAgentTool:output_type -> kandev.plugin.v1.AgentToolResponse
+	20,  // 122: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
+	22,  // 123: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
+	24,  // 124: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
+	26,  // 125: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
+	37,  // 126: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
+	39,  // 127: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
+	31,  // 128: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
+	33,  // 129: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
+	35,  // 130: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
+	29,  // 131: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
+	47,  // 132: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
+	49,  // 133: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
+	52,  // 134: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
+	55,  // 135: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
+	58,  // 136: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
+	61,  // 137: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
+	64,  // 138: kandev.plugin.v1.Host.ListExecutorProfiles:output_type -> kandev.plugin.v1.ListExecutorProfilesResponse
+	67,  // 139: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
+	71,  // 140: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
+	74,  // 141: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
+	78,  // 142: kandev.plugin.v1.Host.ListMessages:output_type -> kandev.plugin.v1.ListMessagesResponse
+	84,  // 143: kandev.plugin.v1.Host.ListPendingInteractions:output_type -> kandev.plugin.v1.ListPendingInteractionsResponse
+	86,  // 144: kandev.plugin.v1.Host.GetInteraction:output_type -> kandev.plugin.v1.GetInteractionResponse
+	95,  // 145: kandev.plugin.v1.Host.InvokeUtilityAgent:output_type -> kandev.plugin.v1.InvokeUtilityAgentResponse
+	100, // 146: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
+	102, // 147: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
+	104, // 148: kandev.plugin.v1.Host.MoveTask:output_type -> kandev.plugin.v1.MoveTaskResponse
+	106, // 149: kandev.plugin.v1.Host.SendMessage:output_type -> kandev.plugin.v1.SendMessageResponse
+	108, // 150: kandev.plugin.v1.Host.PreviewPluginOwnedTaskTree:output_type -> kandev.plugin.v1.PreviewPluginOwnedTaskTreeResponse
+	110, // 151: kandev.plugin.v1.Host.DeletePluginOwnedTaskTree:output_type -> kandev.plugin.v1.DeletePluginOwnedTaskTreeResponse
+	88,  // 152: kandev.plugin.v1.Host.RespondToPermission:output_type -> kandev.plugin.v1.RespondToPermissionResponse
+	91,  // 153: kandev.plugin.v1.Host.AnswerClarification:output_type -> kandev.plugin.v1.AnswerClarificationResponse
+	93,  // 154: kandev.plugin.v1.Host.CancelClarification:output_type -> kandev.plugin.v1.CancelClarificationResponse
+	114, // [114:155] is the sub-list for method output_type
+	73,  // [73:114] is the sub-list for method input_type
+	73,  // [73:73] is the sub-list for extension type_name
+	73,  // [73:73] is the sub-list for extension extendee
+	0,   // [0:73] is the sub-list for field type_name
 }
 
 func init() { file_kandev_plugin_v1_plugin_proto_init() }
@@ -8050,13 +8216,15 @@ func file_kandev_plugin_v1_plugin_proto_init() {
 	file_kandev_plugin_v1_plugin_proto_msgTypes[98].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[99].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[101].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[103].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[104].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kandev_plugin_v1_plugin_proto_rawDesc), len(file_kandev_plugin_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   113,
+			NumMessages:   115,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -130,6 +130,11 @@ service Host {
   // session is running, resume/start it otherwise).
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
   rpc UpdateTask(UpdateTaskRequest) returns (UpdateTaskResponse);
+  // MoveTask transitions a task to a workflow step through the same path the
+  // board's own move uses (validation, WIP admission, task.moved publication,
+  // auto-start gates, queue reconciliation) — unlike UpdateTask, which rejects
+  // workflow_step_id. Requires api_write:tasks.
+  rpc MoveTask(MoveTaskRequest) returns (MoveTaskResponse);
   rpc SendMessage(SendMessageRequest) returns (SendMessageResponse);
   rpc PreviewPluginOwnedTaskTree(PreviewPluginOwnedTaskTreeRequest) returns (PreviewPluginOwnedTaskTreeResponse);
   rpc DeletePluginOwnedTaskTree(DeletePluginOwnedTaskTreeRequest) returns (DeletePluginOwnedTaskTreeResponse);
@@ -859,6 +864,28 @@ message UpdateTaskRequest {
 }
 message UpdateTaskResponse {
   Task task = 1;
+}
+// MoveTask transitions a task to a workflow step. workflow_id is optional:
+// omitted inherits the task's current workflow, present-empty is rejected.
+// position is not optional: an omitted position and a position of zero are
+// the same request, both placing the task at the top of the target step.
+message MoveTaskRequest {
+  string task_id = 1;
+  string workflow_step_id = 2;
+  optional string workflow_id = 3;
+  int32 position = 4;
+}
+// transitioned reports whether a ledger row was written for this move
+// (false when the task was already on the target step). queued_for_step_id
+// is the sole admission discriminator, reported on both values of
+// transitioned: absent means admitted (when transitioned) or not applicable
+// (when not), present means queued for that step holding no WIP slot.
+// from_step_id is the step the task left; empty when transitioned is false.
+message MoveTaskResponse {
+  Task task = 1;
+  bool transitioned = 2;
+  optional string queued_for_step_id = 3;
+  string from_step_id = 4;
 }
 // SendMessage delivers a prompt to a task session (api_write:messages). The
 // server records a user message stamped source = "plugin:<id>" and dispatches

--- a/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
@@ -439,6 +439,7 @@ const (
 	Host_InvokeUtilityAgent_FullMethodName         = "/kandev.plugin.v1.Host/InvokeUtilityAgent"
 	Host_CreateTask_FullMethodName                 = "/kandev.plugin.v1.Host/CreateTask"
 	Host_UpdateTask_FullMethodName                 = "/kandev.plugin.v1.Host/UpdateTask"
+	Host_MoveTask_FullMethodName                   = "/kandev.plugin.v1.Host/MoveTask"
 	Host_SendMessage_FullMethodName                = "/kandev.plugin.v1.Host/SendMessage"
 	Host_PreviewPluginOwnedTaskTree_FullMethodName = "/kandev.plugin.v1.Host/PreviewPluginOwnedTaskTree"
 	Host_DeletePluginOwnedTaskTree_FullMethodName  = "/kandev.plugin.v1.Host/DeletePluginOwnedTaskTree"
@@ -544,6 +545,11 @@ type HostClient interface {
 	// session is running, resume/start it otherwise).
 	CreateTask(ctx context.Context, in *CreateTaskRequest, opts ...grpc.CallOption) (*CreateTaskResponse, error)
 	UpdateTask(ctx context.Context, in *UpdateTaskRequest, opts ...grpc.CallOption) (*UpdateTaskResponse, error)
+	// MoveTask transitions a task to a workflow step through the same path the
+	// board's own move uses (validation, WIP admission, task.moved publication,
+	// auto-start gates, queue reconciliation) — unlike UpdateTask, which rejects
+	// workflow_step_id. Requires api_write:tasks.
+	MoveTask(ctx context.Context, in *MoveTaskRequest, opts ...grpc.CallOption) (*MoveTaskResponse, error)
 	SendMessage(ctx context.Context, in *SendMessageRequest, opts ...grpc.CallOption) (*SendMessageResponse, error)
 	PreviewPluginOwnedTaskTree(ctx context.Context, in *PreviewPluginOwnedTaskTreeRequest, opts ...grpc.CallOption) (*PreviewPluginOwnedTaskTreeResponse, error)
 	DeletePluginOwnedTaskTree(ctx context.Context, in *DeletePluginOwnedTaskTreeRequest, opts ...grpc.CallOption) (*DeletePluginOwnedTaskTreeResponse, error)
@@ -828,6 +834,16 @@ func (c *hostClient) UpdateTask(ctx context.Context, in *UpdateTaskRequest, opts
 	return out, nil
 }
 
+func (c *hostClient) MoveTask(ctx context.Context, in *MoveTaskRequest, opts ...grpc.CallOption) (*MoveTaskResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MoveTaskResponse)
+	err := c.cc.Invoke(ctx, Host_MoveTask_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *hostClient) SendMessage(ctx context.Context, in *SendMessageRequest, opts ...grpc.CallOption) (*SendMessageResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SendMessageResponse)
@@ -985,6 +1001,11 @@ type HostServer interface {
 	// session is running, resume/start it otherwise).
 	CreateTask(context.Context, *CreateTaskRequest) (*CreateTaskResponse, error)
 	UpdateTask(context.Context, *UpdateTaskRequest) (*UpdateTaskResponse, error)
+	// MoveTask transitions a task to a workflow step through the same path the
+	// board's own move uses (validation, WIP admission, task.moved publication,
+	// auto-start gates, queue reconciliation) — unlike UpdateTask, which rejects
+	// workflow_step_id. Requires api_write:tasks.
+	MoveTask(context.Context, *MoveTaskRequest) (*MoveTaskResponse, error)
 	SendMessage(context.Context, *SendMessageRequest) (*SendMessageResponse, error)
 	PreviewPluginOwnedTaskTree(context.Context, *PreviewPluginOwnedTaskTreeRequest) (*PreviewPluginOwnedTaskTreeResponse, error)
 	DeletePluginOwnedTaskTree(context.Context, *DeletePluginOwnedTaskTreeRequest) (*DeletePluginOwnedTaskTreeResponse, error)
@@ -1086,6 +1107,9 @@ func (UnimplementedHostServer) CreateTask(context.Context, *CreateTaskRequest) (
 }
 func (UnimplementedHostServer) UpdateTask(context.Context, *UpdateTaskRequest) (*UpdateTaskResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateTask not implemented")
+}
+func (UnimplementedHostServer) MoveTask(context.Context, *MoveTaskRequest) (*MoveTaskResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MoveTask not implemented")
 }
 func (UnimplementedHostServer) SendMessage(context.Context, *SendMessageRequest) (*SendMessageResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SendMessage not implemented")
@@ -1594,6 +1618,24 @@ func _Host_UpdateTask_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Host_MoveTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MoveTaskRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostServer).MoveTask(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Host_MoveTask_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostServer).MoveTask(ctx, req.(*MoveTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Host_SendMessage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SendMessageRequest)
 	if err := dec(in); err != nil {
@@ -1812,6 +1854,10 @@ var Host_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateTask",
 			Handler:    _Host_UpdateTask_Handler,
+		},
+		{
+			MethodName: "MoveTask",
+			Handler:    _Host_MoveTask_Handler,
 		},
 		{
 			MethodName: "SendMessage",

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -501,23 +501,23 @@ subscription vocabulary and wildcard rules are in the
 
 ### Host API matrix
 
-| Host surface   | Methods                                          | Required manifest capability                                                | Notes                                                                                                                                                                                       |
-| -------------- | ------------------------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| State          | GetState, SetState, DeleteState, ListState       | state: true                                                                 | Plugin-scoped JSON objects keyed by scope/scopeID/key; no transactions                                                                                                                      |
-| Config         | GetConfig                                        | None                                                                        | Reads this plugin's validated config_schema; secret fields are cleartext in the subprocess; config updates restart active plugins                                                           |
-| Secrets        | RevealSecret, GetSecret, SetSecret, DeleteSecret | secrets: true                                                               | Encrypted vault; plugin-owned keys are namespaced; never log values                                                                                                                         |
-| Tasks          | Tasks().List, Tasks().Get                        | api_read: tasks                                                             | Typed DTOs and opaque pagination cursor                                                                                                                                                     |
-| Tasks writes   | Tasks().Create, Tasks().Update                   | api_write: tasks                                                            | Implemented; routed through Kandev services so events/WS updates fire                                                                                                                       |
-| Sessions       | Sessions().List, Sessions().CodeStats            | api_read: sessions                                                          | Typed session and computed code-stat records                                                                                                                                                |
-| Workspaces     | Workspaces().List                                | api_read: workspaces                                                        | Instance-visible workspaces                                                                                                                                                                 |
-| Workflows      | Workflows().List, Workflows().ListSteps          | api_read: workflows                                                         | List steps by workflow id                                                                                                                                                                   |
-| Agent profiles | AgentProfiles().List                             | api_read: agent_profiles                                                    | Global agent profiles exposed by the Host data API                                                                                                                                          |
-| Repositories   | Repositories().List                              | api_read: repositories                                                      | List by workspace id                                                                                                                                                                        |
-| Messages       | Messages().List                                  | api_read: messages                                                          | Historical user/agent content; Kandev system blocks are stripped                                                                                                                            |
-| Message send   | Messages().Send                                  | api_write: messages                                                         | Sends a prompt to a task session and records plugin:<id> author                                                                                                                             |
-| Interactions   | Interactions().ListPending, Interactions().Get   | api_read: interactions                                                      | Durable record of agent requests still owed a human answer; Get resolves resolved ones too                                                                                                  |
-| Interaction responses | Interactions().RespondToPermission, .AnswerClarification, .CancelClarification | api_write: interactions           | Routed through the services the native UI drives; first terminal response wins                                                                                                             |
-| Utility agent  | InvokeUtilityAgent(ctx, prompt)                  | agent_invoke: true plus config_schema.utility_agent (format: utility-agent) | One-shot completion using the selected utility-agent ID; Kandev resolves that utility's enabled profile, permissions, and launch settings. Missing or stale bindings are FailedPrecondition |
+| Host surface          | Methods                                                                        | Required manifest capability                                                | Notes                                                                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| State                 | GetState, SetState, DeleteState, ListState                                     | state: true                                                                 | Plugin-scoped JSON objects keyed by scope/scopeID/key; no transactions                                                                                                                      |
+| Config                | GetConfig                                                                      | None                                                                        | Reads this plugin's validated config_schema; secret fields are cleartext in the subprocess; config updates restart active plugins                                                           |
+| Secrets               | RevealSecret, GetSecret, SetSecret, DeleteSecret                               | secrets: true                                                               | Encrypted vault; plugin-owned keys are namespaced; never log values                                                                                                                         |
+| Tasks                 | Tasks().List, Tasks().Get                                                      | api_read: tasks                                                             | Typed DTOs and opaque pagination cursor                                                                                                                                                     |
+| Tasks writes          | Tasks().Create, Tasks().Update, Tasks().Move                                   | api_write: tasks                                                            | Implemented; routed through Kandev services so events/WS updates fire. Update rejects a workflow step change; Move is the only path that moves a task between steps                         |
+| Sessions              | Sessions().List, Sessions().CodeStats                                          | api_read: sessions                                                          | Typed session and computed code-stat records                                                                                                                                                |
+| Workspaces            | Workspaces().List                                                              | api_read: workspaces                                                        | Instance-visible workspaces                                                                                                                                                                 |
+| Workflows             | Workflows().List, Workflows().ListSteps                                        | api_read: workflows                                                         | List steps by workflow id                                                                                                                                                                   |
+| Agent profiles        | AgentProfiles().List                                                           | api_read: agent_profiles                                                    | Global agent profiles exposed by the Host data API                                                                                                                                          |
+| Repositories          | Repositories().List                                                            | api_read: repositories                                                      | List by workspace id                                                                                                                                                                        |
+| Messages              | Messages().List                                                                | api_read: messages                                                          | Historical user/agent content; Kandev system blocks are stripped                                                                                                                            |
+| Message send          | Messages().Send                                                                | api_write: messages                                                         | Sends a prompt to a task session and records plugin:<id> author                                                                                                                             |
+| Interactions          | Interactions().ListPending, Interactions().Get                                 | api_read: interactions                                                      | Durable record of agent requests still owed a human answer; Get resolves resolved ones too                                                                                                  |
+| Interaction responses | Interactions().RespondToPermission, .AnswerClarification, .CancelClarification | api_write: interactions                                                     | Routed through the services the native UI drives; first terminal response wins                                                                                                              |
+| Utility agent         | InvokeUtilityAgent(ctx, prompt)                                                | agent_invoke: true plus config_schema.utility_agent (format: utility-agent) | One-shot completion using the selected utility-agent ID; Kandev resolves that utility's enabled profile, permissions, and launch settings. Missing or stale bindings are FailedPrecondition |
 
 The Go signatures, filters, DTOs, and pagination types live in
 apps/backend/pkg/pluginsdk/host.go and data_types.go. api_write task/message
@@ -652,7 +652,7 @@ type Host interface {
 
     // Tasks/Sessions/Workspaces/Workflows/AgentProfiles/Repositories return
 	// Host data accessors. List/Get operations require their own api_read
-	// resource; task Create/Update require api_write:tasks.
+	// resource; task Create/Update/Move require api_write:tasks.
 	Tasks() TaskReader
 	Sessions() SessionReader
 	Workspaces() WorkspaceReader
@@ -829,8 +829,9 @@ with a message naming the missing capability; declare what you use.
 ### Live Host writes
 
 `api_write` is live, not advisory. Declare only the exact resource you mutate:
-`api_write: ["tasks"]` enables `host.Tasks().Create(ctx, CreateTaskInput{...})`
-and `.Update(ctx, UpdateTaskInput{...})`; `api_write: ["messages"]` enables
+`api_write: ["tasks"]` enables `host.Tasks().Create(ctx, CreateTaskInput{...})`,
+`.Update(ctx, UpdateTaskInput{...})`, and `.Move(ctx, MoveTaskInput{...})`;
+`api_write: ["messages"]` enables
 `host.Messages().Send(ctx, taskID, sessionID, text)`;
 `api_write: ["interactions"]` enables the interaction response methods above. A blank
 `sessionID` targets the task's primary session. Send queues behind a running
@@ -839,11 +840,16 @@ session or resumes/starts it when appropriate, returning `queued`, `sent`, or
 
 Task writes use Kandev's first-party service layer, so normal task events and
 browser updates occur. Kandev stamps the source as `plugin:<id>` and reserves
-the `metadata.source` key; plugin metadata is stored under that source. A task
-write can update only title, description, state, and workflow step. Creating a
-task can select an existing repository or provide a complete, credential-free
-remote descriptor only when the plugin owns that `repository_providers` id.
-Treat all write calls as user-visible mutations and honor `ctx.Done()`.
+the `metadata.source` key; plugin metadata is stored under that source. `.Update`
+writes only title, description, and state: it rejects a workflow step change.
+Moving a task between workflow steps goes through `.Move` instead, which routes
+through the same path the board's own drag-and-drop move uses (validation, WIP
+admission, `task.moved` publication, auto-start gates, queue reconciliation),
+so a plugin-driven move triggers `on_enter`/`on_exit` step actions the same way
+a manual move does. Creating a task can select an existing repository or
+provide a complete, credential-free remote descriptor only when the plugin
+owns that `repository_providers` id. Treat all write calls as user-visible
+mutations and honor `ctx.Done()`.
 
 ## Authenticated declared actions
 

--- a/docs/specs/plugins/README.md
+++ b/docs/specs/plugins/README.md
@@ -33,6 +33,7 @@ plugin security boundaries.
 
 
 - [Plugin-Contributed Agent Tools](requirements/agent-tools.md)
+- [Plugin-Initiated Workflow Step Transitions](requirements/plugin-initiated-step-transitions.md)
 - [Plugin Authoring Experience](requirements/authoring-experience.md)
 - [Plugin Marketplace](requirements/marketplace.md)
 - [Plugin nav items in the sidebar footer icon row](requirements/plugin-nav-sidebar-footer.md)
@@ -45,6 +46,7 @@ plugin security boundaries.
 
 
 
+- [Plugin-Initiated Workflow Step Transitions](system-design/plugin-initiated-step-transitions.md)
 - [Plugin Marketplace](system-design/marketplace.md)
 - [Plugin nav items in the sidebar footer icon row System Design Part 1](system-design/plugin-nav-sidebar-footer-01.md)
 - [Plugin nav items in the sidebar footer icon row System Design Part 2](system-design/plugin-nav-sidebar-footer-02.md)

--- a/docs/specs/plugins/requirements/plugin-initiated-step-transitions.md
+++ b/docs/specs/plugins/requirements/plugin-initiated-step-transitions.md
@@ -1,0 +1,354 @@
+---
+status: draft
+system: plugins
+created: 2026-08-26
+owners:
+  - nova28
+---
+
+# Plugin-Initiated Workflow Step Transitions Requirements
+
+> Technical design, wire contract, and code-path evidence:
+> `docs/specs/plugins/system-design/plugin-initiated-step-transitions.md`.
+
+## Overview
+
+A plugin can already relocate a card on the board, and doing so starts nothing.
+`Host.UpdateTask` accepts `workflow_step_id` and the adapter forwards it to
+`taskservice.UpdateTask`, which assigns `task.WorkflowStepID` directly
+(`service_tasks.go:1593`) and never calls `publishTaskMovedEvent`, whose only
+call sites are the shared move and queue-promotion paths. Without that event
+`autoStartTaskForStep` never runs, so no `on_enter` action fires and no agent
+launches. A plugin "Dispatch" button built on `UpdateTask` moves cards and
+starts no work.
+
+This system owns the contract because the durable decision is *what a plugin
+may do to an operator's board and under whose identity*, not how a move is
+implemented.
+
+## Terminology
+
+- **Move:** a change to a task's `workflow_step_id`, `workflow_id`, or
+  `position` through the task service's move path.
+- **Transition:** a move where the step actually changed. A same-step move is
+  not a transition and writes no ledger row (`step_transitions.go:74`).
+- **Admitted / Queued:** a move is **queued** if and only if `QueuedForStepID`
+  is non-empty, meaning the task *is* on the target step but holds no capacity
+  slot (`internal/task/models/models.go:805-810`); every other outcome is
+  **admitted**. The discriminator is `QueuedForStepID`, not `WIPAdmitted`; the
+  design file records why the two are not complements.
+- **Plugin identity:** the string `plugin:<id>`, already produced by
+  `pluginHost.pluginSource()` and stamped on plugin-created tasks and messages.
+
+## Prior art
+
+Recorded in the design file: the wiki was unavailable (tooling access, not an
+empty wiki); one on-point `saas-kb` hit (Factory.ai's Actor/Source audit
+split), plus what we do differently.
+
+## Contract decisions
+
+The argument, rejected alternatives, and code citations are in the design file.
+
+**Actor: `integration`, identified by `plugin:<id>`, under a new `plugin_move`
+trigger.** Not a new `plugin` actor kind, and not the authenticated user driving
+the surface: there is no `authn` identity on a plugin gRPC context, and a plugin
+can act on a webhook or timer with no human anywhere. `ActorIntegration`
+already covers this shape of caller. `StepHistoryActor` must not be `Human`, because `Human` is what stamps the
+operator's user id onto an unattended move.
+
+**`plugin_move` is added to both trigger vocabularies.** The task-level ledger
+and the session-level history use separate, non-overlapping enums. Adding it to
+only one leaves the session history recording `manual`, the value reserved for
+human board moves, on every plugin move.
+
+**Capability: `api_write:tasks`, unchanged.** It already confers agent launch,
+so a new capability closes no open door. The `PluginOwnedTaskTree` ownership
+rule is deliberately not applied; safety comes from the auto-start gates, not
+from ownership. The design file argues both.
+
+**Reach, stated plainly: a plugin holding `api_write:tasks` may move any task in
+the install, in any workspace.** Deliberate, not an omission: a plugin host
+binds no workspace and no scope filter applies. Per-workspace scoping is a
+separate contract (see Out of scope).
+
+**Shape: a dedicated `MoveTask` RPC; `UpdateTask` stops accepting the field.**
+`UpdateTaskRequest` has no `workflow_id` or `position`, so routing it internally
+leaves cross-workflow moves unrepresentable and its response cannot report
+admission. The design file specifies the full field list and the single
+admission discriminator, because third parties compile against it. `UpdateTask`
+must then reject `workflow_step_id` — a breaking change to a shipped field, and
+the right one, since every current use is already silently broken — enforced on
+the plugin-facing update path only, never in the shared task-service method that
+MCP also uses.
+
+## Requirements
+
+### REQ-PLUGINS-STEP-MOVE-001: Plugin-initiated moves use the board's move path
+
+**Intent:** A plugin that moves a card runs the same move implementation the
+board runs — the same validation, admission, event publication, and step-entry
+dispatch — so a plugin surface can dispatch work.
+
+**One deliberate divergence.** The plugin path is *not* option-for-option
+identical to the board's: a plugin move is unattended, so it takes the
+stricter agent-shaped option and rejects a task with a live session (AC-001.8).
+Read AC-001.1 as "same method, same gates", not "same options"; the design file
+names the option, why it diverges, and what it costs a retrying plugin.
+
+**User story:** As a plugin author, I want to move a task to a workflow step
+and have the step's configured actions run, so that a "Dispatch" control in my
+plugin starts work instead of silently relocating a card.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-STEP-MOVE-001.1:** When a plugin requests a move, the system
+  shall perform it through the same task-service move method the board's HTTP
+  and WebSocket handlers call, and shall not re-implement validation,
+  admission, event publication, or step-entry dispatch in the plugin layer.
+  The move options are not identical to the board's: see AC-001.8 and Intent.
+- **AC-PLUGINS-STEP-MOVE-001.2:** When a plugin moves a task onto a step whose
+  `on_enter` actions include `auto_start_agent`, and no auto-start gate
+  applies, the system shall start an agent for that task.
+- **AC-PLUGINS-STEP-MOVE-001.3:** When a plugin moves a task onto a step
+  without an `auto_start_agent` action, the system shall complete the move and
+  start no agent.
+- **AC-PLUGINS-STEP-MOVE-001.4:** When a plugin move would start an agent but
+  the task has an unresolved dependency, is queued for capacity, has a terminal
+  pull request, or consumes a deferred launch intent instead, the system shall
+  complete the move and start no agent, applying each of those gates exactly as
+  the board's move does.
+- **AC-PLUGINS-STEP-MOVE-001.5:** When a plugin moves an Office task, the
+  system shall route step entry to the Office run path rather than the
+  session-based launch path, leaving the Office scheduler's ownership intact.
+- **AC-PLUGINS-STEP-MOVE-001.6:** When a plugin names a target step that does
+  not exist, does not belong to the named workflow, or belongs to a workflow in
+  a different workspace than the task, the system shall reject the move with an
+  invalid-argument error and change no persisted field.
+- **AC-PLUGINS-STEP-MOVE-001.7:** When a plugin moves an archived task, the
+  system shall reject the move with a failed-precondition error and change no
+  persisted field.
+- **AC-PLUGINS-STEP-MOVE-001.8:** When a plugin moves a task that has any
+  session in a starting or running state, the system shall reject the move with
+  a failed-precondition error and change no persisted field, matching the
+  agent-initiated move path rather than the human board path.
+
+- **AC-PLUGINS-STEP-MOVE-001.9:** The rejections AC-001.6 through AC-001.8
+  name shall be evaluated before the move's write. "Change no persisted field"
+  binds the rejected move itself, not a concurrent writer that commits between
+  the check and the write.
+
+### REQ-PLUGINS-STEP-MOVE-002: The move's outcome is reportable
+
+**Intent:** A plugin can tell what actually happened, so it renders truth
+rather than an assumption.
+
+**User story:** As a plugin author, I want the move result to tell me whether
+the task was admitted, queued, or unchanged, so that my UI does not claim work
+started when it is waiting for capacity.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-STEP-MOVE-002.1:** When a plugin move lands on a step that is at
+  its WIP limit, the system shall treat the move as successful, place the task
+  on the target step holding no capacity slot, and report the queued outcome
+  and the step it is queued for.
+- **AC-PLUGINS-STEP-MOVE-002.2:** When a plugin move is admitted, the system
+  shall report the admitted outcome, deriving admitted-versus-queued solely
+  from whether the task is queued for a step and never from the capacity-slot
+  flag alone.
+- **AC-PLUGINS-STEP-MOVE-002.3:** When a plugin requests a move to the step the
+  task already occupies, the system shall apply any position change, report
+  that no transition occurred, write no transition ledger row, publish no move
+  event, and start no agent. The answer shall still report the task's admission
+  state as AC-002.2 derives it, so a repeat against a step that is at its WIP
+  limit reports the task still queued.
+- **AC-PLUGINS-STEP-MOVE-002.4:** The system shall report the move outcome in
+  fields owned by the move response itself, so that reporting does not depend
+  on any other change to the task read shape, and shall carry exactly one
+  admission discriminator rather than two fields that could disagree.
+- **AC-PLUGINS-STEP-MOVE-002.5:** The system shall answer the move once the step
+  change is committed, without waiting for step-entry actions to finish, and the
+  answer shall report admission rather than whether an agent started. AC-005.13
+  governs when post-commit work fails.
+- **AC-PLUGINS-STEP-MOVE-002.6:** The system shall report the step the task
+  left, read in the same operation that determines whether the step changed, so
+  that the reported from-step and the transition ledger row name the same step
+  for the same move.
+
+### REQ-PLUGINS-STEP-MOVE-003: Plugin moves are attributable
+
+**Intent:** An operator can tell which plugin moved a card, and a plugin move
+is never recorded as a person's action.
+
+**User story:** As an operator, I want a plugin's move recorded as that
+plugin's action, so that an unattended automated move is not attributed to me.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-STEP-MOVE-003.1:** When a plugin move changes a task's step, the
+  system shall record a transition ledger row whose actor kind is the
+  integration actor and whose actor identifier is that plugin's `plugin:<id>`
+  provenance string.
+- **AC-PLUGINS-STEP-MOVE-003.2:** When a plugin move changes a task's step, the
+  system shall record a trigger value distinct from every existing trigger in
+  **both** the task-level ledger's and the session-level history's trigger
+  vocabularies, and shall not change the ledger's collection-contract version.
+  The session-level row is written only when the task already has a session;
+  see AC-003.5.
+- **AC-PLUGINS-STEP-MOVE-003.3:** When a plugin move is recorded, the system
+  shall not write any authenticated user's identifier as the move's actor
+  identifier on either the task-level ledger or the session-level history, and
+  the session-level history's trigger shall not fall back to the manual value
+  reserved for human board moves.
+- **AC-PLUGINS-STEP-MOVE-003.4:** When a plugin move changes a task's step, the
+  system shall record exactly one transition ledger row for that move.
+- **AC-PLUGINS-STEP-MOVE-003.5:** When a plugin moves a task that has no
+  session, the system shall write the task-level ledger row and write no
+  session-level history row, because that history's session column is a
+  non-null foreign key to the session table. This is the feature's most common
+  case, since a move onto an auto-start step precedes the session that move
+  creates. The session-level trigger value is therefore exercised only by moves
+  of tasks that already have a session.
+
+### REQ-PLUGINS-STEP-MOVE-004: One move path, gated by task write access
+
+**Intent:** The corrected path is the only plugin move path, so a second one
+cannot drift from the board's.
+
+**User story:** As a maintainer, I want exactly one way for a plugin to change
+a task's step, so that a future change to move semantics cannot leave a plugin
+path behind.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-STEP-MOVE-004.1:** When a plugin without declared task write
+  access requests a move, the system shall deny it as a permission failure and
+  change no persisted field.
+- **AC-PLUGINS-STEP-MOVE-004.2:** When a plugin with declared task write access
+  requests a move, the system shall not require any additional capability
+  beyond task write access.
+- **AC-PLUGINS-STEP-MOVE-004.3:** When a plugin requests a task update whose
+  workflow step identifier is present, whether or not its value is empty, the
+  system shall reject the request with an invalid-argument error that names the
+  move operation, and shall change no persisted field including the other fields
+  in the same request. This rejection shall be evaluated before the request's
+  other field validations, so that a request carrying both a step identifier and
+  another invalid field names the move operation.
+- **AC-PLUGINS-STEP-MOVE-004.5:** The rejection in AC-004.3 shall be enforced on
+  the plugin-facing update path only. A non-plugin caller of the shared
+  task-service update method shall retain its ability to set a workflow step
+  identifier, leaving the shared method's role for other callers unchanged.
+- **AC-PLUGINS-STEP-MOVE-004.4:** The set of code paths permitted to mutate a
+  task's workflow step shall remain pinned by test after this change, with the
+  plugin move path routing through an already-pinned path rather than adding a
+  new one.
+- **AC-PLUGINS-STEP-MOVE-004.6:** Every rejection these requirements name shall
+  answer with the status code the system design's error-mapping table assigns
+  it, and each such code shall be observable by a plugin. The plugin path shall
+  not reuse the MCP handler's move-error classifier, which buckets step and
+  workflow mismatches as a conflict where AC-001.6 requires invalid-argument.
+
+### REQ-PLUGINS-STEP-MOVE-005: Defined behavior under retry, races, and absent input
+
+**Intent:** Concurrency, retry, and defaulting behavior are stated rather than
+discovered by an implementer.
+
+**User story:** As a plugin author, I want retry and race behavior defined, so
+that a webhook redelivery or two plugins acting at once has a knowable result.
+
+Criteria below are labelled **(pin)** or **(new)**; the design file defines
+both labels.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-STEP-MOVE-005.1:** (new) When a plugin repeats an identical move
+  request after one has already succeeded, and the task holds no starting or
+  running session, the system shall treat the repeat as a same-step move: it
+  shall succeed, report that no transition occurred, and start no additional
+  agent. When such a session exists, AC-001.8 governs instead and the repeat is
+  rejected with a failed-precondition error; the design file states why the gate
+  wins and what that rejection tells a plugin.
+- **AC-PLUGINS-STEP-MOVE-005.2:** (pin) When two callers move the same task
+  concurrently, the system shall serialize them on the target step's capacity
+  so that admissions never exceed the step's WIP limit, and shall promote
+  queued tasks in the shared path's existing order: position, then priority
+  tier, then queued-at falling back to created-at, then created-at, then task
+  identifier. The design file names the priority ladder and the query this
+  order belongs to; both are binding on the pin test.
+- **AC-PLUGINS-STEP-MOVE-005.3:** (pin) When a move event is delivered for a
+  transition the task has already left, the system shall not run the superseded
+  destination's step-entry actions.
+- **AC-PLUGINS-STEP-MOVE-005.4:** (new) When a plugin omits the target workflow
+  identifier, the system shall use the task's current workflow, and that
+  omission shall be carried by field presence so that an omitted identifier and
+  a present empty one are distinguishable on the wire. Position carries no
+  presence: an omitted position and a position of zero are the same request,
+  both writing position zero; a negative position is invalid.
+- **AC-PLUGINS-STEP-MOVE-005.5:** (new) When a plugin supplies an empty task
+  identifier or an empty target step identifier, the system shall reject the
+  request with an invalid-argument error naming the missing field. A
+  present-but-empty target workflow identifier shall likewise be rejected rather
+  than fall back to the task's current workflow, since a present empty value
+  states an intent that cannot be honored.
+- **AC-PLUGINS-STEP-MOVE-005.6:** (new) When a plugin names a task identifier that
+  does not exist, the system shall answer not-found. A plugin holding task write
+  access is not otherwise restricted in which tasks it may name.
+- **AC-PLUGINS-STEP-MOVE-005.7:** (new) When a move fails before the step change is
+  committed, the system shall leave no transition ledger row for that move and
+  change no persisted field.
+- **AC-PLUGINS-STEP-MOVE-005.13:** (pin) When a move fails *after* the step
+  change is committed, the system shall report the failure while leaving the
+  committed step change, its ledger row, and any dispatched step-entry actions
+  in place. This feature shall not narrow the window for the existing callers
+  that share the path; the design file records what runs inside it.
+- **AC-PLUGINS-STEP-MOVE-005.8:** (pin) When a plugin move vacates a step that has
+  tasks queued for it, the system shall run the same capacity reconciliation
+  the board's move runs, and shall record the resulting promotion under its own
+  trigger rather than the plugin's.
+- **AC-PLUGINS-STEP-MOVE-005.9:** (new) The system shall provide no caller-supplied
+  deduplication key for moves. A repeated request is judged only against the
+  task's step at that moment, so a redelivery arriving after the task returned
+  to its origin shall be treated as a fresh move and may start an agent again.
+- **AC-PLUGINS-STEP-MOVE-005.10:** (pin) When two callers move the same task to
+  different steps concurrently, the system shall serialize the writes on the
+  workspace row lock, commit them in the order they reach the task write, and
+  record one transition row per committed change rather than collapsing them.
+  It shall not rebase a plugin move onto the state the earlier writer
+  committed: the destination is the caller's, while the recorded from-step is
+  read under the write transaction's own row lock.
+- **AC-PLUGINS-STEP-MOVE-005.11:** (new) When a plugin moves a task that is attached
+  to no workflow and names no target workflow, the system shall reject the move
+  with an invalid-argument error rather than infer a workflow from the step.
+- **AC-PLUGINS-STEP-MOVE-005.12:** (pin) When the target step's WIP limit is absent,
+  zero, or negative, the system shall admit the move rather than queue it,
+  treating a non-positive limit as unlimited, and shall report it as admitted
+  because the task is queued for no step.
+- **AC-PLUGINS-STEP-MOVE-005.14:** (pin) When the moved task is ephemeral, the
+  system shall admit the move and report it as admitted even though the task
+  holds no capacity slot, because an ephemeral task is queued for no step.
+
+## Out of scope
+
+- **Changing move semantics for any existing caller.** The board's HTTP and
+  WebSocket handlers, the MCP move tool, bulk move, queue promotion, and launch
+  recovery keep their current behavior, options, and attribution — including the
+  post-commit failure window pinned by AC-005.13.
+- **A new plugin actor kind or a ledger contract-version bump.** The existing
+  integration actor and an added trigger value cover this.
+- **Exposing move history to plugins.** Reading the ledger or session history
+  through the Host API is a separate contract.
+- **A frontend Host API move.** That surface holds no task-write path; adding
+  one is a separate decision with a different actor answer, since it does carry
+  an authenticated user.
+- **Position semantics beyond passing the caller's value through.** Kandev does
+  not renumber siblings on move today and this does not introduce it.
+- **Making `Task`'s read shape carry board fields.** That is PR #3044's
+  contract; this feature reports its outcome without depending on it.
+- **Plugin-initiated task state changes.** `UpdateTask`'s `state` field is
+  unchanged.
+- **Per-workspace plugin scoping.** Whether plugins should be installable per
+  workspace affects every capability, not just moves.
+- **Removing `workflow_step_id` from the update request message.** The field
+  stays declared and starts returning an error, so a plugin compiled against the
+  current proto gets a named rejection rather than wire-level silence.

--- a/docs/specs/plugins/system-design/plugin-initiated-step-transitions.md
+++ b/docs/specs/plugins/system-design/plugin-initiated-step-transitions.md
@@ -1,0 +1,581 @@
+---
+status: draft
+system: plugins
+requirements:
+  - REQ-PLUGINS-STEP-MOVE-001
+  - REQ-PLUGINS-STEP-MOVE-002
+  - REQ-PLUGINS-STEP-MOVE-003
+  - REQ-PLUGINS-STEP-MOVE-004
+  - REQ-PLUGINS-STEP-MOVE-005
+created: 2026-08-26
+owners:
+  - nova28
+---
+
+# Plugin-Initiated Workflow Step Transitions System Design
+
+## Purpose and boundaries
+
+This design carries the technical detail behind
+`docs/specs/plugins/requirements/plugin-initiated-step-transitions.md`: the
+wire contract a third party compiles against, the enforcement seam, the error
+mapping, the two trigger vocabularies, and the code-path facts that constrain
+what the acceptance criteria can promise. The requirements file owns the behavior; this
+file owns how it is expressed and why the alternatives were rejected.
+
+Nothing here redefines the task system's move semantics. The move path is
+reused unchanged; the design decisions are about the plugin-facing surface.
+
+## Corrections to the originating report
+
+**`UpdateTask` is not silent about the transition.** It sets `steptelemetry`
+attribution and calls `recordManualStepTransition`, so the task-level ledger row
+*is* written. What is missing is the `task.moved` event, WIP admission,
+target-step validation, and the queue-vacate pull.
+
+**`StepHistoryActor` is never persisted as a value.** It only decides whether an
+authenticated user id is looked up, so the persisted actor of record is
+`task_step_transitions.actor_kind` / `actor_id`.
+
+## Prior art
+
+
+**Our own wiki: unavailable, no substitute consulted.** The configured vault is
+outside this sandbox's readable tree and `obsidian-wiki` / `qmd` are not
+installed, so the semantic pass could not run; the one reachable vault has zero
+Kandev pages. This leg returned nothing useful, and the reason is tooling access
+rather than an empty wiki — a later pass on a machine with vault access may find
+prior reasoning this spec did not see.
+
+**What other products shipped (`saas-kb`, `category: ai_sdlc`).** One hit was on
+point: Factory.ai's audit model splits attribution into **Actor** ("the user or
+service principal who initiated the action") and **Source** ("the surface that
+originated the event") (`Factory.ai/Guides/enterprise_audit-log.md`) — the same
+shape as `actor_kind`/`actor_id` plus `trigger`, confirming a service principal
+is a first-class actor rather than a stand-in for the human who configured it.
+Everything else scored ~0.009 and is noise.
+
+**What we are doing differently.** Factory.ai reports a `null` actor for
+system-initiated events. We do not: that would lose *which* plugin moved the
+card, the only question an operator will ask.
+
+## Why the actor is `integration`, identified by `plugin:<id>`
+
+The originating report offered a new `plugin` actor kind, or the authenticated
+user driving the plugin surface. Neither is right.
+
+**The authenticated user is not implementable and not honest.** `hostForPlugin`
+(`internal/plugins/service.go:612`) binds a host to `pluginID` and capabilities
+only. There is no `authn` identity on a plugin gRPC context — that seam exists
+only in the HTTP handlers (`authn.FromGin`). A plugin's Go backend can act on a
+webhook, a timer, or its own logic with no human anywhere, so "the user driving
+the surface" frequently does not exist. The frontend Host API
+(`apps/web/lib/plugins/host-api.ts`) contributes UI components and exposes no
+task-write path, so it supplies no authenticated alternative.
+
+**A new `plugin` actor kind invents a value we already have.**
+`steptelemetry.ActorKind` includes `ActorIntegration`
+(`internal/steptelemetry/steptelemetry.go:51`) with a production writer for
+exactly this shape of caller: registered external automation with a stable id
+(`watcher_dispatch.go:378` sets `ActorID: src.WatchID(evt)`, under
+`ActorKind: ActorIntegration` on 377, for Jira and Linear creates). A plugin is that.
+
+**`ActorID = "plugin:<id>"` reuses one provenance string.** The same value is
+already produced by `pluginHost.pluginSource()` and already appears in
+`metadata.source` on plugin-created tasks and plugin-sent messages, so the
+ledger joins to those rows without a second vocabulary.
+
+**`MoveTaskOptions.StepHistoryActor` must not be `Human`.** It is a control
+flag, not a stored value: `recordManualStepTransition`
+(`service_workflow.go:1199`) uses it only to decide whether to look up an
+authenticated user id, and `CreateStepTransition` takes no actor-kind argument.
+`Human` is what causes the operator's user id to be stamped on the row, and an
+unattended automated move must not inherit it — the same reasoning the field's
+own doc comment gives for agent moves. Because the value itself is never
+persisted, `Agent`, `System` and the zero value are observationally identical
+here; the requirement is only that it is not `Human`.
+
+## Why `api_write:tasks` and not a new capability
+
+A plugin holding `api_write:tasks` can already create tasks and start agents, so
+a move-specific capability closes no door that is open today. It can also set
+`workflow_step_id` through `UpdateTask` right now — that is the defect — so
+gating the *fixed* path behind a new capability would make the correct path
+harder to reach than the broken one, and every existing plugin would keep the
+broken behavior until it re-declared.
+
+The `PluginOwnedTaskTree` ownership rule that guards plugin-owned task deletion
+is deliberately not applied here. Moving a task is not destructive, and
+restricting moves to plugin-created tasks would defeat the purpose: a dispatch
+plugin exists precisely to move work it did not create. Safety comes from the
+auto-start gates the move runs through, not from ownership.
+
+## The two trigger vocabularies
+
+The "why" column is already caller-specific, but the two persisted surfaces
+have **separate, non-overlapping** vocabularies. A plugin move writes to both,
+so `plugin_move` must be added to both.
+
+| | Task-level ledger | Session-level history |
+|---|---|---|
+| Table | `task_step_transitions` | `session_step_history` |
+| Enum | `steptelemetry.Trigger` (`steptelemetry.go:28-42`) | `wfmodels.StepTransitionTrigger` (`workflow/models/models.go:310-325`) |
+| Written by | `steptelemetry.FromContext`, in-transaction (`step_transitions.go:88`) | `recordManualStepTransition` → `CreateStepTransition` |
+| Declares | `task_created`, `manual_move`, `task_update`, `mcp_move`, `mcp_deferred_move`, `engine_transition`, `user_cancellation`, `wip_pull`, `bulk_move`, `unarchive_restore`, `workflow_attached`, `workflow_detached`, `unknown` | `manual`, `auto_complete`, `approval`, `on_turn_start`, `on_children_completed`, `task_update`, `queue_promotion` |
+| Notably lacks | `queue_promotion` | `mcp_move`, `wip_pull` |
+
+**The session-level row is conditional, and usually absent.**
+`recordManualStepTransition` returns early when the task has no session; its
+comment gives the reason: `session_step_history.session_id` is a NOT NULL FK to
+`task_sessions`, so a session-less move cannot be recorded without a schema
+change. This feature's most common case — a plugin moving a card onto a step
+whose `on_enter` starts an agent — is by definition a task with no session yet,
+because the move is what creates it. So a plugin move writes the task-level
+ledger row always and the session-level row only when a session already exists,
+and `plugin_move` in `wfmodels.StepTransitionTrigger` is exercised only by the
+latter. AC-003.5 states this; adding the value is still required, because the
+moment a task has a session the fallback below applies.
+
+Adding `plugin_move` to only the first is the failure mode this design exists to
+prevent. `recordManualStepTransition` defaults an empty trigger to
+`StepTransitionTriggerManual`, so a plugin move would persist
+`session_step_history.trigger = "manual"` — the value reserved for human board
+moves — under a requirement whose entire point is that a plugin move is not a
+person's action.
+
+`steptelemetry.ContractVersion`'s doc states it is bumped "only for a change to
+what a row means, **not** for adding a new Trigger/ActorKind value", so
+`plugin_move` costs no contract bump and no telemetry re-activation. Neither
+`trigger` column carries a CHECK constraint, so neither addition needs a
+migration.
+
+## The wire contract
+
+This is externally consumed: third-party plugin authors compile against it
+through `pkg/pluginsdk` and the generated clients. It is specified here rather
+than invented during build, because a correction after release is a *second*
+breaking change on top of the `UpdateTask` one.
+
+Added to the existing `Host` service in
+`apps/backend/proto/kandev/plugin/v1/plugin.proto`, beside `CreateTask` and
+`UpdateTask`:
+
+```proto
+rpc MoveTask(MoveTaskRequest) returns (MoveTaskResponse);
+
+message MoveTaskRequest {
+  string task_id = 1;
+  string workflow_step_id = 2;
+  optional string workflow_id = 3;
+  int32 position = 4;
+}
+
+message MoveTaskResponse {
+  Task task = 1;
+  bool transitioned = 2;
+  optional string queued_for_step_id = 3;
+  string from_step_id = 4;
+}
+```
+
+- **`task_id`, not `id`.** `GetTaskRequest` uses a bare `id`, but this message
+  carries three identifiers; `DeletePluginOwnedTaskTreeRequest` sets the
+  precedent for qualifying (`root_task_id`) when a bare `id` would be
+  ambiguous.
+- **`workflow_step_id` is a bare `string`, required.** There is no move with no
+  destination, so omitted and empty are the same error and presence adds
+  nothing.
+- **`workflow_id` is `optional`; `position` is a bare `int32`.** proto3 cannot
+  distinguish an omitted bare `string` from `""`, and `workflow_id` has a
+  meaningful absent case — inherit the task's current workflow — that is
+  genuinely distinct from a present empty value, which AC-005.5 rejects. So it
+  carries presence. `position` does **not**: AC-005.4 defines an omitted
+  position and a position of zero as the same request, both placing the task at
+  the top of the target step, so presence would encode a distinction with no
+  behavioral consequence and invite an implementer to invent one. An earlier
+  draft made `position` `optional` on the reasoning that "no position stated"
+  was distinct from zero; it is not, because Out of scope keeps position
+  semantics to pass-through and AC-002.3 applies a position change even on a
+  same-step move — so a load-bearing absent case would have silently changed
+  where a step-only move lands. `int32` matches `plugin.proto:378` and `:445`.
+- **Exactly one admission discriminator: the presence of
+  `queued_for_step_id`.** There is deliberately no `bool admitted` beside it,
+  because two fields encoding one fact can disagree and a builder would have to
+  decide which wins. Read as: `transitioned = false` → the task was
+  already on the target step; `transitioned = true` with `queued_for_step_id`
+  absent → admitted; `transitioned = true` with `queued_for_step_id` present →
+  queued for that step, holding no slot. `queued_for_step_id` is reported on
+  **both** values of `transitioned`, never suppressed by a no-transition answer:
+  per Terminology a queued task *is* on its target step, so a repeat against a
+  full step is a same-step move whose honest answer is "no transition, still
+  queued here". Suppressing it would make the retry AC-005.1 describes
+  indistinguishable from a successful admission.
+- **`from_step_id`** is the step the task left, empty when `transitioned` is
+  false, so a plugin can render the transition without a second read.
+- **Both outcome fields come from the write transaction, not from a pre-read.**
+  `MoveTaskResult` (`service_workflow.go:388-391`) carries only `Task` and
+  `WorkflowStep` today, so this feature adds `FromStepID string` and
+  `Transitioned bool` to it. **Neither is populated from the `oldStepID` and
+  `stepChanged` values `MoveTaskWithOptions` computes near `:493`.** Those come
+  from the earlier unlocked `GetTask`, and the ledger row is not written from
+  them: `updateTaskTx` and every sibling step-writer
+  (`UpdateTaskIfWorkflowStepHasCapacity`, the admission-gated path, …)
+  independently re-derive the from-step through `readTaskStepInTx` — a
+  `FOR UPDATE` read taken *inside* the transaction, after the workspace row
+  lock — and pass that to `recordStepTransition`. Under the concurrency
+  AC-005.10 pins, the two reads can name different steps, so a response built
+  on the earlier one would contradict its own ledger row. *(Round-4
+  correction: round 3 specified the `:493` variables here. AC-002.6 itself was
+  right and is unchanged; only this mechanism was wrong.)*
+- **`Transitioned` is `WorkflowStepTransitionID != 0`.** That field already
+  exists on `models.Task`, is assigned from `recordStepTransition`'s return on
+  every write path, and reaches the event payload as `step_transition_id`.
+  `recordStepTransition` returns `0` and writes no row when the from-step
+  equals the to-step, so zero *is* "no transition".
+  Deriving it from `stepChanged` instead would let a stale snapshot report
+  `transitioned = true` with no ledger row behind it, breaking AC-003.1.
+- **`FromStepID` has no carrier yet, so it gets the same one.** The from-step
+  the ledger row was written from is carried up beside the transition id: one
+  more transient `json:"-"` field on `models.Task`, assigned at the same
+  statement, from the same variable. That is the existing
+  `WorkflowStepTransitionID` pattern applied to the other half of the same row,
+  not a new mechanism. Adding reported fields changes no move semantics, so
+  this stays inside Out of scope's boundary. A plugin-seam pre-read is still
+  rejected: its own snapshot can disagree with the ledger too. Taking both
+  fields from the row the transaction wrote makes AC-002.6's agreement
+  structural rather than something a builder must maintain.
+- **No enum is introduced.** `plugin.proto` declares none today, and a
+  three-value outcome enum would be the only one in the file; the
+  presence-based reading carries the same information in the file's existing
+  style.
+- **The response carries the full `Task`**, so no follow-up `GetTask` is
+  needed. Its admission fields are whatever the read shape offers at the time;
+  because the outcome is readable from `transitioned` / `queued_for_step_id`
+  alone, this feature does not depend on PR #3044 landing.
+
+### Why not route `UpdateTask` internally to the move path
+
+`UpdateTaskRequest` has no `workflow_id` or `position` field, so cross-workflow
+moves would stay unrepresentable and position would silently default to the top
+of the step. A partial failure across two service methods with no shared
+transaction has no defined outcome. And a dedicated RPC lets the response report
+admission, which `UpdateTaskResponse` cannot.
+
+## Where `UpdateTask`'s rejection is enforced
+
+The rejection lives on the plugin-facing update path, **not** in the shared task
+service. `taskservice.UpdateTask` keeps accepting `WorkflowStepID` unchanged:
+its own comment describes it as "a mutation boundary used by plugins and MCP"
+(`service_tasks.go:1643`), so rejecting there would break the MCP use that
+comment anticipates and would exceed this feature's plugin-only scope.
+
+The seam is the plugins package's own task-update entry and the adapter behind
+it — `internal/plugins/host_write.go:203`, which builds `TaskUpdateInput`, and
+`pluginsTaskWriterAdapter.UpdateTask` (`internal/backendapp/services.go:1281`),
+which is constructed exactly once (`services.go:233`) and wired only into
+`pluginsSvc.SetDataSources`, so nothing but the plugin path reaches it.
+
+That adapter already sets the precedent: it validates `state` there and returns
+`codes.InvalidArgument`, with a comment saying it does so because "the REST/MCP
+path validates state at its HTTP handler". Plugin-only input validation already
+belongs at this layer; `workflow_step_id` joins `state`.
+
+The field stays declared in the proto and starts returning an error, rather than
+being removed, so a plugin compiled against the current proto gets a named
+rejection instead of wire-level unknown-field silence.
+
+**"Carries" means present, not non-empty.** `UpdateTaskRequest.workflow_step_id`
+is `optional string` (`plugin.proto:774`), so presence and emptiness are
+distinguishable on the wire, and AC-004.3 rejects on *presence* — an explicitly
+present `""` is rejected exactly like a present step id. The reasoning is
+AC-005.5's, inverted: a present empty value states an intent, and here the
+intent it states is "update the step", which is the operation this path no
+longer serves. Treating present-empty as absent would leave a silently accepted
+no-op on the one path the feature exists to close.
+
+**It is checked before the request's other field validations.** The adapter
+already validates `state` and returns `InvalidArgument`; AC-004.3 requires the
+error to *name the move operation*, which it cannot do if a co-submitted invalid
+`state` answers first. Ordering the step check first makes the guidance
+deterministic for a request that is wrong in two ways at once, and matches
+AC-004.3's "change no persisted field including the other fields in the same
+request".
+
+## Why the session gate wins over retry idempotency
+
+AC-001.8 rejects a move against a task holding any starting or running session.
+AC-005.1 promises an identical repeat succeeds as a same-step move. **Spec
+Review round 3 found these collide on this feature's own headline path**, and
+this section records the decision: **AC-001.8 wins, and AC-005.1 is narrowed to
+the window where no session is active.**
+
+The collision is structural, not a wording accident.
+`MoveTaskWithOptions` calls `validateTaskMove` at `service_workflow.go:486`;
+`stepChanged := oldStepID != workflowStepID` is not computed until `:494`. The
+session gate therefore runs *before* the same-step determination exists and
+cannot consult it. `validateMoveSessions` (`:1155-1169`) then rejects on **any**
+session in `Starting`/`Running` unless `AllowActivePrimarySession` is set — the
+option the board's handlers pass and the agent-initiated path does not, and
+which AC-001.8 declines by choosing the agent shape.
+
+It bites on the common case, not an edge: AC-003.5 records that a move onto an
+auto-start step *precedes* the session it creates, so the first successful move
+produces a live session within moments. A webhook redelivery — exactly what
+REQ-005's Intent names — arrives inside that window.
+
+**Why AC-001.8 is the one that survives.** Narrowing it instead would need a
+same-step carve-out either inside `MoveTaskWithOptions`, which changes move
+semantics for every existing caller and is out of scope, or in front of it in
+the plugin seam, which AC-001.1 forbids and which races anyway: the task's step
+can change between the seam's check and the shared path's read. Narrowing
+AC-005.1 needs no shared-path change at all and leaves AC-001.8 a truthful
+`(pin)`.
+
+**What the rejection tells a plugin, and why it is a usable answer.** A
+`FailedPrecondition` here is not a bare failure — it is the signal that this
+task already has a live session, which for a redelivery is precisely the
+information the caller wanted: the first delivery landed and the agent is
+running, so do not retry. It is distinguishable from every other rejection by
+code plus a re-read of the task's step: same step and a live session means the
+move already happened. The cost is that a plugin cannot treat move-and-forget as
+unconditionally idempotent; it must handle this code. That cost is stated here
+and in AC-005.1 rather than discovered at build time.
+
+The narrower promise still holds where it matters: a redelivery arriving after
+the agent finished, or against a step with no `auto_start_agent`, finds no live
+session and gets AC-005.1's clean no-op.
+
+## Error mapping
+
+Third parties branch on these codes, so they are fixed here rather than left to
+the handler. AC-004.6 makes the table binding.
+
+| Case | AC | Code |
+|---|---|---|
+| Target step unknown, not in the named workflow, or in another workspace | 001.6 | `InvalidArgument` |
+| Task is archived | 001.7 | `FailedPrecondition` |
+| Task has a starting or running session | 001.8 | `FailedPrecondition` |
+| Plugin lacks `api_write:tasks` | 004.1 | `PermissionDenied` |
+| `UpdateTask` carries `workflow_step_id` | 004.3 | `InvalidArgument` |
+| Empty `task_id` or `workflow_step_id`; present-but-empty `workflow_id` | 005.5 | `InvalidArgument` |
+| Task id names no task | 005.6 | `NotFound` |
+| Named `workflow_id` is well-formed but no such workflow exists | 001.6 | `InvalidArgument` |
+| Task on no workflow and none named | 005.11 | `InvalidArgument` |
+| Negative `position` | 005.4 | `InvalidArgument` |
+| Target step at its WIP limit | 002.1 | **not an error** — success reporting queued |
+
+**`NotFound` is reserved for the addressed resource.** The task is what the RPC
+addresses, so naming no task answers `NotFound`; every other identifier in the
+request — the target step, and the workflow qualifying it — describes the
+*destination* and is request content, so naming nothing answers
+`InvalidArgument`. That rule is what places the unknown-workflow row above, and
+it is stated because the table is binding under AC-004.6 and a builder must be
+able to place a case the table does not enumerate verbatim.
+
+**When one request trips two rows, the first check in this ladder wins.** The
+table lists cases, not order; this orders them: capability (004.1) → request
+shape, including `UpdateTask`'s rejected `workflow_step_id` and a negative
+position (004.3, 005.5, 005.4) → the task load (005.6) → the task's own state
+(001.7, 001.8) → the destination, which can only be checked once the task has
+supplied the workflow it is qualified against (001.6, 005.11) → WIP admission,
+which is not an error at all. So a request naming both a task that does not
+exist and an unknown target step answers `NotFound`, and one from a plugin
+lacking the capability answers `PermissionDenied` whichever else is wrong —
+which also stops a non-writer probing which task ids exist, the reasoning Reach
+applies to a future per-workspace scope. Stated because AC-004.6 gives every row
+its own test, so two implementations checking in different orders return
+different codes for the same request.
+
+`InvalidArgument` versus `FailedPrecondition` splits on whether the *request* is
+malformed or the *task's state* forbids an otherwise well-formed request. An
+archived or busy task is the latter: the caller sent nothing wrong and retrying
+the identical request can succeed once the state changes.
+
+**The existing classifier must not be reused.** `classifyMoveTaskError`
+(`internal/mcp/handlers/config_task_handlers.go:243`) is the only precedent for
+turning these errors into caller-facing codes, and it buckets *four* of the
+cases above — archived, active session, different workspace, and step not
+belonging to the target workflow — into a single `Conflict` by lowercase
+substring matching. Two of those are cases AC-001.6 requires to answer
+`InvalidArgument`, so adopting it would violate the requirement it appears to
+serve. The plugin path maps its own codes at the plugin-facing seam, beside the
+`state` validation already there.
+
+The shared validators (`validateTaskMove`, `validateMoveSessions`) stay
+untouched: they return bare `fmt.Errorf` strings today, every other caller
+depends on that, and adding typed sentinels would be a change to shared move
+semantics this feature puts out of scope. The seam therefore recognises those
+errors to classify them. That is a real coupling to message text, and it is the
+lesser cost — the alternative changes a shared path for every existing caller.
+It is contained by keeping the mapping in one function with a test per row of
+the table above, so a reworded validator error fails a test rather than silently
+degrading a plugin's error handling to `Unknown`.
+
+## Reading the `(pin)` and `(new)` labels
+
+REQ-005's criteria carry one of two labels. A **`(pin)`** records behavior the
+system already has, so that routing plugin moves through the shared path cannot
+silently change it: it is discharged by a test that the behavior still holds,
+needs no new implementation, and a failure is a shared-path regression rather
+than work to build here. A **`(new)`** is construction this feature owes.
+
+## Code-path facts that constrain the criteria
+
+### The defect's call sites, in full
+
+`publishTaskMovedEvent` (`service_events.go:719`) has exactly three call sites,
+all in `service_workflow.go` — `579`, `882`, `900` — inside `MoveTaskWithOptions`
+and the queue-promotion paths. None is reachable from `taskservice.UpdateTask`,
+which is why a plugin-set `workflow_step_id` relocates a card and dispatches
+nothing.
+
+### The post-commit failure window is real and is not narrowed here
+
+`MoveTaskWithOptions` commits the step change and its in-transaction ledger row
+through `updateMovedTask`, and only then publishes `task.moved`, records session
+history, runs `pullNextTaskOnVacate` and `pullTasksFromNewFeederWork`, and
+finally re-reads the task — returning an error if that re-read fails
+(`"failed to refresh task after feeder pull"`). A move can therefore return an
+error with the row already written and the agent already dispatched.
+
+This is why the requirements scope "no ledger row" to failures *before* the
+commit, and pin the post-commit behavior as-is. The consequence for a plugin
+author — a move error does not mean nothing happened, so re-read the task rather
+than assume the move was rolled back — belongs in the plugin authoring guide
+rather than in an acceptance criterion, since no test of this system can
+discharge it. Narrowing the window would
+change move semantics for every existing caller, which is out of scope.
+
+### Admitted-versus-queued must be read from `QueuedForStepID`
+
+In `updateTaskWithWorkflowStepAdmission` (`repository/sqlite/task.go`):
+
+```go
+admitted = task.IsEphemeral || limit <= 0 || occupants < limit
+// on the admitted branch:
+task.WIPAdmitted = !task.IsEphemeral
+task.QueuedForStepID = ""
+```
+
+`WIPAdmitted` and `QueuedForStepID` are not complements. An ephemeral task is
+admitted by the function's own return value while persisting
+`WIPAdmitted = false` **and** `QueuedForStepID = ""`. Reading `WIPAdmitted`
+alone would report that task as queued when it is queued for nothing.
+
+The discriminator is therefore `QueuedForStepID`: queued if and only if it is
+non-empty, admitted otherwise. This makes the ephemeral case report correctly
+instead of becoming a third outcome. It is defensive rather than reachable
+today — task creation rejects an ephemeral task that names a workflow
+(`service_tasks.go:594`), so an ephemeral task is not expected to be on a board
+— but the branch exists in the writer and an implementer reading it would
+otherwise infer a third reportable state.
+
+### Rejections are checked before the write, not atomically with it
+
+`MoveTaskWithOptions` runs `validateTaskMove` (`:486`) — archived task, target
+step, workspace, and sessions — before it computes any change and before the
+admission write. AC-001.9 states the consequence plainly: "change no persisted
+field" in AC-001.6 through AC-001.8 binds *the rejected move*, which writes
+nothing on the rejecting path, and is not a claim that the task is unchanged
+when the caller observes the error. A concurrent writer committing between the
+check and the write is AC-005.10's territory, and this path serializes on the
+workspace row lock rather than re-validating under it.
+
+This is the same shape as the post-commit window above: both are properties of
+the shared path that this feature pins rather than narrows, because narrowing
+either means changing move semantics for every existing caller.
+
+### Promotion ordering is by position and priority first
+
+AC-005.2 pins the order queued tasks are promoted in. The promotion path is
+`pullNextTaskOnVacate` → `promoteNextQueuedTask` → `nextQueuedCandidate` →
+`NextQueuedTaskForStepExcluding` (`repository/sqlite/task.go:1538`) or
+`NextPullCandidateExcluding` (`:1491`).
+
+**AC-005.2's order is the one in `NextQueuedTaskForStepExcluding`**, quoted in
+full because the pin test is written from it:
+
+```sql
+ORDER BY t.position ASC,
+         CASE LOWER(COALESCE(t.priority, ''))
+           WHEN 'critical' THEN 0
+           WHEN 'high'     THEN 1
+           WHEN 'medium'   THEN 2
+           WHEN 'low'      THEN 3
+           WHEN 'none'     THEN 4
+           ELSE 4
+         END ASC,
+         COALESCE(t.queued_at, t.created_at) ASC,
+         t.created_at ASC,
+         t.id ASC
+```
+
+That `CASE` is the "priority tier" AC-005.2 names: five declared values, with
+any unrecognised or absent priority folded onto the same rank as `none`. A pin
+test must therefore not assume unknown priorities sort last on their own — they
+tie with `none` and are separated by the keys below.
+
+**The two queries do not share this order, and the sibling is not on the
+production path.** `NextPullCandidateExcluding` has **four** keys — position,
+the same priority `CASE`, `created_at`, `id` — and **no `queued_at` tier at
+all**. `nextFeederQueuedCandidate` (`service_workflow.go:1006-1026`) prefers
+`NextQueuedTaskForStepExcluding` whenever the repository satisfies that
+narrower interface, which the real sqlite `*Repository` always does, so
+`NextPullCandidateExcluding` is reached only by test doubles. Pinning AC-005.2
+against it would produce a red test that looks like a shared-path regression and
+is not one.
+
+Position and priority tier are the primary and secondary keys; queued-at is only
+the third. An earlier draft of AC-005.2 named queued-at as the primary key,
+having read the `ORDER BY` of `ListQueuedTasks` (`:1705`) — a general listing
+helper that is not on the promotion path at all. A pin test written from that
+wording fails against any data with mixed positions or priorities, and the
+`(pin)` convention would then have pointed the implementer at a shared-path
+regression that does not exist.
+
+### The plugin path does not rebase onto a concurrent writer's state
+
+AC-005.10 pins concurrent-move behavior, and what it can pin is bounded by which
+admission writer this path uses. `updateTaskWithWorkflowStepAdmission` runs
+`rebaseTaskForStepAdmissionCAS` only when `expectedStepID != ""`, and the sole
+caller passing a non-empty expected step is the workflow engine's guarded
+re-evaluation (`orchestrator/workflow_store.go:429`). `MoveTaskWithOptions`
+reaches the writer with no expected step and captures `oldStepID` from a read
+taken before the transaction.
+
+That is deliberate. The writer's own comment: "The unconditional
+(`expectedStepID == ""`) callers — manual/bulk/feeder moves — must NOT call
+this: their caller-built `task` already carries this operation's own field
+changes (Position, move-lifecycle metadata, …) that have no other source of
+truth, so rebasing from a fresh row would drop them instead of protecting them."
+
+So the plugin path serializes on the workspace row lock, commits in arrival
+order, and writes the caller's snapshot: the *destination* and caller-built
+fields are the ones this caller asked for, not a rebase onto what the earlier
+writer committed. The recorded *from*-step is a separate read — `readTaskStepInTx`,
+inside the write transaction under its row lock — so the ledger chain stays
+contiguous even where the caller's snapshot had gone stale. AC-005.10 states that
+split rather than promising a rebase, because promising one would mean changing
+shared move semantics for every existing caller — out of scope, and the reason the
+CAS variant exists as a separate entry point in the first place.
+
+## Reach
+
+AC-005.6 answers `NotFound` for a task id that names no task, and deliberately
+says nothing more restrictive. Should a future contract introduce per-workspace
+plugin scoping — listed under Out of scope — a task outside a plugin's scope
+should also answer `NotFound` rather than a permission error, so that scoping
+cannot be used to probe which task ids exist. That is recorded as the intended
+direction, not as a criterion this feature discharges.
+
+A plugin holding `api_write:tasks` may move any task in the install, in any
+workspace. There is no narrower scope available to enforce: `hostForPlugin`
+binds no workspace, and `authorizeTaskID` (`service_access.go:59`) returns `nil`
+immediately when `callerScope(ctx)` reports the caller unscoped, which is every
+plugin gRPC context. A plugin is an install-level extension the operator chose
+to install — the same trust level at which it can already create tasks and start
+agents.
+
+Per-workspace plugin scoping is a separate contract. If it is ever added, this
+reach narrows with it and no acceptance criterion changes, because the criteria
+state the not-found convention rather than a workspace filter.

--- a/docs/specs/plugins/system-design/plugin-initiated-step-transitions.md
+++ b/docs/specs/plugins/system-design/plugin-initiated-step-transitions.md
@@ -335,11 +335,11 @@ AC-005.1 needs no shared-path change at all and leaves AC-001.8 a truthful
 `FailedPrecondition` here is not a bare failure — it is the signal that this
 task already has a live session, which for a redelivery is precisely the
 information the caller wanted: the first delivery landed and the agent is
-running, so do not retry. It is distinguishable from every other rejection by
-code plus a re-read of the task's step: same step and a live session means the
-move already happened. The cost is that a plugin cannot treat move-and-forget as
-unconditionally idempotent; it must handle this code. That cost is stated here
-and in AC-005.1 rather than discovered at build time.
+running, so do not retry. A re-read to "same step, live session" cannot prove
+this move caused it — a pre-existing session looks identical, so certainty
+needs the plugin's own delivery state. The cost is that a plugin cannot treat
+move-and-forget as unconditionally idempotent; it must handle this code. That
+cost is stated here and in AC-005.1 rather than discovered at build time.
 
 The narrower promise still holds where it matters: a redelivery arriving after
 the agent finished, or against a step with no `auto_start_agent`, finds no live


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3123/3088cf0c9034.html)
<!-- kandev-pr-walkthrough-end -->

## Reviewer Brief

- **What changed**: Plugin-initiated task moves (`pluginsdk` `Tasks().Update` setting `WorkflowStepID`) now route through the same `MoveTaskWithOptions` path the board's own drag-and-drop move uses, instead of a silent direct-write helper.
- **Why**: A plugin could relocate a task to a new workflow step, but the move never called `publishTaskMovedEvent` or `autoStartTaskForStep` — so a step's `on_enter` actions (auto-start agent, etc.) never fired for plugin-initiated moves, silently diverging from every other move path in the product.
- **Risk**: Concurrency-sensitive — the fix introduces a same-step CAS recheck (`UpdateTaskIfWorkflowMatches`) to close a TOCTOU window where a task could be moved again between a plugin's read and its write. Backend-only; no frontend or UI surface touched.
- **How verified**: `make -C apps/backend test lint typecheck`, `make lint-format`, `make fmt` all green on the rebased branch. Two of the two remaining test failures (`internal/task/service`'s `TestRepositoryBranchPolicyServiceGitflowStarterIsAtomicAndOneTime`, `internal/worktree`'s 7 path-related failures) were proven pre-existing by reproducing them identically against `origin/main` in a scratch worktree at the merge base — unrelated to this diff, which never touches either package's production files.
- **Rollback**: Revert cleanly; no schema/migration changes, no feature flag.

## Screenshots

N/A — backend-only change, no UI-visible behavior.

## Design docs

- `docs/specs/plugins/requirements/plugin-initiated-step-transitions.md`
- `docs/specs/plugins/system-design/plugin-initiated-step-transitions.md`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->