### PR TITLE
fix: expire and reap stale queued board moves

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -665,7 +665,15 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 	// avoid racing on_enter against the running turn. Apply it now: the move
 	// is the explicit transition the agent requested, so skip the regular
 	// on_turn_complete evaluation against the (still old) step.
-	if pendingMove, exists := s.messageQueue.TakePendingMove(ctx, data.SessionID); exists {
+	//
+	// A move that has been armed longer than the TTL is not applied: the board
+	// state it was authored against is long gone, and applying it would
+	// relocate the card behind the user's back. discardStalePendingMove drops
+	// it (and its hand-off prompt) and returns true, so this turn falls through
+	// to the normal on_turn_complete handling below, exactly as if no move had
+	// been armed. See pending_move_reaper.go.
+	if pendingMove, exists := s.messageQueue.TakePendingMove(ctx, data.SessionID); exists &&
+		!s.discardStalePendingMove(ctx, data.TaskID, data.SessionID, pendingMove) {
 		s.applyPendingMove(ctx, data.TaskID, data.SessionID, session, pendingMove)
 		return
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -669,12 +669,11 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 	// A move that has been armed longer than the TTL is not applied: the board
 	// state it was authored against is long gone, and applying it would
 	// relocate the card behind the user's back. discardStalePendingMove drops
-	// it (and its hand-off prompt) and returns true, so this turn falls through
-	// to the normal on_turn_complete handling below, exactly as if no move had
-	// been armed. See pending_move_reaper.go.
-	if pendingMove, exists := s.messageQueue.TakePendingMove(ctx, data.SessionID); exists &&
-		!s.discardStalePendingMove(ctx, data.TaskID, data.SessionID, pendingMove) {
-		s.applyPendingMove(ctx, data.TaskID, data.SessionID, session, pendingMove)
+	// it (and its hand-off prompt), so this turn falls through to the normal
+	// on_turn_complete handling below, exactly as if no move had been armed.
+	// Fresh moves are claimed with an exact-row comparison before application.
+	// See pending_move_reaper.go.
+	if s.handlePendingMoveAtAgentReady(ctx, data.TaskID, data.SessionID, session) {
 		return
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -3015,11 +3015,40 @@ func legacyPendingMoveID(sessionID string, move *messagequeue.PendingMove) strin
 	return fmt.Sprintf("legacy-%x", sum[:])
 }
 
-func (s *Service) removePendingMoveHandoffPrompt(ctx context.Context, sessionID, taskID, moveID string) {
+// removePendingMoveHandoffPrompt reports whether cleanup is complete. A false
+// result means queue storage failed and a durable caller must preserve enough
+// correlation state to retry.
+func (s *Service) removePendingMoveHandoffPrompt(ctx context.Context, sessionID, taskID, moveID string) bool {
 	if s.messageQueue == nil {
-		return
+		return true
 	}
-	for _, entry := range s.messageQueue.GetStatus(ctx, sessionID).Entries {
+	entryID, listed := s.pendingMoveHandoffPromptID(ctx, sessionID, taskID, moveID)
+	if !listed {
+		return false
+	}
+	if entryID == "" {
+		return true
+	}
+	_, removed, err := s.messageQueue.TakeQueuedEntry(ctx, sessionID, entryID)
+	if err != nil {
+		s.logger.Warn("failed to remove pending-move hand-off prompt",
+			zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
+		return false
+	}
+	if removed {
+		s.pendingMoveHandoffPromptRemoved(ctx, sessionID, taskID, moveID, entryID)
+	}
+	return true
+}
+
+func (s *Service) pendingMoveHandoffPromptID(ctx context.Context, sessionID, taskID, moveID string) (string, bool) {
+	entries, _, err := s.messageQueue.SnapshotSession(ctx, sessionID)
+	if err != nil {
+		s.logger.Warn("failed to list pending-move hand-off prompts",
+			zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
+		return "", false
+	}
+	for _, entry := range entries {
 		if entry.TaskID != taskID || entry.QueuedBy != messagequeue.QueuedByMoveTask {
 			continue
 		}
@@ -3031,19 +3060,21 @@ func (s *Service) removePendingMoveHandoffPrompt(ctx context.Context, sessionID,
 		if !matches {
 			continue
 		}
-		_, removed, err := s.messageQueue.TakeQueuedEntry(ctx, sessionID, entry.ID)
-		if err != nil {
-			s.logger.Warn("failed to remove stale pending-move hand-off prompt",
-				zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
-			return
-		}
-		if removed {
-			s.publishQueueStatusEvent(ctx, sessionID)
-			s.logger.Warn("dropped stale pending-move hand-off prompt",
-				zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.String("move_id", moveID))
-		}
+		return entry.ID, true
+	}
+	return "", true
+}
+
+func (s *Service) pendingMoveHandoffPromptRemoved(
+	ctx context.Context,
+	sessionID, taskID, moveID, entryID string,
+) {
+	if entryID == "" {
 		return
 	}
+	s.publishQueueStatusEvent(ctx, sessionID)
+	s.logger.Warn("dropped pending-move hand-off prompt",
+		zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.String("move_id", moveID))
 }
 
 func (s *Service) syncTaskStateForPendingMove(ctx context.Context, taskID, fromStepID, toStepID string) {

--- a/apps/backend/internal/orchestrator/idle_session_reaper.go
+++ b/apps/backend/internal/orchestrator/idle_session_reaper.go
@@ -157,9 +157,12 @@ func (r *idleSessionReaper) runLoop(ctx context.Context, tick func(ctx context.C
 // startIdleSessionReaper wires the reaper into Service.Start. The
 // reaper captures the canonical fail-closed reclaim primitive so
 // the per-tick work is a thin scan + loop, not a new policy. The tick also
-// drives reclaimStuckSignalSessionsOnce (stuck_signal_watchdog.go) — a
-// second scan sharing this ticker rather than a second background
-// goroutine, preserving the reaper's single-goroutine-owner invariant.
+// drives reclaimStuckSignalSessionsOnce (stuck_signal_watchdog.go) and
+// reapStalePendingMovesOnce (pending_move_reaper.go) — further scans
+// sharing this ticker rather than background goroutines of their own,
+// preserving the reaper's single-goroutine-owner invariant. The 30s
+// cadence is far finer than either of those needs; they are here for the
+// goroutine budget, not for the interval.
 func (s *Service) startIdleSessionReaper(ctx context.Context) {
 	if s.idleReaper == nil {
 		return
@@ -167,6 +170,7 @@ func (s *Service) startIdleSessionReaper(ctx context.Context) {
 	if !s.idleReaper.start(ctx, func(tickCtx context.Context) {
 		s.reclaimIdleSessionsOnce(tickCtx)
 		s.reclaimStuckSignalSessionsOnce(tickCtx)
+		s.reapStalePendingMovesOnce(tickCtx)
 	}) {
 		return
 	}

--- a/apps/backend/internal/orchestrator/messagequeue/pending_move_expiry_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/pending_move_expiry_test.go
@@ -131,14 +131,15 @@ func TestRepository_ListPendingMoves(t *testing.T) {
 	}
 }
 
-func TestRepository_DeletePendingMove(t *testing.T) {
+func TestRepository_DeletePendingMoveIfMatch(t *testing.T) {
 	for name, repo := range pendingMoveRepos(t) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 
 			// A missing row is a successful no-op, not an error: the sweep
 			// races takes and transfers, and losing that race is normal.
-			removed, err := repo.DeletePendingMove(ctx, "sess-absent")
+			absent := PendingMoveRecord{SessionID: "sess-absent", Move: PendingMove{MoveID: "absent", QueuedAt: time.Now().UTC()}}
+			removed, err := repo.DeletePendingMoveIfMatch(ctx, absent, "")
 			if err != nil {
 				t.Fatalf("delete absent row: %v", err)
 			}
@@ -154,7 +155,12 @@ func TestRepository_DeletePendingMove(t *testing.T) {
 				}
 			}
 
-			removed, err = repo.DeletePendingMove(ctx, "sess-a")
+			moveA, err := repo.GetPendingMove(ctx, "sess-a")
+			if err != nil || moveA == nil {
+				t.Fatalf("load sess-a before delete: move=%+v err=%v", moveA, err)
+			}
+			recordA := PendingMoveRecord{SessionID: "sess-a", Move: *moveA}
+			removed, err = repo.DeletePendingMoveIfMatch(ctx, recordA, "")
 			if err != nil {
 				t.Fatalf("delete sess-a: %v", err)
 			}
@@ -175,7 +181,7 @@ func TestRepository_DeletePendingMove(t *testing.T) {
 			}
 
 			// Deleting twice is idempotent.
-			removed, err = repo.DeletePendingMove(ctx, "sess-a")
+			removed, err = repo.DeletePendingMoveIfMatch(ctx, recordA, "")
 			if err != nil {
 				t.Fatalf("second delete of sess-a: %v", err)
 			}
@@ -183,5 +189,113 @@ func TestRepository_DeletePendingMove(t *testing.T) {
 				t.Fatal("second delete reported a removal")
 			}
 		})
+	}
+}
+
+func TestRepository_DeletePendingMoveIfMatchPreservesReplacement(t *testing.T) {
+	for name, repo := range pendingMoveRepos(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			queuedAtA := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+			moveA := &PendingMove{
+				MoveID: "move-a", TaskID: "task-a", WorkflowID: "wf-a",
+				WorkflowStepID: "step-a", QueuedAt: queuedAtA,
+			}
+			if err := repo.SetPendingMove(ctx, "sess", moveA); err != nil {
+				t.Fatalf("arm move A: %v", err)
+			}
+
+			records, err := repo.ListPendingMoves(ctx)
+			if err != nil {
+				t.Fatalf("list move A: %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("listed %d records, want 1", len(records))
+			}
+
+			moveB := &PendingMove{
+				MoveID: "move-b", TaskID: "task-b", WorkflowID: "wf-b",
+				WorkflowStepID: "step-b", QueuedAt: queuedAtA.Add(time.Hour),
+			}
+			if err := repo.SetPendingMove(ctx, "sess", moveB); err != nil {
+				t.Fatalf("replace with move B: %v", err)
+			}
+
+			removed, err := repo.DeletePendingMoveIfMatch(ctx, records[0], "")
+			if err != nil {
+				t.Fatalf("delete inspected move A: %v", err)
+			}
+			if removed {
+				t.Fatal("delete of inspected move A removed replacement move B")
+			}
+
+			got, err := repo.GetPendingMove(ctx, "sess")
+			if err != nil {
+				t.Fatalf("get replacement move B: %v", err)
+			}
+			if got == nil || got.MoveID != moveB.MoveID || !got.QueuedAt.Equal(moveB.QueuedAt) {
+				t.Fatalf("replacement move B was not preserved: got %+v, want %+v", got, moveB)
+			}
+		})
+	}
+}
+
+func TestSQLiteRepository_DeletePendingMoveIfMatchRollsBackPromptFailure(t *testing.T) {
+	repo := newTestSQLiteRepo(t)
+	sqlRepo := repo.(*sqliteRepository)
+	ctx := context.Background()
+	queuedAt := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	move := &PendingMove{
+		MoveID: "move-a", TaskID: "task-a", WorkflowID: "wf-a",
+		WorkflowStepID: "step-a", QueuedAt: queuedAt,
+	}
+	if err := repo.SetPendingMove(ctx, "sess", move); err != nil {
+		t.Fatalf("arm pending move: %v", err)
+	}
+	prompt := &QueuedMessage{
+		ID: "handoff", SessionID: "sess", TaskID: "task-a", Content: "target-step hand-off",
+		QueuedAt: queuedAt, QueuedBy: QueuedByMoveTask,
+	}
+	if err := repo.Insert(ctx, prompt, 10); err != nil {
+		t.Fatalf("queue hand-off prompt: %v", err)
+	}
+	records, err := repo.ListPendingMoves(ctx)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("list pending move: records=%+v err=%v", records, err)
+	}
+	if _, err := sqlRepo.db.Exec(`
+		CREATE TRIGGER fail_handoff_delete
+		BEFORE DELETE ON queued_messages
+		WHEN OLD.id = 'handoff'
+		BEGIN
+			SELECT RAISE(ABORT, 'injected prompt delete failure');
+		END
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+
+	removed, err := repo.DeletePendingMoveIfMatch(ctx, records[0], prompt.ID)
+	if err == nil {
+		t.Fatal("expected correlated prompt delete failure")
+	}
+	if removed {
+		t.Fatal("failed transaction reported pending move removed")
+	}
+	if got, getErr := repo.GetPendingMove(ctx, "sess"); getErr != nil || got == nil {
+		t.Fatalf("pending move was not rolled back: move=%+v err=%v", got, getErr)
+	}
+	if entries, listErr := repo.ListBySession(ctx, "sess"); listErr != nil || len(entries) != 1 {
+		t.Fatalf("hand-off prompt was not preserved: entries=%+v err=%v", entries, listErr)
+	}
+
+	if _, err := sqlRepo.db.Exec(`DROP TRIGGER fail_handoff_delete`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	removed, err = repo.DeletePendingMoveIfMatch(ctx, records[0], prompt.ID)
+	if err != nil || !removed {
+		t.Fatalf("retry exact delete: removed=%v err=%v", removed, err)
+	}
+	if entries, listErr := repo.ListBySession(ctx, "sess"); listErr != nil || len(entries) != 0 {
+		t.Fatalf("hand-off prompt survived retry: entries=%+v err=%v", entries, listErr)
 	}
 }

--- a/apps/backend/internal/orchestrator/messagequeue/pending_move_expiry_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/pending_move_expiry_test.go
@@ -1,0 +1,187 @@
+package messagequeue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPendingMove_IsStaleAt(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	ttl := time.Hour
+
+	cases := []struct {
+		name     string
+		queuedAt time.Time
+		ttl      time.Duration
+		want     bool
+	}{
+		{name: "well inside ttl", queuedAt: now.Add(-time.Minute), ttl: ttl, want: false},
+		{name: "exactly at ttl is not yet stale", queuedAt: now.Add(-ttl), ttl: ttl, want: false},
+		{name: "just past ttl", queuedAt: now.Add(-ttl - time.Nanosecond), ttl: ttl, want: true},
+		{name: "long past ttl", queuedAt: now.Add(-9 * 24 * time.Hour), ttl: ttl, want: true},
+		// An unset queued_at column and a clock skew must not be able to
+		// mass-expire the table. Same rejection the idle-session reaper
+		// applies to zero/future UpdatedAt.
+		{name: "zero queued_at is never stale", queuedAt: time.Time{}, ttl: ttl, want: false},
+		{name: "future queued_at is never stale", queuedAt: now.Add(time.Hour), ttl: ttl, want: false},
+		{name: "zero ttl disables expiry", queuedAt: now.Add(-9 * 24 * time.Hour), ttl: 0, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			move := &PendingMove{QueuedAt: tc.queuedAt}
+			if got := move.IsStaleAt(now, tc.ttl); got != tc.want {
+				t.Fatalf("IsStaleAt(%v, %v) = %v, want %v", tc.queuedAt, tc.ttl, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("nil move is never stale", func(t *testing.T) {
+		var move *PendingMove
+		if move.IsStaleAt(now, ttl) {
+			t.Fatal("nil move reported stale")
+		}
+	})
+}
+
+// TestPendingMoveTTL_IsGenerouslyAboveAnyRealTurn pins the intent of the
+// constant rather than its exact value: it must be far above the seconds-to-
+// minutes window a deferred move legitimately occupies, and far below the
+// multi-day replay that motivated it.
+func TestPendingMoveTTL_IsGenerouslyAboveAnyRealTurn(t *testing.T) {
+	if PendingMoveTTL < 4*time.Hour {
+		t.Fatalf("PendingMoveTTL = %v; too tight to survive a long but legitimate turn", PendingMoveTTL)
+	}
+	if PendingMoveTTL > 72*time.Hour {
+		t.Fatalf("PendingMoveTTL = %v; too loose to prevent a days-later replay", PendingMoveTTL)
+	}
+}
+
+// pendingMoveRepos exercises both Repository implementations so the sweep's
+// two new methods cannot drift between production SQLite and the in-memory
+// double the orchestrator tests run against.
+func pendingMoveRepos(t *testing.T) map[string]Repository {
+	t.Helper()
+	return map[string]Repository{
+		"sqlite": newTestSQLiteRepo(t),
+		"memory": NewMemoryRepository(),
+	}
+}
+
+func TestRepository_ListPendingMoves(t *testing.T) {
+	for name, repo := range pendingMoveRepos(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			records, err := repo.ListPendingMoves(ctx)
+			if err != nil {
+				t.Fatalf("list on empty table: %v", err)
+			}
+			if len(records) != 0 {
+				t.Fatalf("empty table returned %d records", len(records))
+			}
+
+			// session_id is UNIQUE but task_id is not: one task legitimately
+			// carries several armed rows keyed to different sessions. The
+			// sweep has to see all of them.
+			queuedAt := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+			seed := []struct {
+				sessionID string
+				move      PendingMove
+			}{
+				{"sess-a", PendingMove{MoveID: "m-a", TaskID: "task-1", WorkflowID: "wf-1", WorkflowStepID: "step-blocked", Position: 2, QueuedAt: queuedAt, Actor: "agent", SenderSessionID: "sender-a"}},
+				{"sess-b", PendingMove{MoveID: "m-b", TaskID: "task-1", WorkflowID: "wf-1", WorkflowStepID: "step-work", QueuedAt: queuedAt}},
+				{"sess-c", PendingMove{MoveID: "m-c", TaskID: "task-2", WorkflowID: "wf-1", WorkflowStepID: "step-qa", QueuedAt: queuedAt}},
+			}
+			for _, entry := range seed {
+				move := entry.move
+				if err := repo.SetPendingMove(ctx, entry.sessionID, &move); err != nil {
+					t.Fatalf("arm %s: %v", entry.sessionID, err)
+				}
+			}
+
+			records, err = repo.ListPendingMoves(ctx)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(records) != len(seed) {
+				t.Fatalf("listed %d records, want %d", len(records), len(seed))
+			}
+
+			bySession := make(map[string]PendingMove, len(records))
+			for _, record := range records {
+				bySession[record.SessionID] = record.Move
+			}
+			for _, entry := range seed {
+				got, ok := bySession[entry.sessionID]
+				if !ok {
+					t.Fatalf("session %s missing from listing", entry.sessionID)
+				}
+				if got.MoveID != entry.move.MoveID || got.TaskID != entry.move.TaskID ||
+					got.WorkflowID != entry.move.WorkflowID || got.WorkflowStepID != entry.move.WorkflowStepID ||
+					got.Position != entry.move.Position || got.Actor != entry.move.Actor ||
+					got.SenderSessionID != entry.move.SenderSessionID {
+					t.Fatalf("session %s round-tripped as %+v, want %+v", entry.sessionID, got, entry.move)
+				}
+				if !got.QueuedAt.Equal(entry.move.QueuedAt) {
+					t.Fatalf("session %s queued_at = %v, want %v", entry.sessionID, got.QueuedAt, entry.move.QueuedAt)
+				}
+			}
+		})
+	}
+}
+
+func TestRepository_DeletePendingMove(t *testing.T) {
+	for name, repo := range pendingMoveRepos(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// A missing row is a successful no-op, not an error: the sweep
+			// races takes and transfers, and losing that race is normal.
+			removed, err := repo.DeletePendingMove(ctx, "sess-absent")
+			if err != nil {
+				t.Fatalf("delete absent row: %v", err)
+			}
+			if removed {
+				t.Fatal("delete of an absent row reported a removal")
+			}
+
+			for _, sessionID := range []string{"sess-a", "sess-b"} {
+				if err := repo.SetPendingMove(ctx, sessionID, &PendingMove{
+					MoveID: "m-" + sessionID, TaskID: "task-1", WorkflowStepID: "step-x",
+				}); err != nil {
+					t.Fatalf("arm %s: %v", sessionID, err)
+				}
+			}
+
+			removed, err = repo.DeletePendingMove(ctx, "sess-a")
+			if err != nil {
+				t.Fatalf("delete sess-a: %v", err)
+			}
+			if !removed {
+				t.Fatal("delete of an armed row reported no removal")
+			}
+			if move, err := repo.GetPendingMove(ctx, "sess-a"); err != nil || move != nil {
+				t.Fatalf("sess-a still armed after delete: move=%+v err=%v", move, err)
+			}
+
+			// Deleting one session must not touch its siblings.
+			move, err := repo.GetPendingMove(ctx, "sess-b")
+			if err != nil {
+				t.Fatalf("get sess-b: %v", err)
+			}
+			if move == nil {
+				t.Fatal("sibling row sess-b was removed by an unrelated delete")
+			}
+
+			// Deleting twice is idempotent.
+			removed, err = repo.DeletePendingMove(ctx, "sess-a")
+			if err != nil {
+				t.Fatalf("second delete of sess-a: %v", err)
+			}
+			if removed {
+				t.Fatal("second delete reported a removal")
+			}
+		})
+	}
+}

--- a/apps/backend/internal/orchestrator/messagequeue/pending_move_sweep.go
+++ b/apps/backend/internal/orchestrator/messagequeue/pending_move_sweep.go
@@ -1,0 +1,144 @@
+package messagequeue
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Sweep support for pending_moves.
+//
+// TakePendingMove can only reach a move whose session still reaches turn-end,
+// so it is not enough on its own: session_id is UNIQUE, and a row whose keyed
+// session is gone (or whose turn never ended cleanly) is removed by nothing.
+// These two methods give the orchestrator's reaper a session-independent view
+// of the table plus an unconditional delete. See
+// orchestrator/pending_move_reaper.go for the policy that drives them.
+
+// ListPendingMoves returns every armed deferred move, keyed by session.
+func (r *sqliteRepository) ListPendingMoves(ctx context.Context) ([]PendingMoveRecord, error) {
+	rows, err := r.ro.QueryxContext(ctx, `
+		SELECT session_id, move_id, task_id, workflow_id, workflow_step_id, step_position, queued_at, actor, sender_session_id
+		FROM pending_moves
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list pending moves: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []PendingMoveRecord
+	for rows.Next() {
+		var (
+			sessionID, moveID, taskID, workflowID, workflowStepID string
+			position                                              int
+			queuedAt                                              time.Time
+			actor, senderSessionID                                string
+		)
+		if err := rows.Scan(&sessionID, &moveID, &taskID, &workflowID, &workflowStepID,
+			&position, &queuedAt, &actor, &senderSessionID); err != nil {
+			return nil, fmt.Errorf("scan pending move: %w", err)
+		}
+		records = append(records, PendingMoveRecord{
+			SessionID: sessionID,
+			Move: PendingMove{
+				MoveID:          moveID,
+				TaskID:          taskID,
+				WorkflowID:      workflowID,
+				WorkflowStepID:  workflowStepID,
+				Position:        position,
+				QueuedAt:        queuedAt,
+				Actor:           actor,
+				SenderSessionID: senderSessionID,
+			},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending moves: %w", err)
+	}
+	return records, nil
+}
+
+// DeletePendingMove removes the deferred move for a session, reporting whether
+// a row was actually removed.
+func (r *sqliteRepository) DeletePendingMove(ctx context.Context, sessionID string) (bool, error) {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin delete pending move tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	// Same per-session lock every other pending-move mutation takes. Without
+	// it the sweep could delete a row that a concurrent TransferSession just
+	// re-keyed, or race TakePendingMove across backend instances.
+	if err := r.lockSessionTx(ctx, tx, sessionID); err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, r.db.Rebind(`DELETE FROM pending_moves WHERE session_id = ?`), sessionID)
+	if err != nil {
+		return false, fmt.Errorf("delete pending move: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("delete pending move rows affected: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// ListPendingMoves returns every armed deferred move, keyed by session.
+func (r *memoryRepository) ListPendingMoves(_ context.Context) ([]PendingMoveRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pendingMoves) == 0 {
+		return nil, nil
+	}
+	records := make([]PendingMoveRecord, 0, len(r.pendingMoves))
+	for sessionID, move := range r.pendingMoves {
+		records = append(records, PendingMoveRecord{SessionID: sessionID, Move: *move})
+	}
+	// Map iteration order is random; sort so callers (and tests) see a stable
+	// sweep order.
+	sort.Slice(records, func(i, j int) bool { return records[i].SessionID < records[j].SessionID })
+	return records, nil
+}
+
+// DeletePendingMove removes the deferred move for a session, reporting whether
+// a row was actually removed.
+func (r *memoryRepository) DeletePendingMove(_ context.Context, sessionID string) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.pendingMoves[sessionID]; !ok {
+		return false, nil
+	}
+	delete(r.pendingMoves, sessionID)
+	return true, nil
+}
+
+// ListPendingMoves returns every armed deferred move, keyed by session. Used by
+// the orchestrator's sweep, which must see rows whose session will never emit
+// another agent.ready.
+func (s *Service) ListPendingMoves(ctx context.Context) ([]PendingMoveRecord, error) {
+	records, err := s.repo.ListPendingMoves(ctx)
+	if err != nil {
+		s.logger.Error("list pending moves failed", zap.Error(err))
+		return nil, err
+	}
+	return records, nil
+}
+
+// DeletePendingMove drops a session's deferred move without applying it.
+// Reports whether a row was actually removed.
+func (s *Service) DeletePendingMove(ctx context.Context, sessionID string) (bool, error) {
+	removed, err := s.repo.DeletePendingMove(ctx, sessionID)
+	if err != nil {
+		s.logger.Error("delete pending move failed",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return false, err
+	}
+	return removed, nil
+}

--- a/apps/backend/internal/orchestrator/messagequeue/pending_move_sweep.go
+++ b/apps/backend/internal/orchestrator/messagequeue/pending_move_sweep.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 // Sweep support for pending_moves.
@@ -15,7 +13,7 @@ import (
 // so it is not enough on its own: session_id is UNIQUE, and a row whose keyed
 // session is gone (or whose turn never ended cleanly) is removed by nothing.
 // These two methods give the orchestrator's reaper a session-independent view
-// of the table plus an unconditional delete. See
+// of the table plus an exact-row atomic discard. See
 // orchestrator/pending_move_reaper.go for the policy that drives them.
 
 // ListPendingMoves returns every armed deferred move, keyed by session.
@@ -61,9 +59,16 @@ func (r *sqliteRepository) ListPendingMoves(ctx context.Context) ([]PendingMoveR
 	return records, nil
 }
 
-// DeletePendingMove removes the deferred move for a session, reporting whether
-// a row was actually removed.
-func (r *sqliteRepository) DeletePendingMove(ctx context.Context, sessionID string) (bool, error) {
+// DeletePendingMoveIfMatch removes the deferred move only when it is still the
+// exact row the caller inspected. A fresh move can replace a listed row before
+// the sweep reaches DELETE; matching move_id and queued_at preserves that
+// replacement. The optional hand-off prompt is deleted after the comparison
+// succeeds but before commit, so either both deletes commit or both roll back.
+func (r *sqliteRepository) DeletePendingMoveIfMatch(
+	ctx context.Context,
+	expected PendingMoveRecord,
+	handoffEntryID string,
+) (bool, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("begin delete pending move tx: %w", err)
@@ -72,10 +77,13 @@ func (r *sqliteRepository) DeletePendingMove(ctx context.Context, sessionID stri
 	// Same per-session lock every other pending-move mutation takes. Without
 	// it the sweep could delete a row that a concurrent TransferSession just
 	// re-keyed, or race TakePendingMove across backend instances.
-	if err := r.lockSessionTx(ctx, tx, sessionID); err != nil {
+	if err := r.lockSessionTx(ctx, tx, expected.SessionID); err != nil {
 		return false, err
 	}
-	result, err := tx.ExecContext(ctx, r.db.Rebind(`DELETE FROM pending_moves WHERE session_id = ?`), sessionID)
+	result, err := tx.ExecContext(ctx, r.db.Rebind(`
+		DELETE FROM pending_moves
+		WHERE session_id = ? AND move_id = ? AND queued_at = ?
+	`), expected.SessionID, expected.Move.MoveID, expected.Move.QueuedAt)
 	if err != nil {
 		return false, fmt.Errorf("delete pending move: %w", err)
 	}
@@ -83,10 +91,21 @@ func (r *sqliteRepository) DeletePendingMove(ctx context.Context, sessionID stri
 	if err != nil {
 		return false, fmt.Errorf("delete pending move rows affected: %w", err)
 	}
+	if affected == 0 {
+		return false, nil
+	}
+	if handoffEntryID != "" {
+		if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+			DELETE FROM queued_messages
+			WHERE id = ? AND session_id = ? AND task_id = ? AND queued_by = ?
+		`), handoffEntryID, expected.SessionID, expected.Move.TaskID, QueuedByMoveTask); err != nil {
+			return false, fmt.Errorf("delete pending move hand-off prompt: %w", err)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return false, err
 	}
-	return affected > 0, nil
+	return true, nil
 }
 
 // ListPendingMoves returns every armed deferred move, keyed by session.
@@ -106,15 +125,35 @@ func (r *memoryRepository) ListPendingMoves(_ context.Context) ([]PendingMoveRec
 	return records, nil
 }
 
-// DeletePendingMove removes the deferred move for a session, reporting whether
-// a row was actually removed.
-func (r *memoryRepository) DeletePendingMove(_ context.Context, sessionID string) (bool, error) {
+// DeletePendingMoveIfMatch removes the deferred move and optional hand-off
+// prompt under one lock, but only when the move still matches the inspected
+// row.
+func (r *memoryRepository) DeletePendingMoveIfMatch(
+	_ context.Context,
+	expected PendingMoveRecord,
+	handoffEntryID string,
+) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.pendingMoves[sessionID]; !ok {
+	stored, ok := r.pendingMoves[expected.SessionID]
+	if !ok || stored.MoveID != expected.Move.MoveID || !stored.QueuedAt.Equal(expected.Move.QueuedAt) {
 		return false, nil
 	}
-	delete(r.pendingMoves, sessionID)
+	delete(r.pendingMoves, expected.SessionID)
+	if handoffEntryID != "" {
+		entries := r.entries[expected.SessionID]
+		for i, entry := range entries {
+			if entry.ID != handoffEntryID || entry.TaskID != expected.Move.TaskID || entry.QueuedBy != QueuedByMoveTask {
+				continue
+			}
+			r.entries[expected.SessionID] = append(entries[:i], entries[i+1:]...)
+			if len(r.entries[expected.SessionID]) == 0 {
+				delete(r.entries, expected.SessionID)
+				delete(r.nextPosition, expected.SessionID)
+			}
+			break
+		}
+	}
 	return true, nil
 }
 
@@ -122,23 +161,15 @@ func (r *memoryRepository) DeletePendingMove(_ context.Context, sessionID string
 // the orchestrator's sweep, which must see rows whose session will never emit
 // another agent.ready.
 func (s *Service) ListPendingMoves(ctx context.Context) ([]PendingMoveRecord, error) {
-	records, err := s.repo.ListPendingMoves(ctx)
-	if err != nil {
-		s.logger.Error("list pending moves failed", zap.Error(err))
-		return nil, err
-	}
-	return records, nil
+	return s.repo.ListPendingMoves(ctx)
 }
 
-// DeletePendingMove drops a session's deferred move without applying it.
-// Reports whether a row was actually removed.
-func (s *Service) DeletePendingMove(ctx context.Context, sessionID string) (bool, error) {
-	removed, err := s.repo.DeletePendingMove(ctx, sessionID)
-	if err != nil {
-		s.logger.Error("delete pending move failed",
-			zap.String("session_id", sessionID),
-			zap.Error(err))
-		return false, err
-	}
-	return removed, nil
+// DeletePendingMoveIfMatch atomically drops an exact deferred move and its
+// optional correlated hand-off prompt without applying either one.
+func (s *Service) DeletePendingMoveIfMatch(
+	ctx context.Context,
+	expected PendingMoveRecord,
+	handoffEntryID string,
+) (bool, error) {
+	return s.repo.DeletePendingMoveIfMatch(ctx, expected, handoffEntryID)
 }

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -208,6 +208,17 @@ type Repository interface {
 	// TakePendingMove returns and removes the deferred move for a session.
 	// Returns nil, nil if absent.
 	TakePendingMove(ctx context.Context, sessionID string) (*PendingMove, error)
+
+	// ListPendingMoves returns every armed deferred move, keyed by session.
+	// TakePendingMove can only reach a move whose session still emits
+	// agent.ready, so the sweep needs a session-independent view to find rows
+	// nothing will ever replay.
+	ListPendingMoves(ctx context.Context) ([]PendingMoveRecord, error)
+
+	// DeletePendingMove removes the deferred move for a session without
+	// returning it. Reports whether a row was actually removed; a missing row
+	// is a successful no-op, not an error.
+	DeletePendingMove(ctx context.Context, sessionID string) (bool, error)
 }
 
 // applyMetadataUpdates merges metadata key updates into current; a nil value removes the key.

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -215,10 +215,12 @@ type Repository interface {
 	// nothing will ever replay.
 	ListPendingMoves(ctx context.Context) ([]PendingMoveRecord, error)
 
-	// DeletePendingMove removes the deferred move for a session without
-	// returning it. Reports whether a row was actually removed; a missing row
-	// is a successful no-op, not an error.
-	DeletePendingMove(ctx context.Context, sessionID string) (bool, error)
+	// DeletePendingMoveIfMatch removes the deferred move only when the stored
+	// row still matches the exact record previously returned by
+	// ListPendingMoves. When handoffEntryID is non-empty, the correlated queue
+	// entry is removed in the same transaction. Reports whether the move row was
+	// removed; a missing or replaced row is a successful no-op, not an error.
+	DeletePendingMoveIfMatch(ctx context.Context, expected PendingMoveRecord, handoffEntryID string) (bool, error)
 }
 
 // applyMetadataUpdates merges metadata key updates into current; a nil value removes the key.

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -1032,19 +1032,30 @@ func (s *Service) SetPendingMove(ctx context.Context, sessionID string, move *Pe
 		zap.String("workflow_step_id", move.WorkflowStepID))
 }
 
+// GetPendingMoveWithError retrieves the pending move for a session without
+// removing it. It distinguishes an empty queue from a storage failure so
+// callers that must preserve deferred workflow state can fail closed.
+func (s *Service) GetPendingMoveWithError(ctx context.Context, sessionID string) (*PendingMove, bool, error) {
+	move, err := s.repo.GetPendingMove(ctx, sessionID)
+	if err != nil {
+		return nil, false, err
+	}
+	if move == nil {
+		return nil, false, nil
+	}
+	return move, true, nil
+}
+
 // GetPendingMove retrieves the pending move for a session without removing it.
 func (s *Service) GetPendingMove(ctx context.Context, sessionID string) (*PendingMove, bool) {
-	move, err := s.repo.GetPendingMove(ctx, sessionID)
+	move, exists, err := s.GetPendingMoveWithError(ctx, sessionID)
 	if err != nil {
 		s.logger.Error("get pending move failed",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 		return nil, false
 	}
-	if move == nil {
-		return nil, false
-	}
-	return move, true
+	return move, exists
 }
 
 // TakePendingMove retrieves and removes the pending move for a session.

--- a/apps/backend/internal/orchestrator/messagequeue/types.go
+++ b/apps/backend/internal/orchestrator/messagequeue/types.go
@@ -229,3 +229,45 @@ type PendingMove struct {
 	// context used to apply the deferred move.
 	SenderSessionID string `json:"sender_session_id,omitempty"`
 }
+
+// PendingMoveTTL bounds how long a deferred move may stay armed before it is
+// treated as stale and dropped instead of applied.
+//
+// A pending move only exists to bridge two moments: the agent called
+// move_task_kandev while its turn was still running, and that same turn ended.
+// In a healthy system those are seconds to minutes apart. A row that outlives
+// this window did not survive a slow turn — its turn never ended cleanly (crash,
+// restart, parked session), and the board state it was authored against is gone.
+// Replaying it then relocates a card against a board that has moved on.
+//
+// 24h is deliberately orders of magnitude above the legitimate window, so no
+// healthy move is ever caught by it, while being far below the multi-day replay
+// that motivated the TTL.
+//
+// It is a code constant rather than an env var or runtime flag, matching the
+// precedent set by the idle-session reaper's thresholds: the orchestrator has no
+// other runtime configuration of this shape, and the value is bounded by a
+// fail-closed invariant rather than by deployment shape.
+const PendingMoveTTL = 24 * time.Hour
+
+// IsStaleAt reports whether the move has been armed longer than ttl.
+//
+// A zero or future QueuedAt is never stale. An unset timestamp column or a
+// clock skew must not be able to mass-expire the table; the same rejection the
+// idle-session reaper applies to zero/future UpdatedAt.
+func (m *PendingMove) IsStaleAt(now time.Time, ttl time.Duration) bool {
+	if m == nil || ttl <= 0 {
+		return false
+	}
+	if m.QueuedAt.IsZero() || m.QueuedAt.After(now) {
+		return false
+	}
+	return now.Sub(m.QueuedAt) > ttl
+}
+
+// PendingMoveRecord pairs a deferred move with the session it is keyed to.
+// Used by the sweep, which works across sessions rather than looking one up.
+type PendingMoveRecord struct {
+	SessionID string
+	Move      PendingMove
+}

--- a/apps/backend/internal/orchestrator/pending_move_reaper.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper.go
@@ -1,0 +1,172 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+)
+
+// Stale pending-move expiry.
+//
+// A move_task_kandev call made while the calling session is mid-turn cannot
+// apply immediately — it would race on_enter against the running turn — so it
+// is persisted to pending_moves and replayed by handleAgentReady once the turn
+// ends. In a healthy system the arm and the replay are seconds to minutes
+// apart.
+//
+// Nothing bounded that window. pending_moves.queued_at was written and never
+// read as a freshness check, and no scan ever visited the table: session_id is
+// UNIQUE, so a row could only be removed by a take/replace on that exact
+// session. A row whose turn never ended cleanly (crash, restart, parked
+// session) therefore stayed armed indefinitely and fired whenever the keyed
+// session next became messageable. Because messaging a WAITING_FOR_INPUT task
+// resumes its session and reaches handleAgentReady, an ordinary nudge could
+// silently relocate a card days later, against a board that had moved on.
+//
+// Two failure modes, two guards:
+//
+//   - Aged out. Handled at replay time by discardStalePendingMove, and swept
+//     as cleanup. Replay time is authoritative: it sits on the only path that
+//     can actually move a card, so a stale row cannot apply even if the sweep
+//     never ran or the process just booted. Correctness does not depend on a
+//     background loop.
+//
+//   - Keyed session no longer exists. Unreachable from replay by construction
+//     — a session that is gone will never emit another agent.ready — so this
+//     one is sweep-only.
+//
+// The sweep deletes rather than tombstones. An expired move never became a
+// step transition, so the ADR 0015 transition audit has nothing legitimate to
+// record; writing one would fabricate a transition that never happened, and a
+// dedicated tombstone table would be durable schema with no consumer. The drop
+// is logged at Warn with the whole row instead, so it stays visible in logs and
+// diagnostic bundles.
+//
+// Both guards also drop the move's hand-off prompt. handleMoveTask queues that
+// prompt ("You were moved to this step with the following message: ...") before
+// the move is applied, and it is authored for the move's *target* step. If the
+// move never lands, the on_enter path that would have drained it never runs, so
+// leaving it queued misdelivers it to the source step's agent on some later
+// turn. applyPendingMove already does this on each of its own drop paths.
+
+// reapStalePendingMovesOnce is the per-tick sweep. It reads every armed move,
+// drops the ones no replay should ever apply, and leaves everything else alone.
+//
+// Each row is best-effort: a failure is logged at Warn and skipped, and the
+// next tick retries. A single-row error never aborts the scan.
+func (s *Service) reapStalePendingMovesOnce(ctx context.Context) {
+	if s.messageQueue == nil {
+		return
+	}
+	records, err := s.messageQueue.ListPendingMoves(ctx)
+	if err != nil {
+		s.logger.Warn("pending-move sweep: list failed; tick skipped", zap.Error(err))
+		return
+	}
+	now := time.Now().UTC()
+	for _, record := range records {
+		if record.SessionID == "" {
+			continue
+		}
+		reason, drop := s.pendingMoveReapReason(ctx, now, record)
+		if !drop {
+			continue
+		}
+		removed, err := s.messageQueue.DeletePendingMove(ctx, record.SessionID)
+		if err != nil {
+			s.logger.Warn("pending-move sweep: delete failed; row preserved for next tick",
+				zap.String("session_id", record.SessionID),
+				zap.Error(err))
+			continue
+		}
+		if !removed {
+			// Raced a take or a transfer between the list and the delete.
+			// Whoever won owns the row now.
+			continue
+		}
+		move := record.Move
+		s.logger.Warn("reaped stale pending move",
+			append(pendingMoveLogFields(record.SessionID, &move), zap.String("reason", reason))...)
+		s.removePendingMoveHandoffPrompt(ctx, record.SessionID, move.TaskID, normalizedPendingMoveID(record.SessionID, &move))
+	}
+}
+
+// pendingMoveReapReason decides whether a row should be dropped, and why.
+//
+// Fail-closed on the session check: a row is reaped for a missing session only
+// when the lookup says exactly that. Any other error (transient DB failure,
+// timeout, cancelled context) preserves the row for the next tick. An uncertain
+// guard is a skip, never a delete — the same invariant reclaimIdleSession
+// carries.
+func (s *Service) pendingMoveReapReason(
+	ctx context.Context,
+	now time.Time,
+	record messagequeue.PendingMoveRecord,
+) (string, bool) {
+	if record.Move.IsStaleAt(now, messagequeue.PendingMoveTTL) {
+		return "ttl_expired", true
+	}
+	if _, err := s.repo.GetTaskSession(ctx, record.SessionID); err != nil {
+		if isTaskSessionNotFound(err) {
+			return "session_missing", true
+		}
+		s.logger.Warn("pending-move sweep: session lookup failed; row preserved for next tick",
+			zap.String("session_id", record.SessionID),
+			zap.Error(err))
+		return "", false
+	}
+	return "", false
+}
+
+// discardStalePendingMove is the replay-time guard, called by handleAgentReady
+// between TakePendingMove and applyPendingMove. Returns true when the move was
+// discarded, in which case the caller falls through to its normal
+// on_turn_complete handling — the correct semantics for "as if no pending move
+// existed".
+//
+// The row is already gone (TakePendingMove removed it), so discarding is just
+// declining to apply it, plus dropping the correlated hand-off prompt.
+func (s *Service) discardStalePendingMove(ctx context.Context, taskID, sessionID string, move *messagequeue.PendingMove) bool {
+	if move == nil {
+		return false
+	}
+	if !move.IsStaleAt(time.Now().UTC(), messagequeue.PendingMoveTTL) {
+		return false
+	}
+	moveID := normalizedPendingMoveID(sessionID, move)
+	move.MoveID = moveID
+	s.logger.Warn("dropping expired pending move instead of applying it",
+		append(pendingMoveLogFields(sessionID, move), zap.Duration("ttl", messagequeue.PendingMoveTTL))...)
+	s.removePendingMoveHandoffPrompt(ctx, sessionID, taskID, moveID)
+	return true
+}
+
+// normalizedPendingMoveID resolves the correlation ID for a move, deriving the
+// legacy identity for rows written before move_id existed. Mirrors what
+// applyPendingMove does before it uses the ID.
+func normalizedPendingMoveID(sessionID string, move *messagequeue.PendingMove) string {
+	if move.MoveID != "" {
+		return move.MoveID
+	}
+	return legacyPendingMoveID(sessionID, move)
+}
+
+// pendingMoveLogFields renders the whole dropped row. The log line is the only
+// record an expired move leaves, so it carries every field needed to work out
+// after the fact what was dropped and where it came from.
+func pendingMoveLogFields(sessionID string, move *messagequeue.PendingMove) []zap.Field {
+	return []zap.Field{
+		zap.String("session_id", sessionID),
+		zap.String("task_id", move.TaskID),
+		zap.String("workflow_id", move.WorkflowID),
+		zap.String("target_step_id", move.WorkflowStepID),
+		zap.String("move_id", normalizedPendingMoveID(sessionID, move)),
+		zap.String("actor", move.Actor),
+		zap.String("sender_session_id", move.SenderSessionID),
+		zap.Time("queued_at", move.QueuedAt),
+		zap.Duration("age", time.Since(move.QueuedAt)),
+	}
+}

--- a/apps/backend/internal/orchestrator/pending_move_reaper.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper.go
@@ -175,36 +175,70 @@ func (s *Service) discardStalePendingMove(
 
 // handlePendingMoveAtAgentReady returns true when normal turn-complete queue
 // handling must stop. A fully discarded stale move returns false so the caller
-// continues exactly as if no move had been armed.
+// continues exactly as if no move had been armed. Storage failures leave the
+// move armed and settle the completed session so a later ready event can retry.
 func (s *Service) handlePendingMoveAtAgentReady(
 	ctx context.Context,
 	taskID, sessionID string,
 	session *models.TaskSession,
 ) bool {
-	move, exists := s.messageQueue.GetPendingMove(ctx, sessionID)
-	if !exists {
-		return false
+	const maxReplayAttempts = 2
+	settleSession := func() {
+		s.setSessionWaitingForInput(ctx, taskID, sessionID, session)
 	}
-	stale, retryPending := s.discardStalePendingMove(ctx, taskID, sessionID, move)
-	if retryPending {
+
+	for attempt := 0; attempt < maxReplayAttempts; attempt++ {
+		move, exists, err := s.messageQueue.GetPendingMoveWithError(ctx, sessionID)
+		if err != nil {
+			s.logger.Warn("failed to read pending move; row preserved for retry",
+				zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
+			settleSession()
+			return true
+		}
+		if !exists {
+			if attempt > 0 {
+				// A concurrent handler won the claim after our compare failed.
+				// Do not resume normal turn-complete processing for this event.
+				settleSession()
+				return true
+			}
+			return false
+		}
+
+		stale, retryPending := s.discardStalePendingMove(ctx, taskID, sessionID, move)
+		if retryPending {
+			settleSession()
+			return true
+		}
+		if stale {
+			return false
+		}
+
+		record := messagequeue.PendingMoveRecord{SessionID: sessionID, Move: *move}
+		removed, err := s.messageQueue.DeletePendingMoveIfMatch(ctx, record, "")
+		if err != nil {
+			s.logger.Warn("failed to claim pending move; row preserved for retry",
+				zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
+			settleSession()
+			return true
+		}
+		if !removed {
+			// A replacement raced the read. Re-read once so the successor can be
+			// applied by this completed turn instead of waiting for an unrelated
+			// ready event. The bounded loop preserves the row if races continue.
+			continue
+		}
+		// The turn is already complete. Settle the session before applying the
+		// move so early validation or storage failures inside applyPendingMove
+		// cannot leave it RUNNING with no active turn.
+		settleSession()
+		s.applyPendingMove(ctx, taskID, sessionID, session, move)
 		return true
 	}
-	if stale {
-		return false
-	}
-	record := messagequeue.PendingMoveRecord{SessionID: sessionID, Move: *move}
-	removed, err := s.messageQueue.DeletePendingMoveIfMatch(ctx, record, "")
-	if err != nil {
-		s.logger.Warn("failed to claim pending move; row preserved for retry",
-			zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
-		return true
-	}
-	if !removed {
-		// A replacement raced the read. Leave the current move and its prompt
-		// for a later ready event instead of draining it in the source step.
-		return true
-	}
-	s.applyPendingMove(ctx, taskID, sessionID, session, move)
+
+	s.logger.Warn("pending move changed repeatedly during replay; row preserved for retry",
+		zap.String("task_id", taskID), zap.String("session_id", sessionID))
+	settleSession()
 	return true
 }
 

--- a/apps/backend/internal/orchestrator/pending_move_reaper.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/models"
 )
 
 // Stale pending-move expiry.
@@ -75,7 +76,15 @@ func (s *Service) reapStalePendingMovesOnce(ctx context.Context) {
 		if !drop {
 			continue
 		}
-		removed, err := s.messageQueue.DeletePendingMove(ctx, record.SessionID)
+		move := record.Move
+		moveID := normalizedPendingMoveID(record.SessionID, &move)
+		handoffEntryID, listed := s.pendingMoveHandoffPromptID(ctx, record.SessionID, move.TaskID, moveID)
+		if !listed {
+			s.logger.Warn("pending-move sweep: prompt cleanup failed; row preserved for next tick",
+				zap.String("session_id", record.SessionID))
+			continue
+		}
+		removed, err := s.messageQueue.DeletePendingMoveIfMatch(ctx, record, handoffEntryID)
 		if err != nil {
 			s.logger.Warn("pending-move sweep: delete failed; row preserved for next tick",
 				zap.String("session_id", record.SessionID),
@@ -83,14 +92,13 @@ func (s *Service) reapStalePendingMovesOnce(ctx context.Context) {
 			continue
 		}
 		if !removed {
-			// Raced a take or a transfer between the list and the delete.
-			// Whoever won owns the row now.
+			// Raced a take, transfer, or replacement between the list and the
+			// compare-and-delete. Whoever won owns the current row now.
 			continue
 		}
-		move := record.Move
 		s.logger.Warn("reaped stale pending move",
-			append(pendingMoveLogFields(record.SessionID, &move), zap.String("reason", reason))...)
-		s.removePendingMoveHandoffPrompt(ctx, record.SessionID, move.TaskID, normalizedPendingMoveID(record.SessionID, &move))
+			append(pendingMoveLogFields(record.SessionID, &move, moveID), zap.String("reason", reason))...)
+		s.pendingMoveHandoffPromptRemoved(ctx, record.SessionID, move.TaskID, moveID, handoffEntryID)
 	}
 }
 
@@ -122,25 +130,81 @@ func (s *Service) pendingMoveReapReason(
 }
 
 // discardStalePendingMove is the replay-time guard, called by handleAgentReady
-// between TakePendingMove and applyPendingMove. Returns true when the move was
-// discarded, in which case the caller falls through to its normal
-// on_turn_complete handling — the correct semantics for "as if no pending move
-// existed".
+// before the move is claimed for application. stale reports that the move must
+// not apply. retryPending additionally reports that the move or a replacement
+// remains armed, so the caller must return without draining its target-step
+// prompt through the source step. A fully discarded stale move falls through
+// to normal on_turn_complete handling, exactly as if no move had been armed.
 //
-// The row is already gone (TakePendingMove removed it), so discarding is just
-// declining to apply it, plus dropping the correlated hand-off prompt.
-func (s *Service) discardStalePendingMove(ctx context.Context, taskID, sessionID string, move *messagequeue.PendingMove) bool {
+// The prompt lookup precedes an atomic exact-row delete. A lookup failure
+// leaves the durable move for retry; a replacement deletes neither row; and a
+// prompt-delete failure rolls back the move delete with the transaction.
+func (s *Service) discardStalePendingMove(
+	ctx context.Context,
+	taskID, sessionID string,
+	move *messagequeue.PendingMove,
+) (stale, retryPending bool) {
 	if move == nil {
-		return false
+		return false, false
 	}
 	if !move.IsStaleAt(time.Now().UTC(), messagequeue.PendingMoveTTL) {
-		return false
+		return false, false
 	}
 	moveID := normalizedPendingMoveID(sessionID, move)
-	move.MoveID = moveID
-	s.logger.Warn("dropping expired pending move instead of applying it",
-		append(pendingMoveLogFields(sessionID, move), zap.Duration("ttl", messagequeue.PendingMoveTTL))...)
-	s.removePendingMoveHandoffPrompt(ctx, sessionID, taskID, moveID)
+	handoffEntryID, listed := s.pendingMoveHandoffPromptID(ctx, sessionID, taskID, moveID)
+	if !listed {
+		s.logger.Warn("expired pending move preserved after prompt cleanup failure",
+			append(pendingMoveLogFields(sessionID, move, moveID), zap.Duration("ttl", messagequeue.PendingMoveTTL))...)
+		return true, true
+	}
+	expected := messagequeue.PendingMoveRecord{SessionID: sessionID, Move: *move}
+	removed, err := s.messageQueue.DeletePendingMoveIfMatch(ctx, expected, handoffEntryID)
+	if err != nil {
+		s.logger.Warn("expired pending move preserved after delete failure",
+			append(pendingMoveLogFields(sessionID, move, moveID), zap.Error(err))...)
+		return true, true
+	}
+	if removed {
+		s.logger.Warn("dropping expired pending move instead of applying it",
+			append(pendingMoveLogFields(sessionID, move, moveID), zap.Duration("ttl", messagequeue.PendingMoveTTL))...)
+		s.pendingMoveHandoffPromptRemoved(ctx, sessionID, taskID, moveID, handoffEntryID)
+		return true, false
+	}
+	return true, true
+}
+
+// handlePendingMoveAtAgentReady returns true when normal turn-complete queue
+// handling must stop. A fully discarded stale move returns false so the caller
+// continues exactly as if no move had been armed.
+func (s *Service) handlePendingMoveAtAgentReady(
+	ctx context.Context,
+	taskID, sessionID string,
+	session *models.TaskSession,
+) bool {
+	move, exists := s.messageQueue.GetPendingMove(ctx, sessionID)
+	if !exists {
+		return false
+	}
+	stale, retryPending := s.discardStalePendingMove(ctx, taskID, sessionID, move)
+	if retryPending {
+		return true
+	}
+	if stale {
+		return false
+	}
+	record := messagequeue.PendingMoveRecord{SessionID: sessionID, Move: *move}
+	removed, err := s.messageQueue.DeletePendingMoveIfMatch(ctx, record, "")
+	if err != nil {
+		s.logger.Warn("failed to claim pending move; row preserved for retry",
+			zap.String("task_id", taskID), zap.String("session_id", sessionID), zap.Error(err))
+		return true
+	}
+	if !removed {
+		// A replacement raced the read. Leave the current move and its prompt
+		// for a later ready event instead of draining it in the source step.
+		return true
+	}
+	s.applyPendingMove(ctx, taskID, sessionID, session, move)
 	return true
 }
 
@@ -157,13 +221,13 @@ func normalizedPendingMoveID(sessionID string, move *messagequeue.PendingMove) s
 // pendingMoveLogFields renders the whole dropped row. The log line is the only
 // record an expired move leaves, so it carries every field needed to work out
 // after the fact what was dropped and where it came from.
-func pendingMoveLogFields(sessionID string, move *messagequeue.PendingMove) []zap.Field {
+func pendingMoveLogFields(sessionID string, move *messagequeue.PendingMove, moveID string) []zap.Field {
 	return []zap.Field{
 		zap.String("session_id", sessionID),
 		zap.String("task_id", move.TaskID),
 		zap.String("workflow_id", move.WorkflowID),
 		zap.String("target_step_id", move.WorkflowStepID),
-		zap.String("move_id", normalizedPendingMoveID(sessionID, move)),
+		zap.String("move_id", moveID),
 		zap.String("actor", move.Actor),
 		zap.String("sender_session_id", move.SenderSessionID),
 		zap.Time("queued_at", move.QueuedAt),

--- a/apps/backend/internal/orchestrator/pending_move_reaper_test.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper_test.go
@@ -18,9 +18,21 @@ type failOncePendingMoveDeleteRepository struct {
 	err error
 }
 
+type failPendingMoveReadRepository struct {
+	messagequeue.Repository
+	err error
+}
+
 type replaceBeforePendingMoveDeleteRepository struct {
 	messagequeue.Repository
 	replacement *messagequeue.PendingMove
+}
+
+func (r *failPendingMoveReadRepository) GetPendingMove(
+	context.Context,
+	string,
+) (*messagequeue.PendingMove, error) {
+	return nil, r.err
 }
 
 func (r *replaceBeforePendingMoveDeleteRepository) DeletePendingMoveIfMatch(
@@ -149,6 +161,78 @@ func TestPendingMove_ExpiredReplayRetriesAfterPromptRemovalFailure(t *testing.T)
 	}
 	if got := sc.svc.messageQueue.GetStatus(sc.ctx, sc.reviewSessionID).Count; got != len(entries) {
 		t.Fatalf("queue count after replay-time cleanup failure = %d, want %d", got, len(entries))
+	}
+
+	session, err := sc.repo.GetTaskSession(sc.ctx, sc.reviewSessionID)
+	if err != nil {
+		t.Fatalf("load session after replay-time cleanup failure: %v", err)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("session state after replay-time cleanup failure = %q, want %q",
+			session.State, models.TaskSessionStateWaitingForInput)
+	}
+}
+
+func TestPendingMove_ReadFailurePreservesTurnForRetry(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	queueRepo := &failPendingMoveReadRepository{
+		Repository: messagequeue.NewMemoryRepository(),
+		err:        errors.New("queue storage unavailable"),
+	}
+	sc.svc.messageQueue = messagequeue.NewService(queueRepo, messagequeue.DefaultMaxPerSession, testLogger())
+
+	sc.svc.handleAgentReady(sc.ctx, watcherAgentReady(sc.reviewSessionID))
+
+	task, err := sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load task after pending-move read failure: %v", err)
+	}
+	if task.WorkflowStepID != stepInReviewID {
+		t.Fatalf("pending-move read failure advanced task to %q, want %q",
+			task.WorkflowStepID, stepInReviewID)
+	}
+	session, err := sc.repo.GetTaskSession(sc.ctx, sc.reviewSessionID)
+	if err != nil {
+		t.Fatalf("load session after pending-move read failure: %v", err)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("session state after pending-move read failure = %q, want %q",
+			session.State, models.TaskSessionStateWaitingForInput)
+	}
+}
+
+func TestPendingMove_ReplaysReplacementAfterClaimRace(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	queueRepo := messagequeue.NewMemoryRepository()
+	initialMove := &messagequeue.PendingMove{
+		MoveID:         "move-initial",
+		TaskID:         "task-1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepInProgressID,
+		QueuedAt:       time.Now().UTC().Add(-time.Minute),
+	}
+	replacement := *initialMove
+	replacement.MoveID = "move-replacement"
+	if err := queueRepo.SetPendingMove(sc.ctx, sc.reviewSessionID, initialMove); err != nil {
+		t.Fatalf("seed initial pending move: %v", err)
+	}
+	sc.svc.messageQueue = messagequeue.NewService(&replaceBeforePendingMoveDeleteRepository{
+		Repository:  queueRepo,
+		replacement: &replacement,
+	}, messagequeue.DefaultMaxPerSession, testLogger())
+
+	sc.svc.handleAgentReady(sc.ctx, watcherAgentReady(sc.reviewSessionID))
+
+	task, err := sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load task after pending-move claim race: %v", err)
+	}
+	if task.WorkflowStepID != stepInProgressID {
+		t.Fatalf("replacement pending move was not applied: workflow_step_id = %q, want %q",
+			task.WorkflowStepID, stepInProgressID)
+	}
+	if _, exists := sc.svc.messageQueue.GetPendingMove(sc.ctx, sc.reviewSessionID); exists {
+		t.Fatal("replacement pending move remained armed after replay")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/pending_move_reaper_test.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,6 +12,44 @@ import (
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
+
+type failOncePendingMoveDeleteRepository struct {
+	messagequeue.Repository
+	err error
+}
+
+type replaceBeforePendingMoveDeleteRepository struct {
+	messagequeue.Repository
+	replacement *messagequeue.PendingMove
+}
+
+func (r *replaceBeforePendingMoveDeleteRepository) DeletePendingMoveIfMatch(
+	ctx context.Context,
+	expected messagequeue.PendingMoveRecord,
+	handoffEntryID string,
+) (bool, error) {
+	if r.replacement != nil {
+		replacement := *r.replacement
+		r.replacement = nil
+		if err := r.SetPendingMove(ctx, expected.SessionID, &replacement); err != nil {
+			return false, err
+		}
+	}
+	return r.Repository.DeletePendingMoveIfMatch(ctx, expected, handoffEntryID)
+}
+
+func (r *failOncePendingMoveDeleteRepository) DeletePendingMoveIfMatch(
+	ctx context.Context,
+	expected messagequeue.PendingMoveRecord,
+	handoffEntryID string,
+) (bool, error) {
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return false, err
+	}
+	return r.Repository.DeletePendingMoveIfMatch(ctx, expected, handoffEntryID)
+}
 
 // watcherAgentReady builds the agent.ready event handleAgentReady receives
 // when the review session's turn ends.
@@ -76,6 +115,43 @@ func TestPendingMove_ExpiredMoveIsNotReplayed(t *testing.T) {
 	}
 }
 
+func TestPendingMove_ExpiredReplayRetriesAfterPromptRemovalFailure(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	sc.stepGetter.steps[stepInReviewID].Events.OnTurnComplete = nil
+	entries, _, err := sc.svc.messageQueue.SnapshotSession(sc.ctx, sc.reviewSessionID)
+	if err != nil {
+		t.Fatalf("snapshot scenario queue: %v", err)
+	}
+	queueRepo := &failOncePendingMoveDeleteRepository{
+		Repository: messagequeue.NewMemoryRepository(),
+		err:        errors.New("queue storage unavailable"),
+	}
+	sc.svc.messageQueue = messagequeue.NewService(queueRepo, messagequeue.DefaultMaxPerSession, testLogger())
+	staleMove := &messagequeue.PendingMove{
+		MoveID: "move-retry", TaskID: "task-1", WorkflowID: "wf1",
+		WorkflowStepID: stepInProgressID, QueuedAt: staleQueuedAt(),
+	}
+	for i := range entries {
+		if entries[i].QueuedBy == messagequeue.QueuedByMoveTask {
+			entries[i].Metadata = map[string]interface{}{messagequeue.MetadataDeferredMoveID: staleMove.MoveID}
+		}
+	}
+	if err := sc.svc.messageQueue.RestoreSession(sc.ctx, sc.reviewSessionID, entries, staleMove); err != nil {
+		t.Fatalf("restore scenario queue: %v", err)
+	}
+
+	sc.svc.handleAgentReady(sc.ctx, watcherAgentReady(sc.reviewSessionID))
+
+	if move, exists := sc.svc.messageQueue.GetPendingMove(sc.ctx, sc.reviewSessionID); !exists {
+		t.Fatal("expired move was lost after replay-time prompt cleanup failure")
+	} else if move.MoveID != staleMove.MoveID {
+		t.Fatalf("preserved move id = %q, want %q", move.MoveID, staleMove.MoveID)
+	}
+	if got := sc.svc.messageQueue.GetStatus(sc.ctx, sc.reviewSessionID).Count; got != len(entries) {
+		t.Fatalf("queue count after replay-time cleanup failure = %d, want %d", got, len(entries))
+	}
+}
+
 // TestPendingMove_FreshMoveStillReplays guards the happy path against the new
 // TTL check: a move armed moments ago must still apply exactly as before.
 func TestPendingMove_FreshMoveStillReplays(t *testing.T) {
@@ -104,25 +180,29 @@ func TestDiscardStalePendingMove(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("nil move is not discarded", func(t *testing.T) {
-		if svc.discardStalePendingMove(ctx, "task-1", "sess-1", nil) {
+		stale, retryPending := svc.discardStalePendingMove(ctx, "task-1", "sess-1", nil)
+		if stale || retryPending {
 			t.Fatal("nil move reported as discarded")
 		}
 	})
 
 	t.Run("fresh move is not discarded", func(t *testing.T) {
 		move := &messagequeue.PendingMove{TaskID: "task-1", QueuedAt: time.Now().UTC()}
-		if svc.discardStalePendingMove(ctx, "task-1", "sess-1", move) {
+		stale, retryPending := svc.discardStalePendingMove(ctx, "task-1", "sess-1", move)
+		if stale || retryPending {
 			t.Fatal("fresh move reported as discarded")
 		}
 	})
 
-	t.Run("stale move is discarded and gets a correlation id", func(t *testing.T) {
+	t.Run("stale move is discarded without mutating the caller", func(t *testing.T) {
 		move := &messagequeue.PendingMove{TaskID: "task-1", QueuedAt: staleQueuedAt()}
-		if !svc.discardStalePendingMove(ctx, "task-1", "sess-1", move) {
+		svc.messageQueue.SetPendingMove(ctx, "sess-1", move)
+		stale, retryPending := svc.discardStalePendingMove(ctx, "task-1", "sess-1", move)
+		if !stale || retryPending {
 			t.Fatal("stale move was not discarded")
 		}
-		if move.MoveID == "" {
-			t.Fatal("discarded move left without a correlation id")
+		if move.MoveID != "" {
+			t.Fatalf("discard mutated caller move id to %q", move.MoveID)
 		}
 	})
 }
@@ -247,6 +327,78 @@ func TestReapStalePendingMoves_NoQueueIsNoOp(t *testing.T) {
 	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
 	svc.messageQueue = nil
 	svc.reapStalePendingMovesOnce(context.Background())
+}
+
+func TestReapStalePendingMoves_RetriesAfterPromptRemovalFailure(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	queueRepo := &failOncePendingMoveDeleteRepository{
+		Repository: messagequeue.NewMemoryRepository(),
+		err:        errors.New("queue storage unavailable"),
+	}
+	svc.messageQueue = messagequeue.NewService(queueRepo, messagequeue.DefaultMaxPerSession, testLogger())
+	ctx := context.Background()
+	const sessionID = "sess-retry"
+	const taskID = "task-retry"
+	const moveID = "move-retry"
+
+	if _, err := svc.messageQueue.QueueMessageWithMetadata(
+		ctx, sessionID, taskID, "target-step hand-off", "", messagequeue.QueuedByMoveTask,
+		false, nil, map[string]interface{}{messagequeue.MetadataDeferredMoveID: moveID},
+	); err != nil {
+		t.Fatalf("queue hand-off prompt: %v", err)
+	}
+	svc.messageQueue.SetPendingMove(ctx, sessionID, &messagequeue.PendingMove{
+		MoveID: moveID, TaskID: taskID, WorkflowID: "wf", WorkflowStepID: "target",
+		QueuedAt: staleQueuedAt(),
+	})
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	assertArmed(t, svc, sessionID, true)
+	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 1 {
+		t.Fatalf("prompt count after failed cleanup = %d, want 1", got)
+	}
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	assertArmed(t, svc, sessionID, false)
+	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {
+		t.Fatalf("prompt count after retry = %d, want 0", got)
+	}
+}
+
+// Reviewer-requested contract coverage: inject a replacement after the sweep
+// has listed stale move A but before its delete. The exact-row claim must lose
+// that race and preserve fresh move B.
+func TestReapStalePendingMoves_PreservesReplacementBetweenListAndDelete(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	queuedAtB := time.Now().UTC().Add(-time.Minute)
+	queueRepo := &replaceBeforePendingMoveDeleteRepository{
+		Repository: messagequeue.NewMemoryRepository(),
+		replacement: &messagequeue.PendingMove{
+			MoveID: "move-b", TaskID: "task-b", WorkflowID: "wf-b",
+			WorkflowStepID: "step-b", QueuedAt: queuedAtB,
+		},
+	}
+	svc.messageQueue = messagequeue.NewService(queueRepo, messagequeue.DefaultMaxPerSession, testLogger())
+	ctx := context.Background()
+	const sessionID = "sess-replaced"
+	svc.messageQueue.SetPendingMove(ctx, sessionID, &messagequeue.PendingMove{
+		MoveID: "move-a", TaskID: "task-a", WorkflowID: "wf-a",
+		WorkflowStepID: "step-a", QueuedAt: staleQueuedAt(),
+	})
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	got, exists := svc.messageQueue.GetPendingMove(ctx, sessionID)
+	if !exists {
+		t.Fatal("fresh replacement move B was removed by stale move A's sweep")
+	}
+	if got.MoveID != "move-b" || got.TaskID != "task-b" || !got.QueuedAt.Equal(queuedAtB) {
+		t.Fatalf("replacement move B changed: %+v", got)
+	}
 }
 
 func armPendingMoveInWorkflow(svc *Service, sessionID, taskID, workflowID string, queuedAt time.Time) {

--- a/apps/backend/internal/orchestrator/pending_move_reaper_test.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper_test.go
@@ -248,3 +248,61 @@ func TestReapStalePendingMoves_NoQueueIsNoOp(t *testing.T) {
 	svc.messageQueue = nil
 	svc.reapStalePendingMovesOnce(context.Background())
 }
+
+func armPendingMoveInWorkflow(svc *Service, sessionID, taskID, workflowID string, queuedAt time.Time) {
+	svc.messageQueue.SetPendingMove(context.Background(), sessionID, &messagequeue.PendingMove{
+		MoveID:         "move-" + sessionID,
+		TaskID:         taskID,
+		WorkflowID:     workflowID,
+		WorkflowStepID: "step-blocked",
+		QueuedAt:       queuedAt,
+	})
+}
+
+// TestReapStalePendingMoves_IsRowLocalAcrossWorkflows pins that the sweep
+// decides each row on its own queued_at and its own keyed session, never on
+// the row's workflow or on its siblings.
+//
+// pending_moves is a GLOBAL table with no workspace column and a workflow_id
+// that is tempting to filter on. Both directions of that temptation are bugs:
+// a sweep scoped to one workflow would leave every other workspace's rows
+// armed forever (the orphans observed in production spanned two independent
+// workflows), while any cross-row logic would let one workspace's state decide
+// another's. Neither shows up in a single-workflow fixture, which is why this
+// test seeds two.
+func TestReapStalePendingMoves_IsRowLocalAcrossWorkflows(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	ctx := context.Background()
+
+	const workflowA = "wf-workspace-a"
+	const workflowB = "wf-workspace-b"
+	fresh := time.Now().UTC().Add(-time.Minute)
+
+	// Workflow A: one stale row and one healthy row.
+	seedPendingMoveSession(t, repo, "task-a-stale", "sess-a-stale")
+	seedPendingMoveSession(t, repo, "task-a-fresh", "sess-a-fresh")
+	armPendingMoveInWorkflow(svc, "sess-a-stale", "task-a-stale", workflowA, staleQueuedAt())
+	armPendingMoveInWorkflow(svc, "sess-a-fresh", "task-a-fresh", workflowA, fresh)
+
+	// Workflow B: the same shapes, plus an orphan within the TTL. Production
+	// had exactly this — an orphan in a workflow other than the one under
+	// investigation.
+	seedPendingMoveSession(t, repo, "task-b-stale", "sess-b-stale")
+	seedPendingMoveSession(t, repo, "task-b-fresh", "sess-b-fresh")
+	armPendingMoveInWorkflow(svc, "sess-b-stale", "task-b-stale", workflowB, staleQueuedAt())
+	armPendingMoveInWorkflow(svc, "sess-b-fresh", "task-b-fresh", workflowB, fresh)
+	armPendingMoveInWorkflow(svc, "sess-b-orphan", "task-b-orphan", workflowB, fresh)
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	for sessionID, wantArmed := range map[string]bool{
+		"sess-a-stale":  false,
+		"sess-b-stale":  false,
+		"sess-b-orphan": false,
+		"sess-a-fresh":  true,
+		"sess-b-fresh":  true,
+	} {
+		assertArmed(t, svc, sessionID, wantArmed)
+	}
+}

--- a/apps/backend/internal/orchestrator/pending_move_reaper_test.go
+++ b/apps/backend/internal/orchestrator/pending_move_reaper_test.go
@@ -1,0 +1,250 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// watcherAgentReady builds the agent.ready event handleAgentReady receives
+// when the review session's turn ends.
+func watcherAgentReady(sessionID string) watcher.AgentEventData {
+	return watcher.AgentEventData{
+		TaskID:           "task-1",
+		SessionID:        sessionID,
+		AgentExecutionID: "ae-review",
+		AgentProfileID:   profileReview,
+	}
+}
+
+// staleQueuedAt is comfortably past PendingMoveTTL. The live rows that
+// motivated this work had been armed for nine days.
+func staleQueuedAt() time.Time {
+	return time.Now().UTC().Add(-messagequeue.PendingMoveTTL - 9*24*time.Hour)
+}
+
+// TestPendingMove_ExpiredMoveIsNotReplayed is the replay-time regression guard
+// and the direct reproduction of the reported defect: a move armed days ago
+// must not relocate the card when its session next reaches turn-end.
+//
+// The scenario's In Review step normally carries an unconditional
+// on_turn_complete transition. It is cleared here so the assertion isolates
+// one thing: the *pending move* did not fire. Whether the ordinary workflow
+// evaluation would then have moved the card is a separate behavior, covered by
+// the scenario's own tests.
+func TestPendingMove_ExpiredMoveIsNotReplayed(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	sc.stepGetter.steps[stepInReviewID].Events.OnTurnComplete = nil
+
+	// Re-arm the move the scenario queued, aged past the TTL. The hand-off
+	// prompt the scenario queued alongside it stays as it was.
+	sc.svc.messageQueue.SetPendingMove(sc.ctx, sc.reviewSessionID, &messagequeue.PendingMove{
+		TaskID:         "task-1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepInProgressID,
+		QueuedAt:       staleQueuedAt(),
+	})
+
+	sc.svc.handleAgentReady(sc.ctx, watcherAgentReady(sc.reviewSessionID))
+
+	task, err := sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.WorkflowStepID != stepInReviewID {
+		t.Fatalf("expired pending move relocated the card: workflow_step_id = %q, want %q",
+			task.WorkflowStepID, stepInReviewID)
+	}
+
+	if move, exists := sc.svc.messageQueue.GetPendingMove(sc.ctx, sc.reviewSessionID); exists {
+		t.Fatalf("expired move still armed after replay: %+v", move)
+	}
+
+	// The hand-off prompt was authored for the move's target step. With the
+	// move dropped, leaving it queued would misdeliver it to the source step's
+	// agent on some later turn.
+	for _, entry := range sc.svc.messageQueue.GetStatus(sc.ctx, sc.reviewSessionID).Entries {
+		if entry.QueuedBy == messagequeue.QueuedByMoveTask {
+			t.Fatalf("hand-off prompt for the expired move survived: %+v", entry)
+		}
+	}
+}
+
+// TestPendingMove_FreshMoveStillReplays guards the happy path against the new
+// TTL check: a move armed moments ago must still apply exactly as before.
+func TestPendingMove_FreshMoveStillReplays(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	sc.svc.messageQueue.SetPendingMove(sc.ctx, sc.reviewSessionID, &messagequeue.PendingMove{
+		TaskID:         "task-1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepInProgressID,
+		QueuedAt:       time.Now().UTC().Add(-time.Minute),
+	})
+
+	sc.svc.handleAgentReady(sc.ctx, watcherAgentReady(sc.reviewSessionID))
+
+	task, err := sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.WorkflowStepID != stepInProgressID {
+		t.Fatalf("fresh pending move did not apply: workflow_step_id = %q, want %q",
+			task.WorkflowStepID, stepInProgressID)
+	}
+}
+
+func TestDiscardStalePendingMove(t *testing.T) {
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	ctx := context.Background()
+
+	t.Run("nil move is not discarded", func(t *testing.T) {
+		if svc.discardStalePendingMove(ctx, "task-1", "sess-1", nil) {
+			t.Fatal("nil move reported as discarded")
+		}
+	})
+
+	t.Run("fresh move is not discarded", func(t *testing.T) {
+		move := &messagequeue.PendingMove{TaskID: "task-1", QueuedAt: time.Now().UTC()}
+		if svc.discardStalePendingMove(ctx, "task-1", "sess-1", move) {
+			t.Fatal("fresh move reported as discarded")
+		}
+	})
+
+	t.Run("stale move is discarded and gets a correlation id", func(t *testing.T) {
+		move := &messagequeue.PendingMove{TaskID: "task-1", QueuedAt: staleQueuedAt()}
+		if !svc.discardStalePendingMove(ctx, "task-1", "sess-1", move) {
+			t.Fatal("stale move was not discarded")
+		}
+		if move.MoveID == "" {
+			t.Fatal("discarded move left without a correlation id")
+		}
+	})
+}
+
+// --- sweep ---
+
+// seedPendingMoveSession creates the task and session rows the sweep's
+// existence check reads. Sessions seeded here are "live"; a session ID that is
+// never seeded reproduces the orphaned-keyed-session row.
+func seedPendingMoveSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessionID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if _, err := repo.GetTask(ctx, taskID); err != nil {
+		if err := repo.CreateTask(ctx, &models.Task{
+			ID: taskID, Title: taskID, State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("create task %s: %v", taskID, err)
+		}
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: taskID, State: models.TaskSessionStateWaitingForInput,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create session %s: %v", sessionID, err)
+	}
+}
+
+func armPendingMove(svc *Service, sessionID, taskID, stepID string, queuedAt time.Time) {
+	svc.messageQueue.SetPendingMove(context.Background(), sessionID, &messagequeue.PendingMove{
+		MoveID:         "move-" + sessionID,
+		TaskID:         taskID,
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepID,
+		QueuedAt:       queuedAt,
+	})
+}
+
+func assertArmed(t *testing.T, svc *Service, sessionID string, want bool) {
+	t.Helper()
+	_, exists := svc.messageQueue.GetPendingMove(context.Background(), sessionID)
+	if exists != want {
+		t.Fatalf("session %s armed = %v, want %v", sessionID, exists, want)
+	}
+}
+
+// TestReapStalePendingMoves covers both sweep reasons in one table, including
+// the orphaned-keyed-session case that no replay-time check can ever reach: a
+// session that no longer exists will never emit another agent.ready, so its row
+// would otherwise stay armed forever.
+//
+// The two "task-multi" rows mirror the live reproduction, where one task
+// carried several armed rows: session_id is UNIQUE in pending_moves, task_id is
+// not. Reaping must be per row, never per task.
+func TestReapStalePendingMoves(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	ctx := context.Background()
+
+	fresh := time.Now().UTC().Add(-time.Minute)
+
+	seedPendingMoveSession(t, repo, "task-expired", "sess-expired")
+	armPendingMove(svc, "sess-expired", "task-expired", "step-blocked", staleQueuedAt())
+
+	seedPendingMoveSession(t, repo, "task-fresh", "sess-fresh")
+	armPendingMove(svc, "sess-fresh", "task-fresh", "step-work", fresh)
+
+	// Orphan: armed well within the TTL, but the keyed session is gone.
+	armPendingMove(svc, "sess-orphan", "task-orphan", "step-human-qa", fresh)
+
+	// One task, two sessions: one stale, one fresh.
+	seedPendingMoveSession(t, repo, "task-multi", "sess-multi-stale")
+	seedPendingMoveSession(t, repo, "task-multi", "sess-multi-fresh")
+	armPendingMove(svc, "sess-multi-stale", "task-multi", "step-ci-fixup", staleQueuedAt())
+	armPendingMove(svc, "sess-multi-fresh", "task-multi", "step-work", fresh)
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	for sessionID, wantArmed := range map[string]bool{
+		"sess-expired":     false, // aged past the TTL
+		"sess-orphan":      false, // keyed session no longer exists
+		"sess-multi-stale": false, // aged past the TTL
+		"sess-fresh":       true,  // healthy
+		"sess-multi-fresh": true,  // healthy sibling of a reaped row
+	} {
+		assertArmed(t, svc, sessionID, wantArmed)
+	}
+
+	// The sweep is idempotent: a second tick neither errors nor disturbs the
+	// rows it correctly preserved.
+	svc.reapStalePendingMovesOnce(ctx)
+	assertArmed(t, svc, "sess-fresh", true)
+	assertArmed(t, svc, "sess-multi-fresh", true)
+}
+
+// TestReapStalePendingMoves_PreservesRowOnSessionLookupError pins the
+// fail-closed invariant: a row is reaped for a missing session only when the
+// lookup positively says the session is missing. A transient failure must leave
+// the row armed for the next tick, never delete it on a guess.
+func TestReapStalePendingMoves_PreservesRowOnSessionLookupError(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	ctx := context.Background()
+
+	armPendingMove(svc, "sess-unknown", "task-1", "step-blocked", time.Now().UTC().Add(-time.Minute))
+
+	// Close the database so GetTaskSession fails with a real infrastructure
+	// error rather than sql.ErrNoRows. Only ErrNoRows becomes
+	// ErrTaskSessionNotFound, so this is exactly the "cannot tell" case.
+	if err := repo.DB().Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	svc.reapStalePendingMovesOnce(ctx)
+
+	assertArmed(t, svc, "sess-unknown", true)
+}
+
+// TestReapStalePendingMoves_NoQueueIsNoOp guards the nil-service path used by
+// orchestrator instances constructed without a message queue.
+func TestReapStalePendingMoves_NoQueueIsNoOp(t *testing.T) {
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.messageQueue = nil
+	svc.reapStalePendingMovesOnce(context.Background())
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3147/885c09598f53.html)
<!-- kandev-pr-walkthrough-end -->

## Problem

A `move_task_kandev` call made while the calling session is mid-turn cannot apply immediately (it would race `on_enter` against the running turn), so it is persisted to `pending_moves` and replayed by `handleAgentReady` once that turn ends. In a healthy system the arm and the replay are seconds to minutes apart.

Nothing bounded that window:

- `pending_moves.queued_at` was written by `SetPendingMove` and **never read as a freshness check** anywhere. `applyPendingMove` used it only to derive `legacyPendingMoveID`.
- No scan ever visited the table. `session_id` is `UNIQUE`, so a row could only be removed by a take/replace on that exact session.

So a row whose turn never ended cleanly (crash, restart, parked session) stayed armed indefinitely and fired whenever its keyed session next became messageable. Because messaging a task in `WAITING_FOR_INPUT` resumes its session and reaches `handleAgentReady`, **an ordinary nudge could silently relocate a card days later**, against a board state that had moved on.

A second failure mode is worse: a row whose keyed session no longer exists is unreachable from replay by construction (a session that is gone never emits another `agent.ready`) and was cleaned up by nothing.

Both modes are live. On the instance this was found on, `pending_moves` holds rows armed since 2026-08-20, including two whose keyed session no longer exists, and one that would drag a verified-Done card backwards.

## Approach

Two guards, split by what each can actually reach.

**Replay time is authoritative.** `discardStalePendingMove` runs in `handleAgentReady` between `TakePendingMove` and `applyPendingMove` — the only path that can actually move a card. A stale row therefore cannot apply even if the sweep never ran, is disabled, or the process just booted; correctness does not depend on a background loop. A discarded move falls through to the normal `on_turn_complete` handling, exactly as if none had been armed.

**The sweep is cleanup.** `reapStalePendingMovesOnce` also removes rows whose keyed session is gone, which replay cannot reach. It runs as a third scan on the existing idle-session reaper tick rather than adding a background goroutine, preserving that file's documented single-goroutine-owner invariant.

## Design decisions

**TTL is a fixed 24h code constant, not config.** A deferred move legitimately lives for seconds to minutes, so 24h is orders of magnitude above any healthy move while being far below the multi-day replay that motivated the change. It follows the precedent `idle_session_reaper.go` states explicitly for thresholds of this shape: the orchestrator has no other runtime config like this, and the value is bounded by a fail-closed invariant rather than deployment shape. It can become a runtime flag later if a deployment actually needs one.

**Expired rows are deleted, not tombstoned.** An expired move never became a step transition, so the ADR 0015 transition audit has nothing legitimate to record — writing one would fabricate a transition that never happened, and a dedicated tombstone table would be durable schema with no consumer. The drop is logged at `Warn` with the whole row (task, session, workflow, target step, move ID, actor, sender, age) so it stays visible in logs and diagnostic bundles.

**Both guards drop the move's hand-off prompt.** `handleMoveTask` queues that prompt before the move is applied, and it is authored for the move's *target* step. If the move never lands, the `on_enter` path that would have drained it never runs, so leaving it queued misdelivers it to the source step's agent on a later turn. `applyPendingMove` already does this on each of its own drop paths.

**The session-existence check is fail-closed.** A row is reaped for a missing session only when `GetTaskSession` returns exactly `models.ErrTaskSessionNotFound`. Any other error (transient DB failure, timeout, cancelled context) preserves the row for the next tick. An uncertain guard is a skip, never a delete — the invariant `reclaimIdleSession` already carries.

**`DeletePendingMove` takes the same per-session lock** every other pending-move mutation takes, so the sweep cannot delete a row a concurrent `TransferSession` just re-keyed, or race `TakePendingMove` across backend instances.

**A zero or future `queued_at` is never stale**, mirroring the idle reaper's rejection of zero/future `UpdatedAt`: an unset column or a clock skew must not be able to mass-expire the table.

## Tests

Both new behaviors were confirmed to fail before the fix and pass after.

`messagequeue` (both `Repository` implementations, so SQLite and the in-memory double cannot drift):
- `ListPendingMoves` round-trips every field across sessions, including several rows for one task.
- `DeletePendingMove` removes exactly one row, leaves siblings alone, and reports a missing row as a no-op rather than an error.
- `IsStaleAt` boundaries, plus zero/future `queued_at` and zero TTL.
- The TTL constant is pinned to a sane range rather than an exact value.

`orchestrator`:
- An armed move older than the TTL does not relocate the card; the row is consumed and its hand-off prompt is dropped.
- A fresh move still applies — regression guard on the existing happy path.
- The sweep reaps an expired row and an **orphaned-keyed-session row that is well within the TTL** (the case no replay-time check can reach), while leaving healthy rows and a healthy sibling of a reaped row untouched. Idempotent across ticks.
- A session lookup that fails with a non-not-found error leaves the row armed (fail-closed).

## Validation

- `go test ./internal/orchestrator/...` — all green.
- `golangci-lint run ./... --new-from-rev=origin/main` — 0 issues.
- Full `go test ./...` shows 5 failing packages, all identical on a pristine checkout of this branch's base and none of them touched here (process-group signalling, `/proc` reads, and an ambient `config.yaml` — sandbox artifacts).

## Not included

No migration is added. Existing armed rows are handled by the two guards at runtime: aged rows expire on their next replay attempt and are swept within one reaper tick, and orphaned rows are swept on the first tick. A one-shot deletion migration would do the same thing less safely, before the fail-closed guards are in play.

## Deployment note

`pending_moves` is global across workspaces, not scoped to one board. On the instance this was developed against the table holds 7 rows, and **6 of them are already past the 24h TTL**, so they are reaped on the first reaper tick after deploy; only one (armed 2026-08-29 03:51Z) is still inside the window. That is the intended fix, but the first tick is not a no-op and its effect spans more than one workspace.

Because of that reach, the second commit adds a test pinning the sweep as **row-local across workflows**, so neither guard can over-reap past the row it is evaluating.

## Known gap, deliberately out of scope

Two of those rows are keyed to sessions in `CANCELLED` state. Those sessions still exist, so the missing-session check does not catch them — but they cannot be resumed, so replay can never reach their rows either. The TTL reaps them within 24h, which makes this a latency question rather than a correctness one.

Adding "terminal session state" as a third reap reason would pull session-lifecycle semantics into this change, so it was left out to keep the diff narrow and the invariants easy to audit. Flagging it explicitly rather than leaving it implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->