### PR TITLE
fix: bound untracked dependency status enumeration

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_git_cmd.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_cmd.go
@@ -40,8 +40,34 @@ const gitOptionalLocksOff = "GIT_OPTIONAL_LOCKS=0"
 func (wt *WorkspaceTracker) pollingGitCommand(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := subproc.NewGitCommand(ctx, args...)
 	cmd.Dir = wt.workDir
-	cmd.Env = append(os.Environ(), gitOptionalLocksOff)
+	cmd.Env = gitCommandEnv(ctx, true)
 	return cmd
+}
+
+func gitCommandEnv(ctx context.Context, lockless bool) []string {
+	env := os.Environ()
+	if lockless {
+		env = replaceGitEnvAssignment(env, gitOptionalLocksOff)
+	}
+	if indexPath := gitIndexFile(ctx); indexPath != "" {
+		env = replaceGitEnvAssignment(env, "GIT_INDEX_FILE="+indexPath)
+	}
+	return env
+}
+
+func replaceGitEnvAssignment(env []string, assignment string) []string {
+	key, _, ok := strings.Cut(assignment, "=")
+	if !ok {
+		return env
+	}
+	prefix := key + "="
+	filtered := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return append(filtered, assignment)
 }
 
 // gitCommand builds a git command for the already-admitted execution context.
@@ -53,6 +79,7 @@ func (wt *WorkspaceTracker) gitCommand(ctx context.Context, lockless bool, args 
 	}
 	cmd := subproc.NewGitCommand(ctx, args...)
 	cmd.Dir = wt.workDir
+	cmd.Env = gitCommandEnv(ctx, false)
 	return cmd
 }
 

