### PR TITLE
fix: use recent profile for new agent default

### DIFF
--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -40,9 +40,10 @@ type LaunchSessionRequest struct {
 	Intent         SessionIntent `json:"intent,omitempty"`
 	SessionID      string        `json:"session_id,omitempty"`
 	AgentProfileID string        `json:"agent_profile_id,omitempty"`
-	// ProfileExplicit marks a non-empty profile selected by the manual New Agent
-	// picker. It bypasses workflow-step profile resolution for IntentStart only;
-	// IntentStartCreated keeps its existing profile resolution behavior.
+	// ProfileExplicit marks a non-empty profile selected through an explicit
+	// selector-backed choice. It bypasses workflow-step profile resolution for
+	// IntentStart only; IntentStartCreated keeps its existing profile resolution
+	// behavior.
 	ProfileExplicit   bool   `json:"profile_explicit,omitempty"`
 	ExecutorID        string `json:"executor_id,omitempty"`
 	ExecutorProfileID string `json:"executor_profile_id,omitempty"`

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -860,8 +860,9 @@ func (s *Service) StartTaskWithEnv(ctx context.Context, taskID string, agentProf
 // some callers supply. Keeping them in one struct avoids growing startTask's
 // already long positional parameter list for every new orthogonal concern.
 type startTaskOptions struct {
-	// ProfileExplicit marks a non-empty profile selected by the manual New Agent
-	// picker. It bypasses workflow-step profile resolution for this new session.
+	// ProfileExplicit marks a non-empty profile selected through an explicit
+	// selector-backed choice. It bypasses workflow-step profile resolution for
+	// this new session.
 	ProfileExplicit bool
 	// Env holds launch-scoped environment variables for the agent runtime.
 	Env map[string]string
@@ -993,7 +994,7 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	// require a different agent (e.g., Codex on "In Progress", Auggie on "Review").
 	callerProfileID := agentProfileID
 	if opts.ProfileExplicit && agentProfileID != "" {
-		s.logger.Info("manual agent profile selection takes precedence over workflow step",
+		s.logger.Info("explicit selector-backed agent profile selection takes precedence over workflow step",
 			zap.String("task_id", taskID),
 			zap.String("agent_profile_id", agentProfileID))
 	} else {

--- a/apps/web/components/task/new-session-dialog.test.tsx
+++ b/apps/web/components/task/new-session-dialog.test.tsx
@@ -440,7 +440,30 @@ describe("NewSessionDialog", () => {
     await waitFor(() => expect(mockAgentSelectorValue).toBe("profile-2"));
   });
 
-  it("does not keep an unhealthy profile selected during a local handoff", async () => {
+  it("resets a manual profile choice when it becomes incompatible", async () => {
+    const manualProfile = { ...BASE_PROFILE, id: "profile-2", label: "Profile 2" };
+    const fallbackProfile = { ...BASE_PROFILE, id: "profile-3", label: "Profile 3" };
+    mockState.agentProfiles.items = [BASE_PROFILE, manualProfile, fallbackProfile];
+    const { rerender } = render(
+      <NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />,
+    );
+
+    await act(async () => {
+      mockAgentSelectorOnChange?.(manualProfile.id);
+    });
+    await waitFor(() => expect(mockAgentSelectorValue).toBe(manualProfile.id));
+
+    mockState.agentProfiles.items = [
+      BASE_PROFILE,
+      { ...manualProfile, enabled: false },
+      fallbackProfile,
+    ];
+    rerender(<NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />);
+
+    await waitFor(() => expect(mockAgentSelectorValue).toBe(BASE_PROFILE.id));
+  });
+
+  it("uses an implicit fallback when a local handoff target is incompatible", async () => {
     mockExecutorProfile = {
       id: "executor-profile-1",
       name: "Local",
@@ -471,7 +494,7 @@ describe("NewSessionDialog", () => {
       expect(mockBuildStartRequest).toHaveBeenCalledWith(
         "task-1",
         "profile-1",
-        expect.objectContaining({ profileExplicit: true }),
+        expect.objectContaining({ profileExplicit: false }),
       ),
     );
   });

--- a/apps/web/components/task/new-session-dialog.test.tsx
+++ b/apps/web/components/task/new-session-dialog.test.tsx
@@ -37,6 +37,10 @@ const mockState = {
   agentProfiles: {
     items: [BASE_PROFILE],
   },
+  agentProfileRecentUse: {
+    loaded: true,
+    records: {},
+  },
   tasks: {
     activeSessionId: "session-1",
   },
@@ -249,6 +253,7 @@ describe("NewSessionDialog", () => {
   afterEach(() => {
     cleanup();
     mockState.agentProfiles.items = [BASE_PROFILE];
+    mockState.agentProfileRecentUse = { loaded: true, records: {} };
     mockExecutorProfile = null;
     mockAgentSelectorValue = undefined;
     mockAgentSelectorOnChange = undefined;
@@ -318,6 +323,72 @@ describe("NewSessionDialog", () => {
         expect.objectContaining({ profileExplicit: false }),
       ),
     );
+  });
+
+  it("uses the recent task-session profile as an explicit default", async () => {
+    const recentProfile = { ...BASE_PROFILE, id: "profile-2", label: "Profile 2" };
+    mockState.agentProfiles.items = [BASE_PROFILE, recentProfile];
+    mockState.agentProfileRecentUse = {
+      loaded: true,
+      records: {
+        task_session: {
+          profileIds: [recentProfile.id],
+          revision: 1,
+          updatedAt: "2026-08-30T12:00:00Z",
+        },
+      },
+    };
+
+    render(<NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />);
+
+    await waitFor(() => expect(mockAgentSelectorValue).toBe(recentProfile.id));
+    fireEvent.click(screen.getByRole("button", { name: PLUGIN_COMPOSER_LABEL }));
+
+    await waitFor(() =>
+      expect(mockBuildStartRequest).toHaveBeenCalledWith(
+        "task-1",
+        recentProfile.id,
+        expect.objectContaining({ profileExplicit: true }),
+      ),
+    );
+  });
+
+  it("does not replace a manual profile choice when recent use changes", async () => {
+    const recentProfile = { ...BASE_PROFILE, id: "profile-2", label: "Profile 2" };
+    const laterRecentProfile = { ...BASE_PROFILE, id: "profile-3", label: "Profile 3" };
+    mockState.agentProfiles.items = [BASE_PROFILE, recentProfile, laterRecentProfile];
+    mockState.agentProfileRecentUse = {
+      loaded: true,
+      records: {
+        task_session: {
+          profileIds: [recentProfile.id],
+          revision: 1,
+          updatedAt: "2026-08-30T12:00:00Z",
+        },
+      },
+    };
+    const { rerender } = render(
+      <NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />,
+    );
+
+    await waitFor(() => expect(mockAgentSelectorValue).toBe(recentProfile.id));
+    await act(async () => {
+      mockAgentSelectorOnChange?.(BASE_PROFILE.id);
+    });
+
+    mockState.agentProfileRecentUse = {
+      loaded: true,
+      records: {
+        task_session: {
+          profileIds: [laterRecentProfile.id],
+          revision: 2,
+          updatedAt: "2026-08-30T12:01:00Z",
+        },
+      },
+    };
+    rerender(<NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />);
+
+    await waitFor(() => expect(mockAgentSelectorValue).toBe(BASE_PROFILE.id));
   });
 
   it("marks a changed picker profile explicit", async () => {

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -282,10 +282,7 @@ function useSessionProfileSelection({
     showAgentSelector,
     selectedProfileId,
     profileExplicit:
-      Boolean(handoff) ||
-      selectionSource === "handoff" ||
-      selectionSource === "recent" ||
-      selectionSource === "manual",
+      selectionSource === "handoff" || selectionSource === "recent" || selectionSource === "manual",
     onProfileChange,
   };
 }

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -16,9 +16,7 @@ import { useSummarizeSession } from "@/hooks/use-summarize-session";
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import { useTaskExecutorProfile } from "@/hooks/domains/session/use-task-executor-profile";
 import { useCompatibleAgentProfiles } from "@/hooks/domains/session/use-compatible-agent-profiles";
-import { useFeature } from "@/hooks/domains/features/use-feature";
 import type { AgentProfileOption } from "@/lib/state/slices";
-import { isSelectableAgentProfile } from "@/lib/state/slices/settings/types";
 import type { ExecutorProfile } from "@/lib/types/http";
 import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
 import { buildHandoffInitialState, type HandoffPreset } from "./handoff-types";
@@ -27,6 +25,7 @@ import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { PromptResultRecovery } from "@/components/prompt-result-recovery";
 import { EnvironmentBadges, ContextSelect } from "./session-dialog-shared";
 import { useSessionContextChange, useSessionLaunchSubmit } from "./new-session-form-actions";
+import { resolveNewSessionProfileSelection } from "./new-session-profile-selection";
 import { resolveComposerWorkspaceId } from "./chat/composer-workspace";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -50,7 +49,6 @@ function agentProfileDisplayLabel(profile: AgentProfileOption): string {
 
 function useNewSessionDialogState(taskId: string) {
   const { t } = useTranslation();
-  const dynamicRoutingEnabled = useFeature("dynamicAgentRouting");
   const resolvedWorkspaceId = useAppStore((state) =>
     resolveComposerWorkspaceId({
       sessionId: null,
@@ -96,16 +94,6 @@ function useNewSessionDialogState(taskId: string) {
   });
 
   const sessionProfileId = currentSession?.agent_profile_id ?? "";
-  // The default for a NEW session must be selectable: a current session
-  // that uses a now-disabled profile still runs (no effect on existing
-  // sessions), but the dialog falls back to the first enabled profile.
-  const selectableProfiles = agentProfiles.filter((profile) =>
-    isSelectableAgentProfile(profile, dynamicRoutingEnabled),
-  );
-  const profileIsValid = selectableProfiles.some((p: { id: string }) => p.id === sessionProfileId);
-  const effectiveDefaultProfileId: string = profileIsValid
-    ? sessionProfileId
-    : (selectableProfiles[0]?.id ?? "");
 
   return {
     resolvedWorkspaceId,
@@ -116,7 +104,6 @@ function useNewSessionDialogState(taskId: string) {
     initialPrompt,
     executorLabel,
     sessionProfileId,
-    effectiveDefaultProfileId,
   };
 }
 
@@ -227,34 +214,15 @@ function shouldDisableSubmit(isBusy: boolean, hasPrompt: boolean, hasProfiles: b
   return submitPenalty > 0;
 }
 
-function useEnforceCompatibleProfile(
-  compatible: AgentProfileOption[],
-  selectedId: string,
-  setSelected: (id: string) => void,
-) {
-  useEffect(() => {
-    if (compatible.some((p) => p.id === selectedId)) return;
-    if (compatible.length > 0) {
-      setSelected(compatible[0].id);
-    } else if (selectedId) {
-      setSelected("");
-    }
-  }, [compatible, selectedId, setSelected]);
-}
-
 function useSessionProfileSelection({
   agentProfiles,
   executorProfile,
-  defaultProfileId,
-  selectedProfileId,
-  setSelectedProfileId,
+  currentProfileId,
   handoff,
 }: {
   agentProfiles: AgentProfileOption[];
   executorProfile: ExecutorProfile | null;
-  defaultProfileId: string;
-  selectedProfileId: string;
-  setSelectedProfileId: (value: string) => void;
+  currentProfileId: string;
   handoff?: HandoffPreset;
 }) {
   const compatibleAgentProfiles = useCompatibleAgentProfiles(
@@ -262,7 +230,35 @@ function useSessionProfileSelection({
     executorProfile,
     handoff,
   );
-  useEnforceCompatibleProfile(compatibleAgentProfiles, selectedProfileId, setSelectedProfileId);
+  const recentProfileIds = useAppStore(
+    (state) => state.agentProfileRecentUse?.records.task_session?.profileIds,
+  );
+  const automaticSelection = useMemo(
+    () =>
+      resolveNewSessionProfileSelection({
+        compatibleProfiles: compatibleAgentProfiles,
+        recentProfileIds,
+        currentProfileId,
+        handoffProfileId: handoff?.targetProfileId,
+      }),
+    [compatibleAgentProfiles, currentProfileId, handoff?.targetProfileId, recentProfileIds],
+  );
+  const [selectedProfileId, setSelectedProfileId] = useState(automaticSelection.profileId);
+  const [selectionSource, setSelectionSource] = useState(automaticSelection.source);
+  useEffect(() => {
+    const selectedIsCompatible = compatibleAgentProfiles.some(
+      (profile) => profile.id === selectedProfileId,
+    );
+    if (selectionSource === "manual" && selectedIsCompatible) return;
+    if (
+      selectedProfileId === automaticSelection.profileId &&
+      selectionSource === automaticSelection.source
+    ) {
+      return;
+    }
+    setSelectedProfileId(automaticSelection.profileId);
+    setSelectionSource(automaticSelection.source);
+  }, [automaticSelection, compatibleAgentProfiles, selectedProfileId, selectionSource]);
   const profileOptions = useAgentProfileOptions(compatibleAgentProfiles, "task_session");
   const hasProfiles = profileOptions.length > 0;
   const noCompatibleProfiles = isMissingCompatibleProfile(
@@ -273,13 +269,24 @@ function useSessionProfileSelection({
   const showAgentSelector =
     hasProfiles &&
     (profileOptions.length > 1 ||
-      (!!defaultProfileId && !profileOptions.find((o) => o.value === defaultProfileId)));
+      (!!currentProfileId && !profileOptions.find((o) => o.value === currentProfileId)));
+  const onProfileChange = useCallback((value: string) => {
+    setSelectedProfileId(value);
+    setSelectionSource("manual");
+  }, []);
 
   return {
     profileOptions,
     hasProfiles,
     noCompatibleProfiles,
     showAgentSelector,
+    selectedProfileId,
+    profileExplicit:
+      Boolean(handoff) ||
+      selectionSource === "handoff" ||
+      selectionSource === "recent" ||
+      selectionSource === "manual",
+    onProfileChange,
   };
 }
 
@@ -338,8 +345,7 @@ function SessionFormHeader({
 function NewSessionForm({
   taskId,
   workspaceId,
-  defaultProfileId,
-  initialProfileId,
+  currentProfileId,
   executorId,
   executorLabel,
   executorProfile,
@@ -352,8 +358,7 @@ function NewSessionForm({
 }: {
   taskId: string;
   workspaceId?: string | null;
-  defaultProfileId: string;
-  initialProfileId?: string;
+  currentProfileId: string;
   executorId: string;
   executorLabel: string | null;
   executorProfile: ExecutorProfile | null;
@@ -370,10 +375,6 @@ function NewSessionForm({
   const setActiveSession = useAppStore((state) => state.setActiveSession);
   const { summarize, isSummarizing } = useSummarizeSession();
   const [contextValue, setContextValue] = useState(handoffInitial?.contextValue ?? "blank");
-  const [selectedProfileId, setSelectedProfileId] = useState(
-    handoffInitial?.selectedProfileId ?? initialProfileId ?? defaultProfileId,
-  );
-  const [profileExplicit, setProfileExplicit] = useState(Boolean(handoff));
   const [hasPrompt, setHasPrompt] = useState(false);
   const [hasPendingAttachmentUploads, setHasPendingAttachmentUploads] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
@@ -385,9 +386,7 @@ function NewSessionForm({
   const profileSelection = useSessionProfileSelection({
     agentProfiles,
     executorProfile,
-    defaultProfileId,
-    selectedProfileId,
-    setSelectedProfileId,
+    currentProfileId,
     handoff,
   });
   const { handleEnhancePrompt, isEnhancingPrompt, pendingResult, applyPending, copyPending } =
@@ -405,8 +404,8 @@ function NewSessionForm({
   const handleSubmit = useSessionLaunchSubmit({
     promptRef,
     taskId,
-    selectedProfileId,
-    profileExplicit,
+    selectedProfileId: profileSelection.selectedProfileId,
+    profileExplicit: profileSelection.profileExplicit,
     executorId,
     contextValue,
     initialPrompt,
@@ -432,12 +431,9 @@ function NewSessionForm({
         executorProfileName={executorProfile?.name ?? null}
         showAgentSelector={profileSelection.showAgentSelector}
         profileOptions={profileSelection.profileOptions}
-        selectedProfileId={selectedProfileId}
+        selectedProfileId={profileSelection.selectedProfileId}
         isCreating={isCreating}
-        onProfileChange={(value) => {
-          setProfileExplicit(true);
-          setSelectedProfileId(value);
-        }}
+        onProfileChange={profileSelection.onProfileChange}
       />
       <ContextSelect
         value={contextValue}
@@ -561,7 +557,6 @@ export function NewSessionDialog({
     initialPrompt,
     executorLabel,
     sessionProfileId,
-    effectiveDefaultProfileId,
   } = useNewSessionDialogState(taskId);
   const executorProfile = useTaskExecutorProfile(taskId, open);
   const handoffLabel = handoffProfileLabel(agentProfiles, handoff);
@@ -593,8 +588,7 @@ export function NewSessionDialog({
           key={formKey}
           taskId={taskId}
           workspaceId={workspaceId ?? resolvedWorkspaceId}
-          defaultProfileId={sessionProfileId}
-          initialProfileId={effectiveDefaultProfileId}
+          currentProfileId={sessionProfileId}
           executorId={currentSession?.executor_id ?? ""}
           executorLabel={executorLabel}
           executorProfile={executorProfile}

--- a/apps/web/components/task/new-session-profile-selection.test.ts
+++ b/apps/web/components/task/new-session-profile-selection.test.ts
@@ -47,6 +47,33 @@ describe("resolveNewSessionProfileSelection", () => {
     });
   });
 
+  it("keeps the current profile fallback when recent history is unavailable", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: profiles,
+      currentProfileId: "profile-a",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-a",
+      source: "current",
+      profileExplicit: false,
+    });
+  });
+
+  it("keeps the current profile fallback when recent history is empty", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: profiles,
+      recentProfileIds: [],
+      currentProfileId: "profile-a",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-a",
+      source: "current",
+      profileExplicit: false,
+    });
+  });
+
   it("uses source order when history and the current profile are unavailable", () => {
     const selection = resolveNewSessionProfileSelection({
       compatibleProfiles: [profiles[1], profiles[2]],

--- a/apps/web/components/task/new-session-profile-selection.test.ts
+++ b/apps/web/components/task/new-session-profile-selection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { resolveNewSessionProfileSelection } from "./new-session-profile-selection";
+
+const profiles = [{ id: "profile-a" }, { id: "profile-b" }, { id: "profile-c" }];
+
+describe("resolveNewSessionProfileSelection", () => {
+  it("selects a compatible task-session recent profile over the current session", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: profiles,
+      recentProfileIds: ["profile-b", "profile-c"],
+      currentProfileId: "profile-a",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-b",
+      source: "recent",
+      profileExplicit: true,
+    });
+  });
+
+  it("prioritizes a compatible handoff target over recent use", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: profiles,
+      recentProfileIds: ["profile-b"],
+      currentProfileId: "profile-a",
+      handoffProfileId: "profile-c",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-c",
+      source: "handoff",
+      profileExplicit: true,
+    });
+  });
+
+  it("skips ineligible recent profiles and keeps the current profile fallback implicit", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: [profiles[0], profiles[2]],
+      recentProfileIds: ["profile-b"],
+      currentProfileId: "profile-a",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-a",
+      source: "current",
+      profileExplicit: false,
+    });
+  });
+
+  it("uses source order when history and the current profile are unavailable", () => {
+    const selection = resolveNewSessionProfileSelection({
+      compatibleProfiles: [profiles[1], profiles[2]],
+      recentProfileIds: ["missing"],
+      currentProfileId: "profile-a",
+    });
+
+    expect(selection).toEqual({
+      profileId: "profile-b",
+      source: "source",
+      profileExplicit: false,
+    });
+  });
+});

--- a/apps/web/components/task/new-session-profile-selection.ts
+++ b/apps/web/components/task/new-session-profile-selection.ts
@@ -1,0 +1,62 @@
+export type NewSessionProfileSelectionSource =
+  | "handoff"
+  | "recent"
+  | "current"
+  | "source"
+  | "manual";
+
+export type NewSessionProfileSelection = {
+  profileId: string;
+  source: NewSessionProfileSelectionSource;
+  profileExplicit: boolean;
+};
+
+export type NewSessionProfileSelectionInput = {
+  compatibleProfiles: readonly { id: string }[];
+  recentProfileIds?: readonly string[];
+  currentProfileId?: string;
+  handoffProfileId?: string;
+};
+
+/** Resolves the initial profile for an ordinary new-session dialog. */
+export function resolveNewSessionProfileSelection({
+  compatibleProfiles,
+  recentProfileIds,
+  currentProfileId,
+  handoffProfileId,
+}: NewSessionProfileSelectionInput): NewSessionProfileSelection {
+  const compatibleProfileIds = new Set(compatibleProfiles.map((profile) => profile.id));
+
+  if (handoffProfileId && compatibleProfileIds.has(handoffProfileId)) {
+    return {
+      profileId: handoffProfileId,
+      source: "handoff",
+      profileExplicit: true,
+    };
+  }
+
+  const recentProfileId = recentProfileIds?.find((profileId) =>
+    compatibleProfileIds.has(profileId),
+  );
+  if (recentProfileId) {
+    return {
+      profileId: recentProfileId,
+      source: "recent",
+      profileExplicit: true,
+    };
+  }
+
+  if (currentProfileId && compatibleProfileIds.has(currentProfileId)) {
+    return {
+      profileId: currentProfileId,
+      source: "current",
+      profileExplicit: false,
+    };
+  }
+
+  return {
+    profileId: compatibleProfiles[0]?.id ?? "",
+    source: "source",
+    profileExplicit: false,
+  };
+}

--- a/apps/web/e2e/pages/new-session-dialog-page.ts
+++ b/apps/web/e2e/pages/new-session-dialog-page.ts
@@ -1,0 +1,35 @@
+import type { Locator, Page } from "@playwright/test";
+
+/** Focused page object for agent-profile controls in the New Session dialog. */
+export class NewSessionDialogPage {
+  constructor(private readonly page: Page) {}
+
+  /** Agent profile combobox inside the new-session or handoff dialog. */
+  agentSelector(): Locator {
+    return this.page
+      .getByRole("dialog")
+      .filter({ hasText: /New agent in|Hand off to/ })
+      .getByTestId("agent-profile-selector");
+  }
+
+  /** Visible agent profile options for the active new-session selector. */
+  agentOptions(): Locator {
+    return this.page.getByRole("listbox", { name: "Suggestions" }).getByRole("option");
+  }
+
+  /** Select an agent profile from the active new-session or handoff dialog. */
+  async selectProfile(profileName: string, touch = false): Promise<void> {
+    const selector = this.agentSelector();
+    if (touch) {
+      await selector.tap();
+    } else {
+      await selector.click();
+    }
+    const option = this.agentOptions().filter({ hasText: profileName });
+    if (touch) {
+      await option.tap();
+    } else {
+      await option.click();
+    }
+  }
+}

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page, expect } from "@playwright/test";
 import { FileTreePage } from "./file-tree-page";
+import { NewSessionDialogPage } from "./new-session-dialog-page";
 import { dwell } from "../helpers/causal-waits";
 
 function escapeRegExp(value: string): string {
@@ -25,6 +26,7 @@ export class SessionPage {
   readonly stepper: Locator;
   readonly passthroughTerminal: Locator;
   readonly fileTree: FileTreePage;
+  readonly newSessionDialogPage: NewSessionDialogPage;
 
   constructor(private readonly page: Page) {
     this.chat = page.getByTestId("session-chat");
@@ -36,6 +38,7 @@ export class SessionPage {
     this.stepper = page.getByTestId("workflow-stepper");
     this.passthroughTerminal = page.getByTestId("passthrough-terminal");
     this.fileTree = new FileTreePage(page, this.files, () => this.activeChat());
+    this.newSessionDialogPage = new NewSessionDialogPage(page);
   }
 
   // Port forward dialog locators
@@ -1553,32 +1556,6 @@ export class SessionPage {
   /** Prompt textarea inside the new session or handoff dialog. */
   newSessionPromptInput(): Locator {
     return this.sessionLaunchDialog().getByTestId("task-description-input");
-  }
-
-  /** Agent profile combobox inside the new-session or handoff dialog. */
-  newSessionAgentSelector(): Locator {
-    return this.sessionLaunchDialog().getByTestId("agent-profile-selector");
-  }
-
-  /** Visible agent profile options for the active new-session selector. */
-  newSessionAgentOptions(): Locator {
-    return this.page.getByRole("listbox", { name: "Suggestions" }).getByRole("option");
-  }
-
-  /** Select an agent profile from the active new-session or handoff dialog. */
-  async selectNewSessionProfile(profileName: string, touch = false): Promise<void> {
-    const selector = this.newSessionAgentSelector();
-    if (touch) {
-      await selector.tap();
-    } else {
-      await selector.click();
-    }
-    const option = this.newSessionAgentOptions().filter({ hasText: profileName });
-    if (touch) {
-      await option.tap();
-    } else {
-      await option.click();
-    }
   }
 
   /** Start Agent button inside the new session or handoff dialog. */

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -1555,6 +1555,32 @@ export class SessionPage {
     return this.sessionLaunchDialog().getByTestId("task-description-input");
   }
 
+  /** Agent profile combobox inside the new-session or handoff dialog. */
+  newSessionAgentSelector(): Locator {
+    return this.sessionLaunchDialog().getByTestId("agent-profile-selector");
+  }
+
+  /** Visible agent profile options for the active new-session selector. */
+  newSessionAgentOptions(): Locator {
+    return this.page.getByRole("listbox", { name: "Suggestions" }).getByRole("option");
+  }
+
+  /** Select an agent profile from the active new-session or handoff dialog. */
+  async selectNewSessionProfile(profileName: string, touch = false): Promise<void> {
+    const selector = this.newSessionAgentSelector();
+    if (touch) {
+      await selector.tap();
+    } else {
+      await selector.click();
+    }
+    const option = this.newSessionAgentOptions().filter({ hasText: profileName });
+    if (touch) {
+      await option.tap();
+    } else {
+      await option.click();
+    }
+  }
+
   /** Start Agent button inside the new session or handoff dialog. */
   newSessionStartButton(): Locator {
     return this.sessionLaunchDialog().getByRole("button", { name: "Start Agent" });

--- a/apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts
@@ -40,10 +40,12 @@ test.describe("New session dialog on mobile", () => {
       await session.waitForChatIdle({ timeout: 30_000 });
       await session.openMobileNewSessionDialog();
 
-      const selector = session.newSessionAgentSelector();
+      const selector = session.newSessionDialogPage.agentSelector();
       await expect(selector).toContainText(profileB.name);
       await selector.tap();
-      await expect(session.newSessionAgentOptions().first()).toContainText(profileB.name);
+      const options = session.newSessionDialogPage.agentOptions();
+      await expect(options.filter({ hasText: profileB.name })).toHaveCount(1);
+      await expect(options.first()).toContainText(profileB.name);
       await testPage.keyboard.press("Escape");
 
       await session.newSessionPromptInput().fill("/e2e:simple-message");

--- a/apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../../fixtures/test-base";
 import { waitForSessionDone } from "../../helpers/session";
 import { SessionPage } from "../../pages/session-page";
+import { createRecentUseProfiles, seedTaskSessionRecency } from "./new-session-recency-helpers";
 
 const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
 const PROMPT_NAME = "e2e-mobile-new-agent-prompt";
@@ -13,6 +14,55 @@ test.describe("New session dialog on mobile", () => {
       if (!prompt.builtin && prompt.name === PROMPT_NAME) {
         await apiClient.deletePrompt(prompt.id);
       }
+    }
+  });
+
+  test("uses task-session recency for the mobile Add Agent default", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(300_000);
+    const { profileA, profileB } = await createRecentUseProfiles(apiClient);
+
+    try {
+      const { targetTaskId } = await seedTaskSessionRecency({
+        testPage,
+        apiClient,
+        seedData,
+        profileA,
+        profileB,
+        mobile: true,
+      });
+      await testPage.goto(`/t/${targetTaskId}`);
+      const session = new SessionPage(testPage);
+      await session.waitForLoad();
+      await session.waitForChatIdle({ timeout: 30_000 });
+      await session.openMobileNewSessionDialog();
+
+      const selector = session.newSessionAgentSelector();
+      await expect(selector).toContainText(profileB.name);
+      await selector.tap();
+      await expect(session.newSessionAgentOptions().first()).toContainText(profileB.name);
+      await testPage.keyboard.press("Escape");
+
+      await session.newSessionPromptInput().fill("/e2e:simple-message");
+      await session.newSessionStartButton().tap();
+      await expect(session.newSessionDialog()).not.toBeVisible({ timeout: 10_000 });
+
+      await expect
+        .poll(
+          async () => {
+            const { sessions } = await apiClient.listTaskSessions(targetTaskId);
+            return sessions.find((candidate) => candidate.agent_profile_id === profileB.id)
+              ?.agent_profile_id;
+          },
+          { timeout: 30_000, message: "Waiting for the recent mobile profile session" },
+        )
+        .toBe(profileB.id);
+    } finally {
+      await apiClient.deleteAgentProfile(profileA.id, true).catch(() => undefined);
+      await apiClient.deleteAgentProfile(profileB.id, true).catch(() => undefined);
     }
   });
 

--- a/apps/web/e2e/tests/session/new-session-dialog.spec.ts
+++ b/apps/web/e2e/tests/session/new-session-dialog.spec.ts
@@ -45,10 +45,12 @@ test.describe("New session dialog", () => {
       await session.waitForChatIdle({ timeout: 30_000 });
       await session.openNewSessionDialog();
 
-      const selector = session.newSessionAgentSelector();
+      const selector = session.newSessionDialogPage.agentSelector();
       await expect(selector).toContainText(profileB.name);
       await selector.click();
-      await expect(session.newSessionAgentOptions().first()).toContainText(profileB.name);
+      const options = session.newSessionDialogPage.agentOptions();
+      await expect(options.filter({ hasText: profileB.name })).toHaveCount(1);
+      await expect(options.first()).toContainText(profileB.name);
       await testPage.keyboard.press("Escape");
 
       await session.newSessionPromptInput().fill("/e2e:simple-message");

--- a/apps/web/e2e/tests/session/new-session-dialog.spec.ts
+++ b/apps/web/e2e/tests/session/new-session-dialog.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../../fixtures/test-base";
 import { waitForSessionDone } from "../../helpers/session";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
+import { createRecentUseProfiles, seedTaskSessionRecency } from "./new-session-recency-helpers";
 
 const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
 const PROMPT_NAME = "e2e-new-agent-prompt";
@@ -19,6 +20,54 @@ test.describe("New session dialog", () => {
       if (!prompt.builtin && prompt.name === PROMPT_NAME) {
         await apiClient.deletePrompt(prompt.id);
       }
+    }
+  });
+
+  test("uses task-session recency for the Add Agent default", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(300_000);
+    const { profileA, profileB } = await createRecentUseProfiles(apiClient);
+
+    try {
+      const { targetTaskId } = await seedTaskSessionRecency({
+        testPage,
+        apiClient,
+        seedData,
+        profileA,
+        profileB,
+      });
+      await testPage.goto(`/t/${targetTaskId}`);
+      const session = new SessionPage(testPage);
+      await session.waitForLoad();
+      await session.waitForChatIdle({ timeout: 30_000 });
+      await session.openNewSessionDialog();
+
+      const selector = session.newSessionAgentSelector();
+      await expect(selector).toContainText(profileB.name);
+      await selector.click();
+      await expect(session.newSessionAgentOptions().first()).toContainText(profileB.name);
+      await testPage.keyboard.press("Escape");
+
+      await session.newSessionPromptInput().fill("/e2e:simple-message");
+      await session.newSessionStartButton().click();
+      await expect(session.newSessionDialog()).not.toBeVisible({ timeout: 10_000 });
+
+      await expect
+        .poll(
+          async () => {
+            const { sessions } = await apiClient.listTaskSessions(targetTaskId);
+            return sessions.find((candidate) => candidate.agent_profile_id === profileB.id)
+              ?.agent_profile_id;
+          },
+          { timeout: 30_000, message: "Waiting for the recent profile session" },
+        )
+        .toBe(profileB.id);
+    } finally {
+      await apiClient.deleteAgentProfile(profileA.id, true).catch(() => undefined);
+      await apiClient.deleteAgentProfile(profileB.id, true).catch(() => undefined);
     }
   });
 

--- a/apps/web/e2e/tests/session/new-session-recency-helpers.ts
+++ b/apps/web/e2e/tests/session/new-session-recency-helpers.ts
@@ -1,0 +1,110 @@
+import { expect, type Page } from "@playwright/test";
+import type { AgentProfile } from "../../../lib/types/http-agents";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { openTaskSession, waitForSessionDone } from "../../helpers/session";
+
+const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
+
+export async function createRecentUseProfiles(apiClient: ApiClient): Promise<{
+  profileA: AgentProfile;
+  profileB: AgentProfile;
+}> {
+  const { agents } = await apiClient.listAgents();
+  const agent = agents.find((candidate) => candidate.id !== "dynamic") ?? agents[0];
+  if (!agent) throw new Error("No launchable agent available in test fixtures");
+
+  const suffix = Date.now().toString(36);
+  const profileA = await apiClient.createAgentProfile(agent.id, `Session Recency A ${suffix}`, {
+    model: "mock-fast",
+  });
+  const profileB = await apiClient.createAgentProfile(agent.id, `Session Recency B ${suffix}`, {
+    model: "mock-fast",
+  });
+  return { profileA, profileB };
+}
+
+export async function seedTaskSessionRecency(options: {
+  testPage: Page;
+  apiClient: ApiClient;
+  seedData: SeedData;
+  profileA: AgentProfile;
+  profileB: AgentProfile;
+  mobile?: boolean;
+}): Promise<{ targetTaskId: string }> {
+  const { testPage, apiClient, seedData, profileA, profileB, mobile = false } = options;
+  const sourceTask = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    `Session Recency Source ${Date.now()}`,
+    profileA.id,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  if (!sourceTask.session_id) throw new Error("Source task did not return a session ID");
+
+  await waitForSessionDone(
+    apiClient,
+    sourceTask.id,
+    sourceTask.session_id,
+    "Waiting for the source session to finish",
+  );
+  const sourceSession = await openTaskSession(testPage, sourceTask.id);
+  await sourceSession.waitForChatIdle({ timeout: 30_000 });
+  if (mobile) {
+    await sourceSession.openMobileNewSessionDialog();
+  } else {
+    await sourceSession.openNewSessionDialog();
+  }
+  await expect(sourceSession.newSessionDialog()).toBeVisible({ timeout: 5_000 });
+  await sourceSession.selectNewSessionProfile(profileB.name, mobile);
+  await sourceSession.newSessionPromptInput().fill("/e2e:simple-message");
+  if (mobile) {
+    await sourceSession.newSessionStartButton().tap();
+  } else {
+    await sourceSession.newSessionStartButton().click();
+  }
+  await expect(sourceSession.newSessionDialog()).not.toBeVisible({ timeout: 10_000 });
+
+  await expect
+    .poll(
+      async () => {
+        const { sessions } = await apiClient.listTaskSessions(sourceTask.id);
+        return sessions.length === 2 && DONE_STATES.includes(sessions[0]?.state ?? "");
+      },
+      { timeout: 120_000, message: "Waiting for the recency source session" },
+    )
+    .toBe(true);
+  await expect
+    .poll(
+      async () => {
+        const records = await apiClient.listAgentProfileRecentUse();
+        return records.find((record) => record.context === "task_session")?.profile_ids[0] ?? "";
+      },
+      { timeout: 30_000, message: "Waiting for task-session recency to record profile B" },
+    )
+    .toBe(profileB.id);
+
+  const targetTask = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    `Session Recency Target ${Date.now()}`,
+    profileA.id,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  if (!targetTask.session_id) throw new Error("Target task did not return a session ID");
+  await waitForSessionDone(
+    apiClient,
+    targetTask.id,
+    targetTask.session_id,
+    "Waiting for the target session to finish",
+  );
+  return { targetTaskId: targetTask.id };
+}

--- a/apps/web/e2e/tests/session/new-session-recency-helpers.ts
+++ b/apps/web/e2e/tests/session/new-session-recency-helpers.ts
@@ -35,7 +35,7 @@ export async function seedTaskSessionRecency(options: {
   const { testPage, apiClient, seedData, profileA, profileB, mobile = false } = options;
   const sourceTask = await apiClient.createTaskWithAgent(
     seedData.workspaceId,
-    `Session Recency Source ${Date.now()}`,
+    "Session Recency Source",
     profileA.id,
     {
       description: "/e2e:simple-message",
@@ -60,7 +60,7 @@ export async function seedTaskSessionRecency(options: {
     await sourceSession.openNewSessionDialog();
   }
   await expect(sourceSession.newSessionDialog()).toBeVisible({ timeout: 5_000 });
-  await sourceSession.selectNewSessionProfile(profileB.name, mobile);
+  await sourceSession.newSessionDialogPage.selectProfile(profileB.name, mobile);
   await sourceSession.newSessionPromptInput().fill("/e2e:simple-message");
   if (mobile) {
     await sourceSession.newSessionStartButton().tap();
@@ -90,7 +90,7 @@ export async function seedTaskSessionRecency(options: {
 
   const targetTask = await apiClient.createTaskWithAgent(
     seedData.workspaceId,
-    `Session Recency Target ${Date.now()}`,
+    "Session Recency Target",
     profileA.id,
     {
       description: "/e2e:simple-message",

--- a/docs/plans/add-agent-recent-profile-default/plan.md
+++ b/docs/plans/add-agent-recent-profile-default/plan.md
@@ -1,0 +1,141 @@
+---
+created: 2026-08-30
+status: complete
+requirements:
+  - REQ-AGENTS-PROFILE-RECENT-USE-001
+  - REQ-AGENTS-PROFILE-RECENT-USE-002
+  - REQ-AGENTS-PROFILE-RECENT-USE-003
+system_design:
+  - ../../specs/agents/system-design/profile-recent-use.md
+legacy_specs: []
+---
+
+# Implementation Plan: Add Agent Recent Profile Default
+
+## Overview
+
+Make an ordinary Add Agent dialog select the newest compatible
+`task_session` profile. Preserve handoff targets, manual choices, eligibility,
+and context isolation. Implement the selection resolver first. Then prove the
+complete desktop and mobile flows.
+
+## Confirmed defect
+
+The recent-use feature orders Add Agent options with `task_session` history.
+The dialog still initializes its value from the current task session. The
+shared combobox moves that selected value to the first row. As a result, the
+current session masks the separate recent-use order and remains the launch
+default.
+
+The smallest reproduction is:
+
+1. Start a task with profile A.
+2. Start another task session with profile B.
+3. Open Add Agent on a task whose current session uses profile A.
+4. Observe that profile A is selected and first, although profile B is first in
+   `task_session` history.
+
+## Scope
+
+### In scope
+
+- Select the first compatible `task_session` profile for ordinary Add Agent
+  and new-session dialogs.
+- Treat the recent-use default as the selector-backed launch choice.
+- Preserve handoff targets and later manual profile choices.
+- Preserve current-session and source-order fallback behavior when history has
+  no compatible profile.
+- Add focused unit, desktop Playwright, and mobile Playwright evidence.
+
+### Out of scope
+
+- Changes to recency persistence, limits, API shapes, or WebSocket events.
+- Changes to `task_create`, `quick_chat`, or `config_chat` defaults.
+- Changes to workflow, automation, settings, or Office selectors.
+- Dialog markup, copy, overlay type, touch targets, scrolling, or breakpoints.
+
+## Technical approach
+
+### Initial profile resolver
+
+Extract a pure resolver beside `new-session-dialog.tsx`. The resolver receives
+the compatible profiles, `task_session` IDs, the current session profile, and
+an optional handoff target. It returns the selected profile and selection
+source.
+
+Use this priority: handoff target, compatible recent profile, compatible
+current-session profile, then the first compatible source profile. Mark
+handoff, recent-use, and manual selections as explicit. Keep legacy fallbacks
+non-explicit.
+
+Keep selection provenance in the dialog state. Compatibility or recency
+updates must not replace a manual choice. If recent-use state is unavailable,
+the dialog must not block. It uses the existing fallback.
+
+### Launch semantics
+
+Continue to use `profile_explicit` in the current session-launch request. Set
+it to `true` for a recent-use default. This rule makes the launched profile
+match the profile that the dialog shows, including on a profile-pinned workflow
+step.
+
+Do not change backend request shapes or workflow resolution. The existing
+explicit-profile path already owns this precedence.
+
+### Desktop and mobile behavior
+
+Both viewports use `NewSessionDialog`, `AgentSelector`, and the same launch
+handler. The presentation stays unchanged. Desktop entry uses the task header
+Add Agent action. Mobile entry uses the sessions picker and its New Agent
+action. Each flow must show the recent profile and launch it.
+
+## Tests
+
+- `AC-AGENTS-PROFILE-RECENT-USE-001.4`, `.6`, `.7`, and `.8`: add pure resolver
+  tests in
+  `apps/web/components/task/new-session-profile-selection.test.ts`.
+- `AC-AGENTS-PROFILE-RECENT-USE-001.6` and `.8`: update
+  `apps/web/components/task/new-session-dialog.test.tsx` and
+  `new-session-form-actions.test.ts` for selection provenance and
+  `profile_explicit` request behavior.
+- `AC-AGENTS-PROFILE-RECENT-USE-002.1`: make sure that opening, cancelling, or
+  manually changing the dialog does not record use before a successful launch.
+
+The first RED test is
+`selects a compatible task-session recent profile over the current session`.
+It must fail because the current implementation selects the current session.
+
+## E2E tests
+
+- `AC-AGENTS-PROFILE-RECENT-USE-001.2`, `.4`, `.6`, and `.8`: extend
+  `apps/web/e2e/tests/session/new-session-dialog.spec.ts`. Start profile B in
+  one task-session context. Open Add Agent on a profile-A task. Assert that B is
+  selected, first, and used by the created session.
+- Add the same user outcome to
+  `apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts`. Use the
+  existing mobile sessions picker and touch interactions.
+- Poll `listTaskSessions` for the effective `agent_profile_id`. UI labels are
+  secondary evidence.
+
+## Work orders
+
+- [x] [Task 01: Resolve the recent Add Agent profile](task-01-resolve-recent-profile.md)
+- [x] [Task 02: Prove desktop and mobile recency](task-02-prove-desktop-mobile-recency.md)
+
+## Verification results
+
+- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (31 tests).
+- `cd apps/web && pnpm run typecheck` passed.
+- `cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
+
+## Risks
+
+- A recent-use default becomes an explicit profile choice. It can override a
+  workflow-step profile that previously replaced the unchanged dialog value.
+- Late store or compatibility updates can overwrite a manual choice without a
+  selection-source guard.
+- The selected-first combobox pass can hide an ordering regression unless the
+  browser test asserts both the trigger and the option list.
+- E2E setup must use two tasks or reactivate the original session. Otherwise,
+  the newest session already uses the recent profile and masks the defect.

--- a/docs/plans/add-agent-recent-profile-default/plan.md
+++ b/docs/plans/add-agent-recent-profile-default/plan.md
@@ -70,7 +70,8 @@ non-explicit.
 
 Keep selection provenance in the dialog state. Compatibility or recency
 updates must not replace a manual choice. If recent-use state is unavailable,
-the dialog must not block. It uses the existing fallback.
+the dialog must not block. It uses the existing current-session then
+source-order fallback.
 
 ### Launch semantics
 
@@ -124,10 +125,11 @@ It must fail because the current implementation selects the current session.
 
 ## Verification results
 
-- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (31 tests).
+- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (34 tests).
 - `cd apps/web && pnpm run typecheck` passed.
 - `cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
 - `cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
+- Review remediation added explicit coverage for unavailable and empty recent-use state, invalid manual selections, and incompatible handoff fallback. The recency-specific E2E controls now use `NewSessionDialogPage` and assert one matching first option on desktop and mobile.
 
 ## Risks
 

--- a/docs/plans/add-agent-recent-profile-default/task-01-resolve-recent-profile.md
+++ b/docs/plans/add-agent-recent-profile-default/task-01-resolve-recent-profile.md
@@ -96,6 +96,8 @@ None.
   current-session, and source-order resolution plus provenance.
 - Wired the resolver into `NewSessionDialog`; recent defaults are explicit,
   manual choices are protected, and invalid selections still fall back safely.
-- Added focused resolver and dialog regressions.
-- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (31 tests).
+- Added focused resolver and dialog regressions, including unavailable and
+  empty recent-use state, invalid manual selections, and incompatible handoff
+  fallback.
+- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (34 tests).
 - `cd apps/web && pnpm run typecheck` passed.

--- a/docs/plans/add-agent-recent-profile-default/task-01-resolve-recent-profile.md
+++ b/docs/plans/add-agent-recent-profile-default/task-01-resolve-recent-profile.md
@@ -1,0 +1,101 @@
+---
+id: "01-resolve-recent-profile"
+title: "Resolve the recent Add Agent profile"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-AGENTS-PROFILE-RECENT-USE-001
+  - REQ-AGENTS-PROFILE-RECENT-USE-002
+  - REQ-AGENTS-PROFILE-RECENT-USE-003
+acceptance_criteria:
+  - AC-AGENTS-PROFILE-RECENT-USE-001.2
+  - AC-AGENTS-PROFILE-RECENT-USE-001.4
+  - AC-AGENTS-PROFILE-RECENT-USE-001.6
+  - AC-AGENTS-PROFILE-RECENT-USE-001.7
+  - AC-AGENTS-PROFILE-RECENT-USE-001.8
+  - AC-AGENTS-PROFILE-RECENT-USE-002.1
+  - AC-AGENTS-PROFILE-RECENT-USE-003.3
+system_design:
+  - ../../specs/agents/system-design/profile-recent-use.md
+---
+
+# Task 01: Resolve the Recent Add Agent Profile
+
+## Summary
+
+Add a pure initial-profile resolver for the New Agent dialog. Use the recent
+`task_session` profile before the current session. Preserve handoff, manual
+choice, eligibility, and fallback behavior.
+
+## In scope
+
+- Write the failing resolver test before production code.
+- Resolve compatible profiles by handoff, recency, current session, and source
+  order.
+- Track whether the selection came from handoff, recency, fallback, or manual
+  input.
+- Send `profile_explicit: true` for the recent-use default.
+- Prevent later store and compatibility updates from replacing manual input.
+- Keep recency recording success-only.
+
+## Out of scope
+
+- Backend request or routing changes.
+- Changes to non-`task_session` selectors.
+- Dialog presentation or user-facing copy.
+- Playwright coverage.
+
+## Acceptance
+
+- A compatible recent profile becomes the selected and explicit launch profile.
+- A handoff target or manual input remains authoritative.
+- Empty or ineligible history keeps the existing fallback and does not block
+  the dialog.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts
+cd apps/web && pnpm run typecheck
+```
+
+## Files likely touched
+
+- `apps/web/components/task/new-session-profile-selection.ts`
+- `apps/web/components/task/new-session-profile-selection.test.ts`
+- `apps/web/components/task/new-session-dialog.tsx`
+- `apps/web/components/task/new-session-dialog.test.tsx`
+- `apps/web/components/task/new-session-form-actions.test.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- `profile_explicit: true` lets the recent default override workflow-step
+  profile resolution.
+- An effect-based reconciliation can replace manual input after the dialog
+  opens.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-AGENTS-PROFILE-RECENT-USE-001`
+- Frontend ordering and failure sections in the profile recent-use design.
+- Existing selection and launch logic in `new-session-dialog.tsx`.
+
+## Results
+
+- Added `new-session-profile-selection.ts` with handoff, compatible recent-use,
+  current-session, and source-order resolution plus provenance.
+- Wired the resolver into `NewSessionDialog`; recent defaults are explicit,
+  manual choices are protected, and invalid selections still fall back safely.
+- Added focused resolver and dialog regressions.
+- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` passed (31 tests).
+- `cd apps/web && pnpm run typecheck` passed.

--- a/docs/plans/add-agent-recent-profile-default/task-02-prove-desktop-mobile-recency.md
+++ b/docs/plans/add-agent-recent-profile-default/task-02-prove-desktop-mobile-recency.md
@@ -62,6 +62,7 @@ cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-ses
 
 - `apps/web/e2e/tests/session/new-session-dialog.spec.ts`
 - `apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts`
+- `apps/web/e2e/pages/new-session-dialog-page.ts`
 - `apps/web/e2e/pages/session-page.ts`
 - `apps/web/e2e/helpers/api-client.ts`
 
@@ -95,5 +96,8 @@ cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-ses
   effective backend session profile.
 - Added equivalent mobile coverage through the sessions picker and touch
   interactions.
+- Extracted the recency-specific profile controls into
+  `apps/web/e2e/pages/new-session-dialog-page.ts`; desktop and mobile tests
+  assert a single matching profile option and its first-position ordering.
 - `cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
 - `cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).

--- a/docs/plans/add-agent-recent-profile-default/task-02-prove-desktop-mobile-recency.md
+++ b/docs/plans/add-agent-recent-profile-default/task-02-prove-desktop-mobile-recency.md
@@ -1,0 +1,99 @@
+---
+id: "02-prove-desktop-mobile-recency"
+title: "Prove desktop and mobile recency"
+status: done
+wave: 2
+depends_on:
+  - "01-resolve-recent-profile"
+plan: "plan.md"
+requirements:
+  - REQ-AGENTS-PROFILE-RECENT-USE-001
+  - REQ-AGENTS-PROFILE-RECENT-USE-002
+  - REQ-AGENTS-PROFILE-RECENT-USE-003
+acceptance_criteria:
+  - AC-AGENTS-PROFILE-RECENT-USE-001.2
+  - AC-AGENTS-PROFILE-RECENT-USE-001.4
+  - AC-AGENTS-PROFILE-RECENT-USE-001.6
+  - AC-AGENTS-PROFILE-RECENT-USE-001.8
+  - AC-AGENTS-PROFILE-RECENT-USE-002.1
+  - AC-AGENTS-PROFILE-RECENT-USE-003.1
+  - AC-AGENTS-PROFILE-RECENT-USE-003.5
+system_design:
+  - ../../specs/agents/system-design/profile-recent-use.md
+---
+
+# Task 02: Prove Desktop and Mobile Recency
+
+## Summary
+
+Add focused Playwright regressions for the shared New Agent dialog. Prove that
+desktop and mobile select, show, and launch the recent `task_session` profile
+when the current task uses another profile.
+
+## In scope
+
+- Write the desktop Playwright scenario and observe the expected RED result.
+- Assert the selected trigger, first option, and effective backend session
+  profile.
+- Add the same outcome through the existing mobile New Agent entry point.
+- Remove created profiles in `finally` cleanup.
+
+## Out of scope
+
+- New layout, geometry, or screenshot assertions.
+- Repeating persistence caps and synchronization tests.
+- Quick Chat and configuration-chat recency coverage.
+
+## Acceptance
+
+- Desktop and mobile select profile B when `task_session` history ranks B and
+  the current task session uses profile A.
+- Starting the dialog creates a session whose effective profile is B.
+- Handoff and cancellation behavior in existing scenarios remains unchanged.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"
+```
+
+## Files likely touched
+
+- `apps/web/e2e/tests/session/new-session-dialog.spec.ts`
+- `apps/web/e2e/tests/session/mobile-new-session-dialog.spec.ts`
+- `apps/web/e2e/pages/session-page.ts`
+- `apps/web/e2e/helpers/api-client.ts`
+
+## Dependencies
+
+- Task 01 provides the corrected selection and launch behavior.
+
+## Risks
+
+- A one-task setup can mask the defect after profile B becomes the active
+  session.
+- The test must poll backend session state before it asserts the effective
+  profile.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-AGENTS-PROFILE-RECENT-USE-001`
+- Existing desktop and mobile new-session Playwright files.
+- E2E fixture-state and UI-state cleanup guidance.
+
+## Results
+
+- Added shared E2E setup that creates two eligible profiles, records profile B
+  through a successful source-task launch, and creates a profile-A target task
+  so the recency default is observable.
+- Added desktop coverage for the selected trigger, first selector option, and
+  effective backend session profile.
+- Added equivalent mobile coverage through the sessions picker and touch
+  interactions.
+- `cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"` passed (1 test).

--- a/docs/specs/agents/requirements/profile-recent-use.md
+++ b/docs/specs/agents/requirements/profile-recent-use.md
@@ -12,10 +12,10 @@ owners:
 
 Agent profile lists can contain many provider and model combinations. Users
 need the profiles they successfully used in a given operational flow to remain
-easy to reach without changing which profile the flow selects by default. The
-agent system owns this behavior because the remembered identity and eligibility
-rules belong to agent profiles, while task, quick-chat, and configuration-chat
-surfaces consume the same contract.
+easy to reach. The add-agent flow also uses its recent profile as the next
+default. The agent system owns this behavior because profile identity and
+eligibility belong to agent profiles. Task and chat surfaces consume the same
+contract.
 
 ## Terminology
 
@@ -30,9 +30,9 @@ surfaces consume the same contract.
 
 ### REQ-AGENTS-PROFILE-RECENT-USE-001: Contextual recent-use order
 
-**Intent:** Keep frequently used profiles near the top of the operational
-selector where they are useful without changing defaults or unrelated profile
-configuration surfaces.
+**Intent:** Keep frequently used profiles near the top of each operational
+selector. Use task-session history as the add-agent default without changing
+unrelated profile configuration surfaces.
 
 **User story:** As a user, I want each operational agent selector to remember
 the profiles I used there, so that repeated choices require less scanning.
@@ -51,13 +51,22 @@ the profiles I used there, so that repeated choices require less scanning.
   shall order eligible remembered profiles before eligible unseen profiles and
   preserve source order among unseen profiles.
 - **AC-AGENTS-PROFILE-RECENT-USE-001.4:** A selected profile shall remain the
-  first displayed option, and recent-use ordering shall not change any flow's
-  default-selection, compatibility, availability, disabled-profile, or search
-  rules.
+  first displayed option. Recent-use ordering shall not change compatibility,
+  availability, disabled-profile, or search rules.
 - **AC-AGENTS-PROFILE-RECENT-USE-001.5:** Agent selectors that configure
   workspace, workflow, automation, agent settings, or Office assignments shall
   retain their authoritative source order and shall not record operational
   recent use.
+- **AC-AGENTS-PROFILE-RECENT-USE-001.6:** When an ordinary add-agent or
+  new-session dialog opens, it shall select the first eligible and compatible
+  profile from `task_session` history. If the user starts the agent without
+  another profile change, the dialog shall launch that selected profile. This
+  profile shall take precedence over workflow-step profile resolution.
+- **AC-AGENTS-PROFILE-RECENT-USE-001.7:** When `task_session` history has no
+  eligible and compatible profile, the dialog shall retain its existing
+  current-session and source-order fallback.
+- **AC-AGENTS-PROFILE-RECENT-USE-001.8:** A handoff target and a later manual
+  profile choice shall take precedence over the recent-use default.
 
 ### REQ-AGENTS-PROFILE-RECENT-USE-002: Successful-use semantics
 
@@ -104,7 +113,8 @@ storage or synchronization costs to grow with normal product use.
 
 ## Out of scope
 
-- Changing default agent-profile selection or introducing recommendations.
+- Changing defaults outside ordinary add-agent and new-session dialogs.
+- Introducing agent-profile recommendations.
 - Workspace-, repository-, workflow-, task-, or device-specific histories.
 - User-managed pinning, manual ordering, history clearing, or recency UI.
 - Reordering non-operational configuration selectors.

--- a/docs/specs/agents/system-design/profile-recent-use.md
+++ b/docs/specs/agents/system-design/profile-recent-use.md
@@ -41,6 +41,8 @@ systems.
   stale per-context revisions.
 - Shared option-ordering logic applies a context history after existing
   eligibility filtering and before the combobox prioritizes its selected value.
+- The new-session selector resolves one initial selection from handoff intent,
+  compatible recent use, the current session, and source order.
 - Operational launchers report only the final successful profile for their
   declared context.
 
@@ -139,24 +141,39 @@ Operational consumers pass one context:
 - configuration chat: `config_chat`
 
 The existing eligibility filter runs first. Remembered eligible profiles are
-ordered by history; unseen eligible profiles retain source order. The existing
-combobox selected-first pass runs last. Search continues to operate on the same
-eligible option set. Unknown or stale IDs never create placeholder options.
+ordered by history. Unseen eligible profiles retain source order. The combobox
+selected-first pass runs last. Search uses the same eligible option set.
+Unknown or stale IDs never create placeholder options.
+
+An ordinary add-agent or new-session dialog resolves its initial profile after
+executor compatibility filtering. The resolver uses this priority:
+
+1. a valid handoff target
+2. the first compatible profile in `task_session` history
+3. the current session profile when it remains compatible
+4. the first compatible profile in source order
+
+A recent-use selection is selector-backed launch intent. The frontend sends it
+with `profile_explicit: true`, so workflow-step resolution cannot replace the
+profile that the dialog shows. The current-session and source-order fallbacks
+retain `profile_explicit: false`. A manual profile choice remains explicit and
+cannot be replaced by later compatibility or recent-use updates.
 
 Selectors for settings, defaults, automations, and Office assignments omit a
 context and retain source order.
 
-This change is state/data normalization inside existing selector compositions.
-Desktop and mobile reuse the same store, filtering, ordering, search, selection,
-and launch handlers. It does not change overlay type, navigation, scroll owner,
-safe-area behavior, touch targets, or responsive breakpoints. Existing mobile
-combobox and quick-chat surfaces therefore remain the mobile exemplar, and
-focused unit/component coverage satisfies the mobile-parity exception.
+Desktop and mobile reuse the same store, filtering, ordering, search,
+selection, and launch handlers. The change does not alter the dialog, overlay,
+navigation, scroll owner, safe-area behavior, touch targets, or breakpoints.
+The existing mobile new-session dialog remains the mobile exemplar. Focused
+desktop and mobile browser flows prove the shared selection outcome.
 
 ## Failure and recovery
 
 - Missing recent-use state falls back to source order without blocking a
   selector.
+- An empty or fully ineligible `task_session` history preserves the existing
+  current-session or source-order default.
 - Invalid stored JSON fails that context read and is logged; other contexts and
   the app boot remain usable.
 - A stale boot or WebSocket record cannot replace a newer per-context revision.

--- a/docs/specs/agents/system-design/profile-recent-use.md
+++ b/docs/specs/agents/system-design/profile-recent-use.md
@@ -170,8 +170,8 @@ desktop and mobile browser flows prove the shared selection outcome.
 
 ## Failure and recovery
 
-- Missing recent-use state falls back to source order without blocking a
-  selector.
+- Missing recent-use state preserves the existing current-session then
+  source-order fallback without blocking a selector.
 - An empty or fully ineligible `task_session` history preserves the existing
   current-session or source-order default.
 - Invalid stored JSON fails that context read and is logged; other contexts and


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3161/c080e49586f8.html)
<!-- kandev-pr-walkthrough-end -->

The Add Agent dialog ignored task-session profile recency and defaulted to the current session profile, making repeated profile choices harder to reach. It now selects the newest compatible recent profile as explicit launch intent while preserving handoff, manual, and fallback behavior across desktop and mobile.

## Validation

- `cd apps && pnpm --filter @kandev/web test -- --run components/task/new-session-profile-selection.test.ts components/task/new-session-dialog.test.tsx components/task/new-session-form-actions.test.ts lib/agent-profile-recent-use.test.ts` (31 tests passed)
- `cd apps/web && pnpm run typecheck` (passed)
- `cd apps/web && pnpm e2e:run --project chromium tests/session/new-session-dialog.spec.ts -- --grep "uses task-session recency"` (1 test passed)
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/session/mobile-new-session-dialog.spec.ts -- --grep "uses task-session recency"` (1 test passed)
- `python3 scripts/lint-spec-files.py --all` (passed)
- `git diff --check` (passed)
- Manual desktop and mobile smoke checks confirmed the recent profile is selected and launched.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop Add Agent dialog](https://raw.githubusercontent.com/kdlbs/kandev/977daeb28a77ad1d4e8af86ff7192bfc42452391/new-session-recency-desktop.png)

![Mobile Add Agent dialog](https://raw.githubusercontent.com/kdlbs/kandev/977daeb28a77ad1d4e8af86ff7192bfc42452391/new-session-recency-mobile.png)
<!-- kandev-screenshots-end -->