### PR TITLE
fix(backend): retry PR creation after push to absorb GitHub eventual consistency

### DIFF
--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -51,6 +51,15 @@ type GitOperator struct {
 	remoteContributionErr      error
 	contributionDestination    *models.ContributionDestination
 	contributionDestinationErr error
+	// prCreateRetryAttempts is the number of times to attempt PR creation after a
+	// successful branch push. GitHub's eventual consistency can briefly return
+	// "no commits between base and head" (or similar) for a ref it has not yet
+	// indexed, so we retry instead of surfacing that transient failure to the user.
+	// Set to 1 to disable the backoff (push, then one create attempt).
+	prCreateRetryAttempts int
+	// prCreateRetryBaseDelay is the initial backoff between create attempts. Each
+	// attempt waits baseDelay*attempt (linear backoff) before retrying.
+	prCreateRetryBaseDelay time.Duration
 
 	mu         sync.Mutex // Prevents concurrent git operations
 	inProgress bool
@@ -60,10 +69,12 @@ type GitOperator struct {
 // NewGitOperator creates a new GitOperator for the given workspace directory.
 func NewGitOperator(workDir string, log *logger.Logger, workspaceTracker *WorkspaceTracker) *GitOperator {
 	return &GitOperator{
-		workDir:          workDir,
-		logger:           log.WithFields(zap.String("component", "git-operator")),
-		workspaceTracker: workspaceTracker,
-		environment:      os.Environ,
+		workDir:                workDir,
+		logger:                 log.WithFields(zap.String("component", "git-operator")),
+		workspaceTracker:       workspaceTracker,
+		environment:            os.Environ,
+		prCreateRetryAttempts:  3,
+		prCreateRetryBaseDelay: 2 * time.Second,
 	}
 }
 
@@ -1294,14 +1305,20 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 
 	switch provider {
 	case prProviderAzureRepos:
-		created, createErr := g.createAzureReposPR(ctx, result, remoteURL, branch, title, body, baseBranch, draft)
-		return finalizePRCreationAfterPush(created, createErr)
+		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+			func() (*PRCreateResult, error) {
+				return g.createAzureReposPR(ctx, result, remoteURL, branch, title, body, baseBranch, draft)
+			})
 	case prProviderGitHub:
-		created, createErr := g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
-		return finalizePRCreationAfterPush(created, createErr)
+		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+			func() (*PRCreateResult, error) {
+				return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
+			})
 	case prProviderGitLab:
-		created, createErr := g.createGitLabPR(ctx, result, gitLabInfo, branch, title, body, baseBranch, draft)
-		return finalizePRCreationAfterPush(created, createErr)
+		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+			func() (*PRCreateResult, error) {
+				return g.createGitLabPR(ctx, result, gitLabInfo, branch, title, body, baseBranch, draft)
+			})
 	default:
 		result.Error = "unsupported git remote for PR creation"
 		return result, nil
@@ -1340,8 +1357,74 @@ func (g *GitOperator) createManagedContributionPR(
 	}
 	result.Provider = string(prProviderGitHub)
 	result.BranchPushed = true
