### PR TITLE
test(e2e): stabilize PR status badge hover

### DIFF
--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -707,6 +707,7 @@ test.describe("PR status badge", () => {
     });
     await expect(icon).toHaveAttribute("data-pr-count", "2", { timeout: 15_000 });
     await taskRow.hover();
+    await expect(taskActions).toBeVisible();
     await expect(menuSlot).toHaveCSS("width", "24px");
     await icon.hover();
 

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -706,9 +706,12 @@ test.describe("PR status badge", () => {
       mergeable_state: "dirty",
     });
     await expect(icon).toHaveAttribute("data-pr-count", "2", { timeout: 15_000 });
+    await taskRow.hover();
+    await expect(menuSlot).toHaveCSS("width", "24px");
     await icon.hover();
 
     const multiSummary = visibleTaskPRSummary(testPage);
+    await expect(multiSummary).toBeVisible();
     const entries = multiSummary.getByTestId("pr-task-status-entry");
     await expect(entries).toHaveCount(2);
     await expect(entries.nth(0).getByTestId("pr-task-status-number")).toHaveText("PR #2966");


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3150/6b014cc38e7f.html)
<!-- kandev-pr-walkthrough-end -->

The PR status badge E2E could lose its tooltip when the task-row action slot animated under a stationary pointer. Synchronizing that layout transition before hovering the badge removes the contention-sensitive race.

## Validation

- `pnpm e2e:run --host --no-build tests/pr/pr-status-badge.spec.ts -- --grep "renders readable task PR summary and compact trailing actions" --workers=1 --retries=0` (deterministic red before reordering, green after)
- `pnpm e2e:run --host --no-build tests/pr/pr-status-badge.spec.ts -- --grep "renders readable task PR summary and compact trailing actions" --repeat-each=30 --workers=1 --retries=0`
- `pnpm e2e:run --host --no-build tests/pr/pr-status-badge.spec.ts -- --workers=1 --retries=0`
- `pnpm exec eslint --max-warnings 0 e2e/tests/pr/pr-status-badge.spec.ts`
- `pnpm run e2e:sleep-ratchet`
- `pnpm run typecheck`
- No public documentation change is needed because this only stabilizes test synchronization.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->