### PR TITLE
fix(plugins): correct false claim that some workflow actions need Office to run

### DIFF
--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3613,14 +3613,12 @@ type WorkflowStep struct {
 	// The on_enter action TYPES configured on this step, as authored
 	// (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
 	// step's intent instead of guessing from the step name or stage_type.
-	// This lists what is configured, not a guarantee that every listed type
-	// executes on every transition path: an ordinary task move currently runs
-	// only a subset (auto_start_agent, configure_session, enable_plan_mode,
-	// set_session_mode, reset_agent_context); queue_run,
-	// queue_run_for_each_participant, clear_decisions, and run_code_review
-	// currently execute only via engine-driven triggers (e.g. Office). Action
-	// config is deliberately not exposed: it carries target task ids, payloads
-	// and profile ids. Plugins must ignore action types they do not recognize.
+	// A type appearing here means it is configured, not a guarantee of when or
+	// whether it fires: arrival at a step runs its session-independent actions
+	// on every route, while session-shaped actions additionally require a live
+	// arriving session. Action config is deliberately not exposed: it carries
+	// target task ids, payloads and profile ids. Plugins must ignore action
+	// types they do not recognize.
 	OnEnterActionTypes []string `protobuf:"bytes,10,rep,name=on_enter_action_types,json=onEnterActionTypes,proto3" json:"on_enter_action_types,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3613,12 +3613,14 @@ type WorkflowStep struct {
 	// The on_enter action TYPES configured on this step, as authored
 	// (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
 	// step's intent instead of guessing from the step name or stage_type.
-	// A type appearing here means it is configured, not a guarantee of when or
-	// whether it fires: arrival at a step runs its session-independent actions
-	// on every route, while session-shaped actions additionally require a live
-	// arriving session. Action config is deliberately not exposed: it carries
-	// target task ids, payloads and profile ids. Plugins must ignore action
-	// types they do not recognize.
+	// A type appearing here means it is configured, not a guarantee of when
+	// or whether it fires: arrival at a step always runs its
+	// session-independent actions, while session-shaped actions run through
+	// the orchestrator's own synchronous entry handling instead — which
+	// creates the session itself when starting one, as auto_start_agent
+	// does, rather than requiring one to already exist. Action config is
+	// deliberately not exposed: it carries target task ids, payloads and
+	// profile ids. Plugins must ignore action types they do not recognize.
 	OnEnterActionTypes []string `protobuf:"bytes,10,rep,name=on_enter_action_types,json=onEnterActionTypes,proto3" json:"on_enter_action_types,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3614,13 +3614,12 @@ type WorkflowStep struct {
 	// (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
 	// step's intent instead of guessing from the step name or stage_type.
 	// A type appearing here means it is configured, not a guarantee of when
-	// or whether it fires: arrival at a step always runs its
-	// session-independent actions, while session-shaped actions run through
-	// the orchestrator's own synchronous entry handling instead — which
-	// creates the session itself when starting one, as auto_start_agent
-	// does, rather than requiring one to already exist. Action config is
-	// deliberately not exposed: it carries target task ids, payloads and
-	// profile ids. Plugins must ignore action types they do not recognize.
+	// or whether it fires. Session-independent actions use step-entry dispatch,
+	// while session-shaped actions use route-specific session handling. Some
+	// auto_start_agent paths create the required session instead of requiring
+	// one to already exist. Action config is deliberately not exposed: it
+	// carries target task ids, payloads and profile ids. Plugins must ignore
+	// action types they do not recognize.
 	OnEnterActionTypes []string `protobuf:"bytes,10,rep,name=on_enter_action_types,json=onEnterActionTypes,proto3" json:"on_enter_action_types,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -524,13 +524,12 @@ message WorkflowStep {
   // (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
   // step's intent instead of guessing from the step name or stage_type.
   // A type appearing here means it is configured, not a guarantee of when
-  // or whether it fires: arrival at a step always runs its
-  // session-independent actions, while session-shaped actions run through
-  // the orchestrator's own synchronous entry handling instead — which
-  // creates the session itself when starting one, as auto_start_agent
-  // does, rather than requiring one to already exist. Action config is
-  // deliberately not exposed: it carries target task ids, payloads and
-  // profile ids. Plugins must ignore action types they do not recognize.
+  // or whether it fires. Session-independent actions use step-entry dispatch,
+  // while session-shaped actions use route-specific session handling. Some
+  // auto_start_agent paths create the required session instead of requiring
+  // one to already exist. Action config is deliberately not exposed: it
+  // carries target task ids, payloads and profile ids. Plugins must ignore
+  // action types they do not recognize.
   repeated string on_enter_action_types = 10;
 }
 message ListWorkflowStepsRequest {

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -523,12 +523,14 @@ message WorkflowStep {
   // The on_enter action TYPES configured on this step, as authored
   // (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
   // step's intent instead of guessing from the step name or stage_type.
-  // A type appearing here means it is configured, not a guarantee of when or
-  // whether it fires: arrival at a step runs its session-independent actions
-  // on every route, while session-shaped actions additionally require a live
-  // arriving session. Action config is deliberately not exposed: it carries
-  // target task ids, payloads and profile ids. Plugins must ignore action
-  // types they do not recognize.
+  // A type appearing here means it is configured, not a guarantee of when
+  // or whether it fires: arrival at a step always runs its
+  // session-independent actions, while session-shaped actions run through
+  // the orchestrator's own synchronous entry handling instead — which
+  // creates the session itself when starting one, as auto_start_agent
+  // does, rather than requiring one to already exist. Action config is
+  // deliberately not exposed: it carries target task ids, payloads and
+  // profile ids. Plugins must ignore action types they do not recognize.
   repeated string on_enter_action_types = 10;
 }
 message ListWorkflowStepsRequest {

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -523,14 +523,12 @@ message WorkflowStep {
   // The on_enter action TYPES configured on this step, as authored
   // (e.g. "auto_start_agent", "queue_run"), so a plugin can describe this
   // step's intent instead of guessing from the step name or stage_type.
-  // This lists what is configured, not a guarantee that every listed type
-  // executes on every transition path: an ordinary task move currently runs
-  // only a subset (auto_start_agent, configure_session, enable_plan_mode,
-  // set_session_mode, reset_agent_context); queue_run,
-  // queue_run_for_each_participant, clear_decisions, and run_code_review
-  // currently execute only via engine-driven triggers (e.g. Office). Action
-  // config is deliberately not exposed: it carries target task ids, payloads
-  // and profile ids. Plugins must ignore action types they do not recognize.
+  // A type appearing here means it is configured, not a guarantee of when or
+  // whether it fires: arrival at a step runs its session-independent actions
+  // on every route, while session-shaped actions additionally require a live
+  // arriving session. Action config is deliberately not exposed: it carries
+  // target task ids, payloads and profile ids. Plugins must ignore action
+  // types they do not recognize.
   repeated string on_enter_action_types = 10;
 }
 message ListWorkflowStepsRequest {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3214/517185448365.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** The `on_enter_action_types` field comment in `plugin.proto` (and its
compiled Go SDK counterpart) tells plugin authors that `queue_run`,
`queue_run_for_each_participant`, `clear_decisions`, and `run_code_review` only
execute via engine-driven triggers such as Office, implying an ordinary board
move (drag a card between columns) won't run them. That's false: every
committed step transition runs those actions regardless of route.
**After this:** The comment states the real axis instead — session-independent
actions run on every route; session-shaped actions additionally require a live
arriving session — without the misleading enumeration that caused this.
**Who hits this:** Anyone authoring or debugging a Kandev plugin that reads
`WorkflowStep.on_enter_action_types` (via the Go `pluginsdk`, or any language
reading the compiled proto) to reason about what fires on step entry.
**Scope:** Standalone — a comment-only fix plus regenerated Go bindings. A
related but disjoint doc fix (`plugins-02.md`, which already carried the
corrected wording) is on a separate unmerged branch and not part of this PR.
**Not here:** The same false claim also exists in the hand-written
`apps/backend/pkg/pluginsdk/data_types.go` doc comment. That file isn't
generated by `make proto` and isn't touched by this branch's diff, so it's
tracked as a separate follow-up.

The `on_enter_action_types` field comment claimed that four of the nine
on-enter action kinds only run through engine-driven triggers like Office, when
they actually run on every ordinary step transition via `DispatchStepEntry`.
This corrects the comment to describe the real session-shaped vs
session-independent split and regenerates `plugin.pb.go` to match.

## Validation

- `make -C apps/backend build` — full binary set (kandev, mock-agent, acpdbg,
  winjob) compiles clean.
- `cd apps/backend && go test ./pkg/pluginsdk/... ./internal/workflow/engine/...
  ./internal/workflow/stepentry/... ./internal/workflow/stepevents/...
  ./internal/task/repository/sqlite/...` — every package that either declares
  the changed proto message or performs step-entry dispatch, all passing.
- `make -C apps/backend lint` — 0 issues.
- `make fmt`, `make typecheck`, `make lint`, `make lint-format`,
  `pnpm run i18n:ratchet` (from `apps/web`) — all clean.
- `make test` (full suite) has pre-existing failures unrelated to this diff —
  reproduced identically on unmodified `origin/main` with zero code changes
  (host-load-dependent flakiness in unrelated subsystems: config loading,
  dev-launcher bootstrap, workspace dependency cleanup). None of the packages
  this diff touches are affected.
- Cross-vendor independent review (`codex exec`, OpenAI): no findings, "the new
  comment is accurate."
- No E2E — backend-only change, no UI or API surface affected.

## Possible Improvements

Negligible risk: comment-only change, no behavior, wire format, or field
identity affected.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->