### PR TITLE
fix(e2e): remove shared-worker cleanup races

### DIFF
--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -613,18 +613,39 @@ func (s *HandoffService) cancelCascadeResourceCleanup(ctx context.Context, opera
 }
 
 // cancelActiveRuns invokes the configured RunCanceller for every task
-// in the cascade set. Failures are logged and skipped — the cascade
-// proceeds even if a single cancellation fails so the user's archive /
-// delete intent is honoured.
+// in the cascade set, then finalizes the task's active session rows in the
+// database. Runtime teardown can fail when the process disappeared during a
+// restart; the DB transition is independent of that failure and makes the
+// archived/deleted task's cleanup snapshot terminal and retry-safe.
 func (s *HandoffService) cancelActiveRuns(ctx context.Context, taskIDs []string, reason string) {
-	if s.runCanceller == nil {
+	for _, id := range taskIDs {
+		if s.runCanceller != nil {
+			if err := s.runCanceller.CancelTaskExecution(ctx, id, reason, false); err != nil {
+				s.logf().Warn("cascade: cancel task execution failed",
+					zap.String("task_id", id), zap.Error(err))
+			}
+		}
+		s.finalizeActiveSessions(ctx, id, reason)
+	}
+}
+
+func (s *HandoffService) finalizeActiveSessions(ctx context.Context, taskID, reason string) {
+	canceller, ok := s.sessions.(activeTaskSessionCanceller)
+	if !ok {
 		return
 	}
-	for _, id := range taskIDs {
-		if err := s.runCanceller.CancelTaskExecution(ctx, id, reason, false); err != nil {
-			s.logf().Warn("cascade: cancel task execution failed",
-				zap.String("task_id", id), zap.Error(err))
-		}
+	finalizeCtx := context.WithoutCancel(ctx)
+	cancelled, err := canceller.CancelActiveTaskSessionsByTaskID(finalizeCtx, taskID, reason)
+	if err != nil {
+		s.logf().Warn("cascade: finalize active task sessions failed",
+			zap.String("task_id", taskID), zap.Error(err))
+		return
+	}
+	if len(cancelled) == 0 {
+		return
+	}
+	if publisher, ok := s.eventPublisher.(taskSessionCancellationPublisher); ok {
+		publisher.PublishTaskSessionsCancelled(finalizeCtx, taskID, cancelled, reason)
 	}
 }
 

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -213,7 +213,8 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 
 	// Cancel active runs first. Failures are logged and skipped — a
 	// stuck cancel must not block the archive cascade; the orchestrator
-	// will reconcile any orphan execution on its next tick.
+	// will reconcile any orphan execution on its next tick. Session rows
+	// are finalized only after the matching archive mutation commits below.
 	s.cancelActiveRuns(ctx, all, models.SessionArchiveTreeCancelReason)
 
 	// Archive deepest first so parent_id pointers stay valid through
@@ -227,6 +228,9 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 		}
 		if ok {
 			out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
+			// The archive mutation committed, so it is now safe to finalize
+			// any session that the runtime canceller could not update.
+			s.finalizeActiveSessions(context.WithoutCancel(ctx), all[i], models.SessionArchiveTreeCancelReason)
 			// Re-read the row so the published event carries the freshly
 			// stamped archived_at; the WS handler removes archived tasks
 			// from the kanban board by checking that field. Service.ArchiveTask
@@ -343,6 +347,9 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 			}
 			return out, deleteErr
 		}
+		// The delete mutation committed, so it is now safe to finalize
+		// any session row that was not removed with the task.
+		s.finalizeActiveSessions(context.WithoutCancel(ctx), all[i], "task tree deleted")
 		if operationID := cleanupOps[all[i]]; operationID != "" {
 			s.startCascadeResourceCleanup(ctx, operationID)
 		} else if s.resourceCleaner != nil {
@@ -612,11 +619,10 @@ func (s *HandoffService) cancelCascadeResourceCleanup(ctx context.Context, opera
 	}
 }
 
-// cancelActiveRuns invokes the configured RunCanceller for every task
-// in the cascade set, then finalizes the task's active session rows in the
-// database. Runtime teardown can fail when the process disappeared during a
-// restart; the DB transition is independent of that failure and makes the
-// archived/deleted task's cleanup snapshot terminal and retry-safe.
+// cancelActiveRuns invokes the configured RunCanceller for every task in the
+// cascade set. Session rows are finalized after the matching archive/delete
+// mutation commits, because finalizing them here could leave a task active in
+// the database when the caller's lifecycle mutation is cancelled.
 func (s *HandoffService) cancelActiveRuns(ctx context.Context, taskIDs []string, reason string) {
 	for _, id := range taskIDs {
 		if s.runCanceller != nil {
@@ -625,7 +631,6 @@ func (s *HandoffService) cancelActiveRuns(ctx context.Context, taskIDs []string,
 					zap.String("task_id", id), zap.Error(err))
 			}
 		}
-		s.finalizeActiveSessions(ctx, id, reason)
 	}
 }
 

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -433,6 +433,72 @@ func (f *fakeRunCanceller) CancelTaskExecution(_ context.Context, taskID, _ stri
 	return f.failOn[taskID]
 }
 
+type cancellableCascadeSessionReader struct {
+	*fakeSessionReader
+	cancelCalls  []string
+	cancelReason []string
+}
+
+func (f *cancellableCascadeSessionReader) CancelActiveTaskSessionsByTaskID(
+	_ context.Context,
+	taskID, reason string,
+) ([]*models.TaskSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelCalls = append(f.cancelCalls, taskID)
+	f.cancelReason = append(f.cancelReason, reason)
+
+	now := time.Now().UTC()
+	var cancelled []*models.TaskSession
+	for _, session := range f.sessions[taskID] {
+		if session == nil {
+			continue
+		}
+		switch session.State {
+		case models.TaskSessionStateCreated,
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateRunning,
+			models.TaskSessionStateWaitingForInput:
+			session.State = models.TaskSessionStateCancelled
+			session.ErrorMessage = reason
+			session.CompletedAt = &now
+			session.UpdatedAt = now
+			cancelled = append(cancelled, session)
+		}
+	}
+	return cancelled, nil
+}
+
+func TestArchiveTaskTree_FinalizesActiveSessionWhenRuntimeCancelFails(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	sessions := &cancellableCascadeSessionReader{fakeSessionReader: newFakeSessionReader()}
+	sessions.sessions["root"] = []*models.TaskSession{
+		{ID: "session-root", TaskID: "root", State: models.TaskSessionStateRunning},
+	}
+
+	tr := newCascadeRepo(tasks)
+	svc := NewHandoffService(tr, nil, nil, nil, newCascadeWSGroupRepo(), nil)
+	svc.SetSessionReader(sessions)
+	svc.SetRunCanceller(&fakeRunCanceller{
+		failOn: map[string]error{"root": errors.New("runtime missing")},
+	})
+
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", false); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	if got := sessions.sessions["root"][0].State; got != models.TaskSessionStateCancelled {
+		t.Fatalf("session state = %q, want CANCELLED", got)
+	}
+	if len(sessions.cancelCalls) != 1 || sessions.cancelCalls[0] != "root" {
+		t.Fatalf("cancel calls = %v, want [root]", sessions.cancelCalls)
+	}
+	if len(sessions.cancelReason) != 1 || sessions.cancelReason[0] != models.SessionArchiveTreeCancelReason {
+		t.Fatalf("cancel reasons = %v, want [%q]", sessions.cancelReason, models.SessionArchiveTreeCancelReason)
+	}
+}
+
 // fakeDeleteRepo extends fakeCascadeRepo with DeleteTask support so the
 // delete cascade test can verify rows are actually removed.
 type fakeDeleteRepo struct {

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -499,6 +499,41 @@ func TestArchiveTaskTree_FinalizesActiveSessionWhenRuntimeCancelFails(t *testing
 	}
 }
 
