### PR TITLE
fix: resume persisted Quick Chat sessions

### DIFF
--- a/apps/web/components/quick-chat/quick-chat-session-view.test.tsx
+++ b/apps/web/components/quick-chat/quick-chat-session-view.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sessionRows = vi.hoisted(
+  () =>
+    ({}) as Record<
+      string,
+      { task_id?: string; agent_profile_id?: string; is_passthrough?: boolean }
+    >,
+);
+const useEnsureTaskSession = vi.hoisted(() => vi.fn());
+const useSessionResumption = vi.hoisted(() =>
+  vi.fn(() => ({
+    resumptionState: "idle",
+    sessionStatus: null,
+    error: null,
+    taskSessionState: null,
+    worktreePath: null,
+    worktreeBranch: null,
+    resumeSession: vi.fn(),
+  })),
+);
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      taskSessions: { items: sessionRows },
+      quickChat: { sessions: [] },
+      agentProfiles: { items: [] },
+    }),
+}));
+
+vi.mock("@/hooks/use-ensure-task-session", () => ({ useEnsureTaskSession }));
+vi.mock("@/hooks/domains/session/use-session-resumption", () => ({ useSessionResumption }));
+vi.mock("@/components/task/passthrough-terminal", () => ({
+  PassthroughTerminal: () => <div data-testid="passthrough-terminal" />,
+}));
+vi.mock("./quick-chat-content", () => ({
+  QuickChatContent: () => <div data-testid="quick-chat-content" />,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { QuickChatSessionView } from "./quick-chat-session-view";
+
+const session = {
+  kind: "chat" as const,
+  sessionId: "session-1",
+  workspaceId: "workspace-1",
+};
+
+afterEach(() => {
+  cleanup();
+  delete sessionRows[session.sessionId];
+  vi.clearAllMocks();
+});
+
+// @covers AC-TASKS-QUICK-CHAT-EXPIRATION-001.2
+describe("QuickChatSessionView session resumption", () => {
+  it("mounts resumption with the task id stored on the Quick Chat descriptor", () => {
+    render(<QuickChatSessionView session={{ ...session, taskId: "task-from-descriptor" }} />);
+
+    expect(useSessionResumption).toHaveBeenCalledWith("task-from-descriptor", session.sessionId);
+  });
+
+  it("falls back to the hydrated task-session row when the descriptor has no task id", () => {
+    sessionRows[session.sessionId] = { task_id: "task-from-hydrated-row" };
+
+    render(<QuickChatSessionView session={session} />);
+
+    expect(useSessionResumption).toHaveBeenCalledWith("task-from-hydrated-row", session.sessionId);
+  });
+
+  it("passes a null task id until session hydration provides one", () => {
+    const view = render(<QuickChatSessionView session={session} />);
+
+    expect(useSessionResumption).toHaveBeenLastCalledWith(null, session.sessionId);
+
+    sessionRows[session.sessionId] = { task_id: "task-after-hydration" };
+    view.rerender(<QuickChatSessionView session={session} />);
+
+    expect(useSessionResumption).toHaveBeenLastCalledWith(
+      "task-after-hydration",
+      session.sessionId,
+    );
+  });
+});

--- a/apps/web/components/quick-chat/quick-chat-session-view.test.tsx
+++ b/apps/web/components/quick-chat/quick-chat-session-view.test.tsx
@@ -44,6 +44,9 @@ vi.mock("react-i18next", () => ({
 
 import { QuickChatSessionView } from "./quick-chat-session-view";
 
+const DESCRIPTOR_TASK_ID = "task-from-descriptor";
+const HYDRATED_TASK_ID = "task-from-hydrated-row";
+
 const session = {
   kind: "chat" as const,
   sessionId: "session-1",
@@ -58,18 +61,33 @@ afterEach(() => {
 
 // @covers AC-TASKS-QUICK-CHAT-EXPIRATION-001.2
 describe("QuickChatSessionView session resumption", () => {
-  it("mounts resumption with the task id stored on the Quick Chat descriptor", () => {
-    render(<QuickChatSessionView session={{ ...session, taskId: "task-from-descriptor" }} />);
+  it("prefers the descriptor task id over a conflicting hydrated row", () => {
+    sessionRows[session.sessionId] = { task_id: HYDRATED_TASK_ID };
 
-    expect(useSessionResumption).toHaveBeenCalledWith("task-from-descriptor", session.sessionId);
+    render(<QuickChatSessionView session={{ ...session, taskId: DESCRIPTOR_TASK_ID }} />);
+
+    expect(useSessionResumption).toHaveBeenCalledWith(DESCRIPTOR_TASK_ID, session.sessionId);
+  });
+
+  it("waits for session hydration before resuming a descriptor task", () => {
+    const view = render(
+      <QuickChatSessionView session={{ ...session, taskId: DESCRIPTOR_TASK_ID }} />,
+    );
+
+    expect(useSessionResumption).toHaveBeenLastCalledWith(null, session.sessionId);
+
+    sessionRows[session.sessionId] = { task_id: HYDRATED_TASK_ID };
+    view.rerender(<QuickChatSessionView session={{ ...session, taskId: DESCRIPTOR_TASK_ID }} />);
+
+    expect(useSessionResumption).toHaveBeenLastCalledWith(DESCRIPTOR_TASK_ID, session.sessionId);
   });
 
   it("falls back to the hydrated task-session row when the descriptor has no task id", () => {
-    sessionRows[session.sessionId] = { task_id: "task-from-hydrated-row" };
+    sessionRows[session.sessionId] = { task_id: HYDRATED_TASK_ID };
 
     render(<QuickChatSessionView session={session} />);
 
-    expect(useSessionResumption).toHaveBeenCalledWith("task-from-hydrated-row", session.sessionId);
+    expect(useSessionResumption).toHaveBeenCalledWith(HYDRATED_TASK_ID, session.sessionId);
   });
 
   it("passes a null task id until session hydration provides one", () => {

--- a/apps/web/components/quick-chat/quick-chat-session-view.tsx
+++ b/apps/web/components/quick-chat/quick-chat-session-view.tsx
@@ -30,9 +30,8 @@ export function QuickChatSessionView({ session, onInitialPromptSent }: QuickChat
   // A tab can arrive from a task event, which carries no session payload.
   // Fetch the row on open so such a tab is usable, not just visible.
   useEnsureTaskSession(session.sessionId);
-  const taskId = useAppStore(
-    (state) => session.taskId ?? state.taskSessions.items[session.sessionId]?.task_id ?? null,
-  );
+  const taskSession = useAppStore((state) => state.taskSessions.items[session.sessionId] ?? null);
+  const taskId = taskSession ? (session.taskId ?? taskSession.task_id ?? null) : null;
   useSessionResumption(taskId, session.sessionId);
   const isPassthrough = useIsQuickChatPassthrough(session.sessionId);
   if (isPassthrough) {

--- a/apps/web/components/quick-chat/quick-chat-session-view.tsx
+++ b/apps/web/components/quick-chat/quick-chat-session-view.tsx
@@ -2,6 +2,7 @@
 
 import { useAppStore } from "@/components/state-provider";
 import { useEnsureTaskSession } from "@/hooks/use-ensure-task-session";
+import { useSessionResumption } from "@/hooks/domains/session/use-session-resumption";
 import { PassthroughTerminal } from "@/components/task/passthrough-terminal";
 import type { QuickChatSession } from "@/lib/state/slices/ui/types";
 import { QuickChatContent } from "./quick-chat-content";
@@ -29,6 +30,10 @@ export function QuickChatSessionView({ session, onInitialPromptSent }: QuickChat
   // A tab can arrive from a task event, which carries no session payload.
   // Fetch the row on open so such a tab is usable, not just visible.
   useEnsureTaskSession(session.sessionId);
+  const taskId = useAppStore(
+    (state) => session.taskId ?? state.taskSessions.items[session.sessionId]?.task_id ?? null,
+  );
+  useSessionResumption(taskId, session.sessionId);
   const isPassthrough = useIsQuickChatPassthrough(session.sessionId);
   if (isPassthrough) {
     return (

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
 import { attachAvailableCommandsCapture, attachShellInputCapture } from "../../helpers/ws-capture";
+import { waitForSessionState } from "../../helpers/session";
 import { SHORTCUTS } from "@/lib/keyboard/constants";
 import {
   openQuickChatSetup,
@@ -754,6 +755,71 @@ test.describe("Quick Chat", () => {
     });
     await effortTrigger.click();
     await expect(testPage.getByTestId("config-option-section-effort")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  // @covers AC-TASKS-QUICK-CHAT-EXPIRATION-001.2
+  test("resumes a restored session after backend restart", async ({
+    testPage,
+    apiClient,
+    backend,
+  }) => {
+    test.setTimeout(120_000);
+
+    const dialog = await openQuickChatSetup(testPage);
+    const startResponse = testPage.waitForResponse(
+      (response) =>
+        response.url().includes("/quick-chat") && response.request().method() === "POST",
+    );
+    await startQuickChatFromSetup(dialog, testPage);
+    const started = (await (await startResponse).json()) as {
+      task_id: string;
+      session_id: string;
+    };
+
+    await sendQuickChatMessage(dialog, testPage, "/e2e:simple-message");
+    await expect(dialog.getByText("simple mock response", { exact: false })).toBeVisible({
+      timeout: 30_000,
+    });
+    await waitForSessionState(apiClient, {
+      taskId: started.task_id,
+      sessionId: started.session_id,
+      expectedState: "WAITING_FOR_INPUT",
+      message: "Quick Chat session did not settle before backend restart",
+      timeout: 30_000,
+    });
+
+    await backend.restart();
+    await testPage.reload();
+    await testPage.waitForLoadState("networkidle");
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await testPage.keyboard.press(`${modifier}+Shift+q`);
+    const restoredDialog = testPage.getByRole("dialog", { name: "Quick Chat" });
+    await expect(restoredDialog).toBeVisible({ timeout: 10_000 });
+    const restoredTab = restoredDialog.locator(
+      `[data-tab-reference="conversation:${started.session_id}"]`,
+    );
+    await expect(restoredTab).toBeVisible({ timeout: 15_000 });
+
+    await waitForSessionState(apiClient, {
+      taskId: started.task_id,
+      sessionId: started.session_id,
+      expectedState: "WAITING_FOR_INPUT",
+      message: "Restored Quick Chat session did not settle after backend restart",
+      timeout: 60_000,
+    });
+    await expect(restoredDialog.getByText("Resumed agent Mock", { exact: false })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const modelSettings = restoredDialog.getByRole("button", {
+      name: "Session model settings",
+    });
+    await expect(modelSettings).toContainText("Mock Fast", { timeout: 15_000 });
+    await modelSettings.click();
+    await expect(testPage.getByTestId("config-option-trigger-effort")).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/apps/web/hooks/use-ensure-task-session.test.ts
+++ b/apps/web/hooks/use-ensure-task-session.test.ts
@@ -20,6 +20,14 @@ function setStoredSessions(items: Record<string, unknown>) {
   mockState.value = { taskSessions: { items }, setTaskSession };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   setStoredSessions({});
@@ -34,6 +42,42 @@ describe("useEnsureTaskSession", () => {
 
     await waitFor(() => expect(mockFetchTaskSession).toHaveBeenCalledWith("session-1"));
     expect(setTaskSession).toHaveBeenCalledWith({ id: "session-1", task_id: "task-1" });
+  });
+
+  it("merges the full row when a placeholder arrives while hydration is pending", async () => {
+    const response = deferred<{
+      session: { id: string; task_id: string; agent_profile_id: string };
+    }>();
+    mockFetchTaskSession.mockReturnValue(response.promise);
+
+    const { rerender } = renderHook(() => useEnsureTaskSession("session-1"));
+    await waitFor(() => expect(mockFetchTaskSession).toHaveBeenCalledTimes(1));
+
+    // A status response can insert a placeholder before the authoritative HTTP row arrives.
+    setStoredSessions({
+      "session-1": {
+        id: "session-1",
+        state: "WAITING_FOR_INPUT",
+        updated_at: "2026-08-29T09:00:00Z",
+      },
+    });
+    rerender();
+
+    response.resolve({
+      session: {
+        id: "session-1",
+        task_id: "task-1",
+        agent_profile_id: "profile-1",
+      },
+    });
+
+    await waitFor(() =>
+      expect(setTaskSession).toHaveBeenCalledWith({
+        id: "session-1",
+        task_id: "task-1",
+        agent_profile_id: "profile-1",
+      }),
+    );
   });
 
   it("does not refetch a session already in the store", () => {
@@ -60,5 +104,38 @@ describe("useEnsureTaskSession", () => {
 
     expect(mockFetchTaskSession).toHaveBeenCalledTimes(1);
     expect(setTaskSession).not.toHaveBeenCalled();
+  });
+
+  it("retries hydration when the active tab changes before the request settles", async () => {
+    const firstResponse = deferred<{ session: { id: string; task_id: string } }>();
+    const secondResponse = deferred<{ session: { id: string; task_id: string } }>();
+    let sessionOneCalls = 0;
+    mockFetchTaskSession.mockImplementation((sessionId: string) => {
+      if (sessionId === "session-1") {
+        sessionOneCalls += 1;
+        return sessionOneCalls === 1 ? firstResponse.promise : secondResponse.promise;
+      }
+      return Promise.resolve({ session: { id: sessionId, task_id: "task-2" } });
+    });
+
+    const { rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) => useEnsureTaskSession(sessionId),
+      { initialProps: { sessionId: "session-1" } },
+    );
+    await waitFor(() => expect(mockFetchTaskSession).toHaveBeenCalledTimes(1));
+
+    rerender({ sessionId: "session-2" });
+    rerender({ sessionId: "session-1" });
+
+    await waitFor(() => expect(mockFetchTaskSession).toHaveBeenCalledTimes(3));
+    secondResponse.resolve({ session: { id: "session-1", task_id: "task-after-return" } });
+
+    await waitFor(() =>
+      expect(setTaskSession).toHaveBeenCalledWith({
+        id: "session-1",
+        task_id: "task-after-return",
+      }),
+    );
+    firstResponse.resolve({ session: { id: "session-1", task_id: "task-stale" } });
   });
 });

--- a/apps/web/hooks/use-ensure-task-session.ts
+++ b/apps/web/hooks/use-ensure-task-session.ts
@@ -22,12 +22,15 @@ export function useEnsureTaskSession(sessionId: string | null): void {
   // Never re-request a session id this hook has already asked for; a chat whose
   // task was deleted elsewhere would otherwise refetch on every render.
   const requested = useRef<Set<string>>(new Set());
+  const hasSessionRef = useRef(hasSession);
+  hasSessionRef.current = hasSession;
 
   useEffect(() => {
-    if (!sessionId || hasSession || requested.current.has(sessionId)) return;
+    if (!sessionId || hasSessionRef.current || requested.current.has(sessionId)) return;
     requested.current.add(sessionId);
 
     let cancelled = false;
+    let settled = false;
     fetchTaskSession(sessionId)
       .then((response) => {
         if (!cancelled && response.session) setTaskSession(response.session);
@@ -35,10 +38,17 @@ export function useEnsureTaskSession(sessionId: string | null): void {
       .catch(() => {
         // The session may be genuinely gone (deleted on another device); the
         // tab strip drops it on the next event or resync.
+      })
+      .finally(() => {
+        settled = true;
       });
 
     return () => {
       cancelled = true;
+      // If the active tab changed while this request was in flight, allow a
+      // later visit to retry. Keep settled failures marked as requested so a
+      // deleted session does not refetch on every tab switch.
+      if (!settled) requested.current.delete(sessionId);
     };
-  }, [sessionId, hasSession, setTaskSession]);
+  }, [sessionId, setTaskSession]);
 }

--- a/docs/plans/quick-chat-session-resume/plan.md
+++ b/docs/plans/quick-chat-session-resume/plan.md
@@ -48,24 +48,31 @@ calls.
 ### Shared Quick Chat session view
 
 Update `apps/web/components/quick-chat/quick-chat-session-view.tsx` to resolve the backing task ID
-from `QuickChatSession.taskId` or `taskSessions.items[sessionId].task_id`. Mount
-`useSessionResumption` before the persisted session view selects its presentation. The existing
-hook owns connection gating, status checks, preference handling, resume fallback, and stale-result
-guards.
+from `QuickChatSession.taskId` or `taskSessions.items[sessionId].task_id`, but pass no task ID to
+the resumption hook until the task-session row is hydrated. This prevents the status request from
+racing the authoritative row fetch. Mount `useSessionResumption` before the persisted session view
+selects its presentation. The existing hook owns connection gating, status checks, preference
+handling, resume fallback, and stale-result guards.
+
+Keep interrupted task-session hydration retryable when the active Quick Chat tab changes before its
+request settles. If another status path inserts a placeholder row first, merge the eventual
+authoritative HTTP response instead of cancelling it when the placeholder becomes visible.
 
 ### Regression evidence
 
-Create `quick-chat-session-view.test.tsx` with focused mocks that prove direct descriptor identity,
-hydrated-row fallback, and no invalid task ID. Add a backend-restart scenario to
-`e2e/tests/chat/quick-chat.spec.ts`. The scenario reopens the restored conversation and observes the
-resumed-agent boot message. It also verifies that dynamic session model settings are available.
+Create `quick-chat-session-view.test.tsx` with focused mocks that prove descriptor precedence,
+hydrated-row fallback, and no resumption before hydration. Add deferred-response coverage to
+`use-ensure-task-session.test.ts` for placeholder merging and active-tab cancellation. Add a
+backend-restart scenario to `e2e/tests/chat/quick-chat.spec.ts`. The scenario reopens the restored
+conversation and observes the resumed-agent boot message. It also verifies that dynamic session
+model settings are available.
 
 ## Tests
 
-| Acceptance criterion | Evidence |
-| --- | --- |
-| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | `quick-chat-session-view.test.tsx` proves the active persisted tab mounts shared resumption with current and fallback task identity. |
-| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | Existing `use-session-resumption.test.ts` proves automatic-start preference and resume behavior remain shared. |
+| Acceptance criterion                   | Evidence                                                                                                                                             |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | `quick-chat-session-view.test.tsx` proves the active persisted tab mounts shared resumption with current and fallback task identity after hydration. |
+| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | Existing `use-session-resumption.test.ts` proves automatic-start preference and resume behavior remain shared.                                       |
 
 ## E2E tests
 
@@ -82,8 +89,8 @@ duplicate mobile restart test.
 
 ## Verification results
 
-- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 3 tests passed.
-- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts`: 21 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 4 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/use-ensure-task-session.test.ts hooks/domains/session/use-session-resumption.test.ts`: 28 tests passed.
 - `pnpm run typecheck`: passed.
 - `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0`: 1 test passed against the production Vite build.
 

--- a/docs/plans/quick-chat-session-resume/plan.md
+++ b/docs/plans/quick-chat-session-resume/plan.md
@@ -1,0 +1,95 @@
+---
+created: 2026-08-29
+status: done
+requirements:
+  - REQ-TASKS-QUICK-CHAT-EXPIRATION-001
+system_design:
+  - ../../specs/tasks/system-design/quick-chat-session-resumption.md
+legacy_specs: []
+---
+
+# Implementation Plan: Quick Chat Session Resume
+
+## Overview
+
+Mount the existing task-session resumption lifecycle when a persisted Quick Chat tab becomes
+visible, then prove the repair at component and browser boundaries. One vertical work order is
+sufficient because the component change and its regression evidence share one lifecycle boundary.
+
+## Scope
+
+### In scope
+
+- Resolve the backing task ID for persisted ordinary, configuration, and passthrough Quick Chat
+  sessions.
+- Invoke the shared open-time session resumption policy for the active Quick Chat tab.
+- Preserve the user preference that prevents automatic agent start on open.
+- Prove backend-restart recovery and restored session model controls.
+
+### Out of scope
+
+- Backend resume, status, or persistence changes.
+- Quick Chat layout, mobile composition, tab navigation, or new user-facing copy.
+- Changes to setup tabs, Quick Terminal PTYs, or regular task-page resumption.
+
+## Confirmed root cause
+
+`QuickChatSessionView` calls `useEnsureTaskSession(sessionId)` but does not mount
+`useSessionResumption(taskId, sessionId)`. Regular task pages and kanban preview tabs mount that
+hook. After a backend restart, opening Quick Chat therefore hydrates the stored session row without
+requesting `task.session.status` or launching the resumable agent runtime.
+
+The focused diagnostic reproduction expected `useSessionResumption("task-1", "session-1")` after
+rendering a persisted Quick Chat session. Session hydration ran, but the resumption mock had zero
+calls.
+
+## Technical approach
+
+### Shared Quick Chat session view
+
+Update `apps/web/components/quick-chat/quick-chat-session-view.tsx` to resolve the backing task ID
+from `QuickChatSession.taskId` or `taskSessions.items[sessionId].task_id`. Mount
+`useSessionResumption` before the persisted session view selects its presentation. The existing
+hook owns connection gating, status checks, preference handling, resume fallback, and stale-result
+guards.
+
+### Regression evidence
+
+Create `quick-chat-session-view.test.tsx` with focused mocks that prove direct descriptor identity,
+hydrated-row fallback, and no invalid task ID. Add a backend-restart scenario to
+`e2e/tests/chat/quick-chat.spec.ts`. The scenario reopens the restored conversation and observes the
+resumed-agent boot message. It also verifies that dynamic session model settings are available.
+
+## Tests
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | `quick-chat-session-view.test.tsx` proves the active persisted tab mounts shared resumption with current and fallback task identity. |
+| `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2` | Existing `use-session-resumption.test.ts` proves automatic-start preference and resume behavior remain shared. |
+
+## E2E tests
+
+`apps/web/e2e/tests/chat/quick-chat.spec.ts` will cover the user-visible desktop flow: start a Quick
+Chat, restart the backend, reload, reopen the restored tab, and observe both successful resume and
+restored model controls. The same `QuickChatSessionView` is rendered in the existing full-screen
+mobile surface. This repair changes no layout, touch behavior, scrolling, navigation, or viewport
+branch. Therefore, shared component coverage and the lifecycle E2E satisfy mobile parity without a
+duplicate mobile restart test.
+
+## Work orders
+
+- [x] [Task 01: Resume Persisted Quick Chat Sessions](task-01-resume-persisted-sessions.md) (`done`)
+
+## Verification results
+
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 3 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts`: 21 tests passed.
+- `pnpm run typecheck`: passed.
+- `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0`: 1 test passed against the production Vite build.
+
+## Risks
+
+- Resumption must not run for client-only setup tabs or Quick Terminal descriptors.
+- Older in-memory conversation descriptors can lack `taskId`. The hydrated task-session fallback
+  must trigger the hook when it becomes available.
+- Backend restart E2E timing must use session state and visible runtime evidence, not fixed sleeps.

--- a/docs/plans/quick-chat-session-resume/task-01-resume-persisted-sessions.md
+++ b/docs/plans/quick-chat-session-resume/task-01-resume-persisted-sessions.md
@@ -25,6 +25,8 @@ recovery, and restored session models.
 
 - Resolve the backing task ID for a persisted Quick Chat from its descriptor or hydrated session
   row.
+- Wait for the task-session row before starting resumption, preserve authoritative hydration when a
+  placeholder arrives first, and retry hydration after an interrupted tab switch.
 - Mount `useSessionResumption` for ordinary, configuration, and passthrough conversation tabs.
 - Add component coverage for direct and fallback task identity.
 - Add a backend-restart Quick Chat Playwright scenario that proves agent and model recovery.
@@ -47,14 +49,15 @@ recovery, and restored session models.
 ## Verification
 
 ```bash
-cd apps/web && pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts
-cd apps/web && pnpm run typecheck
-cd apps/web && pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0
+cd apps/web
+pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/use-ensure-task-session.test.ts hooks/domains/session/use-session-resumption.test.ts
+pnpm run typecheck
+pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0
 ```
 
-All verification commands pass. The component suite covers descriptor and hydrated-row task
-identity, the typecheck passes, and the production-build restart E2E confirms resumed runtime
-evidence and restored dynamic model controls.
+All verification commands pass. The component and hydration suites cover descriptor precedence,
+hydrated-row task identity, placeholder merging, and tab-switch retry. The typecheck passes, and the
+production-build restart E2E confirms resumed runtime evidence and restored dynamic model controls.
 
 ## Files likely touched
 
@@ -70,6 +73,8 @@ None.
 
 - Mount the hook before presentation selection. A later placement violates React hook ordering and
   omits passthrough recovery.
+- Do not start resumption from a descriptor task ID until the task-session row is present; otherwise
+  the status response can replace the authoritative hydration request with a placeholder row.
 - A test that waits only for transcript text can race the runtime state transition. Use backend
   session state and resumed boot or capability evidence.
 
@@ -86,7 +91,7 @@ None.
 
 ## Results
 
-- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 3 tests passed.
-- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts`: 21 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 4 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/use-ensure-task-session.test.ts hooks/domains/session/use-session-resumption.test.ts`: 28 tests passed.
 - `pnpm run typecheck`: passed.
 - `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0`: 1 test passed against the production Vite build.

--- a/docs/plans/quick-chat-session-resume/task-01-resume-persisted-sessions.md
+++ b/docs/plans/quick-chat-session-resume/task-01-resume-persisted-sessions.md
@@ -1,0 +1,92 @@
+---
+id: "01-resume-persisted-sessions"
+title: "Resume Persisted Quick Chat Sessions"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-QUICK-CHAT-EXPIRATION-001
+acceptance_criteria:
+  - AC-TASKS-QUICK-CHAT-EXPIRATION-001.2
+system_design:
+  - ../../specs/tasks/system-design/quick-chat-session-resumption.md
+---
+
+# Task 01: Resume Persisted Quick Chat Sessions
+
+## Summary
+
+Connect the visible persisted Quick Chat conversation to the shared task-session resumption hook.
+Add focused component and browser regression evidence for identity fallback, backend-restart
+recovery, and restored session models.
+
+## In scope
+
+- Resolve the backing task ID for a persisted Quick Chat from its descriptor or hydrated session
+  row.
+- Mount `useSessionResumption` for ordinary, configuration, and passthrough conversation tabs.
+- Add component coverage for direct and fallback task identity.
+- Add a backend-restart Quick Chat Playwright scenario that proves agent and model recovery.
+
+## Out of scope
+
+- Backend, API, store-shape, persistence, and resumption-policy changes.
+- Client-only setup tabs and Quick Terminal PTY lifecycle.
+- Visual, responsive, touch, focus, or copy changes.
+
+## Acceptance
+
+- Opening a persisted Quick Chat with a known backing task invokes shared resumption exactly for
+  that task/session pair, including when the task ID arrives through session hydration.
+- Ordinary, configuration, and passthrough presentations retain their current rendering while the
+  shared automatic-start preference controls whether a stopped resumable agent launches.
+- After a backend restart, reopening a restored Quick Chat resumes the agent and exposes its dynamic
+  session model controls without sending a prompt first.
+
+## Verification
+
+```bash
+cd apps/web && pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0
+```
+
+All verification commands pass. The component suite covers descriptor and hydrated-row task
+identity, the typecheck passes, and the production-build restart E2E confirms resumed runtime
+evidence and restored dynamic model controls.
+
+## Files likely touched
+
+- `apps/web/components/quick-chat/quick-chat-session-view.tsx`
+- `apps/web/components/quick-chat/quick-chat-session-view.test.tsx`
+- `apps/web/e2e/tests/chat/quick-chat.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Mount the hook before presentation selection. A later placement violates React hook ordering and
+  omits passthrough recovery.
+- A test that waits only for transcript text can race the runtime state transition. Use backend
+  session state and resumed boot or capability evidence.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `AC-TASKS-QUICK-CHAT-EXPIRATION-001.2`
+- `docs/specs/tasks/system-design/quick-chat-session-resumption.md`
+- Existing task-page and kanban-preview `useSessionResumption` integrations.
+- Existing Quick Chat dynamic-model and session-resume E2E patterns.
+
+## Results
+
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx`: 3 tests passed.
+- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts`: 21 tests passed.
+- `pnpm run typecheck`: passed.
+- `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0`: 1 test passed against the production Vite build.

--- a/docs/specs/tasks/README.md
+++ b/docs/specs/tasks/README.md
@@ -36,8 +36,6 @@ signals, and task-scoped scheduling contracts.
 
 ### Requirements
 
-
-
 - [Agent-Generated Task Titles](requirements/agent-generated-titles.md)
 - [Additional Session Workspace Reuse](requirements/additional-session-workspace-reuse.md)
 - [Task Archive Confirmation](requirements/archive-confirmation.md)
@@ -111,8 +109,6 @@ signals, and task-scoped scheduling contracts.
 
 ### System design
 
-
-
 - [Attach Workspace Sources](system-design/attach-workspace-sources.md)
 - [Quick Chat Agent Titles](system-design/quick-chat-agent-titles.md)
 - [Quick Chat Session Resumption](system-design/quick-chat-session-resumption.md)
@@ -135,7 +131,7 @@ signals, and task-scoped scheduling contracts.
 
 ## Migration record
 
-Migration remains in progress. The three requirements above now have
+Migration remains in progress. The four requirements above now have
 authoritative, wrapper-free requirement/design pairs. Other migrated files still
 need the same extraction before this system can return to a complete migration
 state.

--- a/docs/specs/tasks/README.md
+++ b/docs/specs/tasks/README.md
@@ -115,6 +115,7 @@ signals, and task-scoped scheduling contracts.
 
 - [Attach Workspace Sources](system-design/attach-workspace-sources.md)
 - [Quick Chat Agent Titles](system-design/quick-chat-agent-titles.md)
+- [Quick Chat Session Resumption](system-design/quick-chat-session-resumption.md)
 - [Active clarification lifecycle](system-design/clarification-active-lifecycle.md)
 - [External task ID idempotency operations](system-design/external-id-idempotency-operations.md)
 - [External task ID idempotency](system-design/external-id-idempotency.md)

--- a/docs/specs/tasks/requirements/quick-chat-expiration.md
+++ b/docs/specs/tasks/requirements/quick-chat-expiration.md
@@ -2,6 +2,7 @@
 status: active
 system: tasks
 created: 2026-07-02
+updated: 2026-08-29
 owners:
   - kandev
 ---
@@ -20,6 +21,10 @@ This document is the migrated task-system source for the capability. The source 
 #### Acceptance criteria
 
 - **AC-TASKS-QUICK-CHAT-EXPIRATION-001.1:** When a consumer uses this capability, the system shall provide the observable behavior and exclusions documented below.
+- **AC-TASKS-QUICK-CHAT-EXPIRATION-001.2:** When a user opens a persisted Quick Chat tab with a
+  stopped, resumable agent, the system shall apply the regular task resumption preference. When
+  automatic start is allowed, the system shall resume the agent and restore session capabilities.
+  When automatic start on open is disabled, the system shall leave the agent stopped.
 
 ## Migrated source detail
 
@@ -290,3 +295,7 @@ deletion.
 - Multiple configuration sessions per workspace.
 - Repository context for configuration sessions.
 - A user-configurable ordinary-chat retention window or automatic expiration for config sessions.
+
+## System design
+
+- [Quick Chat Session Resumption](../system-design/quick-chat-session-resumption.md)

--- a/docs/specs/tasks/system-design/quick-chat-session-resumption.md
+++ b/docs/specs/tasks/system-design/quick-chat-session-resumption.md
@@ -20,8 +20,8 @@ the responsive dialog composition, session protocol, or backend resume semantics
 
 ## Requirement mapping
 
-| Requirement | Design sections |
-| --- | --- |
+| Requirement                           | Design sections                                                              |
+| ------------------------------------- | ---------------------------------------------------------------------------- |
 | `REQ-TASKS-QUICK-CHAT-EXPIRATION-001` | Session identity, open-time control flow, failure and recovery, verification |
 
 ## Session identity
@@ -34,9 +34,11 @@ session view.
 
 ## Open-time control flow
 
-`QuickChatSessionView` first ensures that the persisted task-session row is available. It then
-resolves the backing task ID from the Quick Chat descriptor or the hydrated task-session row and
-mounts the shared `useSessionResumption(taskId, sessionId)` hook for the visible conversation.
+`QuickChatSessionView` first ensures that the persisted task-session row is available. While the row
+is absent, it passes a null task ID to the shared resumption hook so a status request cannot race the
+authoritative HTTP hydration. Once the row exists, it resolves the backing task ID from the Quick
+Chat descriptor or the hydrated task-session row and mounts the shared
+`useSessionResumption(taskId, sessionId)` lifecycle for the visible conversation.
 
 The shared hook owns the remaining lifecycle:
 
@@ -58,9 +60,12 @@ newly visible session once.
 ## Failure and recovery
 
 If the descriptor lacks a task ID, session hydration can supply it and trigger the status check on a
-later render. If neither source supplies a task ID, no resume request is sent. The existing tab
-resync then reconciles a deleted or inaccessible conversation. Stale status responses remain
-subject to the shared monotonic session-state guards.
+later render. If neither source supplies a task ID, no resume request is sent. If the active tab
+changes while hydration is in flight, the request is cancelled and its session ID becomes retryable
+when the tab is revisited. If a status path inserts a placeholder row before the HTTP response,
+hydration still merges the authoritative row. The existing tab resync then reconciles a deleted or
+inaccessible conversation. Stale status responses remain subject to the shared monotonic
+session-state guards.
 
 The change adds no new error copy. Existing session resumption and workspace-restoration errors
 retain their current handling.
@@ -75,7 +80,10 @@ exemplar and receives the same restored runtime state as desktop.
 ## Verification
 
 - A focused component test proves that a persisted Quick Chat resolves its backing task identity
-  and mounts shared session resumption, including the hydrated-row fallback.
+  and mounts shared session resumption only after hydration, including descriptor precedence and the
+  hydrated-row fallback.
+- Deferred hydration tests prove that placeholder status rows do not cancel the authoritative row
+  and that a switched-away tab can retry hydration when revisited.
 - Existing `useSessionResumption` tests continue to prove status, automatic-resume preference,
   workspace fallback, and stale-state behavior.
 - A desktop Playwright scenario restarts the backend, reloads the application, opens the restored

--- a/docs/specs/tasks/system-design/quick-chat-session-resumption.md
+++ b/docs/specs/tasks/system-design/quick-chat-session-resumption.md
@@ -1,0 +1,89 @@
+---
+status: current
+system: tasks
+requirements:
+  - REQ-TASKS-QUICK-CHAT-EXPIRATION-001
+created: 2026-08-29
+owners:
+  - kandev
+---
+
+# Quick Chat Session Resumption System Design
+
+## Purpose and boundaries
+
+The task system owns recovery of persisted Quick Chat task sessions after the agent runtime stops
+or the backend restarts. The shared Quick Chat dialog remains a presentation over those task
+sessions. It does not own a separate runtime lifecycle. This design covers ordinary,
+configuration, and passthrough Quick Chat conversations on desktop and mobile. It does not change
+the responsive dialog composition, session protocol, or backend resume semantics.
+
+## Requirement mapping
+
+| Requirement | Design sections |
+| --- | --- |
+| `REQ-TASKS-QUICK-CHAT-EXPIRATION-001` | Session identity, open-time control flow, failure and recovery, verification |
+
+## Session identity
+
+Every persisted `QuickChatSession` carries its backing task ID and session ID. Creation responses,
+boot hydration, reconnect list responses, and task lifecycle events preserve both identities.
+`taskSessions.items[sessionId].task_id` is the fallback when an older in-memory descriptor does not
+yet contain its task ID. Client-only setup tabs have no backing task and never render the persisted
+session view.
+
+## Open-time control flow
+
+`QuickChatSessionView` first ensures that the persisted task-session row is available. It then
+resolves the backing task ID from the Quick Chat descriptor or the hydrated task-session row and
+mounts the shared `useSessionResumption(taskId, sessionId)` hook for the visible conversation.
+
+The shared hook owns the remaining lifecycle:
+
+1. Wait for the WebSocket connection and request `task.session.status`.
+2. Leave an already-running agent unchanged.
+3. When the session needs resume and is resumable, apply
+   `preventAutoStartAgentOnOpen`. Resume automatically when the preference is disabled. Otherwise,
+   retain the stopped state and the existing composer hint behavior.
+4. Fall back to workspace restoration when a runtime resume fails according to the existing task
+   session recovery policy.
+5. Accept agent startup and capability events through the existing session subscriptions so model,
+   command, and configuration controls become available.
+
+The hook is mounted before selecting the ordinary chat, configuration chat, or passthrough terminal
+presentation. All persisted conversation kinds therefore use one recovery policy. Changing the
+active tab changes the task/session inputs, resets the hook's guarded attempt state, and checks the
+newly visible session once.
+
+## Failure and recovery
+
+If the descriptor lacks a task ID, session hydration can supply it and trigger the status check on a
+later render. If neither source supplies a task ID, no resume request is sent. The existing tab
+resync then reconciles a deleted or inaccessible conversation. Stale status responses remain
+subject to the shared monotonic session-state guards.
+
+The change adds no new error copy. Existing session resumption and workspace-restoration errors
+retain their current handling.
+
+## Responsive behavior
+
+Desktop, tablet, and mobile Quick Chat use the same `QuickChatSessionView` and lifecycle hook. The
+change does not alter layout, navigation, focus, scroll ownership, touch targets, safe-area
+handling, or tab controls. The existing full-screen mobile Quick Chat surface remains the mobile
+exemplar and receives the same restored runtime state as desktop.
+
+## Verification
+
+- A focused component test proves that a persisted Quick Chat resolves its backing task identity
+  and mounts shared session resumption, including the hydrated-row fallback.
+- Existing `useSessionResumption` tests continue to prove status, automatic-resume preference,
+  workspace fallback, and stale-state behavior.
+- A desktop Playwright scenario restarts the backend, reloads the application, opens the restored
+  Quick Chat tab, and proves the agent resumes and dynamic session model controls return.
+- No new mobile Playwright scenario is required because the repair changes only shared state and
+  lifecycle behavior inside the existing responsive component. It introduces no viewport-specific
+  presentation or interaction.
+
+## Related decisions
+
+- [Typed Utility Chats Share the Quick Chat Session Model](../../../decisions/2026-07-14-typed-utility-chat-sessions.md)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3138/07afa9758897.html)
<!-- kandev-pr-walkthrough-end -->

Persisted Quick Chat tabs were hydrated after a backend restart but never entered the shared task-session resumption lifecycle, leaving stopped agents idle. The view now resolves its task identity from the descriptor or hydrated row and resumes through the existing policy, with regression coverage for restored runtime and model controls.

## Important Changes

- Mount `useSessionResumption` for the visible persisted Quick Chat view after resolving its task ID from the descriptor or hydrated task-session row.
- Keep setup tabs and existing ordinary, configuration, and passthrough presentations unchanged while reusing the shared automatic-start preference and recovery behavior.
- Add component identity coverage, a backend-restart Playwright regression, and the linked task-system design and implementation records.

## Validation

- `pnpm exec vitest run components/quick-chat/quick-chat-session-view.test.tsx hooks/domains/session/use-session-resumption.test.ts` - 21 tests passed.
- `pnpm run typecheck` - passed.
- `pnpm exec eslint components/quick-chat/quick-chat-session-view.tsx components/quick-chat/quick-chat-session-view.test.tsx` - passed.
- `pnpm exec prettier --check components/quick-chat/quick-chat-session-view.tsx components/quick-chat/quick-chat-session-view.test.tsx e2e/tests/chat/quick-chat.spec.ts` - passed.
- `python3 scripts/lint-spec-files.py --all` - passed.
- Production-build E2E: `pnpm e2e:run tests/chat/quick-chat.spec.ts -- --grep "resumes a restored session after backend restart" --retries=0` - passed.
- PR asset capture: synthetic Quick Chat screenshots validated at 1440x900 and 393x851.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop Quick Chat tabs](https://raw.githubusercontent.com/kdlbs/kandev/669824f8789e434d485357601df47cdfaea04db9/quick-chat-cross-device--desktop-quick-chat-tabs.png)

![Mobile Quick Chat tabs](https://raw.githubusercontent.com/kdlbs/kandev/669824f8789e434d485357601df47cdfaea04db9/quick-chat-cross-device--mobile-quick-chat-tabs.png)
<!-- kandev-screenshots-end -->