### PR TITLE
test(e2e): disambiguate automation trigger notification

### DIFF
--- a/apps/web/e2e/tests/automations-run-detail.spec.ts
+++ b/apps/web/e2e/tests/automations-run-detail.spec.ts
@@ -390,7 +390,7 @@ test.describe("Automation concurrency note", () => {
     await testPage.getByTestId("automation-run-now").click();
     await expect(
       testPage.getByRole("region", { name: /^Notifications/ }).getByText(/Triggered|Skipped/),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
 
     // The run row is written after the fire returns, so a page that only polls
     // while it can already see something open never learns the run happened.
@@ -415,13 +415,13 @@ test.describe("Automation concurrency note", () => {
 
     await testPage.goto(`/automations/${automationId}`);
     const runsRail = testPage.getByTestId("runs-rail");
-    await expect(runsRail.getByText("Triggered", { exact: true })).toBeVisible();
+    await expect(runsRail.getByText("Triggered", { exact: true })).toBeVisible({ timeout: 15_000 });
 
     await testPage.getByTestId("automation-run-now").click();
     await expect(
       testPage
         .getByRole("region", { name: /^Notifications/ })
         .getByText("Triggered", { exact: true }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/apps/web/e2e/tests/automations-run-detail.spec.ts
+++ b/apps/web/e2e/tests/automations-run-detail.spec.ts
@@ -319,6 +319,7 @@ test.describe("Automation concurrency note", () => {
     testPage: Page,
     seed: Seed & { steps: { name: string }[] },
     name: string,
+    maxConcurrentRuns = 1,
   ): Promise<string> {
     const automations = new AutomationsPage(testPage, seed.workspaceId);
     await automations.gotoNew();
@@ -329,6 +330,9 @@ test.describe("Automation concurrency note", () => {
     await automations.selectFrequency("every day");
     await automations.timeInput.fill("03:17");
     await automations.selectWorkflow("E2E Workflow");
+    if (maxConcurrentRuns !== 1) {
+      await testPage.getByRole("spinbutton").fill(String(maxConcurrentRuns));
+    }
     await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
     await automations.saveButton.click();
     await expect(testPage).toHaveURL(/automations$/, { timeout: 15_000 });
@@ -384,7 +388,9 @@ test.describe("Automation concurrency note", () => {
     await expect(testPage.getByTestId("runs-rail-empty")).toBeVisible({ timeout: 15_000 });
 
     await testPage.getByTestId("automation-run-now").click();
-    await expect(testPage.getByText(/Triggered|Skipped/)).toBeVisible({ timeout: 15_000 });
+    await expect(
+      testPage.getByRole("region", { name: /^Notifications/ }).getByText(/Triggered|Skipped/),
+    ).toBeVisible();
 
     // The run row is written after the fire returns, so a page that only polls
     // while it can already see something open never learns the run happened.
@@ -392,5 +398,30 @@ test.describe("Automation concurrency note", () => {
     await expect(testPage.getByTestId("runs-rail-empty")).toHaveCount(0, { timeout: 30_000 });
     // …and nothing it renders from the pre-trigger snapshot is left standing.
     await expect(testPage.getByTestId("automation-next-run")).not.toContainText("Paused");
+  });
+
+  test("targets the trigger notification when the run rail has the same status", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const automationId = await createScheduledAutomation(
+      testPage,
+      seedData,
+      "Duplicate Triggered",
+      2,
+    );
+    await apiClient.seedAutomationRun(automationId, "triggered");
+
+    await testPage.goto(`/automations/${automationId}`);
+    const runsRail = testPage.getByTestId("runs-rail");
+    await expect(runsRail.getByText("Triggered", { exact: true })).toBeVisible();
+
+    await testPage.getByTestId("automation-run-now").click();
+    await expect(
+      testPage
+        .getByRole("region", { name: /^Notifications/ })
+        .getByText("Triggered", { exact: true }),
+    ).toBeVisible();
   });
 });

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -689,6 +689,11 @@ test.describe("PR status badge", () => {
     await expect(focusedSummary).toBeVisible();
     await testPage.keyboard.press("Escape");
     await expect(focusedSummary).toBeHidden();
+    // End the keyboard-disclosure flow before exercising hover again. Leaving
+    // the dismissed tooltip trigger focused makes the later pointer transition
+    // depend on overlapping focus and hover state.
+    await taskRow.focus();
+    await expect(taskRow).toBeFocused();
     await apiClient.mockGitHubAssociateTaskPR({
       workspace_id: seedData.workspaceId,
       task_id: task.id,

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -709,6 +709,8 @@ test.describe("PR status badge", () => {
     await taskRow.hover();
     await expect(taskActions).toBeVisible();
     await expect(menuSlot).toHaveCSS("width", "24px");
+    // Re-enter from a neutral point after the PR update to deliver a fresh hover transition.
+    await testPage.mouse.move(viewport!.width - 1, viewport!.height - 1);
     await icon.hover();
 
     const multiSummary = visibleTaskPRSummary(testPage);

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -689,11 +689,6 @@ test.describe("PR status badge", () => {
     await expect(focusedSummary).toBeVisible();
     await testPage.keyboard.press("Escape");
     await expect(focusedSummary).toBeHidden();
-    // End the keyboard-disclosure flow before exercising hover again. Leaving
-    // the dismissed tooltip trigger focused makes the later pointer transition
-    // depend on overlapping focus and hover state.
-    await taskRow.focus();
-    await expect(taskRow).toBeFocused();
     await apiClient.mockGitHubAssociateTaskPR({
       workspace_id: seedData.workspaceId,
       task_id: task.id,


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3151/21aee48c442f.html)
<!-- kandev-pr-walkthrough-end -->

The automation run-detail E2E could race a notification against a same-named run status and fail Playwright strict mode. Scope the outcome assertion to the accessible notifications region and pin the duplicate-text case with a deterministic fixture.

## Validation

- `pnpm e2e:run --no-build tests/automations-run-detail.spec.ts -- --grep "manually triggered run|targets the trigger notification" --repeat-each=10 --workers=1 --retries=0` (20 passed)
- `pnpm e2e:run --no-build tests/automations-run-detail.spec.ts -- --workers=1 --retries=0` (8 passed)
- `pnpm run typecheck`
- `pnpm exec prettier --check e2e/tests/automations-run-detail.spec.ts`
- `pnpm exec eslint --config eslint.e2e-sleeps.config.mjs e2e/tests/automations-run-detail.spec.ts`
- `pnpm run e2e:sleep-ratchet`

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->