--- a/apps/backend/internal/agentctl/server/process/workspace_git_index.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_index.go
@@ -1,0 +1,87 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type gitIndexFileContextKey struct{}
+
+func withGitIndexFile(ctx context.Context, indexPath string) context.Context {
+	return context.WithValue(ctx, gitIndexFileContextKey{}, indexPath)
+}
+
+func gitIndexFile(ctx context.Context) string {
+	indexPath, _ := ctx.Value(gitIndexFileContextKey{}).(string)
+	return indexPath
+}
+
+// snapshotGitIndex creates a stable, read-only view of the Git index for a
+// group of related status queries. Git replaces the real index atomically for
+// writes, so a hard link keeps the observed index at one point in time. The
+// copy fallback supports filesystems that do not allow hard links.
+func snapshotGitIndex(ctx context.Context, indexPath string) (string, func(), error) {
+	if err := ctx.Err(); err != nil {
+		return "", nil, err
+	}
+
+	temp, err := os.CreateTemp(filepath.Dir(indexPath), ".kandev-index-snapshot-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create git index snapshot: %w", err)
+	}
+	snapshotPath := temp.Name()
+	cleanup := func() { _ = os.Remove(snapshotPath) }
+	if err := temp.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close git index snapshot: %w", err)
+	}
+	if err := os.Remove(snapshotPath); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("prepare git index snapshot: %w", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := os.Link(indexPath, snapshotPath); err == nil {
+		if err := ctx.Err(); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+		return snapshotPath, cleanup, nil
+	}
+
+	source, err := os.Open(indexPath)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("open git index fallback: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	// The source descriptor remains attached to one index inode even if Git
+	// replaces the original path while the fallback copy is prepared.
+	destination, err := os.OpenFile(snapshotPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("open git index snapshot fallback: %w", err)
+	}
+	_, copyErr := io.Copy(destination, source)
+	closeErr := destination.Close()
+	if copyErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("copy git index snapshot: %w", copyErr)
+	}
+	if closeErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close git index snapshot fallback: %w", closeErr)
+	}
+	if err := ctx.Err(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return snapshotPath, cleanup, nil
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_index_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_index_test.go
@@ -1,0 +1,110 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotGitIndexCleansUp(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+
+	snapshotPath, snapshotCleanup, err := snapshotGitIndex(context.Background(), wt.gitIndexPath)
+	if err != nil {
+		t.Fatalf("snapshotGitIndex() error = %v", err)
+	}
+	if _, err := os.Stat(snapshotPath); err != nil {
+		t.Fatalf("snapshot index is not readable before cleanup: %v", err)
+	}
+
+	snapshotCleanup()
+	if _, err := os.Stat(snapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("snapshot index after cleanup error = %v, want not-exist", err)
+	}
+}
+
+func TestSnapshotGitIndexCancellationCleansUp(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx := &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+
+	_, snapshotCleanup, err := snapshotGitIndex(ctx, wt.gitIndexPath)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("snapshotGitIndex() error = %v, want %v", err, context.Canceled)
+	}
+	if snapshotCleanup != nil {
+		t.Fatal("snapshotGitIndex() returned cleanup after cancellation")
+	}
+
+	assertNoIndexSnapshots(t, filepath.Dir(wt.gitIndexPath))
+}
+
+func TestSnapshotGitIndexErrorCleansUp(t *testing.T) {
+	dir := t.TempDir()
+	missingIndex := filepath.Join(dir, "missing-index")
+
+	_, snapshotCleanup, err := snapshotGitIndex(context.Background(), missingIndex)
+	if err == nil {
+		t.Fatal("snapshotGitIndex() returned nil error for a missing index")
+	}
+	if snapshotCleanup != nil {
+		t.Fatal("snapshotGitIndex() returned cleanup after an error")
+	}
+
+	assertNoIndexSnapshots(t, dir)
+}
+
+func TestSnapshotGitIndexSupportsLinkedWorktree(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	worktreeDir := filepath.Join(t.TempDir(), "linked-worktree")
+	runGit(t, repoDir, "worktree", "add", "-b", "snapshot-worktree", worktreeDir)
+
+	gitEntry, err := os.Stat(filepath.Join(worktreeDir, ".git"))
+	if err != nil {
+		t.Fatalf("linked worktree .git entry: %v", err)
+	}
+	if !gitEntry.Mode().IsRegular() {
+		t.Fatalf("linked worktree .git entry mode = %v, want regular file", gitEntry.Mode())
+	}
+
+	wt := NewWorkspaceTracker(worktreeDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+	if wt.gitIndexPath == "" {
+		t.Fatal("linked worktree did not resolve a git index path")
+	}
+
+	snapshotPath, snapshotCleanup, err := snapshotGitIndex(context.Background(), wt.gitIndexPath)
+	if err != nil {
+		t.Fatalf("snapshotGitIndex() for linked worktree error = %v", err)
+	}
+	t.Cleanup(snapshotCleanup)
+	if filepath.IsAbs(snapshotPath) && strings.HasPrefix(snapshotPath, worktreeDir+string(filepath.Separator)) {
+		t.Fatalf("snapshot index unexpectedly lives in the worktree: %q", snapshotPath)
+	}
+}
+
+func assertNoIndexSnapshots(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, ".kandev-index-snapshot-*"))
+	if err != nil {
+		t.Fatalf("find index snapshots: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary index snapshots remain: %v", matches)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -786,23 +786,33 @@ func carryRemoteSnapshot(update *types.GitStatusUpdate, prior types.GitStatusUpd
 	update.RemoteBehind = prior.RemoteBehind
 }
 
-// parseGitStatusOutput runs git status --porcelain and populates the file lists and map.
+// parseGitStatusOutput collects tracked status and eligible untracked paths,
+// then populates the file lists and map.
 func (wt *WorkspaceTracker) parseGitStatusOutput(ctx context.Context, update *types.GitStatusUpdate) error {
-	// --untracked-files=all shows all files in untracked directories, not just
-	// the directory name. GIT_OPTIONAL_LOCKS=0 prevents the status read from
-	// taking .git/index.lock, while the carried observation class keeps fresh
-	// user requests interactive.
+	class := gitWorkClass(ctx)
+	// The tracked query must not receive the dependency-tree exclusion: tracked
+	// paths below node_modules remain part of the workspace status. The
+	// lockless read and carried observation class preserve the existing Git
+	// admission and index-lock behavior.
 	statusOut, err := wt.runGitOutputClass(
 		ctx,
-		gitWorkClass(ctx),
+		class,
 		true,
-		"status", "--porcelain", "--untracked-files=all",
+		"status", "--porcelain", "--untracked-files=no",
 	)
 	if err != nil {
 		return err
 	}
 
-	return wt.applyPorcelainOutput(ctx, statusOut, update)
+	if err := wt.applyPorcelainOutput(ctx, statusOut, update); err != nil {
+		return err
+	}
+
+	untrackedOut, err := wt.runGitOutputClass(ctx, class, true, gitUntrackedFilesArgs...)
+	if err != nil {
+		return err
+	}
+	return wt.applyUntrackedOutput(ctx, untrackedOut, update)
 }
 
 func (wt *WorkspaceTracker) applyPorcelainOutput(

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -790,12 +790,19 @@ func carryRemoteSnapshot(update *types.GitStatusUpdate, prior types.GitStatusUpd
 // then populates the file lists and map.
 func (wt *WorkspaceTracker) parseGitStatusOutput(ctx context.Context, update *types.GitStatusUpdate) error {
 	class := gitWorkClass(ctx)
+	indexSnapshot, cleanup, err := snapshotGitIndex(ctx, wt.gitIndexPath)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	statusCtx := withGitIndexFile(ctx, indexSnapshot)
+
 	// The tracked query must not receive the dependency-tree exclusion: tracked
 	// paths below node_modules remain part of the workspace status. The
 	// lockless read and carried observation class preserve the existing Git
 	// admission and index-lock behavior.
 	statusOut, err := wt.runGitOutputClass(
-		ctx,
+		statusCtx,
 		class,
 		true,
 		"status", "--porcelain", "--untracked-files=no",
@@ -808,7 +815,11 @@ func (wt *WorkspaceTracker) parseGitStatusOutput(ctx context.Context, update *ty
 		return err
 	}
 
-	untrackedOut, err := wt.runGitOutputClass(ctx, class, true, gitUntrackedFilesArgs...)
+	if wt.gitStatusBetweenQueries != nil {
+		wt.gitStatusBetweenQueries()
+	}
+
+	untrackedOut, err := wt.runGitOutputClass(statusCtx, class, true, gitUntrackedFilesArgs...)
 	if err != nil {
 		return err
 	}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -305,33 +305,85 @@ func TestGetGitStatus_PreservesTrackedNodeModules(t *testing.T) {
 	}
 }
 
-func TestGetGitStatus_UsesConsistentIndexSnapshot(t *testing.T) {
-	repoDir, cleanup := setupTestRepo(t)
-	t.Cleanup(cleanup)
-
-	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
-	t.Cleanup(wt.Stop)
-
-	const path = "staged-between-status-queries.txt"
-	writeFile(t, repoDir, path, "staged after the first query\n")
-	wt.gitStatusBetweenQueries = func() {
-		runGit(t, repoDir, "add", path)
+func TestGetGitStatus_UsesConsistentIndexSnapshotAcrossTransitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		setup          func(t *testing.T, repoDir, path string)
+		betweenQueries func(t *testing.T, repoDir, path string)
+		wantUntracked  []string
+		wantFile       *types.FileInfo
+	}{
+		{
+			name: "untracked to staged",
+			path: "staged-between-status-queries.txt",
+			setup: func(t *testing.T, repoDir, path string) {
+				writeFile(t, repoDir, path, "staged after the first query\n")
+			},
+			betweenQueries: func(t *testing.T, repoDir, path string) {
+				runGit(t, repoDir, "add", path)
+			},
+			wantUntracked: []string{"staged-between-status-queries.txt"},
+			wantFile: &types.FileInfo{
+				Path:   "staged-between-status-queries.txt",
+				Status: fileStatusUntracked,
+			},
+		},
+		{
+			name: "tracked to untracked",
+			path: "removed-from-index-between-status-queries.txt",
+			setup: func(t *testing.T, repoDir, path string) {
+				writeFile(t, repoDir, path, "tracked before the first query\n")
+				runGit(t, repoDir, "add", path)
+				runGit(t, repoDir, "commit", "-m", "Track transition fixture")
+			},
+			betweenQueries: func(t *testing.T, repoDir, path string) {
+				runGit(t, repoDir, "rm", "--cached", path)
+			},
+			wantUntracked: nil,
+		},
 	}
 
-	update := types.GitStatusUpdate{Files: make(map[string]types.FileInfo)}
-	if err := wt.parseGitStatusOutput(context.Background(), &update); err != nil {
-		t.Fatalf("parseGitStatusOutput failed: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir, cleanup := setupTestRepo(t)
+			t.Cleanup(cleanup)
 
-	if len(update.Untracked) != 1 || update.Untracked[0] != path {
-		t.Fatalf("untracked paths = %v, want only %q from the stable pre-stage view", update.Untracked, path)
-	}
-	fileInfo, ok := update.Files[path]
-	if !ok {
-		t.Fatalf("stable pre-stage view omitted %q from Files", path)
-	}
-	if fileInfo.Status != fileStatusUntracked || fileInfo.Staged {
-		t.Fatalf("file status = %#v, want an untracked, unstaged entry", fileInfo)
+			wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+			t.Cleanup(wt.Stop)
+			tt.setup(t, repoDir, tt.path)
+			wt.gitStatusBetweenQueries = func() {
+				tt.betweenQueries(t, repoDir, tt.path)
+			}
+
+			update := types.GitStatusUpdate{Files: make(map[string]types.FileInfo)}
+			if err := wt.parseGitStatusOutput(context.Background(), &update); err != nil {
+				t.Fatalf("parseGitStatusOutput failed: %v", err)
+			}
+
+			if len(update.Untracked) != len(tt.wantUntracked) {
+				t.Fatalf("untracked paths = %v, want %v", update.Untracked, tt.wantUntracked)
+			}
+			for i, wantPath := range tt.wantUntracked {
+				if update.Untracked[i] != wantPath {
+					t.Fatalf("untracked path %d = %q, want %q", i, update.Untracked[i], wantPath)
+				}
+			}
+
+			if tt.wantFile == nil {
+				if len(update.Files) != 0 {
+					t.Fatalf("status files = %v, want no entries from the stable pre-removal view", mapKeys(update.Files))
+				}
+				return
+			}
+			fileInfo, ok := update.Files[tt.wantFile.Path]
+			if !ok {
+				t.Fatalf("stable transition view omitted %q", tt.wantFile.Path)
+			}
+			if fileInfo.Status != tt.wantFile.Status || fileInfo.Staged != tt.wantFile.Staged {
+				t.Fatalf("file status = %#v, want %#v", fileInfo, *tt.wantFile)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -305,6 +305,36 @@ func TestGetGitStatus_PreservesTrackedNodeModules(t *testing.T) {
 	}
 }
 
+func TestGetGitStatus_UsesConsistentIndexSnapshot(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+
+	const path = "staged-between-status-queries.txt"
+	writeFile(t, repoDir, path, "staged after the first query\n")
+	wt.gitStatusBetweenQueries = func() {
+		runGit(t, repoDir, "add", path)
+	}
+
+	update := types.GitStatusUpdate{Files: make(map[string]types.FileInfo)}
+	if err := wt.parseGitStatusOutput(context.Background(), &update); err != nil {
+		t.Fatalf("parseGitStatusOutput failed: %v", err)
+	}
+
+	if len(update.Untracked) != 1 || update.Untracked[0] != path {
+		t.Fatalf("untracked paths = %v, want only %q from the stable pre-stage view", update.Untracked, path)
+	}
+	fileInfo, ok := update.Files[path]
+	if !ok {
+		t.Fatalf("stable pre-stage view omitted %q from Files", path)
+	}
+	if fileInfo.Status != fileStatusUntracked || fileInfo.Staged {
+		t.Fatalf("file status = %#v, want an untracked, unstaged entry", fileInfo)
+	}
+}
+
 // TestGetGitStatus_FreshBypassesStaleCache simulates the bug class where the
 // poll loop missed a HEAD change (paused mode, dropped tick) and left
 // currentStatus.Files holding pre-commit entries. fresh=true must re-run

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -215,6 +216,92 @@ func TestGetGitStatus_UntrackedFileWithSpaces(t *testing.T) {
 	}
 	if fileInfo.Diff == "" {
 		t.Error("expected non-empty synthetic Diff for untracked file with spaces")
+	}
+}
+
+// @covers AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13, AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14
+func TestGetGitStatus_ExcludesUntrackedNodeModules(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+
+	dependencyFiles := []string{
+		"node_modules/root-package/index.js",
+		"packages/app/node_modules/nested-package/index.js",
+	}
+	for _, filePath := range dependencyFiles {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(repoDir, filePath)), 0o755); err != nil {
+			t.Fatalf("failed to create dependency directory for %s: %v", filePath, err)
+		}
+		writeFile(t, repoDir, filePath, "dependency content\n")
+	}
+	const sourcePath = "src/untracked-source.ts"
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(repoDir, sourcePath)), 0o755); err != nil {
+		t.Fatalf("failed to create source directory: %v", err)
+	}
+	writeFile(t, repoDir, sourcePath, "export const source = true;\n")
+
+	status, err := wt.getGitStatus(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get git status: %v", err)
+	}
+
+	if len(status.Untracked) != 1 || status.Untracked[0] != sourcePath {
+		t.Fatalf("untracked paths = %v, want only %q", status.Untracked, sourcePath)
+	}
+	if len(status.Files) != 1 {
+		t.Fatalf("status files = %v, want only the ordinary source file", mapKeys(status.Files))
+	}
+	for filePath := range status.Files {
+		if strings.Contains(filePath, "node_modules") {
+			t.Fatalf("dependency path %q entered the status snapshot", filePath)
+		}
+	}
+	fileInfo, ok := status.Files[sourcePath]
+	if !ok {
+		t.Fatalf("ordinary untracked source %q is missing from status", sourcePath)
+	}
+	if fileInfo.Status != "untracked" {
+		t.Errorf("source status = %q, want untracked", fileInfo.Status)
+	}
+	if fileInfo.Diff == "" {
+		t.Error("ordinary untracked source did not receive a synthetic diff")
+	}
+}
+
+// @covers AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14
+func TestGetGitStatus_PreservesTrackedNodeModules(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+
+	const trackedPath = "node_modules/checked-in-package/index.js"
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(repoDir, trackedPath)), 0o755); err != nil {
+		t.Fatalf("failed to create tracked dependency directory: %v", err)
+	}
+	writeFile(t, repoDir, trackedPath, "const version = 1;\n")
+	runGit(t, repoDir, "add", "-f", trackedPath)
+	runGit(t, repoDir, "commit", "-m", "Track dependency fixture")
+	writeFile(t, repoDir, trackedPath, "const version = 2;\n")
+
+	status, err := wt.getGitStatus(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get git status: %v", err)
+	}
+
+	fileInfo, ok := status.Files[trackedPath]
+	if !ok {
+		t.Fatalf("tracked dependency path %q is missing from status; got %v", trackedPath, mapKeys(status.Files))
+	}
+	if fileInfo.Status != "modified" || fileInfo.Staged {
+		t.Fatalf("tracked dependency status = %#v, want unstaged modified", fileInfo)
+	}
+	if fileInfo.Diff == "" {
+		t.Error("tracked dependency did not receive a diff")
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/workspace_git_untracked.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_untracked.go
@@ -1,0 +1,63 @@
+package process
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+// gitUntrackedFilesArgs is the shared query for eligible untracked paths.
+// Git applies the dependency-tree exclusion while walking the worktree, and
+// NUL termination keeps valid paths independent from quoting or newlines.
+var gitUntrackedFilesArgs = []string{
+	"ls-files",
+	"--others",
+	"--exclude-standard",
+	"--exclude=node_modules/",
+	"-z",
+}
+
+func parseGitUntrackedOutput(ctx context.Context, output []byte) ([]string, error) {
+	paths := make([]string, 0)
+	for len(output) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		end := bytes.IndexByte(output, 0)
+		if end < 0 {
+			end = len(output)
+		}
+		if end > 0 {
+			paths = append(paths, string(output[:end]))
+		}
+		if end == len(output) {
+			break
+		}
+		output = output[end+1:]
+	}
+	return paths, nil
+}
+
+func (wt *WorkspaceTracker) applyUntrackedOutput(
+	ctx context.Context,
+	output []byte,
+	update *types.GitStatusUpdate,
+) error {
+	paths, err := parseGitUntrackedOutput(ctx, output)
+	if err != nil {
+		return err
+	}
+	for _, filePath := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		update.Untracked = append(update.Untracked, filePath)
+		update.Files[filePath] = types.FileInfo{
+			Path:   filePath,
+			Status: fileStatusUntracked,
+		}
+	}
+	return nil
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_untracked_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_untracked_test.go
@@ -1,0 +1,46 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParseGitUntrackedOutput(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		output  []byte
+		want    []string
+		wantErr error
+	}{
+		{
+			name:   "nul separates paths with embedded newline",
+			ctx:    context.Background(),
+			output: []byte("directory/line\nbreak.txt\x00plain.txt\x00"),
+			want:   []string{"directory/line\nbreak.txt", "plain.txt"},
+		},
+		{
+			name:    "cancelled context",
+			ctx:     baseCtx,
+			output:  []byte("ignored.txt\x00"),
+			wantErr: context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGitUntrackedOutput(tt.ctx, tt.output)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("parseGitUntrackedOutput() error = %v, want %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseGitUntrackedOutput() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_monitor.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_monitor.go
@@ -245,8 +245,8 @@ func (wt *WorkspaceTracker) getWorkspaceState(ctx context.Context) (workspaceSta
 	}
 	state.diffFilesID = wt.buildDirtyFilesID(string(out))
 
-	// Check untracked files - git diff-files doesn't include them
-	// Use git ls-files to get untracked files, then check their mtimes
+	// Check eligible untracked files - git diff-files doesn't include them.
+	// The shared query excludes dependency trees before Git enumerates paths.
 	untrackedID, err := wt.getUntrackedFilesID(ctx)
 	if err != nil {
 		return state, err
@@ -287,20 +287,23 @@ func (wt *WorkspaceTracker) buildDirtyFilesID(diffFilesOutput string) string {
 // Uses file list + mtimes to detect when untracked files are added, removed, or modified.
 // Returns an error if the git command fails (e.g., timeout, index lock).
 func (wt *WorkspaceTracker) getUntrackedFilesID(ctx context.Context) (string, error) {
-	// Get list of untracked files (excluding ignored)
-	out, stderr, err := wt.runPollingGitOutputWithStderr(ctx, "ls-files", "--others", "--exclude-standard")
+	out, stderr, err := wt.runPollingGitOutputWithStderr(ctx, gitUntrackedFilesArgs...)
 	if err != nil {
 		return "", fmt.Errorf("git ls-files in %s: %w (stderr: %s)",
 			wt.workDir, err, stderr)
 	}
-	if len(out) == 0 {
+
+	files, err := parseGitUntrackedOutput(ctx, out)
+	if err != nil {
+		return "", err
+	}
+	if len(files) == 0 {
 		return "", nil // No untracked files is not an error
 	}
 
 	// Build a string from file paths + mtimes to detect any changes
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	var hashInput strings.Builder
-	for _, file := range lines {
+	for _, file := range files {
 		if file == "" {
 			continue
 		}

--- a/apps/backend/internal/agentctl/server/process/workspace_monitor_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_monitor_test.go
@@ -128,3 +128,61 @@ func TestWorkspaceTracker_StopsWhenGitBroken(t *testing.T) {
 		t.Fatal("workspace tracker goroutines did not stop after git was broken")
 	}
 }
+
+// @covers AC-PLATFORM-WORKSPACE-GIT-STATUS-001.15
+func TestGetUntrackedFilesID_ExcludesNodeModules(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	t.Cleanup(wt.Stop)
+	ctx := context.Background()
+
+	baseline, err := wt.getUntrackedFilesID(ctx)
+	if err != nil {
+		t.Fatalf("failed to get baseline untracked fingerprint: %v", err)
+	}
+
+	const dependencyPath = "node_modules/monitor-package/index.js"
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(repoDir, dependencyPath)), 0o755); err != nil {
+		t.Fatalf("failed to create dependency directory: %v", err)
+	}
+	writeFile(t, repoDir, dependencyPath, "dependency version 1\n")
+	created, err := wt.getUntrackedFilesID(ctx)
+	if err != nil {
+		t.Fatalf("failed to fingerprint created dependency: %v", err)
+	}
+	if created != baseline {
+		t.Fatalf("fingerprint changed after creating dependency content: before %q, after %q", baseline, created)
+	}
+
+	writeFile(t, repoDir, dependencyPath, "dependency version 2\n")
+	modified, err := wt.getUntrackedFilesID(ctx)
+	if err != nil {
+		t.Fatalf("failed to fingerprint modified dependency: %v", err)
+	}
+	if modified != baseline {
+		t.Fatalf("fingerprint changed after modifying dependency content: before %q, after %q", baseline, modified)
+	}
+
+	if err := os.Remove(filepath.Join(repoDir, dependencyPath)); err != nil {
+		t.Fatalf("failed to remove dependency file: %v", err)
+	}
+	removed, err := wt.getUntrackedFilesID(ctx)
+	if err != nil {
+		t.Fatalf("failed to fingerprint removed dependency: %v", err)
+	}
+	if removed != baseline {
+		t.Fatalf("fingerprint changed after removing dependency content: before %q, after %q", baseline, removed)
+	}
+
+	const ordinaryPath = "monitor-source.ts"
+	writeFile(t, repoDir, ordinaryPath, "export const monitored = true;\n")
+	ordinary, err := wt.getUntrackedFilesID(ctx)
+	if err != nil {
+		t.Fatalf("failed to fingerprint ordinary untracked content: %v", err)
+	}
+	if ordinary == baseline {
+		t.Fatal("fingerprint did not change after creating ordinary untracked content")
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -158,6 +158,9 @@ type WorkspaceTracker struct {
 	gitStatusObserveMu      sync.Mutex
 	gitStatusObserveWG      sync.WaitGroup
 	gitStatusWaiterJoined   func() // Optional test synchronization hook; nil in production.
+	// gitStatusBetweenQueries is an optional test hook invoked between the
+	// tracked and untracked queries. It is nil in production.
+	gitStatusBetweenQueries func()
 
 	// Control
 	stopCh          chan struct{}

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -381,15 +381,11 @@ test.describe("Git Changes Panel", () => {
       git.deleteFile(sourcePath);
       for (const dependencyPath of dependencyPaths) {
         git.deleteFile(dependencyPath);
+        fs.rmSync(path.dirname(path.join(repoDir, dependencyPath)), {
+          recursive: true,
+          force: true,
+        });
       }
-      fs.rmSync(path.join(repoDir, "node_modules", "demo-package"), {
-        recursive: true,
-        force: true,
-      });
-      fs.rmSync(path.join(repoDir, "packages", "app", "node_modules", "nested-package"), {
-        recursive: true,
-        force: true,
-      });
     }
   });
 

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -320,6 +320,79 @@ test.describe("Git Changes Panel", () => {
     git.deleteFile("new-feature.ts");
   });
 
+  // @covers AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13, AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14
+  test("omits untracked node_modules before repository ignore exists", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const profile = await createStandardProfile(apiClient, "Git Dependency Tree Profile");
+
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Git Dependency Tree Test",
+      profile.id,
+      {
+        description: "Testing untracked dependency-tree exclusion",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    const session = await openTaskSession(testPage, "Git Dependency Tree Test");
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const git = new GitHelper(repoDir, {
+      ...process.env,
+      HOME: backend.tmpDir,
+      GIT_AUTHOR_NAME: "E2E Test",
+      GIT_AUTHOR_EMAIL: "e2e@test.local",
+      GIT_COMMITTER_NAME: "E2E Test",
+      GIT_COMMITTER_EMAIL: "e2e@test.local",
+    });
+
+    const sourcePath = "untracked-source.ts";
+    const dependencyPaths = [
+      "node_modules/demo-package/package.json",
+      "packages/app/node_modules/nested-package/package.json",
+    ];
+    try {
+      git.createFile(sourcePath, "export const source = true;\n");
+      for (const dependencyPath of dependencyPaths) {
+        fs.mkdirSync(path.dirname(path.join(repoDir, dependencyPath)), { recursive: true });
+        git.createFile(dependencyPath, '{"name":"demo-package"}\n');
+      }
+
+      await session.clickTab("Changes");
+      await expect(session.changes).toBeVisible({ timeout: 10_000 });
+      await expect(testPage.getByTestId("unstaged-files-section")).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(session.changes.getByTestId(`file-row-${sourcePath}`)).toBeVisible({
+        timeout: 15_000,
+      });
+
+      for (const dependencyPath of dependencyPaths) {
+        const rowTestId = `file-row-${dependencyPath.replace(/[/\\]/g, "-")}`;
+        await expect(session.changes.getByTestId(rowTestId)).toHaveCount(0);
+      }
+    } finally {
+      git.deleteFile(sourcePath);
+      for (const dependencyPath of dependencyPaths) {
+        git.deleteFile(dependencyPath);
+      }
+      fs.rmSync(path.join(repoDir, "node_modules", "demo-package"), {
+        recursive: true,
+        force: true,
+      });
+      fs.rmSync(path.join(repoDir, "packages", "app", "node_modules", "nested-package"), {
+        recursive: true,
+        force: true,
+      });
+    }
+  });
+
   /**
    * Verifies that files with spaces in their path are shown correctly in the
    * Changes panel and that their diff content is visible (not "No changes").

--- a/docs/decisions/2026-08-30-bound-untracked-dependency-enumeration.md
+++ b/docs/decisions/2026-08-30-bound-untracked-dependency-enumeration.md
@@ -1,0 +1,50 @@
+# ADR-2026-08-30-bound-untracked-dependency-enumeration: Bound Untracked Dependency Enumeration
+
+**Status:** accepted
+**Date:** 2026-08-30
+**Area:** backend
+
+## Context
+
+Workspace status currently runs `git status --porcelain --untracked-files=all`. Git emits every untracked file when a repository has no applicable ignore rule. Agentctl then parses and enriches each entry. The workspace monitor also lists and stats every untracked file.
+
+This behavior exposed 4,889 pnpm dependency files for several minutes when `pnpm install` finished before the repository created `.gitignore`. The Changes panel received the oversized snapshot, and the monitor repeated work over the same tree. A later ignore rule removed the entries only after another refresh.
+
+Git ignore rules remain the repository's source of truth for ordinary untracked files. Kandev also needs a narrow performance boundary that applies before a dependency manager can create an oversized status snapshot.
+
+## Decision
+
+Agentctl excludes untracked directories named `node_modules` at any repository depth before Git returns individual untracked paths. This exclusion also covers pnpm content under `node_modules/.pnpm`.
+
+Full status uses separate tracked and untracked queries. The tracked query disables untracked enumeration and preserves every tracked change. The untracked query uses Git's standard ignore rules plus the `node_modules/` exclusion. It returns NUL-separated paths for direct insertion into the existing status model.
+
+The workspace monitor uses the same untracked query definition. It does not stat excluded dependency files or refresh status when only those files change.
+
+The first owned exclusion is `node_modules`. Other generated directories continue to follow Git ignore rules. Kandev does not filter tracked paths based on their directory name.
+
+## Consequences
+
+- Missing or late `.gitignore` files cannot make JavaScript dependency trees dominate status collection or the Changes panel.
+- Tracked changes below `node_modules` remain visible because the tracked query has no generated-tree path filter.
+- Ordinary untracked files remain visible and retain the existing diff limits.
+- One full observation uses an extra Git subprocess to keep tracked and untracked policies separate.
+- The Changes panel no longer mirrors raw `git status --untracked-files=all` for untracked `node_modules` content.
+- Future generated-tree exclusions require another reviewed contract change. They must not silently broaden this list.
+
+## Alternatives Considered
+
+### Rely only on repository and global ignore rules
+
+This keeps exact Git status parity, but it does not protect a new repository before its ignore file exists. It also does not protect a repository with an incomplete ignore file.
+
+### Remove dependency paths after parsing status output
+
+This keeps the panel clean, but Git still enumerates the tree and agentctl still receives the large output. It does not solve the main performance problem.
+
+### Stop after a fixed untracked-file limit
+
+This bounds output, but it can hide ordinary source files. The result also depends on enumeration order and gives users an incomplete, unstable snapshot.
+
+### Exclude a broad list of generated directory names
+
+Names such as `dist`, `build`, and `.next` can contain files that a repository expects users to review or stage. Starting with `node_modules` provides the required protection without hiding those project-specific outputs.

--- a/docs/decisions/2026-08-30-bound-untracked-dependency-enumeration.md
+++ b/docs/decisions/2026-08-30-bound-untracked-dependency-enumeration.md
@@ -16,7 +16,7 @@ Git ignore rules remain the repository's source of truth for ordinary untracked 
 
 Agentctl excludes untracked directories named `node_modules` at any repository depth before Git returns individual untracked paths. This exclusion also covers pnpm content under `node_modules/.pnpm`.
 
-Full status uses separate tracked and untracked queries. The tracked query disables untracked enumeration and preserves every tracked change. The untracked query uses Git's standard ignore rules plus the `node_modules/` exclusion. It returns NUL-separated paths for direct insertion into the existing status model.
+Full status uses separate tracked and untracked queries. The tracked query disables untracked enumeration and preserves every tracked change. The untracked query uses Git's standard ignore rules plus the `node_modules/` exclusion. It returns NUL-separated paths for direct insertion into the existing status model. Both queries read a temporary snapshot of the Git index, so a tracking-state change between the commands cannot produce a contradictory projection.
 
 The workspace monitor uses the same untracked query definition. It does not stat excluded dependency files or refresh status when only those files change.
 
@@ -28,6 +28,7 @@ The first owned exclusion is `node_modules`. Other generated directories continu
 - Tracked changes below `node_modules` remain visible because the tracked query has no generated-tree path filter.
 - Ordinary untracked files remain visible and retain the existing diff limits.
 - One full observation uses an extra Git subprocess to keep tracked and untracked policies separate.
+- The temporary index snapshot adds a small per-observation filesystem operation while keeping concurrent user Git writes independent.
 - The Changes panel no longer mirrors raw `git status --untracked-files=all` for untracked `node_modules` content.
 - Future generated-tree exclusions require another reviewed contract change. They must not silently broaden this list.
 

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -217,3 +217,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 2026-08-27-mixed-git-change-facets | [Preserve mixed Git changes as path facets](2026-08-27-mixed-git-change-facets.md) | accepted | backend, agentctl, frontend, protocol | 2026-08-27 |
 | 2026-08-28-bind-github-auto-merge-attempts-to-reviewed-head | [Bind GitHub Auto-Merge Attempts to the Reviewed Head](2026-08-28-bind-github-auto-merge-attempts-to-reviewed-head.md) | accepted | backend, frontend, protocol, security, GitHub | 2026-08-28 |
 | 2026-08-30-context-reset-quiesces-active-turn | [Quiesce Active Turns Before Context Reset](2026-08-30-context-reset-quiesces-active-turn.md) | accepted | backend, workflow | 2026-08-30 |
+| 2026-08-30-bound-untracked-dependency-enumeration | [Bound Untracked Dependency Enumeration](2026-08-30-bound-untracked-dependency-enumeration.md) | accepted | backend | 2026-08-30 |

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
@@ -1,0 +1,104 @@
+---
+created: 2026-08-30
+status: complete
+requirements:
+  - REQ-PLATFORM-WORKSPACE-GIT-STATUS-001
+system_design:
+  - ../../specs/platform/system-design/workspace-git-status.md
+legacy_specs: []
+---
+
+# Implementation Plan: Workspace Git Status Dependency-Tree Exclusion
+
+## Overview
+
+Prevent an untracked `node_modules` tree from entering workspace status before a repository ignore rule exists. First add failing process and browser regressions. Then split tracked and untracked collection so Git excludes dependency trees during enumeration. Use the same untracked query for the monitor fingerprint and the full status snapshot.
+
+The confirmed incident came from task `cc6ea1f5-723d-4354-b46d-529aae52c013`. `pnpm install` completed at 18:55:12 UTC, and `.gitignore` was created at 18:58:01 UTC. At 18:56:54 UTC, the status snapshot grew from 20 to 4,917 files. Of the affected workspace's 4,893 ignored entries, 4,889 were below `node_modules`. The oversized snapshot stayed cached until a 26-file refresh at 19:02:31 UTC.
+
+The root cause is server-side enumeration, not frontend merging. Agentctl runs `git status --porcelain --untracked-files=all`, which emits every untracked dependency file before an ignore rule exists. The monitor independently runs `git ls-files --others --exclude-standard` and stats every returned path. The frontend replaces each status snapshot as designed.
+
+## Scope
+
+### In scope
+
+- Exclude untracked `node_modules` directories at every repository depth before Git returns individual paths.
+- Preserve all tracked changes below `node_modules`.
+- Preserve ordinary untracked, nonignored files and their existing synthetic diffs.
+- Apply one shared untracked-query policy to full status and monitor fingerprints.
+- Add process regressions and one desktop Changes-panel regression.
+
+### Out of scope
+
+- Excluding `.next`, `dist`, `build`, or other generated directory names.
+- Adding repository files or changing a user's Git ignore configuration.
+- Filtering status only in the frontend or after Git has enumerated the dependency tree.
+- Changing Git-status response fields, WebSocket events, or Changes-panel layout.
+- Adding mobile-specific coverage. Desktop and mobile consume the same backend snapshot, and no responsive UI behavior changes.
+
+## Technical approach
+
+### Shared untracked query
+
+- Add `apps/backend/internal/agentctl/server/process/workspace_git_untracked.go` with the shared Git argument definition for untracked paths.
+- Use `git ls-files --others --exclude-standard --exclude=node_modules/ -z` so Git applies repository ignores and the Kandev dependency exclusion during traversal.
+- Parse NUL-separated paths without Git quoting or newline ambiguity. Check the observation context while adding paths.
+- Keep the exclusion list limited to `node_modules/`. Document any later addition through the same requirement, design, and ADR boundary.
+
+### Full status collection
+
+- Update `parseGitStatusOutput` in `apps/backend/internal/agentctl/server/process/workspace_git_status.go` to run the tracked query with `--untracked-files=no`.
+- Run the shared untracked query with the same observation class and context.
+- Add returned paths to `GitStatusUpdate.Untracked` and `GitStatusUpdate.Files` with the existing untracked `FileInfo` shape before `enrichUntrackedFileDiffs` runs.
+- Preserve the current porcelain parser for tracked, staged, deleted, renamed, and mixed-facet paths.
+- Do not remove paths after status parsing. The exclusion must reduce Git output and agentctl work.
+
+### Monitor fingerprint
+
+- Update `getUntrackedFilesID` in `apps/backend/internal/agentctl/server/process/workspace_monitor.go` to use the shared query and NUL parser.
+- Keep the existing path sanitization and mtime fingerprint for eligible untracked files.
+- Ensure dependency-only changes do not alter the fingerprint, while ordinary untracked changes still do.
+
+### Changes-panel evidence
+
+- Extend `apps/web/e2e/tests/git/git-changes-panel.spec.ts` with `omits untracked node_modules before repository ignore exists`.
+- Create an ordinary untracked source file and nested pnpm-style dependency content without adding `.gitignore`.
+- Wait for the ordinary source file in Changes, then assert that no `node_modules` path or package file appears.
+- Clean up the test files through the existing Git fixture boundary.
+
+## Tests
+
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13:** Add `TestGetGitStatus_ExcludesUntrackedNodeModules` in `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`. Create top-level and nested `node_modules` files without ignore rules, plus an ordinary untracked source file. Assert that only the source file enters status and receives a synthetic diff.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14:** Add `TestGetGitStatus_PreservesTrackedNodeModules` in `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`. Force-add and commit a file below `node_modules`, change it, and assert that its tracked status and diff remain visible. Keep `TestGetGitStatus_UntrackedFileWithSpaces` green to protect the new NUL parser.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.15:** Add `TestGetUntrackedFilesID_ExcludesNodeModules` in `apps/backend/internal/agentctl/server/process/workspace_monitor_test.go`. Assert that dependency-only creation and modification keep the same fingerprint, while an ordinary untracked file changes it.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.6 and .8:** Keep the existing diff-budget and large-set tests green. The change reduces the eligible input set but does not change enrichment limits or eligible-path retention.
+
+## E2E tests
+
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13 and .14:** Run the Chromium scenario `omits untracked node_modules before repository ignore exists` in `apps/web/e2e/tests/git/git-changes-panel.spec.ts`. The Changes panel must show the ordinary untracked source file and omit the dependency path.
+- No mobile-specific case is required. The correction occurs before the shared status payload reaches either Changes layout.
+
+## Work orders
+
+- [x] [Task 01: Bound dependency-tree status enumeration](task-01-bound-dependency-tree-status-enumeration.md)
+
+Execution is sequential in the primary conversation. The browser regression, process tests, shared query, and both callers form one TDD slice and share the same status contract.
+
+## Verification results
+
+- RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
+- RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
+- GREEN focused process run: all three new tests passed.
+- GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 727 tests.
+- GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
+- `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
+- The first ambient `make -C apps/backend test` run selected the task runtime's `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.
+
+## Risks
+
+- A path filter on the tracked query can hide tracked files below `node_modules`. Only the untracked query receives the exclusion.
+- A filter after parsing leaves Git enumeration and process-output cost unchanged.
+- Line-based parsing can regress valid filenames that contain newlines. The new untracked query must remain NUL-separated in both callers.
+- Splitting collection adds one Git subprocess to each full observation. Both commands must retain the caller's admission class, context, and timeout behavior.
+- Separate argument builders can make the monitor and full observer drift. They must share one definition.

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
@@ -89,11 +89,13 @@ Execution is sequential in the primary conversation. The browser regression, pro
 - RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
 - RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
 - GREEN focused process run: all three new tests passed.
+- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshot` passed after staging a file between the two status queries.
 - GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
-- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 727 tests.
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 728 tests.
 - GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
 - `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
 - The first ambient `make -C apps/backend test` run selected the task runtime's `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.
+- PR fixup remediation: full status now runs both queries against a temporary stable Git-index snapshot, and E2E cleanup derives dependency directories from `dependencyPaths`.
 
 ## Risks
 
@@ -102,3 +104,4 @@ Execution is sequential in the primary conversation. The browser regression, pro
 - Line-based parsing can regress valid filenames that contain newlines. The new untracked query must remain NUL-separated in both callers.
 - Splitting collection adds one Git subprocess to each full observation. Both commands must retain the caller's admission class, context, and timeout behavior.
 - Separate argument builders can make the monitor and full observer drift. They must share one definition.
+- Separate status queries can observe different index membership. The full observer uses one temporary index snapshot for both queries.

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/plan.md
@@ -72,6 +72,8 @@ The root cause is server-side enumeration, not frontend merging. Agentctl runs `
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14:** Add `TestGetGitStatus_PreservesTrackedNodeModules` in `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`. Force-add and commit a file below `node_modules`, change it, and assert that its tracked status and diff remain visible. Keep `TestGetGitStatus_UntrackedFileWithSpaces` green to protect the new NUL parser.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.15:** Add `TestGetUntrackedFilesID_ExcludesNodeModules` in `apps/backend/internal/agentctl/server/process/workspace_monitor_test.go`. Assert that dependency-only creation and modification keep the same fingerprint, while an ordinary untracked file changes it.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.6 and .8:** Keep the existing diff-budget and large-set tests green. The change reduces the eligible input set but does not change enrichment limits or eligible-path retention.
+- Add `TestGetGitStatus_UsesConsistentIndexSnapshotAcrossTransitions` to cover both untracked-to-staged and tracked-to-untracked index changes between the two status queries.
+- Add focused parser and snapshot lifecycle coverage for embedded-newline paths, cancellation, error cleanup, and linked-worktree Git directories.
 
 ## E2E tests
 
@@ -89,9 +91,10 @@ Execution is sequential in the primary conversation. The browser regression, pro
 - RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
 - RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
 - GREEN focused process run: all three new tests passed.
-- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshot` passed after staging a file between the two status queries.
+- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshotAcrossTransitions` passed for both untracked-to-staged and tracked-to-untracked interleavings.
+- GREEN parser and index-lifecycle process run: `TestParseGitUntrackedOutput` covered NUL-separated paths with embedded newlines and cancellation; `TestSnapshotGitIndex*` covered cleanup, cancellation/error cleanup, and linked-worktree Git directories.
 - GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
-- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 728 tests.
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 737 tests.
 - GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
 - `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
 - The first ambient `make -C apps/backend test` run selected the task runtime's `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
@@ -73,6 +73,7 @@ During RED, run the focused Go command and the focused Chromium command after ad
 ## Files likely touched
 
 - `apps/backend/internal/agentctl/server/process/workspace_git_untracked.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_index.go`
 - `apps/backend/internal/agentctl/server/process/workspace_git_status.go`
 - `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`
 - `apps/backend/internal/agentctl/server/process/workspace_monitor.go`
@@ -107,8 +108,10 @@ None.
 - RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
 - RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
 - GREEN focused process run: all three new tests passed.
+- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshot` passed after staging a file between the two status queries.
 - GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
-- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 727 tests.
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 728 tests.
 - GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
 - `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
 - The first ambient backend suite run selected `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.
+- PR fixup remediation: full status now runs both queries against a temporary stable Git-index snapshot, and E2E cleanup derives dependency directories from `dependencyPaths`.

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
@@ -53,7 +53,7 @@ cd apps
 rtk pnpm install --frozen-lockfile
 
 cd backend
-rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus_ExcludesUntrackedNodeModules|GetGitStatus_PreservesTrackedNodeModules|GetUntrackedFilesID_ExcludesNodeModules)$'
+rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus_ExcludesUntrackedNodeModules|GetGitStatus_PreservesTrackedNodeModules|GetUntrackedFilesID_ExcludesNodeModules|GetGitStatus_UsesConsistentIndexSnapshotAcrossTransitions|ParseGitUntrackedOutput|SnapshotGitIndex.*)$'
 rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus_UntrackedFileWithSpaces|EnrichUntrackedFileDiffs|DiffBudget)'
 rtk go test -race ./internal/agentctl/server/process
 
@@ -108,9 +108,10 @@ None.
 - RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
 - RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
 - GREEN focused process run: all three new tests passed.
-- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshot` passed after staging a file between the two status queries.
+- GREEN tracking-transition process run: `TestGetGitStatus_UsesConsistentIndexSnapshotAcrossTransitions` passed for both untracked-to-staged and tracked-to-untracked interleavings.
+- GREEN parser and index-lifecycle process run: `TestParseGitUntrackedOutput` covered NUL-separated paths with embedded newlines and cancellation; `TestSnapshotGitIndex*` covered cleanup, cancellation/error cleanup, and linked-worktree Git directories.
 - GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
-- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 728 tests.
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 737 tests.
 - GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
 - `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
 - The first ambient backend suite run selected `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.

--- a/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
+++ b/docs/plans/workspace-git-status-dependency-tree-exclusion/task-01-bound-dependency-tree-status-enumeration.md
@@ -1,0 +1,114 @@
+---
+id: "01-bound-dependency-tree-status-enumeration"
+title: "Bound dependency-tree status enumeration"
+status: complete
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-PLATFORM-WORKSPACE-GIT-STATUS-001
+acceptance_criteria:
+  - AC-PLATFORM-WORKSPACE-GIT-STATUS-001.6
+  - AC-PLATFORM-WORKSPACE-GIT-STATUS-001.8
+  - AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13
+  - AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14
+  - AC-PLATFORM-WORKSPACE-GIT-STATUS-001.15
+system_design:
+  - ../../specs/platform/system-design/workspace-git-status.md
+---
+
+# Task 01: Bound Dependency-Tree Status Enumeration
+
+## Summary
+
+Exclude untracked `node_modules` trees in Git before agentctl receives individual dependency paths. Preserve tracked changes and ordinary untracked files, and use the same policy for full snapshots and monitor fingerprints.
+
+## In scope
+
+- Add the browser and process regressions before production changes.
+- Add one shared NUL-separated untracked Git query with the `node_modules/` exclusion.
+- Split full status into tracked porcelain collection and eligible untracked collection.
+- Apply the shared untracked query to monitor fingerprinting.
+- Preserve all existing status, diff, cancellation, admission, and payload contracts outside this exclusion.
+
+## Out of scope
+
+- Other generated directory names.
+- Frontend filtering or presentation changes.
+- Git ignore-file creation or modification.
+- Status schema, route, or WebSocket changes.
+
+## Acceptance
+
+- Untracked top-level and nested `node_modules` files do not enter a status snapshot, synthetic diff work, or the monitor fingerprint when no ignore rule exists.
+- Tracked changes below `node_modules` and ordinary untracked files remain visible with their established metadata and diffs.
+- The Chromium Changes regression shows the ordinary untracked file and no dependency-tree path from the same completed snapshot.
+
+## Verification
+
+If `apps/node_modules` is absent, run the workspace install once before the E2E or frontend lint command.
+
+```bash
+cd apps
+rtk pnpm install --frozen-lockfile
+
+cd backend
+rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus_ExcludesUntrackedNodeModules|GetGitStatus_PreservesTrackedNodeModules|GetUntrackedFilesID_ExcludesNodeModules)$'
+rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus_UntrackedFileWithSpaces|EnrichUntrackedFileDiffs|DiffBudget)'
+rtk go test -race ./internal/agentctl/server/process
+
+cd ../web
+rtk pnpm e2e:run tests/git/git-changes-panel.spec.ts -- --grep "omits untracked node_modules before repository ignore exists"
+
+cd ../..
+rtk make -C apps/backend fmt
+rtk make -C apps/backend test
+rtk make -C apps/backend lint
+rtk pnpm --dir apps --filter @kandev/web lint
+rtk git diff --check
+```
+
+During RED, run the focused Go command and the focused Chromium command after adding their tests. Confirm both fail against the current implementation before changing production code. The final report must contain the later GREEN results.
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/process/workspace_git_untracked.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_status.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`
+- `apps/backend/internal/agentctl/server/process/workspace_monitor.go`
+- `apps/backend/internal/agentctl/server/process/workspace_monitor_test.go`
+- `apps/web/e2e/tests/git/git-changes-panel.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Passing the exclusion to tracked status collection can hide valid tracked changes.
+- Reusing line parsing for untracked output can mishandle filenames with embedded newlines.
+- Different argument lists in the observer and monitor can reintroduce repeated dependency scans.
+- The extra full-status Git command must not lose the current observation class or cancellation behavior.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `REQ-PLATFORM-WORKSPACE-GIT-STATUS-001`, especially acceptance criteria .6, .8, and .13 through .15.
+- `docs/specs/platform/system-design/workspace-git-status.md`, section `Generated untracked dependency trees`.
+- `docs/decisions/2026-08-30-bound-untracked-dependency-enumeration.md`.
+- Existing path, cancellation, diff-budget, and interactive-admission tests in the process package.
+- Existing untracked-file Changes coverage in `apps/web/e2e/tests/git/git-changes-panel.spec.ts`.
+
+## Results
+
+- RED process run: `TestGetGitStatus_ExcludesUntrackedNodeModules` and `TestGetUntrackedFilesID_ExcludesNodeModules` failed against the prior implementation because dependency paths entered status and changed the monitor fingerprint. `TestGetGitStatus_PreservesTrackedNodeModules` passed, protecting the tracked-path contract.
+- RED Chromium run: `omits untracked node_modules before repository ignore exists` failed at the intended assertion because one dependency row was visible.
+- GREEN focused process run: all three new tests passed.
+- GREEN existing regressions: the untracked-space, enrichment, and diff-budget tests passed (9 tests).
+- GREEN race run: `go test -race ./internal/agentctl/server/process` passed, covering 727 tests.
+- GREEN Chromium run: `omits untracked node_modules before repository ignore exists` passed (1 test).
+- `make -C apps/backend fmt`, backend lint (0 issues), web lint, and `git diff --check` passed.
+- The first ambient backend suite run selected `/root/.kandev/config.yaml` through inherited `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values. The isolated rerun with both variables unset passed the complete backend suite.

--- a/docs/specs/platform/requirements/workspace-git-status.md
+++ b/docs/specs/platform/requirements/workspace-git-status.md
@@ -2,7 +2,7 @@
 status: active
 system: platform
 created: 2026-07-19
-updated: 2026-08-27
+updated: 2026-08-30
 owners:
   - kandev
 ---
@@ -11,6 +11,11 @@ owners:
 ## Overview
 
 Users opening or focusing Changes and Review need a current workspace snapshot without a large generated or untracked tree monopolizing agentctl. Repeated requests for the same repository must not amplify expensive Git and filesystem work, and the initial session-hydration path must remain within its two-second live-status budget by falling back when necessary.
+
+## Terminology
+
+- **Dependency tree:** A directory named `node_modules` at any repository depth. The exclusion applies only to untracked content. It includes pnpm package content under `node_modules/.pnpm`. A path that Git tracks remains a tracked path.
+- **Eligible changed path:** A tracked changed path, or an untracked path that Git does not ignore and that is not inside a dependency tree.
 
 ## Requirements
 
@@ -25,13 +30,23 @@ Users opening or focusing Changes and Review need a current workspace snapshot w
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.3:** Overlapping live observations for the same repository share one underlying observation. Different repositories in a multi-repository task may still be observed in parallel.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.4:** Every non-cancelled caller receives the same completed snapshot or error from a shared observation. A caller whose own context is cancelled returns promptly without cancelling or otherwise poisoning the result for other callers.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.5:** Tracker shutdown or the bounded shared-observation deadline cancels the underlying work. Cancelled work does not publish or cache a partial snapshot.
-- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.6:** After Git output is parsed, changed-file and synthetic untracked-diff enrichment performs work proportional to the number of changed entries plus the bounded content processed.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.6:** After Git output is parsed, changed-file and synthetic untracked-diff enrichment performs work proportional to the number of eligible changed entries plus the bounded content processed.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.7:** Existing diff limits remain in force: 10 MiB maximum source file size, 256 KiB maximum per emitted diff representation, and a 2 MiB enrichment threshold per status snapshot. Flattened compatibility diffs and layer-specific diffs all participate in the same snapshot threshold. Because the threshold is checked before enriching each representation, the final accepted representation may preserve the existing overshoot of up to the 256 KiB cap. Existing skip reasons remain unchanged.
-- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.8:** Large changed sets retain every path and its status metadata. Once the total diff budget is exhausted, files that are not enriched retain `budget_exceeded` as their diff skip reason.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.8:** Large changed sets retain every eligible path and its status metadata. Once the total diff budget is exhausted, files that are not enriched retain `budget_exceeded` as their diff skip reason.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.9:** When one path has both index and working-tree changes, the workspace snapshot preserves the staged and unstaged change facets independently, including each facet's status, line totals, rename origin, diff content, and diff skip reason when applicable.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.10:** Changes lists a mixed path in both Staged and Unstaged, with facet-specific status and line totals. Opening either row shows only that layer's diff. Overall changed-file totals continue to count the repository and path once.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.11:** Staging or unstaging a mixed path operates once on its repository-qualified path and the next snapshot removes the consumed facet while preserving any facet that remains.
 - **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.12:** Desktop and mobile Changes surfaces expose the same mixed-path sections, facet-specific diff selection, and staging actions without replacing their established platform-native layouts.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.13:** An untracked path inside a dependency tree does not appear in a workspace snapshot and does not receive per-file status or diff enrichment, even when the repository has no matching ignore rule.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.14:** A tracked changed path inside `node_modules` remains visible. An untracked path outside dependency trees remains visible when Git does not ignore it.
+- **AC-PLATFORM-WORKSPACE-GIT-STATUS-001.15:** Creating, changing, or removing only untracked dependency-tree content does not change the workspace monitor fingerprint or start a full status refresh.
+
+## Out of scope
+
+- Suppressing generated directories other than `node_modules`. They continue to follow repository and global Git ignore rules.
+- Suppressing tracked paths based on a directory name.
+- Filtering dependency trees only after Git has enumerated their files.
+- Changing the Git-status API or WebSocket payload shape.
 
 ## System design
 

--- a/docs/specs/platform/system-design/workspace-git-status.md
+++ b/docs/specs/platform/system-design/workspace-git-status.md
@@ -4,7 +4,7 @@ system: platform
 requirements:
   - REQ-PLATFORM-WORKSPACE-GIT-STATUS-001
 created: 2026-07-19
-updated: 2026-08-27
+updated: 2026-08-30
 owners:
   - kandev
 ---
@@ -18,7 +18,7 @@ This design preserves the technical source detail for `REQ-PLATFORM-WORKSPACE-GI
 
 | Requirement | Design section |
 | --- | --- |
-| `REQ-PLATFORM-WORKSPACE-GIT-STATUS-001` | [Migrated source detail](#migrated-source-detail), [Mixed index and working-tree changes](#mixed-index-and-working-tree-changes), [API surface](#api-surface) |
+| `REQ-PLATFORM-WORKSPACE-GIT-STATUS-001` | [Migrated source detail](#migrated-source-detail), [Generated untracked dependency trees](#generated-untracked-dependency-trees), [Mixed index and working-tree changes](#mixed-index-and-working-tree-changes), [API surface](#api-surface) |
 
 ## Migrated source detail
 
@@ -33,11 +33,23 @@ Users opening or focusing Changes and Review need a current workspace snapshot w
 - Overlapping live observations for the same repository share one underlying observation. Different repositories in a multi-repository task may still be observed in parallel.
 - Every non-cancelled caller receives the same completed snapshot or error from a shared observation. A caller whose own context is cancelled returns promptly without cancelling or otherwise poisoning the result for other callers.
 - Tracker shutdown or the bounded shared-observation deadline cancels the underlying work. Cancelled work does not publish or cache a partial snapshot.
-- After Git output is parsed, changed-file and synthetic untracked-diff enrichment performs work proportional to the number of changed entries plus the bounded content processed.
+- After Git output is parsed, changed-file and synthetic untracked-diff enrichment performs work proportional to the number of eligible changed entries plus the bounded content processed.
 - Existing diff limits remain in force: 10 MiB maximum source file size, 256 KiB maximum per emitted diff representation, and a 2 MiB enrichment threshold per status snapshot. Every flattened or layer-specific representation participates in that threshold. Because the threshold is checked before enriching each representation, the final accepted representation may preserve the existing overshoot of up to the 256 KiB cap. Existing skip reasons remain unchanged.
-- Large changed sets retain every path and its status metadata. Once the total diff budget is exhausted, files that are not enriched retain `budget_exceeded` as their diff skip reason.
+- Large changed sets retain every eligible path and its status metadata. Once the total diff budget is exhausted, files that are not enriched retain `budget_exceeded` as their diff skip reason.
 - Multi-repository responses retain repository identity and partial-success behavior.
 - Verification tooling preserves shared managed Go and lint caches for reuse while keeping invocation scratch and command output outside repository worktrees. The root-level `.verify-cache` and `.tmp` paths are ignored as safeguards against legacy or misconfigured verification runs.
+
+### Generated untracked dependency trees
+
+Agentctl owns the complete workspace snapshot. It collects tracked and untracked state through separate Git queries so a generated dependency tree cannot force Git to emit every package file.
+
+The tracked query uses `git status --porcelain --untracked-files=no`. It preserves index and working-tree changes for every tracked path, including a tracked path below `node_modules`. The untracked query uses `git ls-files --others --exclude-standard --exclude=node_modules/ -z`. Git applies the extra exclusion while it walks the worktree. The `-z` result preserves path names without quoting or line splitting. Agentctl adds each returned path to the existing untracked status projection before diff enrichment.
+
+The extra exclusion applies to directories named `node_modules` at any repository depth. It also covers pnpm's nested `node_modules/.pnpm` store. It does not cover `.next`, `dist`, `build`, or other generated names. Those paths continue to follow Git's repository, global, and command-level ignore rules.
+
+The full status observer and the untracked monitor fingerprint use one shared argument definition. The monitor therefore does not stat dependency-tree files, and changes limited to an untracked dependency tree do not start a full refresh. Filtering parsed status output is not sufficient because Git and agentctl have already paid the enumeration cost at that point.
+
+The status model, HTTP routes, WebSocket events, and frontend stores do not change. A completed polling refresh replaces any older cached snapshot through the existing tracker path. This contract follows [ADR-2026-08-30-bound-untracked-dependency-enumeration](../../../decisions/2026-08-30-bound-untracked-dependency-enumeration.md).
 
 ### Mixed index and working-tree changes
 
@@ -129,6 +141,9 @@ Existing Git-status routes remain in place. Their result and stream payloads add
 | A mixed path's layer diff exceeds its cap or the snapshot budget | The affected facet retains status metadata and reports the existing `truncated` or `budget_exceeded` skip reason; the other facet remains independently usable. |
 | One caller cancels while a shared observation is running | That caller returns its context cancellation promptly; other callers remain eligible to receive the shared result. |
 | The tracker stops or the shared deadline expires | Underlying work is cancelled and no partial result is published or cached. |
+| A repository has an untracked `node_modules` tree without an ignore rule | Git excludes the tree during untracked enumeration. The snapshot contains no dependency-tree paths or synthetic diffs. |
+| A tracked path exists below `node_modules` | The tracked status query preserves its staged or unstaged change in the snapshot. |
+| Only untracked dependency-tree content changes | The monitor fingerprint remains unchanged and does not start a full status refresh. |
 | One repository fails during a multi-repository request | Successful repository entries remain available and the failure is reported on its repository entry. |
 | Stored base commit is a strict ancestor of `merge-base(HEAD, <resolved integration candidate>)` and the target is not a live non-default upstream branch | Commit enumeration and cumulative diff use the freshly computed merge-base, not the stale stored SHA; the count reflects only the branch's own commits. |
 | Comparison target is a live non-default upstream branch (e.g. `origin/develop`) whose merge-base is an ancestor of the integration merge-base | The target's own merge-base is preserved; the range is NOT re-anchored to the integration line. |
@@ -147,7 +162,10 @@ Existing Git-status routes remain in place. Their result and stream payloads add
 - **GIVEN** simultaneous fresh requests for two repositories, **WHEN** multi-repository status runs, **THEN** one observation per repository may run in parallel and each response remains identified with its repository.
 - **GIVEN** one waiter cancels during a shared observation, **WHEN** other waiters remain, **THEN** the cancelled waiter returns promptly and the remaining waiters receive the completed result.
 - **GIVEN** tracker shutdown or the shared-observation deadline while enrichment is running, **WHEN** cancellation reaches the observation, **THEN** filesystem iteration stops and no partial snapshot is cached.
-- **GIVEN** approximately 15,000 untracked text files, **WHEN** fresh status is computed, **THEN** every path is present, emitted diff content obeys the existing limits, files not enriched after total-budget exhaustion have `budget_exceeded`, and post-porcelain enrichment remains linear in the number of entries.
+- **GIVEN** approximately 15,000 eligible untracked text files outside dependency trees, **WHEN** fresh status is computed, **THEN** every path is present, emitted diff content obeys the existing limits, files not enriched after total-budget exhaustion have `budget_exceeded`, and post-porcelain enrichment remains linear in the number of entries.
+- **GIVEN** an untracked `node_modules` tree with thousands of package files and no matching ignore rule, **WHEN** fresh status is computed, **THEN** the tree is excluded before per-file status and diff work while an ordinary untracked source file remains visible.
+- **GIVEN** a tracked file below `node_modules`, **WHEN** the file changes, **THEN** its tracked status remains visible in the workspace snapshot.
+- **GIVEN** a stable workspace fingerprint, **WHEN** only untracked files below `node_modules` change, **THEN** the next monitor check keeps the same untracked fingerprint and does not start a full status refresh.
 - **GIVEN** a tracked file with one staged edit and a different unstaged edit, **WHEN** fresh status is computed, **THEN** its one path entry contains staged and unstaged facets with independent line totals and `HEAD -> index` and `index -> working tree` diffs.
 - **GIVEN** a newly added staged file that receives another unstaged edit, **WHEN** Changes opens on desktop or mobile, **THEN** the same path appears in both Staged and Unstaged, selecting each row shows only that layer, and the overall changed-file count remains one.
 - **GIVEN** a mixed path visible in both sections, **WHEN** the user stages or unstages it, **THEN** one repository-qualified Git mutation runs and the next snapshot shows only the facet that remains.
@@ -181,7 +199,9 @@ Existing Git-status routes remain in place. Their result and stream payloads add
 - Redesigning the desktop Changes panel or compressing it into the mobile layout.
 - Adding hunk-level staging or changing the existing whole-file stage, unstage, and discard semantics.
 - Defining new behavior for Git's unmerged/conflict porcelain states; those continue to follow their existing handling.
+- Suppressing untracked `.next`, `dist`, `build`, or other generated directories without a Git ignore rule.
+- Adding client-side dependency-tree filtering or changing status payload fields.
 
 ## Implementation plan
 
-See [Workspace Git Status Scalability plan](../../../plans/workspace-git-status-scalability/plan.md), [Fork PR Comparison Targets plan](../../../plans/fork-pr-comparison-targets/plan.md), and [Mixed Staged and Unstaged Changes plan](../../../plans/mixed-staged-unstaged-changes/plan.md).
+See [Workspace Git Status Scalability plan](../../../plans/workspace-git-status-scalability/plan.md), [Workspace Git Status Dependency-Tree Exclusion plan](../../../plans/workspace-git-status-dependency-tree-exclusion/plan.md), [Fork PR Comparison Targets plan](../../../plans/fork-pr-comparison-targets/plan.md), and [Mixed Staged and Unstaged Changes plan](../../../plans/mixed-staged-unstaged-changes/plan.md).

--- a/docs/specs/platform/system-design/workspace-git-status.md
+++ b/docs/specs/platform/system-design/workspace-git-status.md
@@ -45,6 +45,8 @@ Agentctl owns the complete workspace snapshot. It collects tracked and untracked
 
 The tracked query uses `git status --porcelain --untracked-files=no`. It preserves index and working-tree changes for every tracked path, including a tracked path below `node_modules`. The untracked query uses `git ls-files --others --exclude-standard --exclude=node_modules/ -z`. Git applies the extra exclusion while it walks the worktree. The `-z` result preserves path names without quoting or line splitting. Agentctl adds each returned path to the existing untracked status projection before diff enrichment.
 
+For each full observation, agentctl pins both queries to a temporary snapshot of the Git index. Git writes the real index atomically, so the snapshot keeps tracking membership stable across the pair without blocking concurrent user Git operations. The snapshot is removed after the observation.
+
 The extra exclusion applies to directories named `node_modules` at any repository depth. It also covers pnpm's nested `node_modules/.pnpm` store. It does not cover `.next`, `dist`, `build`, or other generated names. Those paths continue to follow Git's repository, global, and command-level ignore rules.
 
 The full status observer and the untracked monitor fingerprint use one shared argument definition. The monitor therefore does not stat dependency-tree files, and changes limited to an untracked dependency tree do not start a full refresh. Filtering parsed status output is not sufficient because Git and agentctl have already paid the enumeration cost at that point.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3170/225a8d9c4d81.html)
<!-- kandev-pr-walkthrough-end -->

An untracked `node_modules` tree could overwhelm workspace Git status before a repository ignore rule existed, which also made the monitor repeatedly scan dependency files. Git now excludes those directories during untracked enumeration while preserving tracked dependency paths and ordinary untracked files.

## Important Changes

- Split tracked porcelain collection from eligible untracked collection so the `node_modules/` exclusion cannot hide tracked changes.
- Share one NUL-separated untracked query between full status and monitor fingerprinting, keeping the performance boundary before per-file work.
- Add process, monitor, and Chromium regressions, and record the corrected contract in the requirement, system design, ADR, plan, and work order.

## Validation

- RED then GREEN focused process tests for untracked dependency exclusion, tracked-path preservation, and monitor fingerprints.
- RED then GREEN Chromium test: `omits untracked node_modules before repository ignore exists` (`1 passed`).
- `go test -race ./internal/agentctl/server/process` (`727 passed`).
- `make -C apps/backend fmt`.
- `env -u KANDEV_INTERNAL_CONFIG_FILE -u KANDEV_INTERNAL_CONFIG_HOME_FILE make -C apps/backend test` (complete backend suite passed).
- `make -C apps/backend lint` (0 issues).
- `pnpm --dir apps --filter @kandev/web lint`.
- `python3 scripts/lint-spec-files.py --all` and `git diff --check`.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->