-	created, createErr := g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
-	return finalizePRCreationAfterPush(created, createErr)
+	return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+		func() (*PRCreateResult, error) {
+			return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
+		})
+}
+
+
+// createPRWithRetryAfterPush runs a single provider create call with bounded
+// backoff. The branch has already been pushed by the caller, so a transient
+// provider-side failure (e.g. GitHub's eventual consistency returning "no
+// commits between base and head" before it has indexed the new ref) should be
+// retried rather than surfaced to the user as the generic "Branch was pushed;
+// retry creation" prompt. The first success wins; once attempts are exhausted
+// the final partial failure is finalized into that user-facing prompt.
+func (g *GitOperator) createPRWithRetryAfterPush(
+	ctx context.Context,
+	result *PRCreateResult,
+	title, body, baseBranch string,
+	draft bool,
+	attempt func() (*PRCreateResult, error),
+) (*PRCreateResult, error) {
+	attempts := g.prCreateRetryAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	var last *PRCreateResult
+	var lastErr error
+	for attemptIdx := range attempts {
+		i := attemptIdx + 1
+		if attemptIdx > 0 {
+			delay := g.prCreateRetryBaseDelay * time.Duration(i)
+			if !sleepCtx(ctx, delay) {
+				return finalizePRCreationAfterPush(last, lastErr)
+			}
+		}
+		last, lastErr = attempt()
+		if lastErr == nil && last != nil && last.Success {
+			return last, nil
+		}
+		g.logger.Warn("PR creation attempt failed after push; retrying",
+			zap.Int("attempt", i),
+			zap.Int("total_attempts", attempts),
+			zap.String("error", errOrEmpty(lastErr, last)),
+		)
+	}
+	return finalizePRCreationAfterPush(last, lastErr)
+}
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// errOrEmpty renders a create failure as a single string for logging: the
+// explicit error if present, otherwise the result's Error field.
+func errOrEmpty(err error, result *PRCreateResult) string {
+	if err != nil {
+		return err.Error()
+	}
+	if result != nil {
+		return result.Error
+	}
+	return ""
 }
 
 func finalizePRCreationAfterPush(result *PRCreateResult, createErr error) (*PRCreateResult, error) {

--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -53,8 +53,8 @@ type GitOperator struct {
 	contributionDestinationErr error
 	// prCreateRetryAttempts is the number of times to attempt PR creation after a
 	// successful branch push. GitHub's eventual consistency can briefly return
-	// "no commits between base and head" (or similar) for a ref it has not yet
-	// indexed, so we retry instead of surfacing that transient failure to the user.
+	// "no commits between base and head" for a ref it has not yet indexed, so we
+	// retry that known transient failure instead of surfacing it to the user.
 	// Set to 1 to disable the backoff (push, then one create attempt).
 	prCreateRetryAttempts int
 	// prCreateRetryBaseDelay is the initial backoff between create attempts. Each
@@ -1305,17 +1305,17 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 
 	switch provider {
 	case prProviderAzureRepos:
-		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+		return g.createPRWithRetryAfterPush(ctx, result, title, body,
 			func() (*PRCreateResult, error) {
 				return g.createAzureReposPR(ctx, result, remoteURL, branch, title, body, baseBranch, draft)
 			})
 	case prProviderGitHub:
-		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+		return g.createPRWithRetryAfterPush(ctx, result, title, body,
 			func() (*PRCreateResult, error) {
 				return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
 			})
 	case prProviderGitLab:
-		return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+		return g.createPRWithRetryAfterPush(ctx, result, title, body,
 			func() (*PRCreateResult, error) {
 				return g.createGitLabPR(ctx, result, gitLabInfo, branch, title, body, baseBranch, draft)
 			})
@@ -1357,53 +1357,101 @@ func (g *GitOperator) createManagedContributionPR(
 	}
 	result.Provider = string(prProviderGitHub)
 	result.BranchPushed = true
-	return g.createPRWithRetryAfterPush(ctx, result, title, body, baseBranch, draft,
+	return g.createPRWithRetryAfterPush(ctx, result, title, body,
 		func() (*PRCreateResult, error) {
 			return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
 		})
 }
 
-
-// createPRWithRetryAfterPush runs a single provider create call with bounded
-// backoff. The branch has already been pushed by the caller, so a transient
-// provider-side failure (e.g. GitHub's eventual consistency returning "no
-// commits between base and head" before it has indexed the new ref) should be
-// retried rather than surfaced to the user as the generic "Branch was pushed;
-// retry creation" prompt. The first success wins; once attempts are exhausted
-// the final partial failure is finalized into that user-facing prompt.
+// createPRWithRetryAfterPush runs a provider create call with bounded backoff.
+// The branch has already been pushed by the caller, so only the known
+// eventual-consistency response is retried. Other failures can be ambiguous
+// after a non-idempotent create request, so they are finalized immediately.
+// The first success wins; once attempts are exhausted the final partial failure
+// is finalized into the existing user-facing prompt.
 func (g *GitOperator) createPRWithRetryAfterPush(
 	ctx context.Context,
 	result *PRCreateResult,
-	title, body, baseBranch string,
-	draft bool,
+	title, body string,
 	attempt func() (*PRCreateResult, error),
 ) (*PRCreateResult, error) {
 	attempts := g.prCreateRetryAttempts
 	if attempts < 1 {
 		attempts = 1
 	}
-	var last *PRCreateResult
+	if result == nil {
+		result = &PRCreateResult{}
+	}
+	var last = result
 	var lastErr error
 	for attemptIdx := range attempts {
 		i := attemptIdx + 1
 		if attemptIdx > 0 {
-			delay := g.prCreateRetryBaseDelay * time.Duration(i)
+			delay := prCreateRetryDelay(g.prCreateRetryBaseDelay, attemptIdx)
 			if !sleepCtx(ctx, delay) {
 				return finalizePRCreationAfterPush(last, lastErr)
 			}
 		}
-		last, lastErr = attempt()
+		resetPRCreateAttemptResult(result)
+		attemptResult, attemptErr := attempt()
+		if attemptResult == nil {
+			attemptResult = result
+		}
+		if attemptResult.Provider == "" {
+			attemptResult.Provider = result.Provider
+		}
+		if result.BranchPushed {
+			attemptResult.BranchPushed = true
+		}
+		last, lastErr = attemptResult, attemptErr
 		if lastErr == nil && last != nil && last.Success {
 			return last, nil
+		}
+		if !isRetryablePRCreationFailure(lastErr, last) || attemptIdx == attempts-1 {
+			return finalizePRCreationAfterPush(last, lastErr)
 		}
 		g.logger.Warn("PR creation attempt failed after push; retrying",
 			zap.Int("attempt", i),
 			zap.Int("total_attempts", attempts),
-			zap.String("error", errOrEmpty(lastErr, last)),
+			zap.String("error", g.sanitizePRFailure(errOrEmpty(lastErr, last), title, body)),
 		)
 	}
 	return finalizePRCreationAfterPush(last, lastErr)
 }
+
+func prCreateRetryDelay(base time.Duration, retryIndex int) time.Duration {
+	if retryIndex < 1 {
+		return 0
+	}
+	return base * time.Duration(retryIndex)
+}
+
+func resetPRCreateAttemptResult(result *PRCreateResult) {
+	if result == nil {
+		return
+	}
+	result.Success = false
+	result.PRURL = ""
+	result.Output = ""
+	result.Error = ""
+}
+
+func isRetryablePRCreationFailure(err error, result *PRCreateResult) bool {
+	if result == nil {
+		return false
+	}
+	message := strings.ToLower(errOrEmpty(err, result))
+	if !strings.Contains(message, "no commits between") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(result.Provider)) {
+	case string(prProviderGitHub), string(prProviderGitLab), string(prProviderAzureRepos):
+		return true
+	default:
+		return false
+	}
+}
+
 func sleepCtx(ctx context.Context, d time.Duration) bool {
 	t := time.NewTimer(d)
 	defer t.Stop()
@@ -1422,7 +1470,14 @@ func errOrEmpty(err error, result *PRCreateResult) string {
 		return err.Error()
 	}
 	if result != nil {
-		return result.Error
+		switch {
+		case result.Error != "" && result.Output != "":
+			return result.Error + "\n" + result.Output
+		case result.Error != "":
+			return result.Error
+		default:
+			return result.Output
+		}
 	}
 	return ""
 }

--- a/apps/backend/internal/agentctl/server/process/git_pr_retry_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_retry_test.go
@@ -1,0 +1,250 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCreatePRWithRetryAfterPushClearsTransientResult(t *testing.T) {
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 2
+	operator.prCreateRetryBaseDelay = 0
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	got, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			if attempts == 1 {
+				result.Error = "no commits between base and head"
+				result.Output = "provider failure"
+				return result, nil
+			}
+			result.Success = true
+			result.PRURL = "https://github.com/acme/repo/pull/1"
+			result.Output = "created"
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if !got.Success || got.Error != "" || got.Output != "created" {
+		t.Fatalf("result = %+v, want clean successful result", got)
+	}
+}
+
+func TestCreatePRWithRetryAfterPushDoesNotRetryPermanentFailure(t *testing.T) {
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 3
+	operator.prCreateRetryBaseDelay = 0
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	got, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			result.Error = "authentication failed"
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 for permanent failure", attempts)
+	}
+	if got.Success || !got.BranchPushed || got.Error != "branch was pushed; retry pull request creation" {
+		t.Fatalf("result = %+v, want generic partial result", got)
+	}
+}
+
+func TestCreatePRWithRetryAfterPushExhaustsTransientFailures(t *testing.T) {
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 3
+	operator.prCreateRetryBaseDelay = 0
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	got, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			result.Error = "no commits between base and head"
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if got.Success || !got.BranchPushed || got.Error != "branch was pushed; retry pull request creation" {
+		t.Fatalf("result = %+v, want generic partial result", got)
+	}
+}
+
+func TestCreatePRWithRetryAfterPushStopsWhenContextCanceledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 3
+	operator.prCreateRetryBaseDelay = time.Hour
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	got, err := operator.createPRWithRetryAfterPush(
+		ctx, result, "title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			result.Error = "no commits between base and head"
+			cancel()
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 after cancellation", attempts)
+	}
+	if got.Error != "branch was pushed; retry pull request creation" {
+		t.Fatalf("result = %+v, want generic partial result", got)
+	}
+}
+
+func TestPRCreateRetryDelayUsesLinearBackoff(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		base       time.Duration
+		retryIndex int
+		want       time.Duration
+	}{
+		{name: "first attempt", base: 2 * time.Second, retryIndex: 0, want: 0},
+		{name: "first retry", base: 2 * time.Second, retryIndex: 1, want: 2 * time.Second},
+		{name: "second retry", base: 2 * time.Second, retryIndex: 2, want: 4 * time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := prCreateRetryDelay(test.base, test.retryIndex); got != test.want {
+				t.Fatalf("delay = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCreatePRWithRetryAfterPushPreservesPushMetadata(t *testing.T) {
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 1
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+
+	got, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "title", "body",
+		func() (*PRCreateResult, error) {
+			return &PRCreateResult{
+				Success: true,
+				PRURL:   "https://github.com/acme/repo/pull/1",
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if !got.Success || !got.BranchPushed || got.Provider != string(prProviderGitHub) {
+		t.Fatalf("result = %+v, want successful result with push metadata", got)
+	}
+}
+
+func TestCreatePRWithRetryAfterPushClassifiesProviderOutput(t *testing.T) {
+	operator := NewGitOperator(t.TempDir(), newTestLogger(t), nil)
+	operator.prCreateRetryAttempts = 2
+	operator.prCreateRetryBaseDelay = 0
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	got, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			if attempts == 1 {
+				result.Error = "provider rejected pull request creation"
+				result.Output = "no commits between base and head"
+				return result, nil
+			}
+			result.Success = true
+			result.PRURL = "https://github.com/acme/repo/pull/1"
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	if attempts != 2 || !got.Success {
+		t.Fatalf("attempts = %d, result = %+v, want retry and success", attempts, got)
+	}
+}
+
+func TestCreatePRWithRetryAfterPushSanitizesRetryWarning(t *testing.T) {
+	log, observed := newObservedTestLogger(t)
+	operator := NewGitOperator(t.TempDir(), log, nil)
+	operator.prCreateRetryAttempts = 2
+	operator.prCreateRetryBaseDelay = 0
+	result := &PRCreateResult{
+		Provider:     string(prProviderGitHub),
+		BranchPushed: true,
+	}
+	attempts := 0
+
+	_, err := operator.createPRWithRetryAfterPush(
+		context.Background(), result, "Sensitive title", "body",
+		func() (*PRCreateResult, error) {
+			attempts++
+			if attempts == 1 {
+				result.Error = "no commits between base and head: https://oauth2:embedded-token@git.example/repo Sensitive title"
+				return result, nil
+			}
+			result.Success = true
+			result.PRURL = "https://github.com/acme/repo/pull/1"
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("createPRWithRetryAfterPush returned error: %v", err)
+	}
+	entries := observed.FilterMessage("PR creation attempt failed after push; retrying").All()
+	if len(entries) != 1 {
+		t.Fatalf("retry warning entries = %d, want 1", len(entries))
+	}
+	loggedError := fmt.Sprint(entries[0].ContextMap()["error"])
+	for _, secret := range []string{"embedded-token", "Sensitive title"} {
+		if strings.Contains(loggedError, secret) {
+			t.Fatalf("retry warning contains %q: %q", secret, loggedError)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Create-PR could fail immediately after pushing a task branch with `Branch was pushed; retry pull request creation.` GitHub occasionally hasn't indexed a freshly-pushed ref by the time the create-PR call fires, so a transient "no commits between base and head"-style error surfaced directly to the user instead of being retried.
- `CreatePR` and `createManagedContributionPR` now share `createPRWithRetryAfterPush`, which retries the provider create call up to `prCreateRetryAttempts` times (default 3) with linear backoff (`prCreateRetryBaseDelay*attempt`) before finalizing into the existing user-facing prompt. GitHub, GitLab, and Azure Repos all go through the same retry wrapper.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/agentctl/server/process/...`
- [x] `go test ./internal/agentctl/server/process/...` — all PR/provider-detection tests pass (`TestGitOperatorCreatePR_*`, `TestDetectPRProvider*`); one pre-existing, unrelated failure (`TestRepairManagedRuntimeCacheClearsPreviousStderr`, npm/opencode workspace connectivity) is untouched by this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

