### PR TITLE
fix: restore review state after cancelled terminal-step turns

### DIFF
--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -6251,18 +6251,23 @@ func (s *Service) reconcileCancelledAgentWorkflow(ctx context.Context, session *
 	if session == nil {
 		return
 	}
+	transitioned := false
 	if completionEligible {
-		s.processOnTurnCompleteViaEngineWithCause(ctx, session.TaskID, session, turnCompletionCauseUserCancellation)
+		transitioned = s.processOnTurnCompleteViaEngineWithCause(
+			ctx, session.TaskID, session, turnCompletionCauseUserCancellation,
+		)
 	}
-	s.reconcileCancelledTaskReview(ctx, session.TaskID, session.ID)
+	s.reconcileCancelledTaskReview(ctx, session.TaskID, session.ID, transitioned)
 }
 
-func (s *Service) reconcileCancelledTaskReview(ctx context.Context, taskID, sessionID string) {
-	task, err := s.repo.GetTask(ctx, taskID)
-	if err == nil && task != nil && task.WorkflowStepID != "" && s.workflowStepGetter != nil {
-		step, stepErr := s.workflowStepGetter.GetStep(ctx, task.WorkflowStepID)
-		if stepErr == nil && step != nil && s.workflowStepIsTerminal(ctx, step.ID) {
-			return
+func (s *Service) reconcileCancelledTaskReview(ctx context.Context, taskID, sessionID string, transitioned bool) {
+	if transitioned {
+		task, err := s.repo.GetTask(ctx, taskID)
+		if err == nil && task != nil && task.WorkflowStepID != "" && s.workflowStepGetter != nil {
+			step, stepErr := s.workflowStepGetter.GetStep(ctx, task.WorkflowStepID)
+			if stepErr == nil && step != nil && s.workflowStepIsTerminal(ctx, step.ID) {
+				return
+			}
 		}
 	}
 	s.writeTaskReviewState(ctx, taskID, sessionID)

--- a/apps/backend/internal/orchestrator/task_operations_cancel_review_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_cancel_review_test.go
@@ -1,0 +1,27 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// @covers AC-TASKS-WORKFLOW-CANCELLED-TURN-COMPLETION-001.1
+func TestCancelAgent_ExistingTerminalStepReconcilesReviewState(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	taskID := "task-cancel-existing-terminal"
+	sessionID := "session-cancel-existing-terminal"
+	seedSession(t, repo, taskID, sessionID, "step3")
+
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	svc := createEngineService(t, repo, cancelCompletionStepGetter(false, false), &mockAgentManager{})
+	svc.taskRepo = taskRepo
+
+	require.NoError(t, svc.CancelAgent(ctx, sessionID))
+	assert.Contains(t, taskRepo.stateHistory[taskID], v1.TaskStateReview)
+}

--- a/docs/plans/cancelled-turn-completion/plan.md
+++ b/docs/plans/cancelled-turn-completion/plan.md
@@ -179,6 +179,7 @@ Changes:
 - Frontend focused tests passed (29 workflow API/settings action/component tests, including create-step forwarding), web typecheck and lint passed, and both i18n ratchet/check commands passed.
 - Public documentation validation passed (58 tests and 41 published pages).
 - Managed Playwright coverage passed: desktop enabled/disabled scenarios 2/2 and a clean follow-up mobile run 1/1; the mobile assertion measures the associated label's 44px target.
+- The terminal-step cancellation regression test passed. Cancellation now returns an existing terminal-step task to `REVIEW` when no workflow transition occurs.
 
 ---
 

--- a/docs/plans/cancelled-turn-completion/task-03-cancellation-routing.md
+++ b/docs/plans/cancelled-turn-completion/task-03-cancellation-routing.md
@@ -67,3 +67,15 @@ Verification:
 - `rtk go test -tags fts5 ./internal/orchestrator -run 'TestUserCancelCompletion_SilentCancelDoesNotTrigger' -count=1` — 1 test passed.
 - `rtk go test -tags fts5 ./internal/orchestrator -run 'TestCancelAgent_(TriggersConfiguredTurnComplete|KeepsDisabledStep|BypassesAgentSignal|BlocksPendingClarification|SkipsIneligibleTask|HandlesReconciledRuntime|LeavesQueuedMessageParked|CannotDoubleTransition)|TestUserCancelCompletion_' -count=1` — 18 tests passed.
 - `rtk go test -tags fts5 ./internal/orchestrator -run 'Test(CancelAgent|ReconcileCancelledTurn|UserCancelCompletion)' -count=1` — 30 tests passed, including injected session-state and turn-close failures and terminal-state ordering.
+
+### Regression remediation: 2026-08-29
+
+An existing terminal workflow step suppressed the `REVIEW` state after cancellation. The suppression now requires a workflow transition during the cancelled turn.
+
+Added `TestCancelAgent_ExistingTerminalStepReconcilesReviewState` in a separate test file. The test failed before the correction because no `REVIEW` state write occurred.
+
+Verification:
+
+- `rtk go test -tags fts5 ./internal/orchestrator -run '^TestCancelAgent_ExistingTerminalStepReconcilesReviewState$' -count=1` passed 1 test.
+- The work-order cancellation command passed 18 tests.
+- The review and terminal-state command passed 3 tests.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3141/6f1dd3850e18.html)
<!-- kandev-pr-walkthrough-end -->

Cancelling a turn on an already terminal workflow step left the task in `IN_PROGRESS` after the session settled. The cancellation path now uses the engine's transition result, so no-transition cancellations restore `REVIEW` while terminal transitions still complete directly.

## Validation

- `go test -tags fts5 ./internal/orchestrator -run '^TestCancelAgent_ExistingTerminalStepReconcilesReviewState$' -count=1`
- `go test -tags fts5 ./internal/orchestrator -run 'TestCancelAgent_(TriggersConfiguredTurnComplete|KeepsDisabledStep|BypassesAgentSignal|BlocksPendingClarification|SkipsIneligibleTask|HandlesReconciledRuntime|LeavesQueuedMessageParked|CannotDoubleTransition)|TestUserCancelCompletion_' -count=1`
- `go test -tags fts5 ./internal/orchestrator -run 'TestCancelAgent_(ExistingTerminalStepReconcilesReviewState|TerminalTransitionSkipsIntermediateReview|NonterminalTransitionReconcilesReviewState)$' -count=1`
- `git diff --check`

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->