### PR TITLE
docs(specs): make quorum role resolution step-preferring

### DIFF
--- a/docs/specs/tasks/requirements/workflow-quorum-decision-recording-agent-surface.md
+++ b/docs/specs/tasks/requirements/workflow-quorum-decision-recording-agent-surface.md
@@ -47,10 +47,18 @@ An Office participant can submit a validated verdict with a reason, and the resu
 - **AC-TASKS-QUORUM-RECORDING-001.3:** WHEN the caller is not a participant on the task with
   `decision_required = 1` for `reviewer` or `approver`, THE SYSTEM SHALL reject
   the call with a permission error and write no row.
-- **AC-TASKS-QUORUM-RECORDING-001.4:** WHEN the caller holds both `reviewer` and `approver`, THE SYSTEM
-  SHALL record the decision under `approver`, matching the existing
-  approver-wins precedence in `resolveDeciderRole`
-  (`office/dashboard/decisions.go`).
+- **AC-TASKS-QUORUM-RECORDING-001.4:** WHEN the caller holds both `reviewer` and `approver` seats at
+  the task's current `workflow_step_id`, THE SYSTEM SHALL record the decision
+  under `approver`. WHEN the caller holds those two roles at different steps,
+  THE SYSTEM SHALL record the decision under the role whose seat sits at the
+  task's current `workflow_step_id`, and SHALL NOT apply approver-wins across
+  steps.
+- **AC-TASKS-QUORUM-RECORDING-001.4a:** THE SYSTEM SHALL apply
+  AC-TASKS-QUORUM-RECORDING-001.4 to the agent decision surface only. The human decision path
+  resolves the role step-blind and retains unconditional approver-wins, so the
+  two surfaces MAY record a caller holding both roles under different roles for
+  the same task and step. This divergence is deliberate and is recorded here
+  rather than left implicit.
 - **AC-TASKS-QUORUM-RECORDING-001.5:** THE SYSTEM SHALL resolve the caller's role over the same
   participant population that AC-TASKS-QUORUM-SLATE-001.9 builds, not over rows scoped to the
   task's current step alone. `ListAllTaskParticipants` is step-scoped today, so

--- a/docs/specs/tasks/requirements/workflow-quorum-decision-recording-agent-surface.md
+++ b/docs/specs/tasks/requirements/workflow-quorum-decision-recording-agent-surface.md
@@ -51,8 +51,9 @@ An Office participant can submit a validated verdict with a reason, and the resu
   the task's current `workflow_step_id`, THE SYSTEM SHALL record the decision
   under `approver`. WHEN the caller holds those two roles at different steps,
   THE SYSTEM SHALL record the decision under the role whose seat sits at the
-  task's current `workflow_step_id`, and SHALL NOT apply approver-wins across
-  steps.
+  task's current `workflow_step_id` (which is guaranteed to be one of the two
+  roles by the precondition of AC-TASKS-QUORUM-RECORDING-001.1), and SHALL NOT
+  apply approver-wins across steps.
 - **AC-TASKS-QUORUM-RECORDING-001.4a:** THE SYSTEM SHALL apply
   AC-TASKS-QUORUM-RECORDING-001.4 to the agent decision surface only. The human decision path
   resolves the role step-blind and retains unconditional approver-wins, so the

--- a/docs/specs/tasks/system-design/workflow-quorum-decision-recording.md
+++ b/docs/specs/tasks/system-design/workflow-quorum-decision-recording.md
@@ -245,6 +245,12 @@ counted by that guard at all, so a single pair of counts is either ambiguous
 or actively misleading. `guards` gives the agent the count against each guard
 that exists, which is the question it was actually asking.
 
+This precedence applies only to the agent decision surface. The human decision
+path retains its existing `resolveDeciderRole` behavior and unconditional
+approver precedence, as required by AC-TASKS-QUORUM-RECORDING-001.4a. The two
+paths can therefore persist different roles for the same caller, task, and
+step. Future implementations must preserve this boundary.
+
 **Reason column.** The reason is written to `workflow_step_decisions.comment`,
 the column every Office reader already projects (`office/dashboard/decisions.go:141,428`).
 It is NOT written to `note`, which `Engine.RecordParticipantDecision` currently

