### PR TITLE
test(web): stabilize session hydration ordering

### DIFF
--- a/apps/web/hooks/domains/session/use-session-messages.test.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.test.ts
@@ -38,6 +38,7 @@ const mockState = {
   setActiveTurn: vi.fn(),
   reconcileActiveTurnAfterHydration: vi.fn(),
 };
+const mockStoreApi = { getState: () => mockState };
 
 vi.mock("@/lib/api/domains/session-api", () => ({
   listSessionTurns: (...args: unknown[]) => mockListSessionTurns(...args),
@@ -49,7 +50,7 @@ vi.mock("@/lib/ws/connection", () => ({
 
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
-  useAppStoreApi: () => ({ getState: () => mockState }),
+  useAppStoreApi: () => mockStoreApi,
 }));
 
 import { taskId, sessionId } from "@/lib/types/ids";
@@ -364,6 +365,7 @@ describe("session subscription hydration ordering", () => {
       await readiness.promise;
     });
 
+    expect(mockWebSocketClient.subscribeSessionWithReady).toHaveBeenCalledTimes(1);
     expect(mockWebSocketClient.request).toHaveBeenCalledWith(
       "message.list",
       expect.objectContaining({ session_id: "sess-1" }),


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3168/0c69282f709c.html)
<!-- kandev-pr-walkthrough-end -->

The hydration-ordering test used an unstable mocked store API, so local state rerenders restarted the subscription effect and could issue a second request under CI load. Stabilizing the mock identity makes the test exercise the production store contract and deterministically verifies one subscription and one post-acknowledgement request.

## Validation

- RED: `pnpm test -- --run hooks/domains/session/use-session-messages.test.ts -t "does not request messages before subscription acknowledgement"` failed with three subscriptions before the fix.
- GREEN: the same focused command passed after the fix.
- 32 parallel focused-test stress invocations passed.
- 16 parallel complete-file stress invocations passed.
- `pnpm test -- --run hooks/domains/session/use-session-messages.test.ts` (21 tests)
- `pnpm test -- --run hooks/domains/session` (51 files, 451 tests)
- `pnpm test` reached 1,675 passing files and 14,341 passing tests; only the three unrelated `lib/http-git-server.test.ts` cases failed because the guarded task environment rejects raw Docker bridge inspection.
- `pnpm run typecheck`
- `pnpm exec eslint hooks/domains/session/use-session-messages.test.ts --max-warnings 0`
- `git diff --check`

The defect reproduces on unmodified canonical `kdlbs/kandev` code and is not caused by deployment-local customization. This is a test-harness isolation fix with no production or user-visible UI change, so Playwright coverage, screenshots, and public documentation updates are not applicable.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->