### PR TITLE
fix(plugins): correct pluginsdk doc that misstated which on_enter actions run

### DIFF
--- a/apps/backend/internal/gateway/websocket/port_proxy_auth_test.go
+++ b/apps/backend/internal/gateway/websocket/port_proxy_auth_test.go
@@ -673,8 +673,16 @@ func TestPortProxyCapabilityRoundTrip(t *testing.T) {
 		t.Fatal("capability validated for the wrong port")
 	}
 
-	// Tampered payload: rejected.
-	tampered := cap[:len(cap)-2] + "00"
+	// Tampered payload: rejected. Flip the final byte to a value guaranteed to
+	// differ from the original, rather than a fixed literal: the mac suffix is
+	// hex, so appending a fixed "00" is a ~1/256 no-op whenever the genuine
+	// suffix already ends that way, which flaked this test in CI.
+	lastIdx := len(cap) - 1
+	replacement := byte('0')
+	if cap[lastIdx] == '0' {
+		replacement = '1'
+	}
+	tampered := cap[:lastIdx] + string(replacement)
 	if _, ok := handler.validateCapability(tampered, "sess-1", 5173); ok {
 		t.Fatal("tampered capability validated")
 	}

--- a/apps/backend/internal/plugins/host_data_wire_test.go
+++ b/apps/backend/internal/plugins/host_data_wire_test.go
@@ -437,6 +437,9 @@ func TestPluginHostData_Wire_WorkflowSteps_OnEnterActionTypes(t *testing.T) {
 					OnEnter: []wfmodels.OnEnterAction{
 						{Type: wfmodels.OnEnterAutoStartAgent, Config: map[string]interface{}{"agent_profile_id": "profile-1"}},
 						{Type: wfmodels.OnEnterRunCodeReview},
+						// Unknown types must remain available to plugin callers so they can
+						// apply their own forward-compatible handling.
+						{Type: wfmodels.OnEnterActionType("future_action")},
 					},
 				},
 			},
@@ -456,7 +459,7 @@ func TestPluginHostData_Wire_WorkflowSteps_OnEnterActionTypes(t *testing.T) {
 	require.Len(t, steps, 2)
 
 	require.Equal(t, "step-work", steps[0].ID)
-	require.Equal(t, []string{"auto_start_agent", "run_code_review"}, steps[0].OnEnterActionTypes)
+	require.Equal(t, []string{"auto_start_agent", "run_code_review", "future_action"}, steps[0].OnEnterActionTypes)
 
 	require.Equal(t, "step-todo", steps[1].ID)
 	require.Nil(t, steps[1].OnEnterActionTypes)

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -510,12 +510,9 @@ type WorkflowStep struct {
 	AgentProfileID string
 	// OnEnterActionTypes lists the on_enter action types configured on this
 	// step, as authored. A type appearing here means it is configured, not a
-	// guarantee of when or whether it fires: arrival at a step runs its
-	// session-independent actions on every route, while session-shaped actions
-	// additionally require a live arriving session. Config maps are
-	// deliberately not exposed. Nil when the step has no on_enter actions,
-	// never an empty non-nil slice. Callers must ignore action types they do
-	// not recognize.
+	// guarantee of when or whether it fires. Config maps are deliberately not
+	// exposed. Nil when the step has no on_enter actions, never an empty
+	// non-nil slice. Callers must ignore action types they do not recognize.
 	OnEnterActionTypes []string
 }
 

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -509,13 +509,13 @@ type WorkflowStep struct {
 	WIPLimit       int32 // 0 means unlimited
 	AgentProfileID string
 	// OnEnterActionTypes lists the on_enter action types configured on this
-	// step, as authored. This lists what is configured, not a guarantee that
-	// every listed type executes on every transition path. The ordinary move
-	// path handles auto_start_agent, configure_session, enable_plan_mode,
-	// set_session_mode and reset_agent_context. Other action types can run only
-	// on applicable workflow-engine paths. Config maps are deliberately not
-	// exposed. Nil when the step has no on_enter actions, never an empty
-	// non-nil slice. Callers must ignore action types they do not recognize.
+	// step, as authored. A type appearing here means it is configured, not a
+	// guarantee of when or whether it fires: arrival at a step runs its
+	// session-independent actions on every route, while session-shaped actions
+	// additionally require a live arriving session. Config maps are
+	// deliberately not exposed. Nil when the step has no on_enter actions,
+	// never an empty non-nil slice. Callers must ignore action types they do
+	// not recognize.
 	OnEnterActionTypes []string
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3221/7f108ff09e48.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** The doc comment on `pkg/pluginsdk`'s `WorkflowStep.OnEnterActionTypes` tells a Go plugin author that "the ordinary move path handles `auto_start_agent`, `configure_session`, `enable_plan_mode`, `set_session_mode` and `reset_agent_context`" — a specific, false claim. Two of those (`auto_start_agent`, `enable_plan_mode`) also fire on the no-session move route (`handleTaskMovedNoSession`), and `configure_session` has no engine-level dispatch effect at all. A plugin author who trusts the comment can write logic around a mechanism that doesn't hold.

**After this:** The comment states only what's actually true: the field lists the on_enter action types as authored, with no guarantee of when or whether any of them fire. No action-kind names are enumerated, so there's nothing left in the sentence to go stale as the dispatch engine evolves.

**Who hits this:** Go plugin authors reading `pkg/pluginsdk/data_types.go` directly — root `CLAUDE.md` names this file first as the contract authority for backend plugin authors.

**Scope:** standalone documentation correction and test-only reliability coverage, with no production behavior change. The branch also makes `TestPortProxyCapabilityRoundTrip` deterministic by changing the signed capability's final byte to a guaranteed different value. It adds wire-contract coverage that preserves unknown action types for forward-compatible plugins.

**Not here:** `apps/backend/proto/kandev/plugin/v1/plugin.proto` and its generated `plugin.pb.go` still carry the same originally-false enumeration on this branch. They're owned by a separate in-flight PR fixing the identical defect in the wire contract; touching them here would conflict with that diff.

The doc comment previously enumerated a fixed set of action kinds as "handled" by the ordinary move path. In review, that enumeration turned out to be both incomplete and wrong: `auto_start_agent` and `enable_plan_mode` also fire on `handleTaskMovedNoSession` (`internal/orchestrator/event_handlers_workflow.go:727`), and `configure_session` has no `ActionKind` in the dispatch engine at all (`internal/workflow/engine/types.go` falls through to `default: return Action{}, false`). The fix removes the enumeration entirely rather than trying to patch it, matching the wording already accepted in `docs/specs/plugins/system-design/plugins-02.md`.

## Validation

- `gofmt -l apps/backend/pkg/pluginsdk/data_types.go` — clean
- `go test ./pkg/pluginsdk/... -v` — all pass
- `make -C apps/backend build lint` — all binaries build, `golangci-lint run ./...` → 0 issues
- `make fmt` — no changes
- `make typecheck` — clean
- `make test` — `pkg/pluginsdk` passes; 14 unrelated packages (worktree/launcher/agentctl-process/repoclone/etc.) fail identically at merge base `799b423a9a` in a scratch worktree, confirming pre-existing environment issues, not a regression from this change. One additional repoclone failure on HEAD was reproduced as flaky (passes 3/3 in isolation).
- `make lint` — 0 issues (backend + web + harness + specs + architecture)
- `make lint-format` — Prettier clean
- `cd apps/web && pnpm run i18n:ratchet` — no UI source touched, guard allowlist intact

No E2E: this is a Go doc comment on a struct field, not rendered anywhere, not localized, and produces no diff in runtime behavior. No `apps/web/` paths are touched.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