--- a/docs/specs/tasks/system-design/workflow-quorum-decision-recording.md
+++ b/docs/specs/tasks/system-design/workflow-quorum-decision-recording.md
@@ -232,12 +232,18 @@ generate.
 
 There is deliberately NO scalar `required_count` / `received_count` pair. A step
 may configure several guards, and AC-TASKS-QUORUM-RECORDING-001.4's approver-wins precedence can resolve the
-caller to `approver` while every guard at that step names `reviewer` — which is
-`Office Default`'s Review exactly, per `## Live workflow configuration`. In that
-case AC-TASKS-QUORUM-BINDING-001.7 means the decision is never counted by that guard at all, so a single
-pair of counts is either ambiguous or actively misleading. `guards` gives the
-agent the count against each guard that exists, which is the question it was
-actually asking.
+caller to `approver` while every guard at that step names `reviewer` — this happens
+when both seats sit at the task's current `workflow_step_id`, which `Office
+Default`'s Review reaches whenever a thin workspace seats one agent in both
+roles there (AC-OFFICE-REVIEW-SEATS-002.4/002.5), per `## Live workflow
+configuration`. A caller whose approver seat instead sits at an earlier step,
+such as Work, now resolves to `reviewer` at Review under
+AC-TASKS-QUORUM-RECORDING-001.4's step-preferring rule and is counted
+normally by that guard; approver-wins no longer reaches across steps. In the
+same-step case, AC-TASKS-QUORUM-BINDING-001.7 means the decision is never
+counted by that guard at all, so a single pair of counts is either ambiguous
+or actively misleading. `guards` gives the agent the count against each guard
+that exists, which is the question it was actually asking.
 
 **Reason column.** The reason is written to `workflow_step_decisions.comment`,
 the column every Office reader already projects (`office/dashboard/decisions.go:141,428`).


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3215/17ba345294ba.html)
<!-- kandev-pr-walkthrough-end -->

## What it changes

`AC-TASKS-QUORUM-RECORDING-001.4` required a caller holding both `reviewer`
and `approver` to be recorded under `approver` unconditionally. Combined
with `AC-OFFICE-REVIEW-SEATS-002.4/002.5` — which legitimately seat one agent
in both roles in a thin workspace — and Review's `role: reviewer` guard,
that deadlocks Review re-entry after a task has visited Approval: the
decision records as `approver` and the Review guard never matches.

The conflict is specific to that leg. A first-pass Review never has an
approver seat to collide with, so it is unaffected.

`001.4` now records under the role whose seat sits at the task's current
`workflow_step_id`, and applies approver-wins only when both roles are held
at the same step — never across steps.

Adds `001.4a` to scope the rule to the agent decision surface and declare the
divergence it creates. The human path (`resolveDeciderRole`,
`apps/backend/internal/office/dashboard/decisions.go:343`) resolves roles over
`ListAllTaskParticipants` without reading a participant's step and keeps
unconditional approver-wins. Amending both surfaces at once was out of
scope; the asymmetry is deliberate and recorded rather than left implicit.
Impact is bounded: human rejections are role-waived by `evaluateAnyReject`
and human approvals map by `participant_id`.

`AC-TASKS-QUORUM-RECORDING-001.5` is unaffected — the population role
resolution draws from is unchanged, so role resolution and slate membership
still cannot disagree.

**Specification only; no behaviour change.** The implementing change is plan
unit 6 (B2), whose gate this amendment lifts.

## Provenance

This is prerequisite **D-A** from `Forge/docs/kandev/office/PLAN-next-steps.md`,
ruled and applied 2026-09-01. It is one of the four parts of the plan's
**unit 2**; with P1 and D-B already ruled, **P0 (`6def9e4c`) is the only part
still open.** When both land, unit 2 completes and plan units 4, 6 and 7
unblock together.

## Non-goals

- Does not implement B2 — this PR ships no code.
- Does not amend the human decision path.
- Does not touch `AC-TASKS-QUORUM-RECORDING-001.5`.

## Validation

- `python3 scripts/lint-spec-files.py --all` → All specification files passed.
- All pre-commit hooks passed on the commit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->