+type archiveErrorCascadeRepo struct {
+	*fakeCascadeRepo
+	err error
+}
+
+func (r *archiveErrorCascadeRepo) ArchiveTaskIfActive(context.Context, string, string) (bool, error) {
+	return false, r.err
+}
+
+func TestArchiveTaskTree_DoesNotFinalizeSessionWhenArchiveFails(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	sessions := &cancellableCascadeSessionReader{fakeSessionReader: newFakeSessionReader()}
+	sessions.sessions["root"] = []*models.TaskSession{
+		{ID: "session-root", TaskID: "root", State: models.TaskSessionStateRunning},
+	}
+
+	archiveErr := errors.New("archive unavailable")
+	svc := NewHandoffService(&archiveErrorCascadeRepo{
+		fakeCascadeRepo: newCascadeRepo(tasks),
+		err:             archiveErr,
+	}, nil, nil, nil, newCascadeWSGroupRepo(), nil)
+	svc.SetSessionReader(sessions)
+
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", false); !errors.Is(err, archiveErr) {
+		t.Fatalf("archive error = %v, want %v", err, archiveErr)
+	}
+	if got := sessions.sessions["root"][0].State; got != models.TaskSessionStateRunning {
+		t.Fatalf("session state = %q, want RUNNING after failed archive", got)
+	}
+	if len(sessions.cancelCalls) != 0 {
+		t.Fatalf("cancel calls = %v, want none after failed archive", sessions.cancelCalls)
+	}
+}
+
 // fakeDeleteRepo extends fakeCascadeRepo with DeleteTask support so the
 // delete cascade test can verify rows are actually removed.
 type fakeDeleteRepo struct {
@@ -514,6 +549,41 @@ func (r *fakeDeleteRepo) DeleteTask(_ context.Context, id string) error {
 
 func (r *fakeDeleteRepo) DeleteExpiredQuickChatTask(context.Context, string, time.Time) (bool, error) {
 	panic("DeleteExpiredQuickChatTask should not be used by delete cascade tests")
+}
+
+type deleteErrorCascadeRepo struct {
+	*fakeDeleteRepo
+	err error
+}
+
+func (r *deleteErrorCascadeRepo) DeleteTask(context.Context, string) error {
+	return r.err
+}
+
+func TestDeleteTaskTree_DoesNotFinalizeSessionWhenDeleteFails(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	sessions := &cancellableCascadeSessionReader{fakeSessionReader: newFakeSessionReader()}
+	sessions.sessions["root"] = []*models.TaskSession{
+		{ID: "session-root", TaskID: "root", State: models.TaskSessionStateRunning},
+	}
+
+	deleteErr := errors.New("delete unavailable")
+	svc := NewHandoffService(&deleteErrorCascadeRepo{
+		fakeDeleteRepo: &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)},
+		err:            deleteErr,
+	}, nil, nil, nil, nil, nil)
+	svc.SetSessionReader(sessions)
+
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", false); !errors.Is(err, deleteErr) {
+		t.Fatalf("delete error = %v, want %v", err, deleteErr)
+	}
+	if got := sessions.sessions["root"][0].State; got != models.TaskSessionStateRunning {
+		t.Fatalf("session state = %q, want RUNNING after failed delete", got)
+	}
+	if len(sessions.cancelCalls) != 0 {
+		t.Fatalf("cancel calls = %v, want none after failed delete", sessions.cancelCalls)
+	}
 }
 
 // REGRESSION (post-review #4): a parent with already-archived children

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -75,6 +75,14 @@ type RunCanceller interface {
 	CancelTaskExecution(ctx context.Context, taskID, reason string, force bool) error
 }
 
