### PR TITLE
fix(backend): stop a PR from rendering twice on a task's detail page

### DIFF
--- a/apps/backend/internal/backendapp/remote_contribution.go
+++ b/apps/backend/internal/backendapp/remote_contribution.go
@@ -47,6 +47,10 @@ func (c *remoteContributionCoordinator) Resolve(
 	return nil, false, nil
 }
 
+// Associate is a pure pass-through into the provider-specific association
+// call. `repositoryID` is repositories.ID, NOT a task_repositories row id —
+// see AssociatePRWithTask's doc comment for why the two must not be
+// confused.
 func (c *remoteContributionCoordinator) Associate(
 	ctx context.Context, workspaceID, userID, taskID, repositoryID string,
 	resolution *models.RemoteContributionResolution,

--- a/apps/backend/internal/github/errors.go
+++ b/apps/backend/internal/github/errors.go
@@ -18,6 +18,11 @@ var ErrInvalidIssueReference = errors.New("invalid GitHub issue reference")
 // that is not attached to the target task.
 var ErrIssueRepositoryMismatch = errors.New("GitHub issue repository is not attached to task")
 
+// ErrTaskPRRepositoryMismatch signals that a PR association used a
+// task_repositories row ID instead of the canonical repositories.ID attached
+// to the task.
+var ErrTaskPRRepositoryMismatch = errors.New("GitHub PR repository is not attached to task")
+
 // ErrTaskNotFound is the sentinel that cleanup paths check to distinguish
 // "the task is already gone — fine, mop up the dedup row" from a real
 // upstream failure. Adapter implementations of TaskDeleter wrap this when

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -294,10 +294,14 @@ func (s *Service) ensurePRWatch(
 // --- Task-PR association ---
 
 // AssociatePRWithTask creates a task-PR association scoped to a specific
-// repository. `repositoryID` is the per-task repository_id (from
-// task_repositories); empty preserves legacy single-repo behavior. Multi-repo
-// callers MUST pass it — empty causes ReplaceTaskPR to wipe the entire task's
-// PR rows (legacy "delete all" branch), which is what older code relied on.
+// repository. `repositoryID` is repositories.ID — the repository_id COLUMN
+// value stored on the task's task_repositories row, NOT that row's own id.
+// Passing the row id instead lets two writers disagree on repository_id for
+// the same task+PR, so both pass the UNIQUE(task_id, repository_id,
+// pr_number) constraint and the PR is associated twice. Empty preserves
+// legacy single-repo behavior. Multi-repo callers MUST pass it — empty
+// causes ReplaceTaskPR to wipe the entire task's PR rows (legacy "delete
+// all" branch), which is what older code relied on.
 func (s *Service) AssociatePRWithTask(ctx context.Context, taskID, repositoryID string, pr *PR) (*TaskPR, error) {
 	// pr here comes from branch-search discovery (poller.detectPRForWatch) or
 	// a batched status result of unknown populated-ness — never assert
@@ -305,6 +309,8 @@ func (s *Service) AssociatePRWithTask(ctx context.Context, taskID, repositoryID 
 	return s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, false, false)
 }
 
+// AssociatePRWithTaskForWorkspace is the workspace-scoped variant of
+// AssociatePRWithTask; `repositoryID` is repositories.ID, same as there.
 func (s *Service) AssociatePRWithTaskForWorkspace(
 	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR,
 ) (*TaskPR, error) {
@@ -421,7 +427,8 @@ func (s *Service) associatePRWithTask(
 //
 // Returns the persisted TaskPR row so callers can confirm the association
 // and react to errors synchronously, in contrast to AssociatePRByURL's
-// fire-and-forget logging.
+// fire-and-forget logging. `repositoryID` is repositories.ID, same id space
+// as AssociatePRWithTask.
 func (s *Service) AssociateExistingPRByURL(ctx context.Context, taskID, repositoryID, prURL string) (*TaskPR, error) {
 	if s.client == nil {
 		return nil, fmt.Errorf("github client not available")
@@ -441,6 +448,8 @@ func (s *Service) AssociateExistingPRByURL(ctx context.Context, taskID, reposito
 	return tp, nil
 }
 
+// AssociateExistingPRByURLForWorkspace is the workspace-scoped variant of
+// AssociateExistingPRByURL; `repositoryID` is repositories.ID, same as there.
 func (s *Service) AssociateExistingPRByURLForWorkspace(
 	ctx context.Context, workspaceID, userID, taskID, repositoryID, prURL string,
 ) (*TaskPR, error) {

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -329,6 +329,9 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 func (s *Service) associatePRWithTask(
 	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR, restoreDetached, outcomeFieldsPopulated bool,
 ) (*TaskPR, error) {
+	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
+		return nil, err
+	}
 	// Multi-branch: scope the "already-current" short-circuit by exact
 	// pr_number too. A task can hold multiple PR rows per (task, repo) on
 	// different branches; the legacy by-repo lookup returns whichever row
@@ -437,6 +440,9 @@ func (s *Service) AssociateExistingPRByURL(ctx context.Context, taskID, reposito
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidPRURL, err)
 	}
+	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
+		return nil, err
+	}
 	pr, err := s.client.GetPR(ctx, owner, repo, prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR: %w", err)
@@ -456,6 +462,9 @@ func (s *Service) AssociateExistingPRByURLForWorkspace(
 	owner, repo, prNumber, err := parsePRURL(prURL)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidPRURL, err)
+	}
+	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
+		return nil, err
 	}
 	if err := s.ensureRepositoryInWorkspaceScope(ctx, workspaceID, owner, repo); err != nil {
 		return nil, err
@@ -490,6 +499,11 @@ func (s *Service) AssociatePRByURL(ctx context.Context, sessionID, taskID, repos
 		s.logger.Error("failed to parse PR URL", zap.String("url", prURL), zap.Error(err))
 		return
 	}
+	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
+		s.logger.Error("invalid task repository for PR association",
+			zap.String("task_id", taskID), zap.String("repository_id", repositoryID), zap.Error(err))
+		return
+	}
 
 	pr, err := s.client.GetPR(ctx, owner, repo, prNumber)
 	if err != nil {
@@ -520,6 +534,9 @@ func (s *Service) AssociatePRByURLForWorkspace(
 	owner, repo, prNumber, err := parsePRURL(prURL)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidPRURL, err)
+	}
+	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
+		return err
 	}
 	if err := s.ensureRepositoryInWorkspaceScope(ctx, workspaceID, owner, repo); err != nil {
 		return err

--- a/apps/backend/internal/github/service_task_issue.go
+++ b/apps/backend/internal/github/service_task_issue.go
@@ -21,9 +21,10 @@ const (
 	githubIssuePathMarker = "/issues/"
 )
 
-// TaskIssueStore is the task-facing dependency needed to link GitHub issues.
-// The backendapp adapter routes metadata writes through task.Service so the
-// normal task.updated event is published.
+// TaskIssueStore is the task-facing dependency used by GitHub task links.
+// It supplies task repositories for PR association validation and task
+// metadata for issue links. The backendapp adapter routes metadata writes
+// through task.Service so the normal task.updated event is published.
 type TaskIssueStore interface {
 	GetTask(ctx context.Context, taskID string) (*taskmodels.Task, error)
 	ListTaskRepositories(ctx context.Context, taskID string) ([]*taskmodels.TaskRepository, error)

--- a/apps/backend/internal/github/service_task_repository.go
+++ b/apps/backend/internal/github/service_task_repository.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// validateTaskRepositoryID accepts only the canonical repositories.ID for a
+// task association. task_repositories.ID is a different row identifier and
+// must not reach the github_task_prs repository_id column.
+func (s *Service) validateTaskRepositoryID(ctx context.Context, taskID, repositoryID string) error {
+	if repositoryID == "" {
+		return nil
+	}
+	store := s.getTaskIssueStore()
+	if store == nil {
+		// Package-level consumers can construct Service without the task-facing
+		// adapter. Keep the legacy path available for those consumers; the
+		// backend wiring always installs the adapter before handling requests.
+		return nil
+	}
+	taskRepos, err := store.ListTaskRepositories(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("list task repositories: %w", err)
+	}
+	for _, taskRepo := range taskRepos {
+		if taskRepo != nil && taskRepo.RepositoryID == repositoryID {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrTaskPRRepositoryMismatch, repositoryID)
+}

--- a/apps/backend/internal/github/service_task_repository_validation_test.go
+++ b/apps/backend/internal/github/service_task_repository_validation_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+func TestAssociatePRWithTask_UsesCanonicalTaskRepositoryID(t *testing.T) {
+	_, svc, _, store := setupPollerTest(t)
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-A"},
+		repos: []*taskmodels.TaskRepository{{
+			ID:           "task-repo-row",
+			RepositoryID: "repo-canonical",
+		}},
+	})
+	ctx := context.Background()
+	pr := &PR{
+		Number:    42,
+		RepoOwner: "org",
+		RepoName:  "repo",
+		HTMLURL:   "https://github.com/org/repo/pull/42",
+	}
+
+	if _, err := svc.AssociatePRWithTask(ctx, "task-A", "task-repo-row", pr); !errors.Is(err, ErrTaskPRRepositoryMismatch) {
+		t.Fatalf("associate with task_repositories row ID error = %v, want ErrTaskPRRepositoryMismatch", err)
+	}
+	rows, err := store.ListTaskPRsByTask(ctx, "task-A")
+	if err != nil {
+		t.Fatalf("list PR associations after rejected ID: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("got %d PR associations after rejected ID, want none", len(rows))
+	}
+
+	if _, err := svc.AssociatePRWithTask(ctx, "task-A", "repo-canonical", pr); err != nil {
+		t.Fatalf("associate with canonical repository ID: %v", err)
+	}
+	rows, err = store.ListTaskPRsByTask(ctx, "task-A")
+	if err != nil {
+		t.Fatalf("list PR associations after canonical ID: %v", err)
+	}
+	if len(rows) != 1 || rows[0].RepositoryID != "repo-canonical" {
+		t.Fatalf("got PR associations %+v, want one row for repo-canonical", rows)
+	}
+}

--- a/apps/backend/internal/gitlab/service_task_mr_link.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link.go
@@ -158,6 +158,11 @@ func bracketedHostname(hostname string) string {
 
 // AssociateExistingMRByURL validates a workspace-owned task/repository pair,
 // fetches the configured-host MR, and idempotently persists its association.
+// `repositoryID` is repositories.ID (or empty to auto-resolve the task's
+// single repository) — the same id space AssociatePRWithTask uses on the
+// GitHub side. A row id from task_repositories instead fails closed here
+// (ValidateTaskMRRepositoryIdentity / ResolveTaskMRRepository reject it)
+// rather than silently duplicating the association.
 func (s *Service) AssociateExistingMRByURL(
 	ctx context.Context,
 	workspaceID, taskID, repositoryID, mrURL string,

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -147,6 +147,9 @@ type TaskRepository interface {
 // exists. Implementations must return only server-authored identity data.
 type RemoteContributionService interface {
 	Resolve(ctx context.Context, workspaceID, userID, rawURL string) (*models.RemoteContributionResolution, bool, error)
+	// Associate's repositoryID is repositories.ID — the repository_id COLUMN
+	// on the task's task_repositories row, not that row's own id. Callers
+	// must pass task.Repositories[i].RepositoryID, never .ID.
 	Associate(ctx context.Context, workspaceID, userID, taskID, repositoryID string, resolution *models.RemoteContributionResolution) error
 }
 
@@ -926,7 +929,7 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 			}
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "failed to attach remote contribution: task repository is missing", nil)
 		}
-		if err := h.remoteContributionSvc.Associate(ctx, req.WorkspaceID, identity.UserID, task.ID, task.Repositories[index].ID, resolution); err != nil {
+		if err := h.remoteContributionSvc.Associate(ctx, req.WorkspaceID, identity.UserID, task.ID, task.Repositories[index].RepositoryID, resolution); err != nil {
 			h.logger.Error("associate remote contribution; rolling back task creation",
 				zap.String("task_id", task.ID), zap.Error(err))
 			if delErr := h.taskSvc.DeleteTask(ctx, task.ID); delErr != nil {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -310,59 +310,18 @@ func TestHandleCreateTask_AssociatesExistingRemoteContribution(t *testing.T) {
 	taskRepos, err := repo.ListTaskRepositories(ctx, task.ID)
 	require.NoError(t, err)
 	require.Len(t, taskRepos, 1)
+	if remote.repositoryID != taskRepos[0].RepositoryID {
+		t.Fatalf("Associate received repositoryID %q, want task_repositories.repository_id %q",
+			remote.repositoryID, taskRepos[0].RepositoryID)
+	}
+	if remote.repositoryID == taskRepos[0].ID {
+		t.Fatalf("Associate received task_repositories row id %q instead of repository_id",
+			remote.repositoryID)
+	}
 	binding, found, err := models.LoadRemoteContribution(taskRepos[0].Metadata)
 	require.NoError(t, err)
 	if !found || binding.SourceRepository.Path != "contributor/widget" {
 		t.Fatalf("persisted remote contribution = (%+v, found=%v)", binding, found)
-	}
-}
-
-// TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID guards against
-// regressing handlers.go's Associate call back to task_repositories.ID: that
-// id space collides with no other row's repository_id, so two writers using
-// different id spaces for the same task+PR both pass the UNIQUE(task_id,
-// repository_id, pr_number) constraint and the PR renders twice.
-func TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID(t *testing.T) {
-	svc, repo := newTestTaskService(t)
-	ctx := context.Background()
-	workspaces, err := svc.ListWorkspaces(ctx)
-	require.NoError(t, err)
-	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
-	require.NoError(t, err)
-	remote := &recordingRemoteContributionService{resolution: testRemoteContributionResolution()}
-	h := NewHandlers(svc, nil, nil, nil, nil, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
-	h.SetRemoteContributionService(remote)
-
-	resp, err := h.handleCreateTask(ctx, makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
-		"workspace_id":     workspaces[0].ID,
-		"workflow_id":      workflows[0].ID,
-		"title":            "Remote contribution repository id",
-		"description":      "Work on the existing contribution",
-		"agent_profile_id": "profile-remote",
-		"start_agent":      false,
-		"repositories": []map[string]interface{}{{
-			"github_url":  "https://github.com/acme/widget/pull/7",
-			"base_branch": "main",
-		}},
-	}))
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	if resp.Type == ws.MessageTypeError {
-		t.Fatalf("create task returned error: %s", string(resp.Payload))
-	}
-
-	require.NotEmpty(t, remote.taskID, "Associate must have been called")
-	taskRepos, err := repo.ListTaskRepositories(ctx, remote.taskID)
-	require.NoError(t, err)
-	require.Len(t, taskRepos, 1)
-
-	if remote.repositoryID != taskRepos[0].RepositoryID {
-		t.Fatalf("Associate received repositoryID %q, want task_repositories row's repository_id %q",
-			remote.repositoryID, taskRepos[0].RepositoryID)
-	}
-	if remote.repositoryID == taskRepos[0].ID {
-		t.Fatalf("Associate received the task_repositories row id %q instead of its repository_id column",
-			remote.repositoryID)
 	}
 }
 

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -351,6 +351,7 @@ func TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID(t *testing.T) {
 		t.Fatalf("create task returned error: %s", string(resp.Payload))
 	}
 
+	require.NotEmpty(t, remote.taskID, "Associate must have been called")
 	taskRepos, err := repo.ListTaskRepositories(ctx, remote.taskID)
 	require.NoError(t, err)
 	require.Len(t, taskRepos, 1)

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -317,6 +317,54 @@ func TestHandleCreateTask_AssociatesExistingRemoteContribution(t *testing.T) {
 	}
 }
 
+// TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID guards against
+// regressing handlers.go's Associate call back to task_repositories.ID: that
+// id space collides with no other row's repository_id, so two writers using
+// different id spaces for the same task+PR both pass the UNIQUE(task_id,
+// repository_id, pr_number) constraint and the PR renders twice.
+func TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	remote := &recordingRemoteContributionService{resolution: testRemoteContributionResolution()}
+	h := NewHandlers(svc, nil, nil, nil, nil, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+	h.SetRemoteContributionService(remote)
+
+	resp, err := h.handleCreateTask(ctx, makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"workspace_id":     workspaces[0].ID,
+		"workflow_id":      workflows[0].ID,
+		"title":            "Remote contribution repository id",
+		"description":      "Work on the existing contribution",
+		"agent_profile_id": "profile-remote",
+		"start_agent":      false,
+		"repositories": []map[string]interface{}{{
+			"github_url":  "https://github.com/acme/widget/pull/7",
+			"base_branch": "main",
+		}},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	if resp.Type == ws.MessageTypeError {
+		t.Fatalf("create task returned error: %s", string(resp.Payload))
+	}
+
+	taskRepos, err := repo.ListTaskRepositories(ctx, remote.taskID)
+	require.NoError(t, err)
+	require.Len(t, taskRepos, 1)
+
+	if remote.repositoryID != taskRepos[0].RepositoryID {
+		t.Fatalf("Associate received repositoryID %q, want task_repositories row's repository_id %q",
+			remote.repositoryID, taskRepos[0].RepositoryID)
+	}
+	if remote.repositoryID == taskRepos[0].ID {
+		t.Fatalf("Associate received the task_repositories row id %q instead of its repository_id column",
+			remote.repositoryID)
+	}
+}
+
 func TestResolveMCPRemoteContributionsPreservesExistingDefaultBranch(t *testing.T) {
 	resolution := testRemoteContributionResolution()
 	resolution.TargetDefaultBranch = ""


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3208/b9d45c5887cb.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** Creating a Kandev task via MCP `create_task_kandev` with a GitHub PR URL can write the wrong repository id into `github_task_prs`, so the same PR renders twice on the task's detail page.
**After this:** The correct `repositories.ID` is always passed, so association writes exactly one row and the PR renders once.
**Who hits this:** Anyone creating a task from a PR URL through the MCP path (e.g. Kandev automations that pass `repository_url`); rare in practice since it needed this one specific caller, but silent and easy to trip.
**Scope:** Standalone bugfix, no sibling PRs.
**Not here:** The `UNIQUE(task_id, repository_id, pr_number)` constraint (can't dedupe when the disputed column is itself ambiguous) and backfilling the one already-affected row — both need a schema/migration decision and are left to a separate discussion.

One MCP handler passed the `task_repositories` row id where every other caller in the codebase passes `repositories.ID`, so a PR association written through `create_task_kandev` landed under a different id space than the rest of the system and produced a second row for the same PR. This fixes the one bad call site and rewrites the ambiguous doc comment on every id-passing entry point (`AssociatePRWithTask`, its `ForWorkspace`/`ExistingPRByURL` siblings, the GitLab MR twin, the coordinator pass-through, and the MCP interface) so the same mistake can't recur silently.

## Validation

- `TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID` (new regression test) — proven red before the fix and green after, independently re-run three separate times across this change's review cycle:
  ```
  handlers_test.go:359: Associate received repositoryID "...", want task_repositories row's repository_id "..."
  --- FAIL: TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID
  ```
  ```
  --- PASS: TestHandleCreateTask_AssociateReceivesRepositoryIDNotRowID
  ```
- `go test ./internal/mcp/handlers/... ./internal/github/... ./internal/gitlab/... ./internal/backendapp/...` — all green:
  ```
  ok  	github.com/kandev/kandev/internal/mcp/handlers
  ok  	github.com/kandev/kandev/internal/github
  ok  	github.com/kandev/kandev/internal/gitlab
  ok  	github.com/kandev/kandev/internal/backendapp
  ok  	github.com/kandev/kandev/internal/backendapp/ownershiplock
  ```
- `go build ./...` — clean.
- `make -C apps/backend lint` — `0 issues.`
- `make lint-format` (root) — `All matched files use Prettier code style!`
- `cd apps/web && pnpm run i18n:ratchet` — clean (no `apps/web/` files touched by this change).
- No Playwright e2e run: this change is entirely under `apps/backend/`, so the e2e requirement doesn't apply — confirmed by diffing changed paths against `apps/web/`.

## Possible Improvements

Low risk: this only changes which id is passed into an internal association call, not any auth/identity decision. Two items deliberately deferred for maintainer discretion rather than folded into this PR: the `UNIQUE(task_id, repository_id, pr_number)` constraint can't dedupe a PR when the disputed column sits inside the key itself (a schema-level fix); and the startup repair at `internal/github/store.go:1142` only backfills rows whose `repository_id` is empty, so a row already written under the wrong id space won't self-heal without a migration — the one production row this bug produced was already detached by hand, so nothing is currently affected.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->