### PR TITLE
fix(agentctl): report guarded ACP denials and allow the guarded ACP prefix

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_command_prefix_allowlist_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_command_prefix_allowlist_test.go
@@ -1,0 +1,33 @@
+package utility
+
+import "testing"
+
+func TestResolveACPCommandPrefixAllowsFixedKandevGuard(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveACPCommandPrefix(kandevAgentGuardPath); got != kandevAgentGuardPath {
+		t.Fatalf("resolveACPCommandPrefix(%q) = %q, want fixed guard path", kandevAgentGuardPath, got)
+	}
+}
+
+func TestResolveACPCommandPrefixRejectsGuardLookalikes(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"kandev-agent-guard",
+		"/tmp/kandev-agent-guard",
+		"/usr/local/bin/kandev-agent-guard-copy",
+	} {
+		if got := resolveACPCommandPrefix(name); got != "" {
+			t.Errorf("resolveACPCommandPrefix(%q) = %q, want empty", name, got)
+		}
+	}
+}
+
+func TestResolveACPCommandPrefixRetainsExistingAllowlist(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveACPCommandPrefix("npx"); got != "npx" {
+		t.Fatalf("resolveACPCommandPrefix(npx) = %q, want npx", got)
+	}
+}

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -29,6 +29,7 @@ import (
 const (
 	openCodeCommand       = "opencode"
 	openCodeACPSubcommand = "acp"
+	kandevAgentGuardPath  = "/usr/local/bin/kandev-agent-guard"
 
 	acpCommandTerminateGrace = 250 * time.Millisecond
 	acpCommandForceKillGrace = 500 * time.Millisecond
@@ -85,7 +86,7 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 	cmdArgs := args[1:]
 	if len(cfg.CommandPrefix) > 0 {
 		args = append(append([]string{}, cfg.CommandPrefix...), args...)
-		resolvedCmd = resolveProbeCommand(args[0])
+		resolvedCmd = resolveACPCommandPrefix(args[0])
 		if resolvedCmd == "" {
 			return &PromptResponse{Success: false, Error: fmt.Sprintf("command prefix %q is not an allowed ACP command", args[0])}, nil
 		}
@@ -1237,6 +1238,18 @@ func resolveProbeCommand(name string) string {
 		}
 	}
 	return ""
+}
+
+// resolveACPCommandPrefix validates the optional launcher that wraps an
+// already allow-listed ACP agent command. The deployment guard is accepted
+// only at its fixed image path: accepting a matching basename from another
+// directory would let a caller substitute an untrusted wrapper. Existing
+// allow-listed agent commands retain their prior prefix behavior.
+func resolveACPCommandPrefix(name string) string {
+	if name == kandevAgentGuardPath {
+		return kandevAgentGuardPath
+	}
+	return resolveProbeCommand(name)
 }
 
 // stderrTailLimit bounds how much of a spawned agent's stderr reaches the log:

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -133,13 +133,14 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 	}
 	response, err := e.executeACPSession(ctx, stdin, stdout, workDir, req.AgentID, req.Prompt, model, modelConfigOptions, req.Mode, req.AutoApprovePermissions, mcpServers)
 	if err != nil {
+		responseError := withGuardDenyDiagnostic(err, stderr.tail())
 		e.logger.Error("ACP inference failed",
 			zap.String("agent_id", req.AgentID),
 			zap.Error(err),
 			zap.String("stderr", stderr.tail()))
 		return &PromptResponse{
 			Success:    false,
-			Error:      err.Error(),
+			Error:      responseError,
 			DurationMs: int(time.Since(startTime).Milliseconds()),
 		}, nil
 	}
@@ -150,6 +151,20 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 		Model:      model,
 		DurationMs: int(time.Since(startTime).Milliseconds()),
 	}, nil
+}
+
+// withGuardDenyDiagnostic includes a guard rejection in the utility response
+// without exposing arbitrary child stderr, which may contain provider output.
+// The guard's deny helper emits this fixed prefix before it exits.
+func withGuardDenyDiagnostic(err error, stderr string) string {
+	message := err.Error()
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ERROR: kandev-agent-guard:") {
+			return message + "; " + line
+		}
+	}
+	return message
 }
 
 // executeACPSession performs the ACP handshake, creates a session, optionally

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -65,6 +65,26 @@ func TestDescribeACPFailureKeepsGenuineErrors(t *testing.T) {
 	}
 }
 
+func TestWithGuardDenyDiagnosticIncludesOnlyGuardDenyLine(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("ACP initialize failed: peer disconnected before response")
+	got := withGuardDenyDiagnostic(err, "provider output\nERROR: kandev-agent-guard: no agent command supplied\nTOKEN=must-not-leak")
+	want := "ACP initialize failed: peer disconnected before response; ERROR: kandev-agent-guard: no agent command supplied"
+	if got != want {
+		t.Fatalf("withGuardDenyDiagnostic() = %q, want %q", got, want)
+	}
+}
+
+func TestWithGuardDenyDiagnosticDoesNotExposeOtherStderr(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("ACP initialize failed: peer disconnected before response")
+	if got := withGuardDenyDiagnostic(err, "provider output\nTOKEN=must-not-leak"); got != err.Error() {
+		t.Fatalf("withGuardDenyDiagnostic() = %q, want original error", got)
+	}
+}
+
 func TestStderrBufferTailKeepsTheEnd(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Session-handoff summarization fails. The reported error progressed through two forms:

```
Summarize failed / failed to execute prompt:
  command prefix "/usr/local/bin/kandev-agent-guard" is not an allowed ACP command
```

then, once the prefix was supplied differently:

```
ACP initialize failed: {"code":-32603,"message":"Internal error",
  "data":{"error":"peer disconnected before response"}}
```

The second form was hard to diagnose because the utility ACP executor **captured the guarded child's stderr and then discarded it** when building the returned error, so the guard's own rejection never reached the caller.

## Changes

**`d430887a6` — report guarded ACP denials** (+36/-1)

Adds `withGuardDenyDiagnostic`, which appends the guard's rejection line to the response error. It matches **only** lines prefixed `ERROR: kandev-agent-guard:` — the fixed prefix the guard's `deny()` helper emits before exiting — and deliberately does not forward arbitrary child stderr, which may contain provider output.

**`a6720afe1` — allow guarded ACP inference** (+47/-1)

Adds `resolveACPCommandPrefix` to validate the optional launcher wrapping an already allow-listed ACP agent command. The deployment guard is accepted **only at its exact absolute path** `/usr/local/bin/kandev-agent-guard`; a matching basename from another directory is rejected, since that would let a caller substitute an untrusted wrapper. Existing allow-listed agent commands retain their prior prefix behaviour.

## Verification

- Fork-aware lint base resolver (`scripts/resolve-go-lint-base --comparison-base`) resolves `4d8763e4` from a clean canonical-origin clone.
- `scripts/resolve-go-lint-base.test.sh` passes all fork-aware regression cases.
- The exact `go-lint` pre-commit hook command passes with **0 issues** against canonical base.
- Branch is **2 ahead / 0 behind** `main`; no rebase required.

Both commits carry tests: `acp_executor_test.go` and `acp_command_prefix_allowlist_test.go`.

## Notes for reviewers

Opened as a **draft**. The change touches a command allow-list, so it wants a maintainer's security read rather than an automatic merge. The fix is already live in a local reviewed overlay on the deployment host; this PR is about making it persistent in the normal image path.

Related board task: `63d60af8-d1b8-48ef-a7c8-043a4488dd7a` owns the fork-aware lint base resolution (#3074) that this branch is validated against.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->