### PR TITLE
fix(office): stop agent decisions from re-evaluating a sibling's session

### DIFF
--- a/apps/backend/internal/mcp/handlers/agent_decision_handlers.go
+++ b/apps/backend/internal/mcp/handlers/agent_decision_handlers.go
@@ -63,6 +63,7 @@ func (h *Handlers) handleRecordStepDecision(ctx context.Context, msg *ws.Message
 		AgentProfileID: session.AgentProfileID,
 		Decision:       req.Decision,
 		Reason:         req.Reason,
+		SessionID:      req.SessionID,
 	})
 	if err != nil {
 		if !errors.Is(err, shared.ErrForbidden) && !dashboard.IsAgentDecisionValidationError(err) {

--- a/apps/backend/internal/mcp/handlers/agent_decision_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/agent_decision_handlers_test.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	officeenginedispatcher "github.com/kandev/kandev/internal/office/engine_dispatcher"
+
 	"github.com/kandev/kandev/internal/office/dashboard"
 	"github.com/kandev/kandev/internal/office/shared"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/workflow/engine"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
@@ -132,6 +135,96 @@ func TestHandleRecordStepDecision_SessionDoesNotBelongToTask(t *testing.T) {
 	resp, err := h.handleRecordStepDecision(context.Background(), msg)
 	require.NoError(t, err)
 	assertWSError(t, resp, ws.ErrorCodeValidation)
+}
+
+// fakeAgentDecisionRepo satisfies dashboard.Repository. It embeds the
+// (nil) interface so every method it doesn't override panics if called —
+// only GetTaskWorkflowStepID is exercised by RecordAgentDecision's
+// AC-55(1) precondition check.
+type fakeAgentDecisionRepo struct {
+	dashboard.Repository
+	workflowStepID string
+}
+
+func (r *fakeAgentDecisionRepo) GetTaskWorkflowStepID(_ context.Context, _ string) (string, error) {
+	return r.workflowStepID, nil
+}
+
+// fakeAgentDecisionStore satisfies dashboard.DecisionStore. RecordAgentDecision
+// only checks it for non-nil; the actual decision write happens inside the
+// engine dispatcher's RecordDecision, not through this store.
+type fakeAgentDecisionStore struct {
+	dashboard.DecisionStore
+}
+
+// sessionCapturingDispatcher satisfies shared.WorkflowEngineDispatcher plus
+// the additive capabilities RecordAgentDecision reaches via type assertion
+// (decisionRecordingDispatcher, roleResolvingDispatcher). It captures the
+// SessionID RecordDecision was actually called with, so the test can assert
+// on the transport boundary this file exists to cover: that
+// handleRecordStepDecision's req.SessionID reaches
+// RecordAgentDecisionInput.SessionID and, from there,
+// officeenginedispatcher.RecordDecisionInput.SessionID.
+type sessionCapturingDispatcher struct {
+	gotSessionID string
+}
+
+func (d *sessionCapturingDispatcher) HandleTrigger(
+	context.Context, string, engine.Trigger, any, string,
+) error {
+	return nil
+}
+
+func (d *sessionCapturingDispatcher) ResolveParticipantRole(
+	_ context.Context, _, _, _ string,
+) (string, string, error) {
+	return "approver", "participant-1", nil
+}
+
+func (d *sessionCapturingDispatcher) RecordDecision(
+	_ context.Context, in officeenginedispatcher.RecordDecisionInput,
+) (officeenginedispatcher.RecordDecisionResult, error) {
+	d.gotSessionID = in.SessionID
+	return officeenginedispatcher.RecordDecisionResult{
+		StepID:     in.StepID,
+		DecisionID: "dec-rd3",
+		DecidedAt:  time.Now(),
+	}, nil
+}
+
+// TestHandleRecordStepDecision_PassesSessionIDToDispatcher is the F1 fix
+// from review round 1: handleRecordStepDecision is the only production
+// caller that supplies a non-blank SessionID (the human dashboard path
+// deliberately leaves it blank), so nothing else in the suite proves the
+// transport actually threads req.SessionID through
+// RecordAgentDecisionInput.SessionID into the dispatcher's
+// RecordDecisionInput.SessionID — the exact binding
+// dispatcher_decisions_test.go and agent_decisions_test.go prove happens
+// correctly *once it arrives*. Confirmed this test fails for the right
+// reason: reverting agent_decision_handlers.go's `SessionID: req.SessionID`
+// line (review round 1's measured mutation) makes gotSessionID come back
+// "" instead of "sess-rd3", and this assertion catches that.
+func TestHandleRecordStepDecision_PassesSessionIDToDispatcher(t *testing.T) {
+	_, repo := newTestTaskService(t)
+	seedRecordStepDecisionSession(t, repo, "ws-rd3", "task-rd3", "sess-rd3")
+
+	svc := dashboard.NewDashboardService(
+		&fakeAgentDecisionRepo{workflowStepID: "step-rd3"}, testLogger(t), nil, nil, nil,
+	)
+	svc.SetDecisionStore(&fakeAgentDecisionStore{})
+	dispatcher := &sessionCapturingDispatcher{}
+	svc.SetWorkflowEngineDispatcher(dispatcher)
+
+	h := newRecordStepDecisionHandler(t, repo, svc)
+	msg := makeWSMessage(t, ws.ActionMCPRecordStepDecision, map[string]interface{}{
+		"task_id": "task-rd3", "session_id": "sess-rd3", "decision": "approved", "reason": "lgtm",
+	})
+	resp, err := h.handleRecordStepDecision(context.Background(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, ws.MessageTypeError, resp.Type, "unexpected error response: %s", resp.Payload)
+
+	require.Equal(t, "sess-rd3", dispatcher.gotSessionID)
 }
 
 func TestMapRecordStepDecisionError_ForbiddenMapsTo403(t *testing.T) {

--- a/apps/backend/internal/office/dashboard/agent_decisions.go
+++ b/apps/backend/internal/office/dashboard/agent_decisions.go
@@ -25,6 +25,15 @@ type RecordAgentDecisionInput struct {
 	AgentProfileID string
 	Decision       string
 	Reason         string
+	// SessionID is the deciding agent's own calling session (the MCP path
+	// resolves it from the transport session before calling in). Optional:
+	// blank falls back to RecordDecision's task-scoped active-session
+	// lookup, which is the only behavior available to the human dashboard
+	// path. Threaded straight through to
+	// officeenginedispatcher.RecordDecisionInput.SessionID; see that
+	// field's doc comment for why this matters once a task can carry more
+	// than one concurrent active session (WO-72).
+	SessionID string
 }
 
 // AgentDecisionValidationError marks an error caused by a caller-provided
@@ -146,6 +155,7 @@ func (s *DashboardService) RecordAgentDecision(
 		DeciderID:     in.AgentProfileID,
 		Role:          role,
 		Comment:       in.Reason,
+		SessionID:     in.SessionID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("record decision: %w", err)

--- a/apps/backend/internal/office/dashboard/agent_decisions_test.go
+++ b/apps/backend/internal/office/dashboard/agent_decisions_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/office/dashboard"
 	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/shared"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
 )
 
@@ -229,5 +231,73 @@ func TestRecordAgentDecision_RejectsWhenEngineDispatcherNotWired(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when engine dispatcher is not wired")
+	}
+}
+
+// TestRecordAgentDecision_BindsToSuppliedSessionOverActiveSibling is the
+// end-to-end proof (through the real engine, not a fake) that
+// RecordAgentDecisionInput.SessionID actually reaches
+// RecordParticipantDecision's re-evaluation subpath: once a task can carry
+// more than one concurrent active session (WO-72), a task-scoped
+// active-session lookup (started_at DESC) could return an unrelated sibling
+// instead of the session that made this decision. deps.svc.RecordAgentDecision
+// is only the entry point — twoSessionResolver models the two-session
+// scenario and dashboardTransitionStore.lastLoadStateSessionID captures
+// which session id the engine's LoadState was actually called with, so this
+// asserts the binding itself rather than just that the write succeeded
+// (which it does either way).
+func TestRecordAgentDecision_BindsToSuppliedSessionOverActiveSibling(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTask(t, deps.db, "ad9", "ws-d", "AD9", "in_review", 2)
+	mustAddParticipant(t, deps, "ad9", "agent-1", models.ParticipantRoleApprover)
+
+	store := newDashboardTransitionStore(deps.db)
+	// Leave workflowID blank (unlike the "wf-test" default): a non-empty
+	// WorkflowID would route ResolveParticipantRole's slate construction
+	// through the workflow-scoped participant query, which joins against a
+	// workflow_steps row this test does not seed. Every other
+	// RecordAgentDecision test resolves participants task-scoped (no
+	// workflow_steps row involved either), and that's the behavior this
+	// test needs too — only the session binding is under test here.
+	store.workflowID = ""
+	activeSibling := &taskmodels.TaskSession{
+		ID: "sess-sibling", TaskID: "ad9", State: taskmodels.TaskSessionStateRunning,
+	}
+	reviewerSession := &taskmodels.TaskSession{
+		ID: "sess-reviewer", TaskID: "ad9", State: taskmodels.TaskSessionStateRunning,
+	}
+	resolver := twoSessionResolver{taskID: "ad9", active: activeSibling, other: reviewerSession}
+	deps.svc.SetWorkflowEngineDispatcher(
+		newTestEngineDispatcherWithResolver(deps.wfRepo, logger.Default(), store, resolver),
+	)
+
+	_, err := deps.svc.RecordAgentDecision(context.Background(), dashboard.RecordAgentDecisionInput{
+		TaskID:         "ad9",
+		AgentProfileID: "agent-1",
+		Decision:       engine.DecisionApproved,
+		Reason:         "lgtm",
+		SessionID:      "sess-reviewer",
+	})
+	if err != nil {
+		t.Fatalf("RecordAgentDecision: %v", err)
+	}
+	// loadStateSessionIDs also picks up two calls that are not the write
+	// path under test: ResolveParticipantRole's own LoadState(ctx, taskID,
+	// "") probe (blank sessionID, runs first) and the dashboard's
+	// post-write guards-snapshot diagnostic, which deliberately reads the
+	// task-scoped active session ("sess-sibling") instead — see
+	// resolveLatestSessionID's doc comment. The first *non-blank* session
+	// id is RecordParticipantDecision's re-evaluation subpath, which is
+	// what RecordDecision bound.
+	var boundSessionID string
+	for _, id := range store.loadStateSessionIDs {
+		if id != "" {
+			boundSessionID = id
+			break
+		}
+	}
+	if boundSessionID != "sess-reviewer" {
+		t.Errorf("bound session id = %q (all LoadState calls: %v), want sess-reviewer (the deciding agent's own session, not the active sibling sess-sibling)",
+			boundSessionID, store.loadStateSessionIDs)
 	}
 }

--- a/apps/backend/internal/office/dashboard/agent_decisions_test.go
+++ b/apps/backend/internal/office/dashboard/agent_decisions_test.go
@@ -242,7 +242,7 @@ func TestRecordAgentDecision_RejectsWhenEngineDispatcherNotWired(t *testing.T) {
 // active-session lookup (started_at DESC) could return an unrelated sibling
 // instead of the session that made this decision. deps.svc.RecordAgentDecision
 // is only the entry point — twoSessionResolver models the two-session
-// scenario and dashboardTransitionStore.lastLoadStateSessionID captures
+// scenario and dashboardTransitionStore.loadStateSessionIDs captures
 // which session id the engine's LoadState was actually called with, so this
 // asserts the binding itself rather than just that the write succeeded
 // (which it does either way).

--- a/apps/backend/internal/office/dashboard/engine_test_helpers_test.go
+++ b/apps/backend/internal/office/dashboard/engine_test_helpers_test.go
@@ -140,6 +140,17 @@ type dashboardTransitionStore struct {
 	workflowID string
 	steps      map[string]engine.StepSpec
 	applied    map[string]bool
+	// loadStateSessionIDs captures every sessionID LoadState was called
+	// with, in call order. A single RecordAgentDecision call can trigger
+	// more than one LoadState: RecordParticipantDecision's re-evaluation
+	// subpath calls it first with the decision's bound session, and the
+	// dashboard's post-write agentDecisionGuardsSnapshot diagnostic can
+	// call EvaluateStepQuorum afterward, which resolves and loads state
+	// for the task-scoped active session (deliberately unrelated — see
+	// resolveLatestSessionID's doc comment). A test that wants the
+	// write-path session must read loadStateSessionIDs[0], not just the
+	// most recent call.
+	loadStateSessionIDs []string
 }
 
 func newDashboardTransitionStore(db *sqlx.DB) *dashboardTransitionStore {
@@ -154,6 +165,7 @@ func newDashboardTransitionStore(db *sqlx.DB) *dashboardTransitionStore {
 func (s *dashboardTransitionStore) LoadState(
 	ctx context.Context, taskID, sessionID string,
 ) (engine.MachineState, error) {
+	s.loadStateSessionIDs = append(s.loadStateSessionIDs, sessionID)
 	var stepID string
 	if err := s.db.QueryRowContext(ctx,
 		`SELECT workflow_step_id FROM tasks WHERE id = ?`, taskID,
@@ -278,4 +290,61 @@ func newTestEngineDispatcherWithReevaluation(
 		engine.WithDecisionStore(workflowadapters.NewDecisionAdapter(wfRepo)),
 	)
 	return officeenginedispatcher.New(eng, singleTaskSessionResolver{taskID: taskID, session: session}, log)
+}
+
+// twoSessionResolver models a task carrying two concurrent active sessions
+// (the WO-72 scenario this defect fix targets): active is the session a
+// task-scoped started_at-DESC lookup would return, and other is a second,
+// separate session reachable only by exact id via GetTaskSession. Used to
+// prove RecordAgentDecision's SessionID binds to the deciding agent's own
+// session end-to-end (through the real engine), not the active sibling.
+type twoSessionResolver struct {
+	taskID string
+	active *taskmodels.TaskSession
+	other  *taskmodels.TaskSession
+}
+
+func (r twoSessionResolver) GetActiveTaskSessionByTaskID(
+	_ context.Context, taskID string,
+) (*taskmodels.TaskSession, error) {
+	if taskID == r.taskID {
+		return r.active, nil
+	}
+	return nil, taskmodels.ErrTaskSessionNotFound
+}
+
+func (r twoSessionResolver) GetTaskSessionByTaskID(
+	ctx context.Context, taskID string,
+) (*taskmodels.TaskSession, error) {
+	return r.GetActiveTaskSessionByTaskID(ctx, taskID)
+}
+
+func (r twoSessionResolver) GetTaskSession(
+	_ context.Context, id string,
+) (*taskmodels.TaskSession, error) {
+	if r.active != nil && id == r.active.ID {
+		return r.active, nil
+	}
+	if r.other != nil && id == r.other.ID {
+		return r.other, nil
+	}
+	return nil, taskmodels.ErrTaskSessionNotFound
+}
+
+// newTestEngineDispatcherWithResolver is like
+// newTestEngineDispatcherWithReevaluation but accepts an arbitrary
+// officeenginedispatcher.SessionResolver instead of always wiring
+// singleTaskSessionResolver — needed by tests modeling more than one
+// session on a task (twoSessionResolver above).
+func newTestEngineDispatcherWithResolver(
+	wfRepo *workflowrepo.Repository, log *logger.Logger,
+	store *dashboardTransitionStore, resolver officeenginedispatcher.SessionResolver,
+) *officeenginedispatcher.Dispatcher {
+	eng := engine.New(
+		store,
+		noopCallbackRegistry{},
+		engine.WithParticipantStore(workflowadapters.NewParticipantAdapter(wfRepo)),
+		engine.WithDecisionStore(workflowadapters.NewDecisionAdapter(wfRepo)),
+	)
+	return officeenginedispatcher.New(eng, resolver, log)
 }

--- a/apps/backend/internal/office/dashboard/engine_test_helpers_test.go
+++ b/apps/backend/internal/office/dashboard/engine_test_helpers_test.go
@@ -142,13 +142,16 @@ type dashboardTransitionStore struct {
 	applied    map[string]bool
 	// loadStateSessionIDs captures every sessionID LoadState was called
 	// with, in call order. A single RecordAgentDecision call can trigger
-	// more than one LoadState: RecordParticipantDecision's re-evaluation
-	// subpath calls it first with the decision's bound session, and the
-	// dashboard's post-write agentDecisionGuardsSnapshot diagnostic can
-	// call EvaluateStepQuorum afterward, which resolves and loads state
-	// for the task-scoped active session (deliberately unrelated — see
-	// resolveLatestSessionID's doc comment). A test that wants the
-	// write-path session must read loadStateSessionIDs[0], not just the
+	// more than one LoadState: ResolveParticipantRole's own slate-building
+	// probe calls it first with a blank sessionID, then
+	// RecordParticipantDecision's re-evaluation subpath calls it with the
+	// decision's bound session, and the dashboard's post-write
+	// agentDecisionGuardsSnapshot diagnostic can call EvaluateStepQuorum
+	// afterward, which resolves and loads state for the task-scoped active
+	// session (deliberately unrelated — see resolveLatestSessionID's doc
+	// comment). A test that wants the write-path session must read the
+	// first non-blank entry in loadStateSessionIDs, not index 0 (which is
+	// ResolveParticipantRole's blank-sessionID probe) and not just the
 	// most recent call.
 	loadStateSessionIDs []string
 }

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -74,6 +74,16 @@ type RecordDecisionInput struct {
 	DeciderID     string
 	Role          string
 	Comment       string
+	// SessionID is the deciding agent's own calling session, when known
+	// (the MCP agent path). Optional: blank means "resolve the task's
+	// active session" (AC-16), which is the only behavior available to
+	// the human dashboard path and is unchanged. When set, RecordDecision
+	// binds to this exact session — after it validates the session
+	// belongs to TaskID and is still in an active state — instead of the
+	// task-scoped active-session lookup, so a decision always
+	// re-evaluates against the deciding agent's own session rather than
+	// an arbitrary sibling session on the same task.
+	SessionID string
 }
 
 // RecordDecisionResult mirrors engine.RecordDecisionResult plus the
@@ -260,19 +270,40 @@ func isReusableSessionForTrigger(trigger engine.Trigger, state taskmodels.TaskSe
 }
 
 // RecordDecision is the AC-57a write-side engine decision entry point:
-// it resolves the task's active session per AC-16/16a, then delegates the
+// it resolves a session per AC-16/16a, then delegates the
 // write-and-reevaluate to Engine.RecordParticipantDecision. AC-16a's
 // "no session resolvable" case is not an error here — an empty sessionID
 // tells the engine to record the decision and skip re-evaluation
 // (reported under AC-23/F39 by the engine itself), matching the existing
 // blank-session behavior RecordParticipantDecision already implements.
+//
+// Session resolution has two modes, since RecordDecision is the single
+// funnel both the human dashboard path and the agent MCP path call
+// through:
+//   - in.SessionID set (agent path): resolved via resolveDeciderSessionID,
+//     which binds to that exact session rather than the task-scoped
+//     active-session lookup below. This is what prevents a task carrying
+//     more than one concurrent active session (WO-72) from having an
+//     agent's decision re-evaluate against an arbitrary sibling session's
+//     state instead of its own.
+//   - in.SessionID blank (human path): today's task-scoped
+//     resolveActiveSessionID lookup, unchanged.
 func (d *Dispatcher) RecordDecision(ctx context.Context, in RecordDecisionInput) (RecordDecisionResult, error) {
 	if in.TaskID == "" {
 		return RecordDecisionResult{}, fmt.Errorf("task_id is required")
 	}
-	sessionID, err := d.resolveActiveSessionID(ctx, in.TaskID)
-	if err != nil {
-		return RecordDecisionResult{}, fmt.Errorf("resolve active session: %w", err)
+	var sessionID string
+	var err error
+	if in.SessionID != "" {
+		sessionID, err = d.resolveDeciderSessionID(ctx, in.TaskID, in.SessionID)
+		if err != nil {
+			return RecordDecisionResult{}, fmt.Errorf("resolve decider session: %w", err)
+		}
+	} else {
+		sessionID, err = d.resolveActiveSessionID(ctx, in.TaskID)
+		if err != nil {
+			return RecordDecisionResult{}, fmt.Errorf("resolve active session: %w", err)
+		}
 	}
 	result, err := d.engine.RecordParticipantDecision(ctx, sessionID, engine.DecisionInfo{
 		TaskID:        in.TaskID,
@@ -368,9 +399,64 @@ func (d *Dispatcher) resolveActiveSessionID(ctx context.Context, taskID string) 
 	return session.ID, nil
 }
 
+// isActiveDeciderSessionState mirrors the state filter in
+// GetActiveTaskSessionByTaskID's SQL exactly (task/repository/sqlite/session.go):
+// CREATED/STARTING/RUNNING/WAITING_FOR_INPUT. There is no shared
+// models-level predicate for this set, so keep the two in sync by hand if
+// either changes.
+func isActiveDeciderSessionState(state taskmodels.TaskSessionState) bool {
+	switch state {
+	case taskmodels.TaskSessionStateCreated,
+		taskmodels.TaskSessionStateStarting,
+		taskmodels.TaskSessionStateRunning,
+		taskmodels.TaskSessionStateWaitingForInput:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveDeciderSessionID validates a caller-supplied session id (the
+// RecordDecisionInput.SessionID agent path) rather than resolving the
+// task's active session from scratch. Returns "" (not an error) when the
+// session is missing, belongs to a different task, or has moved out of the
+// active state set (isActiveDeciderSessionState) — RecordDecision treats
+// that identically to AC-16a's "no active session resolvable": the
+// decision is still recorded and re-evaluation is skipped, never an error,
+// because the verdict itself remains valid even though the deciding
+// session has since ended or was misidentified. It deliberately does not
+// fall back to resolveActiveSessionID: a caller that named its own session
+// and got it wrong should not have the decision silently attributed to an
+// unrelated sibling session instead.
+func (d *Dispatcher) resolveDeciderSessionID(ctx context.Context, taskID, sessionID string) (string, error) {
+	session, err := d.sessions.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, taskmodels.ErrTaskSessionNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	if session == nil || session.TaskID != taskID || !isActiveDeciderSessionState(session.State) {
+		return "", nil
+	}
+	return session.ID, nil
+}
+
 // resolveLatestSessionID returns the F38 "any session" id (the task's
 // most recent session regardless of state), or "" when the task has never
 // had one.
+//
+// Stays task-scoped even after WO-72 lets a task carry multiple concurrent
+// sessions (unlike RecordDecision's resolveDeciderSessionID above), because
+// its only caller (EvaluateStepQuorum) only needs a session id to satisfy
+// TransitionStore.LoadState's signature: the read-only guards snapshot
+// consumes state.CurrentStepID (task-row derived) and state.WorkflowID,
+// neither of which varies between a task's concurrent sessions. The
+// per-session MachineState.Data bag LoadState also populates is unused
+// here — grep confirms no reader of engine.MachineState.Data outside
+// tests/PersistData's write path — so an arbitrary sibling session is
+// behaviorally indistinguishable from the "right" one on this specific
+// path. If a guard ever starts reading Data, revisit this.
 func (d *Dispatcher) resolveLatestSessionID(ctx context.Context, taskID string) (string, error) {
 	session, err := d.sessions.GetTaskSessionByTaskID(ctx, taskID)
 	if err != nil {

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
@@ -252,6 +252,30 @@ func TestDispatcher_RecordDecision_SuppliedSessionTerminalStateSkipsReevaluation
 	}
 }
 
+// TestDispatcher_RecordDecision_SuppliedSessionStoreLookupErrorPropagated
+// proves a genuine session-store failure on the supplied-SessionID path is
+// not silently treated as resolveDeciderSessionID's "not found" case
+// (dispatcher.go's errors.Is(err, ErrTaskSessionNotFound) branch) — mirrors
+// TestDispatcher_RecordDecision_PropagatesActiveSessionLookupError for the
+// blank-SessionID path above.
+func TestDispatcher_RecordDecision_SuppliedSessionStoreLookupErrorPropagated(t *testing.T) {
+	dbErr := errors.New("db down")
+	eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
+	sessions := &fakeSessions{byIDErr: dbErr}
+	d := New(eng, sessions, logger.Default())
+
+	_, err := d.RecordDecision(context.Background(), RecordDecisionInput{
+		TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
+		Decision: "approved", SessionID: "sess-any",
+	})
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("err = %v, want wrapped db error", err)
+	}
+	if eng.decisionCalled {
+		t.Error("engine should not be called when the supplied-session lookup fails")
+	}
+}
+
 // TestDispatcher_RecordDecision_RejectsEmptyTaskID mirrors HandleTrigger's
 // existing input validation for the new write-side entry point.
 func TestDispatcher_RecordDecision_RejectsEmptyTaskID(t *testing.T) {

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
@@ -157,6 +157,101 @@ func TestDispatcher_RecordDecision_KeepsResultWhenReevaluationFails(t *testing.T
 	}
 }
 
+// TestDispatcher_RecordDecision_UsesSuppliedSessionOverActiveSibling is the
+// regression proof for the wrong-binding defect: once a task can carry more
+// than one concurrent active session (WO-72), a task-scoped
+// resolveActiveSessionID pick (started_at DESC) can return an unrelated
+// sibling instead of the session that actually made the decision. When the
+// caller supplies its own session id and that session belongs to the task
+// and is still active, RecordDecision must bind to that exact session, not
+// whichever session resolveActiveSessionID would have picked.
+func TestDispatcher_RecordDecision_UsesSuppliedSessionOverActiveSibling(t *testing.T) {
+	eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
+	sessions := &fakeSessions{
+		// The started_at DESC "active" winner is a sibling agent's session.
+		activeSession: &taskmodels.TaskSession{
+			ID: "sess-assignee", TaskID: "task-1", State: taskmodels.TaskSessionStateRunning,
+		},
+		byID: map[string]*taskmodels.TaskSession{
+			"sess-reviewer": {ID: "sess-reviewer", TaskID: "task-1", State: taskmodels.TaskSessionStateRunning},
+		},
+	}
+	d := New(eng, sessions, logger.Default())
+
+	if _, err := d.RecordDecision(context.Background(), RecordDecisionInput{
+		TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
+		Decision: "approved", SessionID: "sess-reviewer",
+	}); err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+	if eng.decisionSession != "sess-reviewer" {
+		t.Errorf("session id = %q, want sess-reviewer (the deciding agent's own session, not the active sibling sess-assignee)", eng.decisionSession)
+	}
+}
+
+// TestDispatcher_RecordDecision_SuppliedSessionForDifferentTaskSkipsReevaluation
+// covers a supplied session that exists but belongs to a different task: it
+// must not be trusted (a cross-task session id is not this decider's own
+// session), and RecordDecision must not silently fall back to the
+// task-scoped active-session lookup either — the caller explicitly named a
+// session, and that session doesn't check out, so it is treated exactly
+// like AC-16a's "no session resolvable": the decision is recorded (the
+// write succeeds either way, so this only proves binding) but
+// re-evaluation is skipped with a blank session id.
+func TestDispatcher_RecordDecision_SuppliedSessionForDifferentTaskSkipsReevaluation(t *testing.T) {
+	eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
+	sessions := &fakeSessions{
+		// If RecordDecision wrongly fell back to the active-session lookup
+		// when the supplied session fails validation, this would surface as
+		// eng.decisionSession == "sess-active-fallback" instead of "".
+		activeSession: &taskmodels.TaskSession{
+			ID: "sess-active-fallback", TaskID: "task-1", State: taskmodels.TaskSessionStateRunning,
+		},
+		byID: map[string]*taskmodels.TaskSession{
+			"sess-foreign": {ID: "sess-foreign", TaskID: "task-2", State: taskmodels.TaskSessionStateRunning},
+		},
+	}
+	d := New(eng, sessions, logger.Default())
+
+	if _, err := d.RecordDecision(context.Background(), RecordDecisionInput{
+		TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
+		Decision: "approved", SessionID: "sess-foreign",
+	}); err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+	if eng.decisionSession != "" {
+		t.Errorf("session id = %q, want blank: a foreign-task session must not bind, and must not fall back to the active-session lookup", eng.decisionSession)
+	}
+}
+
+// TestDispatcher_RecordDecision_SuppliedSessionTerminalStateSkipsReevaluation
+// covers a supplied session that belongs to the task but has since moved to
+// a terminal state (COMPLETED/FAILED/CANCELLED/IDLE) — a stale session id
+// from a decision that took a while to record. Same AC-16a-style skip as
+// the foreign-task case: recorded, re-evaluation skipped, no fallback.
+func TestDispatcher_RecordDecision_SuppliedSessionTerminalStateSkipsReevaluation(t *testing.T) {
+	eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
+	sessions := &fakeSessions{
+		activeSession: &taskmodels.TaskSession{
+			ID: "sess-active-fallback", TaskID: "task-1", State: taskmodels.TaskSessionStateRunning,
+		},
+		byID: map[string]*taskmodels.TaskSession{
+			"sess-done": {ID: "sess-done", TaskID: "task-1", State: taskmodels.TaskSessionStateCompleted},
+		},
+	}
+	d := New(eng, sessions, logger.Default())
+
+	if _, err := d.RecordDecision(context.Background(), RecordDecisionInput{
+		TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
+		Decision: "approved", SessionID: "sess-done",
+	}); err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+	if eng.decisionSession != "" {
+		t.Errorf("session id = %q, want blank: a terminal-state session must not bind, and must not fall back to the active-session lookup", eng.decisionSession)
+	}
+}
+
 // TestDispatcher_RecordDecision_RejectsEmptyTaskID mirrors HandleTrigger's
 // existing input validation for the new write-side entry point.
 func TestDispatcher_RecordDecision_RejectsEmptyTaskID(t *testing.T) {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3218/f6806e1c14db.html)
<!-- kandev-pr-walkthrough-end -->

> **⚠️ Do not merge before WO-72.** This fixes a defect that WO-72 (external plan,
> `29cb11e5`) introduces the conditions for. It is safe to sit on `main` on its own
> — see Scope below — but landing it without WO-72's context leaves the fix
> orphaned. Both changes sit behind `features.office`, `prod: "false"`.

**Today:** `Dispatcher.RecordDecision` resolves the session for a decision by
querying the task's most-recently-started active session
(`started_at DESC LIMIT 1`), with no regard for which agent actually made the
decision. Once a task can carry more than one concurrent active session (which
WO-72 introduces by keying Office sessions on the run's agent instead of the
task assignee), a reviewer's decision can bind to and re-evaluate against a
completely different, sibling agent's session — clearing that sibling's review
status and running the target step's `on_enter` under the wrong agent.

**After this:** An agent's decision binds to the session that actually supplied
it (already sent over MCP as `session_id`, already validated at the handler,
previously discarded before reaching the resolver). A sibling agent's active
session is never touched by another agent's verdict. The human dashboard path
is unchanged — it still has no session to supply, so it keeps resolving the
task's active session exactly as before.

**Who hits this:** Nobody yet. Exactly one session exists per Office task today,
so the ambiguous binding is unreachable in production. It becomes reachable the
moment WO-72 lands and a task can have concurrent sessions.

**Scope:** Standalone, behaviour-preserving defect fix. With one session per
task the supplied session *is* the active session, so every existing caller
resolves identically before and after this change.

**Not here:** WO-72's own session-keying change (`task_operations.go`, keys
Office sessions on the run's agent) — that is WO-72's own work order and lives
outside this repository. Also not touched: the human dashboard decision path,
and the task-scoped resolution used for read-only guard snapshots (see
`resolveLatestSessionID`'s doc comment for why that one stays as-is).

## Important Changes

- `RecordDecisionInput` (`internal/office/engine_dispatcher/dispatcher.go`)
  gains an optional `SessionID`. When supplied, `RecordDecision` validates it
  belongs to the task and is still in an active state before binding to it;
  an invalid/foreign/terminal session records the decision and skips
  re-evaluation (`SkipReason = session_unresolvable`) rather than erroring or
  silently falling back to the ambiguous task-scoped lookup.
- `RecordAgentDecisionInput` (`internal/office/dashboard/agent_decisions.go`)
  and the `record_step_decision_kandev` MCP handler
  (`internal/mcp/handlers/agent_decision_handlers.go`) thread the calling
  session's id through instead of discarding it.

## Validation

- `go build ./...` — clean.
- `go test ./internal/office/... ./internal/mcp/handlers/... -count=1` — all
  green, including the new dispatcher/dashboard/handler tests that assert the
  *bound* session id directly (a passing write does not prove correct binding,
  since the write succeeds either way).
- Mutation testing on every production line this diff adds (transport hop,
  service hop, core resolution) — each reversion kills a test; no surviving
  mutant.
- `make -C apps/backend lint` (`golangci-lint run ./...`) — 0 issues.
- `gofmt -l` on all changed files — no diffs.
- `make lint-format` (prettier over web/cli/packages) — clean.
- `cd apps/web && pnpm run i18n:ratchet` — no-op (no UI source touched).
- `make typecheck` — clean.
- Full `go test ./...`: 3 packages fail (`task/handlers`, `task/service`,
  `worktree`). Confirmed pre-existing and unrelated — reproduced identically
  against the merge base in a scratch worktree with zero branch changes
  present; none of the 3 packages import or are imported by this diff.
- Reviewed by two independent legs across two rounds (this model + Codex,
  cross-vendor) before this PR was opened. No findings survived to the final
  round.

## Possible Improvements

Low risk. One dispatcher branch (`resolveDeciderSessionID`'s not-found path)
has no direct unit test — three lines identical to two existing helpers in the
same file, verified against the real sqlite repository's error mapping, and
only reachable in production on a delete-race the MCP handler already guards
against upstream. Judged not worth a build round; noted here for visibility.

## Design docs

Found and specified during a three-round adversarial review of the Office
close-the-loop plan (2026-08-31): `Forge/docs/kandev/office/PLAN-next-steps.md`
(v4), blocker **B4**. WO-72 (`29cb11e5`) is the companion change this depends
on landing after.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->