### PR TITLE
chore(agentctl): remove ApprovalPolicy field that never governed approval

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -259,11 +259,6 @@ type Config struct {
 	// AutoApprove automatically approves permission requests
 	AutoApprove bool
 
-	// ApprovalPolicy controls when the agent requests approval.
-	// Valid values: "untrusted" (always), "on-failure", "on-request", "never".
-	// Defaults to "on-request" if empty.
-	ApprovalPolicy string
-
 	// McpServers is a list of MCP servers to configure for the agent
 	McpServers []McpServerConfig
 
@@ -323,7 +318,6 @@ func (c *Config) ToSharedConfig() *shared.Config {
 	return &shared.Config{
 		WorkDir:                   c.WorkDir,
 		AutoApprove:               c.AutoApprove,
-		ApprovalPolicy:            c.ApprovalPolicy,
 		McpServers:                mcpServers,
 		AgentID:                   c.AgentID,
 		AgentName:                 c.AgentName,

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
@@ -14,10 +14,6 @@ type Config struct {
 	// AutoApprove automatically approves permission requests
 	AutoApprove bool
 
-	// PermissionPolicy controls the permission mode: "autonomous", "supervised", "plan".
-	// Used to determine hook registration and --permission-mode flag.
-	PermissionPolicy string
-
 	// PermissionTimeout is the maximum time to wait for a permission response.
 	// After timeout, the request is auto-denied with interrupt. Defaults to DefaultPermissionTimeout.
 	PermissionTimeout time.Duration

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
@@ -14,11 +14,6 @@ type Config struct {
 	// AutoApprove automatically approves permission requests
 	AutoApprove bool
 
-	// ApprovalPolicy controls when the agent requests approval.
-	// Valid values: "untrusted" (always), "on-failure", "on-request", "never".
-	// Defaults to "on-request" if empty.
-	ApprovalPolicy string
-
 	// PermissionPolicy controls the permission mode: "autonomous", "supervised", "plan".
 	// Used to determine hook registration and --permission-mode flag.
 	PermissionPolicy string

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -1340,7 +1340,6 @@ func (m *Manager) buildAdapterConfig() error {
 	m.adapterCfg = &adapter.Config{
 		WorkDir:                   m.cfg.WorkDir,
 		AutoApprove:               m.cfg.AutoApprovePermissions,
-		ApprovalPolicy:            m.cfg.ApprovalPolicy,
 		McpServers:                mcpServers,
 		AgentID:                   m.cfg.AgentType, // From registry (e.g., "auggie", "amp", "claude-code")
 		AssumeMcpSse:              m.cfg.AssumeMcpSse,


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3209/eac6cf9c0aeb.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** `adapter.Config.ApprovalPolicy` and `shared.Config.ApprovalPolicy` look like they control when the ACP transport asks for approval, but nothing reads either one — the only transport that exists (`acp.PrepareCommandArgs`) always returns `nil`. Anyone who trusts the field name and tries to "finish wiring it up" would create a second, competing source of truth for approval, sitting below the layer that actually enforces it today.

**After this:** the two dead fields (and the doc comment advertising four values, two of which nothing ever produces) are gone. Approval behavior is unchanged — it was never governed by these fields; it's enforced by `AutoApprovePermissions` in `process/manager.go`, which this PR does not touch.

**Who hits this:** any contributor working in `internal/agentctl/server/adapter` or `.../process` who reads the field, its doc comment, or its still-live wire/config counterpart (`internal/agentctl/server/config`) and reasonably assumes it does something at the transport layer.

**Scope:** standalone chore, no siblings.

**Not here:** the rest of the `approval_policy` chain (HTTP wire field, `Configure` write, log line) is also behaviorally inert end-to-end, but it was already inert before this diff and is out of scope here — filed as a separate follow-up.

Investigated whether approval intent actually takes effect at the transport layer today. It does, through `AutoApprovePermissions`/`process/manager.go`, which derives from the same source (`profileInfo.AutoApprove`) as the removed `ApprovalPolicy` string — so the string was a redundant re-encoding of a bit already enforced elsewhere, not a behavioral gap.

## Validation

- `go build ./...` (apps/backend) — clean
- `go test ./internal/agentctl/server/adapter/... ./internal/agentctl/server/process/... ./internal/agent/runtime/agentctl/...` — green, including `TestConfigureAgent_SendsCommandEnvAndApprovalPolicy` (the HTTP wire-contract test, unaffected since the wire field itself is untouched)
- `golangci-lint run ./internal/agentctl/server/adapter/... ./internal/agentctl/server/process/...` — 0 issues
- `make lint` (backend + web + harness + specs + architecture) — clean
- `make fmt`, `make lint-format`, `pnpm run i18n:ratchet` — clean
- No E2E: diff is 3 backend-only Go files, zero `apps/web/` changes, and no user-visible behavior changes (confirmed no frontend/desktop/docs references to this field)

## Possible Improvements

Low risk: deletions only, zero surviving readers confirmed via keyed-literal audit (no positional-shift risk) and reflection/struct-tag checks. The broader `approval_policy` wire chain (HTTP field → config → log line) remains inert but out of scope — filed separately so the log line doesn't keep implying enforcement that isn't happening.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->