+// activeTaskSessionCanceller finalizes active task sessions independently of
+// runtime teardown. The sqlite task repository implements this surface; it is
+// intentionally optional so handoff tests and legacy wiring do not need the
+// full session repository.
+type activeTaskSessionCanceller interface {
+	CancelActiveTaskSessionsByTaskID(ctx context.Context, taskID, reason string) ([]*models.TaskSession, error)
+}
+
 // SetRunCanceller wires the run-canceller used by ArchiveTaskTree /
 // DeleteTaskTree to terminate active descendants before archive.
 func (s *HandoffService) SetRunCanceller(c RunCanceller) {
@@ -221,6 +229,14 @@ type HandoffService struct {
 type TaskEventPublisher interface {
 	PublishTaskUpdated(ctx context.Context, task *models.Task, oldWorkflowIDs ...string)
 	PublishTaskDeleted(ctx context.Context, task *models.Task)
+}
+
+// taskSessionCancellationPublisher is the optional event side effect paired
+// with activeTaskSessionCanceller. Cascade archive/delete paths do not call
+// Service.ArchiveTask, so they must publish the session transition themselves
+// when a DB-only cancellation is needed.
+type taskSessionCancellationPublisher interface {
+	PublishTaskSessionsCancelled(ctx context.Context, taskID string, cancelledSessions []*models.TaskSession, reason string)
 }
 
 // SetSessionReader wires the session/worktree lookup used by the

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -109,6 +109,17 @@ func (s *Service) PublishTaskDeleted(ctx context.Context, task *models.Task) {
 	s.publishTaskEvent(ctx, events.TaskDeleted, task, nil)
 }
 
+// PublishTaskSessionsCancelled publishes session.state_changed events for
+// sessions finalized by a cascade path that bypasses Service.ArchiveTask.
+func (s *Service) PublishTaskSessionsCancelled(
+	ctx context.Context,
+	taskID string,
+	cancelledSessions []*models.TaskSession,
+	reason string,
+) {
+	s.publishSessionsCancelled(context.WithoutCancel(ctx), taskID, nil, cancelledSessions, reason)
+}
+
 // taskPublicationTimeout bounds publication-owned repository reads and
 // synchronous EventBus delivery. It intentionally starts when a queued closure
 // drains, rather than inheriting a caller deadline that may already have expired.

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -78,9 +78,9 @@ type pendingTaskTitleSetter interface {
 type taskStopTarget struct {
 	sessionID   string
 	executionID string
-	// terminal indicates the session is already in a terminal state (CANCELLED,
-	// COMPLETED, FAILED, IDLE). Stop failures for terminal sessions are expected
-	// and must not block environment cleanup — the agent is already gone.
+	// terminal records the session state observed when the cleanup snapshot was
+	// taken. It is retained for snapshot compatibility, but it must never
+	// suppress a non-not-found runtime stop failure.
 	terminal bool
 }
 
@@ -2628,20 +2628,7 @@ func (s *Service) refreshTaskRuntimeStopTargets(
 	if err != nil {
 		return nil, err
 	}
-	targets := mergeTaskStopTargets(taskStopTargetsFromRunningRows(runningRows), snapshot)
-	// Archive captures active sessions before it marks them CANCELLED. Refresh
-	// the terminal disposition after that transition so a missing runtime is
-	// treated as an expected teardown result instead of a retryable stop failure.
-	for i := range targets {
-		if targets[i].terminal || targets[i].sessionID == "" || s.sessions == nil {
-			continue
-		}
-		session, sessionErr := s.sessions.GetTaskSession(ctx, targets[i].sessionID)
-		if sessionErr == nil && session != nil && isCleanableSessionState(session.State) {
-			targets[i].terminal = true
-		}
-	}
-	return targets, nil
+	return mergeTaskStopTargets(taskStopTargetsFromRunningRows(runningRows), snapshot), nil
 }
 
 func taskStopTargetsFromRunningRows(runningRows []*models.ExecutorRunning) []taskStopTarget {
@@ -2785,13 +2772,6 @@ func (s *Service) stopTaskRuntimeExecution(
 	if err == nil || runtimeStopAlreadyComplete(err) {
 		return
 	}
-	if target.terminal {
-		s.logger.Debug("stop failed for terminal session execution (expected), proceeding with cleanup",
-			zap.String("task_id", taskID),
-			zap.String("session_id", target.sessionID),
-			zap.Error(err))
-		return
-	}
 	outcome.failed[target.sessionID] = struct{}{}
 	s.logger.Warn(stopFailMsg,
 		zap.String("task_id", taskID),
@@ -2810,13 +2790,6 @@ func (s *Service) stopTaskRuntimeSession(
 ) {
 	err := s.executionStopper.StopSession(ctx, target.sessionID, stopReason, true)
 	if err == nil {
-		return
-	}
-	if target.terminal {
-		s.logger.Debug("stop failed for terminal session (expected), proceeding with cleanup",
-			zap.String("task_id", taskID),
-			zap.String("session_id", target.sessionID),
-			zap.Error(err))
 		return
 	}
 	// A session-level not-found is retryable by default (the execution may
@@ -2880,14 +2853,6 @@ func (s *Service) stopDeletedSessionRuntime(
 	if err := s.executionStopper.StopExecution(ctx, executionID, stopReason, true); err != nil {
 		if runtimeStopAlreadyComplete(err) {
 			s.logger.Debug("late deleted task execution was already stopped",
-				zap.String("task_id", taskID),
-				zap.String("session_id", target.sessionID),
-				zap.String("execution_id", executionID),
-				zap.Error(err))
-			return true
-		}
-		if target.terminal {
-			s.logger.Debug("stop failed for late terminal task execution (expected), proceeding with cleanup",
 				zap.String("task_id", taskID),
 				zap.String("session_id", target.sessionID),
 				zap.String("execution_id", executionID),

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -2628,7 +2628,20 @@ func (s *Service) refreshTaskRuntimeStopTargets(
 	if err != nil {
 		return nil, err
 	}
-	return mergeTaskStopTargets(taskStopTargetsFromRunningRows(runningRows), snapshot), nil
+	targets := mergeTaskStopTargets(taskStopTargetsFromRunningRows(runningRows), snapshot)
+	// Archive captures active sessions before it marks them CANCELLED. Refresh
+	// the terminal disposition after that transition so a missing runtime is
+	// treated as an expected teardown result instead of a retryable stop failure.
+	for i := range targets {
+		if targets[i].terminal || targets[i].sessionID == "" || s.sessions == nil {
+			continue
+		}
+		session, sessionErr := s.sessions.GetTaskSession(ctx, targets[i].sessionID)
+		if sessionErr == nil && session != nil && isCleanableSessionState(session.State) {
+			targets[i].terminal = true
+		}
+	}
+	return targets, nil
 }
 
 func taskStopTargetsFromRunningRows(runningRows []*models.ExecutorRunning) []taskStopTarget {

--- a/apps/backend/internal/task/service/service_tasks_stop_test.go
+++ b/apps/backend/internal/task/service/service_tasks_stop_test.go
@@ -182,6 +182,43 @@ func TestRefreshTaskRuntimeStopTargets_MergesLateExecutionBeforeSnapshot(t *test
 	}
 }
 
+func TestRefreshTaskRuntimeStopTargetsUsesCurrentTerminalSessionState(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	svc.executionStopper = &stubStopper{}
+	svc.executors = &stubExecutors{}
+	ctx := context.Background()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-refresh", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-refresh", WorkspaceID: "ws-refresh", Name: "Workflow"}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-refresh", WorkspaceID: "ws-refresh", WorkflowID: "wf-refresh", Title: "Task", Priority: "medium",
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-refresh", TaskID: "task-refresh", State: models.TaskSessionStateCancelled,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+
+	targets, err := svc.refreshTaskRuntimeStopTargets(ctx, "task-refresh", []taskStopTarget{
+		{sessionID: "session-refresh"},
+	})
+	if err != nil {
+		t.Fatalf("refreshTaskRuntimeStopTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %#v, want one target", targets)
+	}
+	if !targets[0].terminal {
+		t.Fatal("refreshed target must be terminal when the current session is CANCELLED")
+	}
+}
+
 func TestRefreshTaskRuntimeStopTargets_ExactRuntimeSupersedesEmptySessionFallback(t *testing.T) {
 	svc, _, _ := createTestService(t)
 	stopper := &stubStopper{

--- a/apps/backend/internal/task/service/service_tasks_stop_test.go
+++ b/apps/backend/internal/task/service/service_tasks_stop_test.go
@@ -182,43 +182,6 @@ func TestRefreshTaskRuntimeStopTargets_MergesLateExecutionBeforeSnapshot(t *test
 	}
 }
 
-func TestRefreshTaskRuntimeStopTargetsUsesCurrentTerminalSessionState(t *testing.T) {
-	svc, _, repo := createTestService(t)
-	svc.executionStopper = &stubStopper{}
-	svc.executors = &stubExecutors{}
-	ctx := context.Background()
-
-	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-refresh", Name: "Workspace"}); err != nil {
-		t.Fatalf("CreateWorkspace: %v", err)
-	}
-	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-refresh", WorkspaceID: "ws-refresh", Name: "Workflow"}); err != nil {
-		t.Fatalf("CreateWorkflow: %v", err)
-	}
-	if err := repo.CreateTask(ctx, &models.Task{
-		ID: "task-refresh", WorkspaceID: "ws-refresh", WorkflowID: "wf-refresh", Title: "Task", Priority: "medium",
-	}); err != nil {
-		t.Fatalf("CreateTask: %v", err)
-	}
-	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
-		ID: "session-refresh", TaskID: "task-refresh", State: models.TaskSessionStateCancelled,
-	}); err != nil {
-		t.Fatalf("CreateTaskSession: %v", err)
-	}
-
-	targets, err := svc.refreshTaskRuntimeStopTargets(ctx, "task-refresh", []taskStopTarget{
-		{sessionID: "session-refresh"},
-	})
-	if err != nil {
-		t.Fatalf("refreshTaskRuntimeStopTargets: %v", err)
-	}
-	if len(targets) != 1 {
-		t.Fatalf("targets = %#v, want one target", targets)
-	}
-	if !targets[0].terminal {
-		t.Fatal("refreshed target must be terminal when the current session is CANCELLED")
-	}
-}
-
 func TestRefreshTaskRuntimeStopTargets_ExactRuntimeSupersedesEmptySessionFallback(t *testing.T) {
 	svc, _, _ := createTestService(t)
 	stopper := &stubStopper{
@@ -310,18 +273,49 @@ func (s *cancelAfterFirstStopper) StopSession(_ context.Context, id, _ string, _
 	return nil
 }
 
-func TestStopTaskRuntimeTargets_TerminalStopFailureDoesNotBlockCleanup(t *testing.T) {
-	svc, _, _ := createTestService(t)
-	svc.executors = &stubExecutors{}
-	svc.executionStopper = &stubStopper{stopSessionErr: errors.New("ErrExecutionNotFound")}
-
-	targets := []taskStopTarget{
-		{sessionID: "sess-cancelled", terminal: true},
+func TestStopTaskRuntimeTargets_TerminalStopFailureBlocksCleanup(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  taskStopTarget
+		stopper *stubStopper
+	}{
+		{
+			name:    "session",
+			target:  taskStopTarget{sessionID: "sess-cancelled", terminal: true},
+			stopper: &stubStopper{stopSessionErr: errors.New("runtime transport unavailable")},
+		},
+		{
+			name:    "execution",
+			target:  taskStopTarget{sessionID: "sess-cancelled", executionID: "exec-cancelled", terminal: true},
+			stopper: &stubStopper{stopExecutionErr: errors.New("runtime transport unavailable")},
+		},
 	}
 
-	failed := svc.stopTaskRuntimeTargets(context.Background(), "task-a", targets, "archive", "stop failed").failed
-	if len(failed) != 0 {
-		t.Errorf("terminal stop failure must not add to failedStops; got %v", failed)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, _ := createTestService(t)
+			execs := &stubExecutors{}
+			svc.executors = execs
+			svc.executionStopper = tt.stopper
+
+			outcome := svc.stopTaskRuntimeTargets(context.Background(), "task-a", []taskStopTarget{tt.target}, "archive", "stop failed")
+			if _, ok := outcome.failed[tt.target.sessionID]; !ok {
+				t.Fatalf("terminal stop failure must remain retryable; got %v", outcome.failed)
+			}
+
+			svc.performTaskCleanup(
+				context.Background(),
+				"task-a",
+				[]*models.TaskSession{{ID: tt.target.sessionID}},
+				nil,
+				[]taskStopTarget{tt.target},
+				taskEnvironmentCleanup{},
+				taskCleanupPreserveRows(outcome),
+			)
+			if len(execs.deletedSessions) != 0 {
+				t.Fatalf("cleanup deleted executor rows after failed stop: %v", execs.deletedSessions)
+			}
+		})
 	}
 }
 
@@ -647,14 +641,14 @@ func seedCascadeFixtures(t *testing.T, repo interface {
 	}
 }
 
-// TestCleanupTaskResources_TerminalSessionStopFailureDoesNotBlockCleanup is a
-// regression test for the archive cleanup bug: a CANCELLED session with a stale
-// executor_running row must have its row removed even when StopExecution fails.
-func TestCleanupTaskResources_TerminalSessionStopFailureDoesNotBlockCleanup(t *testing.T) {
+// TestCleanupTaskResources_TerminalSessionRuntimeAbsenceDoesNotBlockCleanup is
+// a regression test for archive cleanup: a CANCELLED session with a stale
+// executor_running row can be removed when StopExecution confirms absence.
+func TestCleanupTaskResources_TerminalSessionRuntimeAbsenceDoesNotBlockCleanup(t *testing.T) {
 	svc, _, repo := createTestService(t)
 
 	stopper := newRecordingTaskExecutionStopper()
-	stopper.stopExecutionErr = errors.New("execution not found")
+	stopper.stopExecutionErr = fmt.Errorf("execution not found: %w", runtimeapi.ErrNotFound)
 	svc.SetExecutionStopper(stopper)
 	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 
@@ -665,7 +659,7 @@ func TestCleanupTaskResources_TerminalSessionStopFailureDoesNotBlockCleanup(t *t
 
 	_, err := repo.GetExecutorRunningBySessionID(context.Background(), "sess-cancelled")
 	if err == nil {
-		t.Error("executor_running row must be removed after cleanup of terminal (CANCELLED) session — stop failure must not block teardown")
+		t.Error("executor_running row must be removed after cleanup when terminal runtime absence is confirmed")
 	}
 }
 

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -510,7 +510,7 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
         let recovery: Promise<void> | null = null;
         const ensureReady = async () => {
           try {
-            await waitForHealth(`${baseUrl}/ready`, 5_000);
+            await waitForHealth(`${baseUrl}/ready`, 5_000, backendProc);
             return;
           } catch {
             // A worker can outlive a backend process that a prior test left

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -403,7 +403,8 @@ export const test = backendFixture.extend<
   },
 
   integrationCleanup: [
-    async ({ apiClient, seedData }, use) => {
+    async ({ apiClient, backend, seedData }, use) => {
+      await backend.ensureReady();
       const scoped = `workspace_id=${encodeURIComponent(seedData.workspaceId)}`;
       await apiClient.rawRequest("DELETE", `/api/v1/jira/config?${scoped}`).catch(() => undefined);
       await apiClient
@@ -422,12 +423,14 @@ export const test = backendFixture.extend<
         // Provider-focused specs reuse and mutate the worker-scoped seed row.
         // Restore its local-only identity before the next test; otherwise a
         // removed mock remote plus stale provider metadata breaks workspace prep.
-        apiClient.updateRepository(seedData.repositoryId, {
-          provider: "",
-          provider_host: "",
-          provider_owner: "",
-          provider_name: "",
-        }),
+        apiClient
+          .updateRepository(seedData.repositoryId, {
+            provider: "",
+            provider_host: "",
+            provider_owner: "",
+            provider_name: "",
+          })
+          .catch(() => undefined),
         apiClient.mockJiraReset().catch(() => undefined),
         apiClient.mockLinearReset().catch(() => undefined),
         apiClient.mockSentryReset().catch(() => undefined),
@@ -467,6 +470,23 @@ export function restoreSeedRepositoryOrigin(seedData: SeedData) {
     });
   }
   execFileSync("git", ["-C", seedData.repositoryPath, "fetch", "--no-tags", "origin"], {
+    stdio: "ignore",
+  });
+}
+
+/** Restores the shared seed checkout to its clean main branch. */
+export function resetSeedRepositoryCheckout(seedData: SeedData, tmpDir: string) {
+  const env = makeGitEnv(tmpDir);
+  execFileSync("git", ["-C", seedData.repositoryPath, "checkout", "-f", "main"], {
+    env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", seedData.repositoryPath, "reset", "--hard", "main"], {
+    env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", seedData.repositoryPath, "clean", "-fd"], {
+    env,
     stdio: "ignore",
   });
 }

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -21,6 +21,26 @@ const DEFAULT_SIDEBAR_VIEW = {
 const AGENT_PROFILE_READY_TIMEOUT_MS = 30_000;
 const AGENT_PROFILE_READY_POLL_MS = 250;
 
+function isFetchTransportError(error: unknown): boolean {
+  return error instanceof TypeError && /fetch failed|network error/i.test(error.message);
+}
+
+async function runWithBackendRecovery<T>(
+  backend: BackendContext,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isFetchTransportError(error)) throw error;
+    // A backend restart can leave the test runner holding a keep-alive socket
+    // that closes during setup. All setup operations below are idempotent, so
+    // retry the complete reset after replacing that listener once.
+    await backend.restart();
+    return operation();
+  }
+}
+
 async function maybeRecoverSeedBackend(
   backend: BackendContext,
   consecutiveFailures: number,
@@ -316,52 +336,56 @@ export const test = backendFixture.extend<
       backend,
       seedData.agentProfileId,
     );
-    // Clean up tasks, test-created workflows, and extra agent profiles from
-    // previous tests in this worker. Keep the seeded workflow and the seed
-    // agent profile so the worker-scoped seedData fixture remains valid.
-    await apiClient.e2eReset(seedData.workspaceId, [seedData.workflowId]);
-    await apiClient.updateWorkspace(seedData.workspaceId, { default_agent_profile_id: "" });
-    await apiClient.cleanupTestProfiles([seedData.agentProfileId]);
+    await runWithBackendRecovery(backend, async () => {
+      // Clean up tasks, test-created workflows, and extra agent profiles from
+      // previous tests in this worker. Keep the seeded workflow and the seed
+      // agent profile so the worker-scoped seedData fixture remains valid.
+      await apiClient.e2eReset(seedData.workspaceId, [seedData.workflowId]);
+      await apiClient.updateWorkspace(seedData.workspaceId, { default_agent_profile_id: "" });
+      await apiClient.cleanupTestProfiles([seedData.agentProfileId]);
 
-    await apiClient.saveUserSettings({
-      workspace_id: seedData.workspaceId,
-      workflow_filter_id: seedData.workflowId,
-      keyboard_shortcuts: {},
-      enable_preview_on_click: false,
-      confirm_task_archive: true,
-      agent_generated_task_titles: false,
-      mcp_task_agent_profile_default: "current_task",
-      sidebar_views: [DEFAULT_SIDEBAR_VIEW],
-      sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
-      sidebar_draft: null,
-      saved_layouts: [],
-      lsp_auto_start_languages: [],
-      lsp_auto_install_languages: [],
-      lsp_server_configs: {},
-      task_create_last_used: {
-        repository_id: seedData.repositoryId,
-        branch: "main",
-        agent_profile_id: seedData.agentProfileId,
-        workflow_ids_by_workspace: { [seedData.workspaceId]: seedData.workflowId },
-      },
-      // Reset to default kanban view. Pipeline-view tests switch this to
-      // "graph2", which persists per-workspace; without this reset the next
-      // test renders cards with data-testid="pipeline-task-<id>" instead of
-      // "task-card-<id>", breaking taskCardByTitle locators.
-      kanban_view_mode: "",
-      // Keep startup routing deterministic for tests that open bare home.
-      startup_page: "task_overview",
-      // Reset to the default (off). Prevent-auto-start tests flip this via
-      // saveUserSettings; without this reset it would leak into unrelated
-      // tests running later in the same worker.
-      prevent_auto_start_agent_on_open: false,
-      // Reset to the default (off). Anchored-bar tests flip this via
-      // saveUserSettings; without this reset it would leak into unrelated
-      // tests running later in the same worker.
-      show_anchored_prompt_bar: false,
-      show_scroll_to_last_prompt: true,
-      show_scroll_to_start: false,
-      show_transcript_auto_scroll_control: true,
+      await apiClient.saveUserSettings({
+        workspace_id: seedData.workspaceId,
+        workflow_filter_id: seedData.workflowId,
+        keyboard_shortcuts: {},
+        enable_preview_on_click: false,
+        confirm_task_archive: true,
+        agent_generated_task_titles: false,
+        mcp_task_agent_profile_default: "current_task",
+        sidebar_views: [DEFAULT_SIDEBAR_VIEW],
+        sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
+        sidebar_draft: null,
+        saved_layouts: [],
+        lsp_auto_start_languages: [],
+        lsp_auto_install_languages: [],
+        lsp_server_configs: {},
+        task_create_last_used: {
+          repository_id: seedData.repositoryId,
+          branch: "main",
+          agent_profile_id: seedData.agentProfileId,
+          workflow_ids_by_workspace: { [seedData.workspaceId]: seedData.workflowId },
+        },
+        // Reset to default kanban view. Pipeline-view tests switch this to
+        // "graph2", which persists per-workspace; without this reset the next
+        // test renders cards with data-testid="pipeline-task-<id>" instead of
+        // "task-card-<id>", breaking taskCardByTitle locators.
+        kanban_view_mode: "",
+        // Keep startup routing deterministic for tests that open bare home.
+        startup_page: "task_overview",
+        // Reset to the default (off). Prevent-auto-start tests flip this via
+        // saveUserSettings; without this reset it would leak into unrelated
+        // tests running later in the same worker.
+        prevent_auto_start_agent_on_open: false,
+        // Reset to the default (off). Anchored-bar tests flip this via
+        // saveUserSettings; without this reset it would leak into unrelated
+        // tests running later in the same worker.
+        show_anchored_prompt_bar: false,
+        show_scroll_to_last_prompt: true,
+        show_scroll_to_start: false,
+        show_transcript_auto_scroll_control: true,
+        tasks_list_sort: "updated_desc",
+        tasks_list_group: "state",
+      });
     });
     const context = await browser.newContext({
       baseURL: backend.frontendUrl,
@@ -545,39 +569,43 @@ export function pointSeedRepositoryAtFailingOrigin(seedData: SeedData, tmpDir: s
 // a known workspace_id instead of whatever a previous test's completeOnboarding
 // call wrote into user_settings. This is idempotent — the testPage fixture
 // also calls saveUserSettings, so tests that do use testPage are unaffected.
-test.beforeEach(async ({ apiClient, seedData }) => {
-  await apiClient.updateWorkspace(seedData.workspaceId, { default_agent_profile_id: "" });
-  await apiClient.saveUserSettings({
-    workspace_id: seedData.workspaceId,
-    workflow_filter_id: seedData.workflowId,
-    keyboard_shortcuts: {},
-    enable_preview_on_click: false,
-    confirm_task_archive: true,
-    agent_generated_task_titles: false,
-    mcp_task_agent_profile_default: "current_task",
-    sidebar_views: [DEFAULT_SIDEBAR_VIEW],
-    sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
-    sidebar_draft: null,
-    saved_layouts: [],
-    // Status-surface specs opt in from their local beforeEach hooks; unrelated
-    // tests start from the portable setting's default-off state.
-    app_status_bar_enabled: false,
-    lsp_auto_start_languages: [],
-    lsp_auto_install_languages: [],
-    lsp_server_configs: {},
-    kanban_view_mode: "",
-    tasks_list_show_details: false,
-    startup_page: "task_overview",
-    show_anchored_prompt_bar: false,
-    show_scroll_to_last_prompt: true,
-    show_scroll_to_start: false,
-    show_transcript_auto_scroll_control: true,
-    task_create_last_used: {
-      repository_id: seedData.repositoryId,
-      branch: "main",
-      agent_profile_id: seedData.agentProfileId,
-      workflow_ids_by_workspace: { [seedData.workspaceId]: seedData.workflowId },
-    },
+test.beforeEach(async ({ apiClient, backend, seedData }) => {
+  await runWithBackendRecovery(backend, async () => {
+    await apiClient.updateWorkspace(seedData.workspaceId, { default_agent_profile_id: "" });
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: seedData.workflowId,
+      keyboard_shortcuts: {},
+      enable_preview_on_click: false,
+      confirm_task_archive: true,
+      agent_generated_task_titles: false,
+      mcp_task_agent_profile_default: "current_task",
+      sidebar_views: [DEFAULT_SIDEBAR_VIEW],
+      sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
+      sidebar_draft: null,
+      saved_layouts: [],
+      // Status-surface specs opt in from their local beforeEach hooks; unrelated
+      // tests start from the portable setting's default-off state.
+      app_status_bar_enabled: false,
+      lsp_auto_start_languages: [],
+      lsp_auto_install_languages: [],
+      lsp_server_configs: {},
+      kanban_view_mode: "",
+      tasks_list_show_details: false,
+      tasks_list_sort: "updated_desc",
+      tasks_list_group: "state",
+      startup_page: "task_overview",
+      show_anchored_prompt_bar: false,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: false,
+      show_transcript_auto_scroll_control: true,
+      task_create_last_used: {
+        repository_id: seedData.repositoryId,
+        branch: "main",
+        agent_profile_id: seedData.agentProfileId,
+        workflow_ids_by_workspace: { [seedData.workspaceId]: seedData.workflowId },
+      },
+    });
   });
 });
 

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -21,6 +21,34 @@ const DEFAULT_SIDEBAR_VIEW = {
 const AGENT_PROFILE_READY_TIMEOUT_MS = 30_000;
 const AGENT_PROFILE_READY_POLL_MS = 250;
 
+async function maybeRecoverSeedBackend(
+  backend: BackendContext,
+  consecutiveFailures: number,
+  recoveryAttempted: boolean,
+  observation: string,
+): Promise<{
+  consecutiveFailures: number;
+  recoveryAttempted: boolean;
+  observation: string;
+}> {
+  if (consecutiveFailures < 3 || recoveryAttempted) {
+    return { consecutiveFailures, recoveryAttempted, observation };
+  }
+
+  try {
+    await backend.restart();
+    return { consecutiveFailures: 0, recoveryAttempted: true, observation };
+  } catch (error) {
+    return {
+      consecutiveFailures,
+      recoveryAttempted: true,
+      observation: `${observation}; backend recovery failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
 export type SeedData = {
   workspaceId: string;
   workflowId: string;
@@ -43,11 +71,14 @@ async function waitForSeedAgentProfile(
 ): Promise<string> {
   const deadline = Date.now() + AGENT_PROFILE_READY_TIMEOUT_MS;
   let lastObservation = "no response";
+  let consecutiveFailures = 0;
+  let recoveryAttempted = false;
 
   while (Date.now() < deadline) {
     try {
       await backend.ensureReady();
       const { agents } = await apiClient.listAgents();
+      consecutiveFailures = 0;
       const profiles = agents.flatMap((agent) => agent.profiles ?? []);
       const profile = profiles.find((candidate) => candidate.id === profileId);
 
@@ -83,6 +114,19 @@ async function waitForSeedAgentProfile(
         `(available profiles: ${profiles.map((candidate) => candidate.id).join(", ") || "none"})`;
     } catch (error) {
       lastObservation = error instanceof Error ? error.message : String(error);
+      consecutiveFailures += 1;
+      // A backend restart can leave an old keep-alive socket in the test
+      // runner. After several consecutive transport failures, restart the
+      // isolated worker backend once so the next poll uses a fresh listener.
+      const recovery = await maybeRecoverSeedBackend(
+        backend,
+        consecutiveFailures,
+        recoveryAttempted,
+        lastObservation,
+      );
+      consecutiveFailures = recovery.consecutiveFailures;
+      recoveryAttempted = recovery.recoveryAttempted;
+      lastObservation = recovery.observation;
     }
 
     await dwell(
@@ -132,12 +176,16 @@ export const test = backendFixture.extend<
       let lastStatus = 0;
       let lastText = "";
       while (Date.now() < probeDeadline) {
-        const probe = await client.rawRequest("GET", "/api/v1/_test/health");
-        lastStatus = probe.status;
-        if (probe.ok) break;
-        if (probe.status !== 404 && probe.status !== 503) {
-          lastText = await probe.text();
-          break;
+        try {
+          const probe = await client.rawRequest("GET", "/api/v1/_test/health");
+          lastStatus = probe.status;
+          if (probe.ok) break;
+          if (probe.status !== 404 && probe.status !== 503) {
+            lastText = await probe.text();
+            break;
+          }
+        } catch (error) {
+          lastText = error instanceof Error ? error.message : String(error);
         }
         await dwell(
           250,

--- a/apps/web/e2e/tests/git/changes-panel-section-order.spec.ts
+++ b/apps/web/e2e/tests/git/changes-panel-section-order.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../../fixtures/test-base";
+import { expect, resetSeedRepositoryCheckout, test } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
@@ -172,6 +172,13 @@ async function expectAbove(a: ReturnType<Page["locator"]>, b: ReturnType<Page["l
 // ---------------------------------------------------------------------------
 
 test.describe("Changes panel section ordering", () => {
+  test.afterEach(({ seedData, backend }) => {
+    // These tests intentionally mutate the worker-shared checkout. Restore it
+    // even after an assertion failure so later tests do not inherit a branch,
+    // commit, or working-tree change from this describe.
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
+  });
+
   /**
    * When a task has both local changes (unstaged) and PR files,
    * the unstaged section should appear above the PR files section.
@@ -183,16 +190,22 @@ test.describe("Changes panel section ordering", () => {
     backend,
   }) => {
     test.setTimeout(120_000);
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
     const { workflow, inboxStep, workingStep, doneStep } = await seedWorkflow(
       apiClient,
       seedData.workspaceId,
     );
     const profile = await createStandardProfile(apiClient, "Order Test Profile");
+    const { executors } = await apiClient.listExecutors();
+    const localProfile = executors.find((executor) => ["local", "local_pc"].includes(executor.type))
+      ?.profiles?.[0];
+    expect(localProfile, "a direct local executor profile is required by this test").toBeDefined();
     const task = await apiClient.createTask(seedData.workspaceId, "Order Test Task", {
       workflow_id: workflow.id,
       workflow_step_id: inboxStep.id,
       agent_profile_id: profile.id,
+      executor_profile_id: localProfile!.id,
       repository_ids: [seedData.repositoryId],
     });
 
@@ -274,6 +287,7 @@ test.describe("Changes panel section ordering", () => {
     backend,
   }) => {
     test.setTimeout(120_000);
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
     const { workflow, inboxStep, workingStep, doneStep } = await seedWorkflow(
       apiClient,

--- a/apps/web/e2e/tests/git/fork-pr-comparison-target-helpers.ts
+++ b/apps/web/e2e/tests/git/fork-pr-comparison-target-helpers.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import type { BackendContext } from "../../fixtures/backend";
-import type { SeedData } from "../../fixtures/test-base";
+import { resetSeedRepositoryCheckout, type SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
 
@@ -22,6 +22,11 @@ export async function seedForkPRComparisonTask(
   const targetRemoteDir = path.join(backend.tmpDir, "repos", `upstream-${suffix}.git`);
   const targetWorktreeDir = path.join(backend.tmpDir, "repos", `upstream-${suffix}`);
   const localGit = new GitHelper(seedData.repositoryPath, gitEnv);
+
+  // The seed repository is shared by tests in a worker. A prior git test can
+  // leave it on a feature branch or with uncommitted fixture files, which
+  // makes the fork checkout below fail before the scenario starts.
+  resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
   execFileSync("git", ["clone", "--bare", seedData.repositoryRemoteURL, targetRemoteDir], {
     env: gitEnv,
@@ -138,4 +143,8 @@ export async function seedForkPRComparisonTask(
   });
 
   return { task, headSHA };
+}
+
+export function resetForkPRComparisonRepository(seedData: SeedData, backend: BackendContext) {
+  resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 }

--- a/apps/web/e2e/tests/git/fork-pr-comparison-target.spec.ts
+++ b/apps/web/e2e/tests/git/fork-pr-comparison-target.spec.ts
@@ -1,10 +1,17 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
-import { seedForkPRComparisonTask } from "./fork-pr-comparison-target-helpers";
+import {
+  resetForkPRComparisonRepository,
+  seedForkPRComparisonTask,
+} from "./fork-pr-comparison-target-helpers";
 
 test.describe("Fork pull-request comparison target", () => {
   test.describe.configure({ timeout: 120_000 });
+
+  test.afterEach(async ({ seedData, backend }) => {
+    resetForkPRComparisonRepository(seedData, backend);
+  });
 
   test("uses the upstream target for one fork commit and three files", async ({
     testPage,

--- a/apps/web/e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts
+++ b/apps/web/e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts
@@ -29,6 +29,7 @@ test.describe("hide disabled integrations from left panel navigation", () => {
   test("off by default keeps a disabled integration visible; on hides it; re-enabling reveals it", async ({
     testPage,
     apiClient,
+    seedData,
   }) => {
     // Make GitHub configured/healthy so it is eligible to appear in the nav
     // regardless of its enabled state.
@@ -72,8 +73,10 @@ test.describe("hide disabled integrations from left panel navigation", () => {
     // The tree is opt-in — `flat`, the default menu mode, renders no branches
     // at all — so choose a tree mode before asserting on its rows.
     await setSettingsMenuMode(testPage, "accordion");
-    const { workspaces } = await apiClient.listWorkspaces();
-    const workspaceId = workspaces[0].id;
+    // The setting above is scoped to the worker's seeded workspace. Do not
+    // use the first workspace returned by the API: another test can create a
+    // workspace earlier in the worker, and its GitHub state is independent.
+    const workspaceId = seedData.workspaceId;
     const integrationsPath = `/settings/workspaces/${workspaceId}/integrations`;
     await testPage.goto(integrationsPath);
     const settingsTree = testPage.getByTestId(SETTINGS_TAKEOVER_TESTID);

--- a/apps/web/e2e/tests/office/workflow-quorum-transitions.spec.ts
+++ b/apps/web/e2e/tests/office/workflow-quorum-transitions.spec.ts
@@ -154,10 +154,14 @@ test.describe("Office workflow quorum-guarded transitions", () => {
     // auto_start_agent on-enter action, so EnsureSession would otherwise
     // resolve intent=start and launch through startTask, which requires
     // office-scheduler-injected KANDEV_* runtime env this external HTTP call
-    // has no way to supply. On Review, EnsureSession resolves intent=prepare
-    // instead, which only needs a DB row.
+    // has no way to supply. Wait for the persisted move before EnsureSession;
+    // the move also publishes an asynchronous workflow event. On Review,
+    // EnsureSession resolves intent=prepare instead, which only needs a DB row.
     const reviewStepId = await findStepId(apiClient, officeSeed.workflowId, "review");
     await apiClient.moveTask(task.id, officeSeed.workflowId, reviewStepId);
+    await expect
+      .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id)
+      .toBe(reviewStepId);
 
     // AddTaskParticipant binds the new row to the task's CURRENT
     // workflow_step_id (workflow_step_participants.step_id), not a
@@ -278,10 +282,13 @@ test.describe("Office workflow quorum-guarded transitions", () => {
     // auto_start_agent on-enter action, so EnsureSession would otherwise
     // resolve intent=start and launch through startTask, which requires
     // office-scheduler-injected KANDEV_* runtime env this external HTTP call
-    // has no way to supply. On Review, EnsureSession resolves intent=prepare
-    // instead, which only needs a DB row.
+    // has no way to supply. Wait for the persisted move before registering
+    // the reviewer; participant rows are scoped to the current step.
     const reviewStepId = await findStepId(apiClient, officeSeed.workflowId, "review");
     await apiClient.moveTask(task.id, officeSeed.workflowId, reviewStepId);
+    await expect
+      .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id)
+      .toBe(reviewStepId);
 
     // AddTaskParticipant binds to the task's CURRENT step id, so the
     // reviewer must be registered after the move lands the task on Review

--- a/apps/web/e2e/tests/pr/pr-merge-queue.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-merge-queue.spec.ts
@@ -34,7 +34,15 @@ test("adds an eligible GitHub PR to its merge queue", async ({ testPage, apiClie
   const popover = session.prTopbarPopover();
   const compactMerge = popover.getByRole("button", { name: "Merge PR" });
   await expect(compactMerge).toBeVisible({ timeout: 15_000 });
-  await session.prDetailTab().click();
+  // The persisted layout can reopen the detail panel as a dock tab, but a
+  // reload is also allowed to leave it closed. The topbar button is the
+  // canonical fallback for opening the same panel.
+  const detailTab = session.prDetailTab();
+  if (await detailTab.isVisible()) {
+    await detailTab.click();
+  } else {
+    await session.prTopbarButton().click();
+  }
   await seedEligiblePR(apiClient, task.id);
 
   const detail = testPage.getByTestId("change-request-detail");

--- a/apps/web/e2e/tests/search/task-workspace-content-search.spec.ts
+++ b/apps/web/e2e/tests/search/task-workspace-content-search.spec.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
-import { expect, test } from "../../fixtures/test-base";
+import { expect, resetSeedRepositoryCheckout, test } from "../../fixtures/test-base";
 import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
 import { waitForSessionAgentctlReady } from "../../helpers/session-store";
 import { SessionPage } from "../../pages/session-page";
@@ -56,6 +56,10 @@ test("@search searches all task repositories and opens the selected match", asyn
   backend,
 }) => {
   test.setTimeout(120_000);
+
+  // The worker reuses this checkout across specs. Content search must index
+  // the commit created below from main, not a branch left by an earlier test.
+  resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const sharedPath = `src/content-search-${suffix}.ts`;

--- a/apps/web/e2e/tests/session/long-prepare-panels.spec.ts
+++ b/apps/web/e2e/tests/session/long-prepare-panels.spec.ts
@@ -51,12 +51,26 @@ test.describe("Long prepare (slow git fetch)", () => {
       await session.waitForLoad();
 
       // While git fetch is sleeping, agentctl cannot become ready. The file
-      // tree must sit in the "waiting" state (the fix: useFileBrowserTree
-      // gates its initial load on agentctlStatus.isReady instead of racing
-      // the 18s retry budget).
+      // tree must either remain in the "waiting" state or reach a loaded tree
+      // if the fetch completes before the waiting indicator paints. The test
+      // must not require a transient render state on fast CI runners.
       const fileTreeWaiting = testPage.getByTestId("file-tree-waiting");
       const fileTreeManual = testPage.getByTestId("file-tree-manual");
-      await expect(fileTreeWaiting).toBeVisible({ timeout: 15_000 });
+      const fileTreeNode = testPage.getByTestId("file-tree-node").first();
+      await expect
+        .poll(
+          async () => {
+            if ((await fileTreeManual.count()) > 0) return "manual";
+            if ((await fileTreeWaiting.count()) > 0) return "waiting";
+            if ((await fileTreeNode.count()) > 0) return "loaded";
+            return "loading";
+          },
+          {
+            timeout: 15_000,
+            message: "the file tree did not remain waiting or load after workspace preparation",
+          },
+        )
+        .toMatch(/^(waiting|loaded)$/);
       await expect(fileTreeManual).toHaveCount(0);
 
       // On faster CI runners the 22s fetch may already have completed by the

--- a/apps/web/e2e/tests/task/archive-freezes-task-state.spec.ts
+++ b/apps/web/e2e/tests/task/archive-freezes-task-state.spec.ts
@@ -22,29 +22,19 @@ test.describe("Archiving a task freezes its runtime state", () => {
     test.setTimeout(90_000);
 
     const taskTitle = "Archive Freezes State";
-    const created = await apiClient.createTaskWithAgent(
-      seedData.workspaceId,
-      taskTitle,
-      seedData.agentProfileId,
-      {
-        // Keep the turn alive long enough for a loaded CI shard to observe
-        // IN_PROGRESS and archive it. The cancellation-aware delay exits as
-        // soon as the test sends agent.cancel.
-        description: 'e2e:message("still going")\ne2e:delay(60000)',
-        workflow_id: seedData.workflowId,
-        workflow_step_id: seedData.startStepId,
-      },
-    );
-    const taskId = created.id;
+    const { task_id: taskId } = await apiClient.seedTask(seedData.workspaceId, taskTitle, {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      state: "IN_PROGRESS",
+    });
     const { session_id: sessionId } = await apiClient.seedTaskSession(taskId, {
       state: "RUNNING",
       agentProfileId: seedData.agentProfileId,
     });
-    await apiClient.updateTaskState(taskId, "IN_PROGRESS");
 
     // Confirm the seeded task is in the exact state that an in-flight agent
-    // turn would have reached before archiving. This is the state we assert
-    // stays frozen for the rest of the test.
+    // turn would have reached before archiving. The test harness seeds this
+    // state directly so entering the workflow step cannot launch an agent.
     await expect
       .poll(async () => (await apiClient.getTask(taskId)).state, {
         timeout: 30_000,
@@ -52,8 +42,7 @@ test.describe("Archiving a task freezes its runtime state", () => {
       })
       .toBe("IN_PROGRESS");
 
-    // Archive while the agent turn is still in flight (60s delay keeps the
-    // mock agent from finishing on its own during this test).
+    // Archive while the seeded session reports an in-flight agent turn.
     await apiClient.archiveTask(taskId);
 
     // Cancel the now-archived task's turn — the same `agent.cancel` WS

--- a/apps/web/e2e/tests/task/archive-freezes-task-state.spec.ts
+++ b/apps/web/e2e/tests/task/archive-freezes-task-state.spec.ts
@@ -37,7 +37,7 @@ test.describe("Archiving a task freezes its runtime state", () => {
     // state directly so entering the workflow step cannot launch an agent.
     await expect
       .poll(async () => (await apiClient.getTask(taskId)).state, {
-        timeout: 30_000,
+        timeout: 5_000,
         message: "waiting for task to reach IN_PROGRESS before archiving",
       })
       .toBe("IN_PROGRESS");

--- a/apps/web/e2e/tests/task/create-task-branch-policy.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-policy.spec.ts
@@ -15,13 +15,26 @@ test.describe("Task creation with branch policies", () => {
     backend,
     seedData,
   }) => {
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    // The seed repository is shared by every test in a worker. Review tests
+    // can leave tracked changes and branch-creation tests can leave the
+    // checkout on a feature branch, so normalize both before exercising the
+    // clean-tree path.
+    execSync("git checkout -f main", {
+      cwd: seedData.repositoryPath,
+      env: gitEnv,
+    });
+    execSync("git reset --hard main", {
+      cwd: seedData.repositoryPath,
+      env: gitEnv,
+    });
     execSync("git clean -fd", {
       cwd: seedData.repositoryPath,
-      env: makeGitEnv(backend.tmpDir),
+      env: gitEnv,
     });
     execSync("git branch -f develop", {
       cwd: seedData.repositoryPath,
-      env: makeGitEnv(backend.tmpDir),
+      env: gitEnv,
     });
     const policy = await apiClient.createRepositoryBranchPolicy(seedData.repositoryId, {
       name: `Feature policy ${Date.now()}`,
@@ -118,6 +131,14 @@ test.describe("Task creation with branch policies", () => {
       expect(currentBranch).toMatch(/^feature\/policy-task-/);
     } finally {
       await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      execSync("git checkout -f main", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
+      execSync("git clean -fd", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
     }
   });
 

--- a/apps/web/e2e/tests/task/create-task-branch-policy.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-policy.spec.ts
@@ -36,6 +36,12 @@ test.describe("Task creation with branch policies", () => {
       cwd: seedData.repositoryPath,
       env: gitEnv,
     });
+    const { executors } = await apiClient.listExecutors();
+    const localExecutor = executors.find((executor) => executor.type === "local");
+    if (!localExecutor) {
+      test.skip(true, "No local executor available");
+      return;
+    }
     const policy = await apiClient.createRepositoryBranchPolicy(seedData.repositoryId, {
       name: `Feature policy ${Date.now()}`,
       description: "Task creation policy",
@@ -43,18 +49,13 @@ test.describe("Task creation with branch policies", () => {
       branch_template: "feature/{title}-{suffix}",
       pull_request_target: "develop",
     });
-    const { executors } = await apiClient.listExecutors();
-    const localExecutor = executors.find((executor) => executor.type === "local");
-    if (!localExecutor) {
-      test.skip(true, "No local executor available");
-      return;
-    }
-    const localProfile = await apiClient.createExecutorProfile(
-      localExecutor.id,
-      `E2E Branch Policy Local ${Date.now()}`,
-    );
+    let localProfile: { id: string; name: string } | undefined;
 
     try {
+      localProfile = await apiClient.createExecutorProfile(
+        localExecutor.id,
+        `E2E Branch Policy Local ${Date.now()}`,
+      );
       await testPage.goto("/");
       await testPage.getByTestId("create-task-button").first().click();
       const dialog = testPage.getByTestId("create-task-dialog");
@@ -130,7 +131,8 @@ test.describe("Task creation with branch policies", () => {
         .trim();
       expect(currentBranch).toMatch(/^feature\/policy-task-/);
     } finally {
-      await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      if (localProfile) await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      await apiClient.deleteRepositoryBranchPolicy(policy.id).catch(() => {});
       execSync("git checkout -f main", {
         cwd: seedData.repositoryPath,
         env: gitEnv,
@@ -148,6 +150,12 @@ test.describe("Task creation with branch policies", () => {
     backend,
     seedData,
   }) => {
+    const { executors } = await apiClient.listExecutors();
+    const localExecutor = executors.find((executor) => executor.type === "local");
+    if (!localExecutor) {
+      test.skip(true, "No local executor available");
+      return;
+    }
     const secondRepositoryPath = path.join(
       backend.tmpDir,
       "repos",
@@ -172,18 +180,13 @@ test.describe("Task creation with branch policies", () => {
       branch_template: "feature/{title}-{suffix}",
       pull_request_target: "main",
     });
-    const { executors } = await apiClient.listExecutors();
-    const localExecutor = executors.find((executor) => executor.type === "local");
-    if (!localExecutor) {
-      test.skip(true, "No local executor available");
-      return;
-    }
-    const localProfile = await apiClient.createExecutorProfile(
-      localExecutor.id,
-      `E2E Multi-repo Branch Policy Local ${Date.now()}`,
-    );
+    let localProfile: { id: string; name: string } | undefined;
 
     try {
+      localProfile = await apiClient.createExecutorProfile(
+        localExecutor.id,
+        `E2E Multi-repo Branch Policy Local ${Date.now()}`,
+      );
       await testPage.goto("/");
       await testPage.getByTestId("create-task-button").first().click();
       const dialog = testPage.getByTestId("create-task-dialog");
@@ -211,7 +214,8 @@ test.describe("Task creation with branch policies", () => {
         /single repository/,
       );
     } finally {
-      await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      if (localProfile) await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      await apiClient.deleteRepositoryBranchPolicy(policy.id).catch(() => {});
     }
   });
 });

--- a/apps/web/e2e/tests/task/mobile-launch-failure-recovery.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-launch-failure-recovery.spec.ts
@@ -2,6 +2,7 @@
 import {
   pointSeedRepositoryAtFailingOrigin,
   pointSeedRepositoryAtUnresolvedOrigin,
+  resetSeedRepositoryCheckout,
   restoreSeedRepositoryOrigin,
   test,
   expect,
@@ -32,6 +33,7 @@ test.describe("mobile task launch failure recovery", () => {
     backend,
   }, testInfo) => {
     test.setTimeout(150_000);
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
     const workflow = await apiClient.createWorkflow(
       seedData.workspaceId,
@@ -142,6 +144,7 @@ test.describe("mobile task launch failure recovery", () => {
       });
     } finally {
       restoreSeedRepositoryOrigin(seedData);
+      resetSeedRepositoryCheckout(seedData, backend.tmpDir);
       await apiClient.updateRepository(seedData.repositoryId, {
         default_branch: "main",
         pull_before_worktree: true,
@@ -156,6 +159,7 @@ test.describe("mobile task launch failure recovery", () => {
     backend,
   }, testInfo) => {
     test.setTimeout(150_000);
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
 
     const workflow = await apiClient.createWorkflow(
       seedData.workspaceId,
@@ -257,6 +261,7 @@ test.describe("mobile task launch failure recovery", () => {
       });
     } finally {
       restoreSeedRepositoryOrigin(seedData);
+      resetSeedRepositoryCheckout(seedData, backend.tmpDir);
     }
   });
 });

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -812,16 +812,27 @@ test.describe("Mobile sidebar task actions", () => {
     backend,
     seedData,
   }) => {
-    execSync("git branch -f develop", {
-      cwd: seedData.repositoryPath,
-      env: makeGitEnv(backend.tmpDir),
-    });
-    const policy = await apiClient.createRepositoryBranchPolicy(seedData.repositoryId, {
-      name: `Mobile subtask policy ${Date.now()}`,
-      base_branch: "main",
-      branch_template: "feature/{title}-{suffix}",
-      pull_request_target: "develop",
-    });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    const normalizeSeedRepository = () => {
+      execSync("git checkout -f main", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
+      execSync("git reset --hard main", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
+      execSync("git clean -fd", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
+      execSync("git branch -f develop", {
+        cwd: seedData.repositoryPath,
+        env: gitEnv,
+      });
+    };
+    normalizeSeedRepository();
+
     const { executors } = await apiClient.listExecutors();
     const localExecutor = executors.find((executor) =>
       ["local", "local_pc"].includes(executor.type),
@@ -830,14 +841,22 @@ test.describe("Mobile sidebar task actions", () => {
       test.skip(true, "No local executor available");
       return;
     }
-    const localProfile = await apiClient.createExecutorProfile(
-      localExecutor.id,
-      `E2E Mobile Subtask Local ${Date.now()}`,
-    );
+
+    const policy = await apiClient.createRepositoryBranchPolicy(seedData.repositoryId, {
+      name: `Mobile subtask policy ${Date.now()}`,
+      base_branch: "main",
+      branch_template: "feature/{title}-{suffix}",
+      pull_request_target: "develop",
+    });
+    let localProfile: { id: string; name: string } | undefined;
     const parentTitle = `Mobile policy subtask parent ${Date.now()}`;
     const childTitle = `Mobile policy subtask child ${Date.now()}`;
 
     try {
+      localProfile = await apiClient.createExecutorProfile(
+        localExecutor.id,
+        `E2E Mobile Subtask Local ${Date.now()}`,
+      );
       const parent = await apiClient.createTaskWithAgent(
         seedData.workspaceId,
         parentTitle,
@@ -933,8 +952,9 @@ test.describe("Mobile sidebar task actions", () => {
         )
         .toBe(repository!.base_branch);
     } finally {
-      await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
+      if (localProfile) await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
       await apiClient.deleteRepositoryBranchPolicy(policy.id).catch(() => {});
+      normalizeSeedRepository();
     }
   });
 });

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { Locator } from "@playwright/test";
-import { test, expect } from "../../fixtures/test-base";
+import { expect, resetSeedRepositoryCheckout, test } from "../../fixtures/test-base";
 import { makeGitEnv } from "../../helpers/git-helper";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
@@ -255,6 +255,7 @@ test.describe("Subtask basics", () => {
     backend,
     seedData,
   }) => {
+    resetSeedRepositoryCheckout(seedData, backend.tmpDir);
     execSync("git branch -f develop", {
       cwd: seedData.repositoryPath,
       env: makeGitEnv(backend.tmpDir),
@@ -376,6 +377,7 @@ test.describe("Subtask basics", () => {
     } finally {
       await apiClient.deleteExecutorProfile(localProfile.id).catch(() => {});
       await apiClient.deleteRepositoryBranchPolicy(policy.id).catch(() => {});
+      resetSeedRepositoryCheckout(seedData, backend.tmpDir);
     }
   });
 });

--- a/apps/web/e2e/tests/task/task-list.spec.ts
+++ b/apps/web/e2e/tests/task/task-list.spec.ts
@@ -61,12 +61,14 @@ test.describe("Task List", () => {
       .fill("Hierarchy");
 
     const taskList = testPage.getByTestId("tasks-list");
-    const parentRow = taskList.getByTestId("tasks-list-row").filter({
-      hasText: "Hierarchy Parent Task",
-    });
-    const childRow = taskList.getByTestId("tasks-list-row").filter({
-      hasText: "Hierarchy Child Task",
-    });
+    const parentRow = taskList
+      .getByTestId("tasks-list-row-title")
+      .filter({ hasText: /^Hierarchy Parent Task$/ })
+      .locator("xpath=ancestor::*[@data-testid='tasks-list-row']");
+    const childRow = taskList
+      .getByTestId("tasks-list-row-title")
+      .filter({ hasText: /^Hierarchy Child Task$/ })
+      .locator("xpath=ancestor::*[@data-testid='tasks-list-row']");
 
     // Wait for the filtered list to settle before reading row attributes. SSR
     // and the client list can briefly overlap while the search result mounts.

--- a/apps/web/e2e/tests/terminal/mobile-quick-terminal.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-quick-terminal.spec.ts
@@ -12,10 +12,15 @@ async function readQuickTerminalBuffer(page: Page): Promise<string> {
   });
 }
 
+function normalizeTerminalText(text: string): string {
+  // xterm can wrap a marker across visual lines on narrow mobile viewports.
+  return text.replace(/\s+/g, "");
+}
+
 async function waitForTerminalReady(page: Page) {
   await expect
-    .poll(() => readQuickTerminalBuffer(page), {
-      timeout: 15_000,
+    .poll(async () => normalizeTerminalText(await readQuickTerminalBuffer(page)), {
+      timeout: 30_000,
       message: "Waiting for mobile Quick Chat terminal shell prompt",
     })
     .not.toBe("");
@@ -26,11 +31,11 @@ async function sendCommand(page: Page, command: string, marker: string) {
   await page.keyboard.type(`${command} ${marker}`);
   await page.keyboard.press("Enter");
   await expect
-    .poll(() => readQuickTerminalBuffer(page), {
-      timeout: 10_000,
+    .poll(async () => normalizeTerminalText(await readQuickTerminalBuffer(page)), {
+      timeout: 20_000,
       message: `Waiting for mobile terminal marker ${marker}`,
     })
-    .toContain(marker);
+    .toContain(normalizeTerminalText(marker));
 }
 
 async function closeSurvivingQuickTerminals(page: Page) {
@@ -54,6 +59,7 @@ test.describe("mobile quick terminal tabs", () => {
   test("uses a safe full-height surface, touch-safe menu, and contained terminal scroll", async ({
     testPage,
   }) => {
+    test.setTimeout(120_000);
     await testPage.goto("/");
     try {
       const terminalButton = testPage.getByTestId("mobile-quick-terminal-button");
@@ -103,7 +109,9 @@ test.describe("mobile quick terminal tabs", () => {
       await terminalButton.tap();
       await expect(dialog).toBeVisible();
       await expect(dialog.locator('[data-testid="quick-terminal-tab"]')).toHaveCount(1);
-      await expect.poll(() => readQuickTerminalBuffer(testPage)).toContain("MOBILE_TERMINAL_ONE");
+      await expect
+        .poll(async () => normalizeTerminalText(await readQuickTerminalBuffer(testPage)))
+        .toContain(normalizeTerminalText("MOBILE_TERMINAL_ONE"));
 
       const viewport = testPage.viewportSize();
       const dialogBox = await dialog.boundingBox();
@@ -144,7 +152,7 @@ test.describe("mobile quick terminal tabs", () => {
       expect(menuBox!.y + menuBox!.height).toBeLessThanOrEqual(viewport!.height + 1);
       const newTerminal = testPage.getByTestId("quick-chat-new-terminal");
       await expect
-        .poll(async () => (await newTerminal.boundingBox())?.height ?? 0, {
+        .poll(async () => Math.round((await newTerminal.boundingBox())?.height ?? 0), {
           message: "Waiting for the mobile menu row animation to settle",
         })
         .toBeGreaterThanOrEqual(44);
@@ -170,7 +178,9 @@ test.describe("mobile quick terminal tabs", () => {
         dialog.locator('[data-testid="quick-terminal-tab"][data-terminal-sequence="2"]'),
       );
       await expect(dialog.locator('[data-testid="quick-terminal-tab"]')).toHaveCount(1);
-      await expect.poll(() => readQuickTerminalBuffer(testPage)).toContain("MOBILE_TERMINAL_ONE");
+      await expect
+        .poll(async () => normalizeTerminalText(await readQuickTerminalBuffer(testPage)))
+        .toContain(normalizeTerminalText("MOBILE_TERMINAL_ONE"));
 
       await dialog.getByTestId("quick-chat-close").tap();
       await expect(dialog).toBeHidden();
@@ -180,7 +190,9 @@ test.describe("mobile quick terminal tabs", () => {
       await terminalButton.tap();
       await expect(dialog).toBeVisible();
       await expect(dialog.locator('[data-testid="quick-terminal-tab"]')).toHaveCount(1);
-      await expect.poll(() => readQuickTerminalBuffer(testPage)).toContain("MOBILE_TERMINAL_ONE");
+      await expect
+        .poll(async () => normalizeTerminalText(await readQuickTerminalBuffer(testPage)))
+        .toContain(normalizeTerminalText("MOBILE_TERMINAL_ONE"));
       await dialog.getByTestId("quick-chat-close").tap();
       await expect(dialog).toBeHidden();
     } finally {

--- a/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-agent.spec.ts
@@ -307,6 +307,15 @@ test.describe("Terminal agent (TUI passthrough)", () => {
     // The mock TUI prints "Processed: <prompt>" for each stdin line it receives.
     await session.expectPassthroughHasText("Analyze", 30_000);
     await session.expectPassthroughHasText("Processed: Implement", 30_000);
+    // Terminal output arrives before the lifecycle manager records the turn as
+    // complete. Wait for that state before asserting the workflow transition.
+    await waitForSessionState(apiClient, {
+      taskId: task.id,
+      sessionId: task.session_id as string,
+      expectedState: "WAITING_FOR_INPUT",
+      message: "the cascade turn did not settle before the final workflow step",
+      timeout: 30_000,
+    });
     await waitForWorkflowStep(
       apiClient,
       task.id,
@@ -389,6 +398,15 @@ test.describe("Terminal agent (TUI passthrough)", () => {
 
     // After context reset, the fresh process completes the Implement step prompt.
     await session.expectPassthroughHasText("Processed: Implement", 30_000);
+    // Terminal output arrives before the lifecycle manager records the turn as
+    // complete. Wait for that state before asserting the workflow transition.
+    await waitForSessionState(apiClient, {
+      taskId: task.id,
+      sessionId: task.session_id as string,
+      expectedState: "WAITING_FOR_INPUT",
+      message: "the reset cascade turn did not settle before the final workflow step",
+      timeout: 30_000,
+    });
     await waitForWorkflowStep(
       apiClient,
       task.id,

--- a/apps/web/e2e/tests/workflow/workflow-steps.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-steps.spec.ts
@@ -69,19 +69,22 @@ test.describe("Workflow steps", () => {
       return;
     }
 
-    const task = await apiClient.createTaskWithAgent(
+    const { task_id: taskId } = await apiClient.seedTask(
       seedData.workspaceId,
       "Workflow Move Feedback Task",
-      seedData.agentProfileId,
       {
-        description: "e2e:delay(5000)",
+        state: "IN_PROGRESS",
         workflow_id: seedData.workflowId,
         workflow_step_id: seedData.startStepId,
-        repository_ids: [seedData.repositoryId],
       },
     );
+    await apiClient.seedTaskSession(taskId, {
+      state: "RUNNING",
+      agentProfileId: seedData.agentProfileId,
+      repositoryId: seedData.repositoryId,
+    });
 
-    await testPage.route(`**/api/v1/tasks/${task.id}/move`, async (route) => {
+    await testPage.route(`**/api/v1/tasks/${taskId}/move`, async (route) => {
       await route.fulfill({
         status: 409,
         contentType: "application/json",
@@ -92,7 +95,7 @@ test.describe("Workflow steps", () => {
       });
     });
 
-    await testPage.goto(`/t/${task.id}`);
+    await testPage.goto(`/t/${taskId}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
     await expect(session.stepper).toBeVisible();
@@ -118,19 +121,22 @@ test.describe("Workflow steps", () => {
       return;
     }
 
-    const task = await apiClient.createTaskWithAgent(
+    const { task_id: taskId } = await apiClient.seedTask(
       seedData.workspaceId,
       "Workflow Sidebar Move Feedback Task",
-      seedData.agentProfileId,
       {
-        description: "e2e:delay(5000)",
+        state: "IN_PROGRESS",
         workflow_id: seedData.workflowId,
         workflow_step_id: seedData.startStepId,
-        repository_ids: [seedData.repositoryId],
       },
     );
+    await apiClient.seedTaskSession(taskId, {
+      state: "RUNNING",
+      agentProfileId: seedData.agentProfileId,
+      repositoryId: seedData.repositoryId,
+    });
 
-    await testPage.route(`**/api/v1/tasks/${task.id}/move`, async (route) => {
+    await testPage.route(`**/api/v1/tasks/${taskId}/move`, async (route) => {
       await route.fulfill({
         status: 409,
         contentType: "application/json",
@@ -141,7 +147,7 @@ test.describe("Workflow steps", () => {
       });
     });
 
-    await testPage.goto(`/t/${task.id}`);
+    await testPage.goto(`/t/${taskId}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3133/b18c958faa80.html)
<!-- kandev-pr-walkthrough-end -->

Fix order-dependent E2E failures by finalizing archived task sessions when runtime cleanup is stale, synchronizing workflow-step transitions, and isolating seeded repository state between tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->