### PR TITLE
fix(backend): repair office session race guard that could never trigger

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_office.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office.go
@@ -202,7 +202,9 @@ func (e *Executor) tryReuseExistingSession(
 // createOfficeSession inserts a fresh task_sessions row for the given
 // (task, agent) pair with state CREATED. Mirrors PrepareSession's repo lookups
 // (primary repo, executor config, agent profile snapshot) but stores
-// agent_profile_id so the row participates in the office-session unique index.
+// agent_profile_id so the row can participate in office-session uniqueness
+// enforcement once it exists (no index currently constrains this pair — see
+// taskrepo.ErrOfficeSessionRaceConflict's doc comment).
 //
 // is_primary is left false: office sessions don't use the primary mechanism;
 // it stays for kanban / quick-chat advanced-mode resume.

--- a/apps/backend/internal/task/repository/sqlite/errors.go
+++ b/apps/backend/internal/task/repository/sqlite/errors.go
@@ -37,9 +37,13 @@ var ErrNoPrimarySession = errors.New("no primary session")
 var ErrExternalIDConflict = repoerrors.ErrExternalIDConflict
 
 // ErrOfficeSessionRaceConflict is classified by isOfficeTaskSessionUniqueViolation
-// (office_task_session_uniqueness.go) and returned by CreateTaskSession and by
-// every full-row session update that routes through the unexported
-// updateTaskSessionWithStateGuard — UpdateTaskSession,
+// (office_task_session_uniqueness.go) and returned by every session-create
+// method that routes through the unexported createTaskSession —
+// CreateTaskSession, CreateTaskSessionWithInitialRuntimeSeed,
+// CreateTaskSessionWithWorkspaceBinding,
+// CreateTaskSessionWithSharedGroupWorkspaceBinding, and
+// CreateOfficeTaskSession — and by every full-row session update that routes
+// through the unexported updateTaskSessionWithStateGuard — UpdateTaskSession,
 // UpdateTaskSessionWithMetadata, UpdateTaskSessionIfCurrentState, and
 // UpdateTaskSessionIfCurrentStateRemovingMetadataKeys — when a write violates
 // uniq_office_task_session — i.e. two callers raced past their

--- a/apps/backend/internal/task/repository/sqlite/errors.go
+++ b/apps/backend/internal/task/repository/sqlite/errors.go
@@ -37,10 +37,14 @@ var ErrNoPrimarySession = errors.New("no primary session")
 var ErrExternalIDConflict = repoerrors.ErrExternalIDConflict
 
 // ErrOfficeSessionRaceConflict is classified by isOfficeTaskSessionUniqueViolation
-// (office_task_session_uniqueness.go) and returned by CreateTaskSession and
-// UpdateTaskSessionIfCurrentState when a write violates uniq_office_task_session
-// — i.e. two callers raced past their SELECT-then-INSERT (or a resume raced a
-// fresh create) for the same (task_id, agent_profile_id) pair while both rows
+// (office_task_session_uniqueness.go) and returned by CreateTaskSession and by
+// every full-row session update that routes through the unexported
+// updateTaskSessionWithStateGuard — UpdateTaskSession,
+// UpdateTaskSessionWithMetadata, UpdateTaskSessionIfCurrentState, and
+// UpdateTaskSessionIfCurrentStateRemovingMetadataKeys — when a write violates
+// uniq_office_task_session — i.e. two callers raced past their
+// SELECT-then-INSERT (or a resume raced a fresh create) for the same
+// (task_id, agent_profile_id) pair while both rows
 // are "live" (CREATED, STARTING, RUNNING, IDLE, or WAITING_FOR_INPUT).
 // Terminal rows for the same pair are unaffected — the index only
 // constrains the live set. Callers should re-read and reuse the winning row

--- a/apps/backend/internal/task/repository/sqlite/errors.go
+++ b/apps/backend/internal/task/repository/sqlite/errors.go
@@ -36,11 +36,25 @@ var ErrNoPrimarySession = errors.New("no primary session")
 // return the winner rather than treating this as a hard failure.
 var ErrExternalIDConflict = repoerrors.ErrExternalIDConflict
 
-// ErrOfficeSessionRaceConflict is returned by CreateTaskSession when the
-// insert violates the uniq_office_task_session partial unique index — i.e.
-// two callers raced past their SELECT-then-INSERT for the same
-// (task_id, agent_profile_id) pair. Callers should re-read and reuse the
-// winning row rather than treating this as a hard failure.
+// ErrOfficeSessionRaceConflict is classified by isOfficeTaskSessionUniqueViolation
+// (office_task_session_uniqueness.go) and returned by CreateTaskSession and
+// UpdateTaskSessionIfCurrentState when a write violates uniq_office_task_session
+// — i.e. two callers raced past their SELECT-then-INSERT (or a resume raced a
+// fresh create) for the same (task_id, agent_profile_id) pair while both rows
+// are "live" (CREATED, STARTING, RUNNING, IDLE, or WAITING_FOR_INPUT).
+// Terminal rows for the same pair are unaffected — the index only
+// constrains the live set. Callers should re-read and reuse the winning row
+// rather than treating this as a hard failure (see
+// executor_office.go's EnsureSessionForAgentWithCreation).
+//
+// uniq_office_task_session does NOT exist in the schema yet: a table-wide
+// version of it broke live kanban-relaunch and workflow-replacement flows,
+// which intentionally create a second live session for the same pair (see
+// TestCreateStartSession_KanbanRunnerCreatesDistinctSession). Scoping the
+// index to office sessions only is tracked as Kandev task
+// 05864a73-2dd9-4b15-98ab-35643d9d55e4; until it lands, this sentinel cannot
+// fire and the guarded call sites are dead code kept for that follow-up to
+// activate.
 var ErrOfficeSessionRaceConflict = errors.New("office task session race conflict")
 
 // ErrWorkflowResolutionConflict is returned by UpdateTaskIfWorkflowMatches and

--- a/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness.go
+++ b/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness.go
@@ -24,6 +24,14 @@ const officeTaskSessionIndexName = "uniq_office_task_session"
 // uniq_office_task_session in this table (the only other unique constraint is
 // the id primary key), so matching it attributes the violation correctly — a
 // bare "UNIQUE constraint failed" match would also fire on the primary key.
+//
+// SQLite lists the columns in the index's own DEFINITION order, not table
+// column order (verified directly: an index declared ON t(b, a) reports
+// "t.b, t.a"). This message is therefore contingent on the eventual
+// uniq_office_task_session DDL declaring its columns as
+// (task_id, agent_profile_id) in that order — flipping the order in the
+// migration silently deadens this match again, with the code, tests, and
+// comments all still reading correct.
 const sqliteOfficeTaskSessionViolationMessage = "UNIQUE constraint failed: task_sessions.task_id, task_sessions.agent_profile_id"
 
 // isOfficeTaskSessionUniqueViolation reports whether err is a violation of

--- a/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness.go
+++ b/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness.go
@@ -1,0 +1,46 @@
+package sqlite
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// officeTaskSessionIndexName names the partial unique index that would
+// enforce at most one "live" task_sessions row per (task_id,
+// agent_profile_id) pair. It is not wired into base_schema.go yet — see
+// ErrOfficeSessionRaceConflict's doc comment in errors.go for why — but
+// naming it here keeps isOfficeTaskSessionUniqueViolation attributable to
+// this constraint specifically once it lands. Mirrors the (workspace_id,
+// external_id) classification in task_external_id.go.
+const officeTaskSessionIndexName = "uniq_office_task_session"
+
+// sqliteOfficeTaskSessionViolationMessage is the substring go-sqlite3 puts in
+// a UNIQUE-constraint error for this specific index. SQLite's driver exposes
+// no typed access to the violated index's name, only the column list of the
+// failing index ("UNIQUE constraint failed: task_sessions.task_id,
+// task_sessions.agent_profile_id"); that column pair is unique to
+// uniq_office_task_session in this table (the only other unique constraint is
+// the id primary key), so matching it attributes the violation correctly — a
+// bare "UNIQUE constraint failed" match would also fire on the primary key.
+const sqliteOfficeTaskSessionViolationMessage = "UNIQUE constraint failed: task_sessions.task_id, task_sessions.agent_profile_id"
+
+// isOfficeTaskSessionUniqueViolation reports whether err is a violation of
+// uniq_office_task_session specifically, not any unique violation. On
+// PostgreSQL it inspects the typed pgconn.PgError's constraint name; on
+// SQLite (no typed access to the constraint name) it matches the column-list
+// message documented above. A plain strings.Contains(err.Error(), the index
+// name) is not sufficient by itself: Postgres embeds the constraint name in
+// its error text, but SQLite never does, so that check alone would leave
+// this classification dead on SQLite even with the index in place.
+func isOfficeTaskSessionUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505" && pgErr.ConstraintName == officeTaskSessionIndexName
+	}
+	return strings.Contains(err.Error(), sqliteOfficeTaskSessionViolationMessage)
+}

--- a/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_postgres_test.go
@@ -1,0 +1,78 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// TestPostgresOfficeTaskSessionUniqueViolation covers the typed PostgreSQL
+// error branch and both repository write paths with a temporary scoped index.
+// The production migration remains deferred because the shared task_sessions
+// table also serves Kanban sessions.
+func TestPostgresOfficeTaskSessionUniqueViolation(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	const taskID = "task-office-unique-pg"
+	seedPostgresTask(t, repo, taskID)
+
+	if _, err := repo.db.Exec(`
+		CREATE UNIQUE INDEX uniq_office_task_session
+		ON task_sessions(task_id, agent_profile_id)
+		WHERE agent_profile_id IS NOT NULL AND state IN (
+			'CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT'
+		)
+	`); err != nil {
+		t.Fatalf("create scoped index: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = repo.db.Exec(`DROP INDEX IF EXISTS uniq_office_task_session`)
+	})
+
+	first := &models.TaskSession{
+		ID:             "sess-office-unique-pg-1",
+		TaskID:         taskID,
+		AgentProfileID: "agent-office-pg",
+		State:          models.TaskSessionStateCreated,
+	}
+	if err := repo.CreateTaskSession(ctx, first); err != nil {
+		t.Fatalf("create first office session: %v", err)
+	}
+
+	duplicate := &models.TaskSession{
+		ID:             "sess-office-unique-pg-duplicate",
+		TaskID:         taskID,
+		AgentProfileID: "agent-office-pg",
+		State:          models.TaskSessionStateCreated,
+	}
+	err = repo.CreateTaskSession(ctx, duplicate)
+	if err == nil || !errors.Is(err, ErrOfficeSessionRaceConflict) {
+		t.Fatalf("duplicate insert error = %v, want ErrOfficeSessionRaceConflict", err)
+	}
+
+	updateCandidate := &models.TaskSession{
+		ID:             "sess-office-unique-pg-update",
+		TaskID:         taskID,
+		AgentProfileID: "agent-other-pg",
+		State:          models.TaskSessionStateCreated,
+	}
+	if err := repo.CreateTaskSession(ctx, updateCandidate); err != nil {
+		t.Fatalf("create update candidate: %v", err)
+	}
+	updateCandidate.AgentProfileID = "agent-office-pg"
+	changed, err := repo.UpdateTaskSessionIfCurrentState(
+		ctx,
+		updateCandidate,
+		models.TaskSessionStateCreated,
+	)
+	if changed || err == nil || !errors.Is(err, ErrOfficeSessionRaceConflict) {
+		t.Fatalf("conflicting update = changed=%t err=%v, want typed race conflict", changed, err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_test.go
+++ b/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_test.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,22 +13,17 @@ import (
 
 // officeSessionSeed describes a task_sessions row to insert directly,
 // bypassing CreateTaskSession so tests can construct rows with a specific
-// (task_id, agent_profile_id, state) shape and control NULL vs empty-string
-// agent_profile_id explicitly.
+// (task_id, agent_profile_id, state) shape.
 type officeSessionSeed struct {
 	id             string
 	taskID         string
-	agentProfileID *string // nil => SQL NULL
+	agentProfileID string
 	state          models.TaskSessionState
 }
 
 func insertOfficeSession(t *testing.T, db *sqlx.DB, s officeSessionSeed) {
 	t.Helper()
 	now := time.Now().UTC()
-	var agentProfileID interface{}
-	if s.agentProfileID != nil {
-		agentProfileID = *s.agentProfileID
-	}
 	_, err := db.Exec(`
 		INSERT INTO task_sessions (
 			id, task_id, agent_profile_id, executor_id, executor_profile_id, environment_id,
@@ -38,7 +35,7 @@ func insertOfficeSession(t *testing.T, db *sqlx.DB, s officeSessionSeed) {
 		          '{}', '{}', '{}', '{}',
 		          ?, '', '{}', ?, NULL, ?,
 		          0, '', 0, '')
-	`, s.id, s.taskID, agentProfileID, string(s.state), now, now)
+	`, s.id, s.taskID, s.agentProfileID, string(s.state), now, now)
 	if err != nil {
 		t.Fatalf("insert office session %s: %v", s.id, err)
 	}
@@ -46,18 +43,22 @@ func insertOfficeSession(t *testing.T, db *sqlx.DB, s officeSessionSeed) {
 
 // TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage exercises
 // isOfficeTaskSessionUniqueViolation against a real SQLite UNIQUE-constraint
-// error. uniq_office_task_session is not wired into base_schema.go — a
-// table-wide partial index on this pair broke live kanban-relaunch and
-// workflow-replacement flows (see the follow-up card linked from
-// ErrOfficeSessionRaceConflict's doc comment) — so this test builds and
-// drops its own scoped index rather than relying on production schema.
+// error, then drives both production call sites that wrap it in
+// ErrOfficeSessionRaceConflict (createTaskSession's INSERT and
+// updateTaskSessionWithStateGuard's UPDATE) to prove the wrapping itself,
+// not just the classifier. uniq_office_task_session is not wired into
+// base_schema.go — a table-wide partial index on this pair broke live
+// kanban-relaunch and workflow-replacement flows (see the follow-up card
+// linked from ErrOfficeSessionRaceConflict's doc comment) — so this test
+// builds and drops its own scoped index rather than relying on production
+// schema.
 func TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage(t *testing.T) {
 	repo := newRepoForHealTests(t)
 	insertTask(t, repo.db, "task-classify-1")
 	agent := "agent-classify"
 
 	if _, err := repo.db.Exec(`
-		CREATE UNIQUE INDEX uniq_office_task_session
+		CREATE UNIQUE INDEX uniq_office_task_session_probe
 		ON task_sessions(task_id, agent_profile_id)
 		WHERE agent_profile_id IS NOT NULL AND state IN (
 			'CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT'
@@ -66,11 +67,11 @@ func TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage(t *testing.T
 		t.Fatalf("create scoped index: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = repo.db.Exec(`DROP INDEX IF EXISTS uniq_office_task_session`)
+		_, _ = repo.db.Exec(`DROP INDEX IF EXISTS uniq_office_task_session_probe`)
 	})
 
 	insertOfficeSession(t, repo.db, officeSessionSeed{
-		id: "sess-classify-1", taskID: "task-classify-1", agentProfileID: &agent,
+		id: "sess-classify-1", taskID: "task-classify-1", agentProfileID: agent,
 		state: models.TaskSessionStateCreated,
 	})
 
@@ -91,6 +92,42 @@ func TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage(t *testing.T
 	}
 	if !isOfficeTaskSessionUniqueViolation(err) {
 		t.Fatalf("expected err to classify as an office task session unique violation, got: %v", err)
+	}
+
+	// The raw INSERT above only proves SQLite's message format. Also drive
+	// the two real production call sites that route through the
+	// classifier, so a change that breaks either wrapping fails here rather
+	// than only after the follow-up index lands.
+	ctx := context.Background()
+
+	// CreateTaskSession -> createTaskSession's INSERT path.
+	createErr := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "sess-classify-3", TaskID: "task-classify-1", AgentProfileID: agent,
+		State: models.TaskSessionStateCreated,
+	})
+	if createErr == nil {
+		t.Fatal("expected CreateTaskSession into an occupied live (task, agent) slot to fail")
+	}
+	if !errors.Is(createErr, ErrOfficeSessionRaceConflict) {
+		t.Fatalf("expected errors.Is(err, ErrOfficeSessionRaceConflict) from CreateTaskSession, got: %v", createErr)
+	}
+
+	// UpdateTaskSession -> updateTaskSessionWithStateGuard's UPDATE path
+	// (e.g. a terminal-session resume racing another live row into the
+	// same slot).
+	insertOfficeSession(t, repo.db, officeSessionSeed{
+		id: "sess-classify-4", taskID: "task-classify-1", agentProfileID: "agent-classify-other",
+		state: models.TaskSessionStateCreated,
+	})
+	updateErr := repo.UpdateTaskSession(ctx, &models.TaskSession{
+		ID: "sess-classify-4", TaskID: "task-classify-1", AgentProfileID: agent,
+		State: models.TaskSessionStateCreated,
+	})
+	if updateErr == nil {
+		t.Fatal("expected UpdateTaskSession moving a session into an occupied live (task, agent) slot to fail")
+	}
+	if !errors.Is(updateErr, ErrOfficeSessionRaceConflict) {
+		t.Fatalf("expected errors.Is(err, ErrOfficeSessionRaceConflict) from UpdateTaskSession, got: %v", updateErr)
 	}
 }
 

--- a/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_test.go
+++ b/apps/backend/internal/task/repository/sqlite/office_task_session_uniqueness_test.go
@@ -1,0 +1,115 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// officeSessionSeed describes a task_sessions row to insert directly,
+// bypassing CreateTaskSession so tests can construct rows with a specific
+// (task_id, agent_profile_id, state) shape and control NULL vs empty-string
+// agent_profile_id explicitly.
+type officeSessionSeed struct {
+	id             string
+	taskID         string
+	agentProfileID *string // nil => SQL NULL
+	state          models.TaskSessionState
+}
+
+func insertOfficeSession(t *testing.T, db *sqlx.DB, s officeSessionSeed) {
+	t.Helper()
+	now := time.Now().UTC()
+	var agentProfileID interface{}
+	if s.agentProfileID != nil {
+		agentProfileID = *s.agentProfileID
+	}
+	_, err := db.Exec(`
+		INSERT INTO task_sessions (
+			id, task_id, agent_profile_id, executor_id, executor_profile_id, environment_id,
+			repository_id, base_branch, base_commit_sha,
+			agent_profile_snapshot, executor_snapshot, environment_snapshot, repository_snapshot,
+			state, error_message, metadata, started_at, completed_at, updated_at,
+			is_primary, review_status, is_passthrough, task_environment_id
+		) VALUES (?, ?, ?, '', '', '', '', '', '',
+		          '{}', '{}', '{}', '{}',
+		          ?, '', '{}', ?, NULL, ?,
+		          0, '', 0, '')
+	`, s.id, s.taskID, agentProfileID, string(s.state), now, now)
+	if err != nil {
+		t.Fatalf("insert office session %s: %v", s.id, err)
+	}
+}
+
+// TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage exercises
+// isOfficeTaskSessionUniqueViolation against a real SQLite UNIQUE-constraint
+// error. uniq_office_task_session is not wired into base_schema.go — a
+// table-wide partial index on this pair broke live kanban-relaunch and
+// workflow-replacement flows (see the follow-up card linked from
+// ErrOfficeSessionRaceConflict's doc comment) — so this test builds and
+// drops its own scoped index rather than relying on production schema.
+func TestIsOfficeTaskSessionUniqueViolation_ClassifiesSQLiteMessage(t *testing.T) {
+	repo := newRepoForHealTests(t)
+	insertTask(t, repo.db, "task-classify-1")
+	agent := "agent-classify"
+
+	if _, err := repo.db.Exec(`
+		CREATE UNIQUE INDEX uniq_office_task_session
+		ON task_sessions(task_id, agent_profile_id)
+		WHERE agent_profile_id IS NOT NULL AND state IN (
+			'CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT'
+		)
+	`); err != nil {
+		t.Fatalf("create scoped index: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = repo.db.Exec(`DROP INDEX IF EXISTS uniq_office_task_session`)
+	})
+
+	insertOfficeSession(t, repo.db, officeSessionSeed{
+		id: "sess-classify-1", taskID: "task-classify-1", agentProfileID: &agent,
+		state: models.TaskSessionStateCreated,
+	})
+
+	_, err := repo.db.Exec(`
+		INSERT INTO task_sessions (
+			id, task_id, agent_profile_id, executor_id, executor_profile_id, environment_id,
+			repository_id, base_branch, base_commit_sha,
+			agent_profile_snapshot, executor_snapshot, environment_snapshot, repository_snapshot,
+			state, error_message, metadata, started_at, completed_at, updated_at,
+			is_primary, review_status, is_passthrough, task_environment_id
+		) VALUES (?, 'task-classify-1', ?, '', '', '', '', '', '',
+		          '{}', '{}', '{}', '{}',
+		          'CREATED', '', '{}', datetime('now'), NULL, datetime('now'),
+		          0, '', 0, '')
+	`, "sess-classify-2", agent)
+	if err == nil {
+		t.Fatal("expected inserting a second live row for the same pair to violate the scoped index")
+	}
+	if !isOfficeTaskSessionUniqueViolation(err) {
+		t.Fatalf("expected err to classify as an office task session unique violation, got: %v", err)
+	}
+}
+
+// TestIsOfficeTaskSessionUniqueViolation_IgnoresUnrelatedViolation asserts
+// the classifier does not fire on an unrelated UNIQUE-constraint error (the
+// tasks primary key here), which a bare "UNIQUE constraint failed" substring
+// match would have misclassified.
+func TestIsOfficeTaskSessionUniqueViolation_IgnoresUnrelatedViolation(t *testing.T) {
+	repo := newRepoForHealTests(t)
+	insertTask(t, repo.db, "task-classify-2")
+
+	_, err := repo.db.Exec(`
+		INSERT INTO tasks (id, workspace_id, workflow_id, workflow_step_id, title, description, state, created_at, updated_at)
+		VALUES ('task-classify-2', '', '', '', 'dup', '', 'todo', datetime('now'), datetime('now'))
+	`)
+	if err == nil {
+		t.Fatal("expected duplicate task id to violate the tasks primary key")
+	}
+	if isOfficeTaskSessionUniqueViolation(err) {
+		t.Fatalf("expected primary-key violation not to be misclassified as an office task session unique violation: %v", err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -946,10 +946,12 @@ func (r *Repository) createTaskSession(ctx context.Context, exec taskSessionExec
 		dialect.BoolToInt(session.IsPrimary), session.ReviewStatus,
 		dialect.BoolToInt(session.IsPassthrough), session.TaskEnvironmentID, session.Name)
 
-	if err != nil && strings.Contains(err.Error(), "uniq_office_task_session") {
+	if err != nil && isOfficeTaskSessionUniqueViolation(err) {
 		// Two callers raced past their SELECT-then-INSERT for the same
 		// (task_id, agent_profile_id) — surface a typed sentinel so callers
 		// can classify with errors.Is rather than driver-message matching.
+		// Currently unreachable: no index enforces this pair yet (see
+		// ErrOfficeSessionRaceConflict's doc comment).
 		return fmt.Errorf("%w: %w", ErrOfficeSessionRaceConflict, err)
 	}
 	return err
@@ -1208,9 +1210,11 @@ func (r *Repository) GetActiveTaskSessionByTaskID(ctx context.Context, taskID st
 }
 
 // GetTaskSessionByTaskAndAgent retrieves the office task session for the given
-// (task_id, agent_profile_id) pair. The pair is unique across non-NULL
-// agent_profile_id rows, so at most one row matches. Returns nil, nil when
-// no session exists for the pair.
+// (task_id, agent_profile_id) pair. This pair is NOT unique at the schema
+// level — no index enforces it (see ErrOfficeSessionRaceConflict's doc
+// comment for why) — so both live and terminal rows can accumulate for the
+// same pair, and ORDER BY started_at DESC LIMIT 1 is load-bearing to pick the
+// most recent one. Returns nil, nil when no session exists for the pair.
 func (r *Repository) GetTaskSessionByTaskAndAgent(ctx context.Context, taskID, agentInstanceID string) (*models.TaskSession, error) {
 	if taskID == "" || agentInstanceID == "" {
 		return nil, nil
@@ -1441,6 +1445,16 @@ func (r *Repository) updateTaskSessionWithStateGuard(
 	}
 	result, err := exec.ExecContext(ctx, r.db.Rebind(query), args...)
 	if err != nil {
+		if isOfficeTaskSessionUniqueViolation(err) {
+			// A terminal-session resume (updateSessionStarting) or another
+			// full-row update raced another live row into the same
+			// (task_id, agent_profile_id) slot — same classification as the
+			// createTaskSession INSERT path, so callers can errors.Is this
+			// regardless of which write hit the constraint. Currently
+			// unreachable: no index enforces this pair yet (see
+			// ErrOfficeSessionRaceConflict's doc comment).
+			return false, fmt.Errorf("%w: %w", ErrOfficeSessionRaceConflict, err)
+		}
 		return false, err
 	}
 	rows, err := result.RowsAffected()

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -877,6 +877,7 @@ func (r *Repository) CreateOfficeTaskSession(ctx context.Context, session *model
 	return tx.Commit()
 }
 
+// createTaskSession inserts a task session through the supplied database handle.
 func (r *Repository) createTaskSession(ctx context.Context, exec taskSessionExecutor, session *models.TaskSession) error {
 	if session.ID == "" {
 		session.ID = uuid.New().String()
@@ -1390,6 +1391,8 @@ func (r *Repository) updateTaskSession(
 	return nil
 }
 
+// updateTaskSessionWithStateGuard writes a full session row while an optional
+// expected state guard still matches the stored row.
 func (r *Repository) updateTaskSessionWithStateGuard(
 	ctx context.Context,
 	exec taskSessionExecutor,

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -916,10 +916,12 @@ func (r *Repository) createTaskSession(ctx context.Context, exec taskSessionExec
 	if err != nil {
 		return fmt.Errorf("failed to serialize repository snapshot: %w", err)
 	}
-	// agent_profile_id is NULL-able. Empty string would defeat the partial
-	// unique index since SQLite treats two empty strings as equal — store NULL
-	// for kanban / quick-chat rows and a real value only for office sessions
-	// (per ADR 0005, kanban and office now share the same column).
+	// agent_profile_id is NULL-able and stored as NULL when empty. No unique
+	// index currently constrains (task_id, agent_profile_id) — see
+	// ErrOfficeSessionRaceConflict's doc comment (errors.go). Per ADR 0005,
+	// kanban and office share this column, and every row (kanban included)
+	// carries a non-NULL value in practice — nothing here scopes NULL to
+	// kanban specifically.
 	var agentProfileID interface{}
 	if session.AgentProfileID != "" {
 		agentProfileID = session.AgentProfileID
@@ -1416,8 +1418,10 @@ func (r *Repository) updateTaskSessionWithStateGuard(
 	// would clobber metadata set via those side-channel paths since the
 	// caller's in-memory copy may be stale.
 
-	// agent_profile_id is stored as NULL when empty so the partial unique
-	// index over (task_id, agent_profile_id) ignores kanban / quick-chat rows.
+	// agent_profile_id is stored as NULL when empty. No unique index
+	// currently constrains (task_id, agent_profile_id) — see
+	// ErrOfficeSessionRaceConflict's doc comment (errors.go) for why, and
+	// for what still guards this pair despite that.
 	var agentProfileID interface{}
 	if session.AgentProfileID != "" {
 		agentProfileID = session.AgentProfileID

--- a/docs/specs/office/requirements/tasks.md
+++ b/docs/specs/office/requirements/tasks.md
@@ -30,13 +30,18 @@ identity, inline editable properties, and the chat / activity views.
 #### Acceptance criteria
 
 - **AC-OFFICE-TASKS-001.1:** A task progresses through statuses `todo → in_progress → in_review → done`, with `blocked` and `cancelled` as branchable states. Status transitions are user- or agent-driven and feed the reactivity pipeline (section E).
-- **AC-OFFICE-TASKS-001.2:** Every office task has zero or more **task sessions**: one per `(task_id, agent_instance_id)` pair. A session represents one agent's persistent conversation thread on the task, not a single launch.
+- **AC-OFFICE-TASKS-001.2:** Every office task has zero or more **task sessions**: one per `(task_id, agent_profile_id)` pair. A session represents one agent's persistent conversation thread on the task, not a single launch.
 - **AC-OFFICE-TASKS-001.3:** Sessions cycle through `CREATED → STARTING → RUNNING → IDLE → RUNNING → IDLE → ...` for as many turns as the agent is woken. A session is terminal (`COMPLETED` / `FAILED` / `CANCELLED`) only when the agent leaves the task's participants list.
 - **AC-OFFICE-TASKS-001.4:** Wakeups (section E) drive transitions IDLE → RUNNING. Turn-complete events drive RUNNING → IDLE, tearing down the executor and agent process entirely; the conversation is preserved via the stored ACP session token.
 - **AC-OFFICE-TASKS-001.5:** Kanban / quick-chat sessions keep their per-launch model and `WAITING_FOR_INPUT` semantics - office's IDLE state is office-scoped.
 - **AC-OFFICE-TASKS-001.6:** Tasks form a tree via `parent_id`. Parent tasks act as the default home for shared specs, plans, and coordination documents.
 - **AC-OFFICE-TASKS-001.7:** Child tasks can read parent-owned documents and write parent-owned coordination documents by default. Document handoffs reuse the existing **blocker mechanism**: a consumer task is blocked-by the producer task and reads the resulting documents from its wakeup prompt context. There is no separate "required documents" data type.
 - **AC-OFFICE-TASKS-001.8:** Agents can list related tasks (parent, children, siblings, blockers, blocked) and can read/write allowed task documents via MCP or CLI tools.
+
+The current schema stores the agent identity in `task_sessions.agent_profile_id`.
+The schema does not yet enforce one live Office row per pair. A future migration
+must define an Office-only discriminator because Kanban rows also use this
+column.
 
 ## System design
 

--- a/docs/specs/office/system-design/tasks-01.md
+++ b/docs/specs/office/system-design/tasks-01.md
@@ -27,12 +27,24 @@ Office tasks are the unit of work in office mode: a single task carries a descri
 
 This spec consolidates the office task surface: lifecycle, parent/child handoffs, approval flow, advanced execution mode, blocker cycle detection, the reactivity pipeline, per-(task, agent) session identity, inline editable properties, and the chat / activity views.
 
+### Session constraint boundary
+
+The current schema stores the Office agent identity in
+`task_sessions.agent_profile_id`. The schema does not enforce one live Office
+row per `(task_id, agent_profile_id)` pair yet. A future migration must define
+an Office-only discriminator because Kanban rows also use this column and can
+legitimately share the pair.
+
+The repository classifies the planned constraint's PostgreSQL and SQLite errors.
+The insert path reloads the winning row. The update path returns a typed conflict
+for a future caller to handle before the constraint becomes active.
+
 ## What
 
 ### A. Lifecycle and identity
 
 - A task progresses through statuses `todo → in_progress → in_review → done`, with `blocked` and `cancelled` as branchable states. Status transitions are user- or agent-driven and feed the reactivity pipeline (section E).
-- Every office task has zero or more **task sessions**: one per `(task_id, agent_instance_id)` pair. A session represents one agent's persistent conversation thread on the task, not a single launch.
+- Every office task has zero or more **task sessions**: one per `(task_id, agent_profile_id)` pair. A session represents one agent's persistent conversation thread on the task, not a single launch.
 - Sessions cycle through `CREATED → STARTING → RUNNING → IDLE → RUNNING → IDLE → ...` for as many turns as the agent is woken. A session is terminal (`COMPLETED` / `FAILED` / `CANCELLED`) only when the agent leaves the task's participants list.
 - Wakeups (section E) drive transitions IDLE → RUNNING. Turn-complete events drive RUNNING → IDLE, tearing down the executor and agent process entirely; the conversation is preserved via the stored ACP session token.
 - Kanban / quick-chat sessions keep their per-launch model and `WAITING_FOR_INPUT` semantics - office's IDLE state is office-scoped.
@@ -106,10 +118,10 @@ A backend pipeline runs synchronously on every relevant task property change. Pr
 
 ### G. Per-(task, agent) session lifecycle
 
-- `task_sessions` rows are keyed by `(task_id, agent_instance_id)` for office tasks. The same pair reuses one row across many wakeups. Kanban / quick-chat sessions leave `agent_instance_id` NULL and keep their per-launch + `is_primary` model.
+- `task_sessions` rows use `(task_id, agent_profile_id)` for Office identity. The same pair reuses one row across many wakeups. Kanban and quick-chat sessions also use `agent_profile_id` and keep their per-launch and `is_primary` model.
 - A single task may carry multiple sessions: assignee, each reviewer, each approver, each @-mentioned agent. Each maintains its own conversation; one agent's notes never appear in another's buffer.
-- On wakeup, `EnsureSessionForAgent(task, agent_instance)`:
-  1. Looks up the row by `(task_id, agent_instance_id)`.
+- On wakeup, `EnsureSessionForAgent(task, agent_profile_id)`:
+  1. Looks up the row by `(task_id, agent_profile_id)`.
   2. If found and IDLE: flip to RUNNING.
   3. If found and RUNNING/STARTING: return as-is (idempotent).
   4. If found and terminal: create a new row (prior pair was retired).
@@ -181,16 +193,16 @@ The Chat tab displays a chronological merge of:
 task_sessions
   id                     TEXT PK
   task_id                TEXT FK -> office_tasks.id
-  agent_instance_id      TEXT  nullable  -- office: set; kanban/quick-chat: NULL
+  agent_profile_id       TEXT  nullable  -- shared by Office, Kanban, and quick-chat
   acp_session_id         TEXT  nullable  -- preserved across IDLE turns
   state                  enum   CREATED | STARTING | RUNNING | IDLE
                                 | WAITING_FOR_INPUT | COMPLETED | FAILED | CANCELLED
   is_primary             bool   -- kanban resume; office never reads this
   ...
 
-  UNIQUE INDEX uniq_office_task_session
-    ON task_sessions(task_id, agent_instance_id)
-    WHERE agent_instance_id IS NOT NULL;
+  -- Planned constraint, not present in the current schema:
+  -- one live Office row per (task_id, agent_profile_id).
+  -- The Office-only discriminator remains a separate schema decision.
 
 office_task_approval_decisions
   id              TEXT PK


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3228/9a78b3cc9189.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** `ErrOfficeSessionRaceConflict`'s classifier matched only the string `uniq_office_task_session` — an index that was never created, and that SQLite's UNIQUE-violation errors never contain anyway (SQLite reports the column list, not the index name). The guard read as armed and was permanently dead. The parallel UPDATE-side session-mutation path had no race classification at all, and several doc comments asserted a schema-level unique index exists when none does.
**After this:** The classifier matches SQLite's actual error text (column-list substring) and mirrors this repo's existing Postgres `PgError` pattern; it is wired into both the INSERT (`createTaskSession`, reached by all 5 session-create entry points) and UPDATE (`updateTaskSessionWithStateGuard`, reached by all 4 session-update entry points) paths. Every doc comment that implied the index already exists now says plainly that it doesn't.
**Who hits this:** Anyone building on `(task_id, agent_profile_id)` uniqueness for Office sessions — most immediately an already-open follow-up card that adds the actual DB-level unique index, which needs this classifier working correctly once that index lands.
**Scope:** standalone defect fix; no schema change.
**Not here:** Adding the unique index itself. A table-wide index on `(task_id, agent_profile_id)` was attempted and reverted during this work because it broke real, currently-shipped flows — kanban relaunch, workflow-replacement sessions, and `spawn_session`'s default-profile inheritance all legitimately create a second live session sharing that pair. Scoping the constraint to Office only is a schema/contract decision, filed as its own follow-up card rather than folded into this PR.

Discovered while auditing Office's session-identity guard: the sentinel exists and is consumed by real recovery logic (`executor_office.go`'s `EnsureSessionForAgentWithCreation`), but nothing could ever make it fire.

## Validation

- `make -C apps/backend fmt` — clean (no diff)
- `make -C apps/backend lint` — `0 issues.`
- `go test ./internal/task/repository/sqlite/... ./internal/orchestrator/... ./internal/mcp/handlers/...` — all packages `ok`
- `make -C apps/backend test` (full suite) — only `internal/worktree` fails, a pre-existing macOS `/var` symlink temp-dir issue unrelated to this diff (independently reproduced against `origin/main` in earlier rounds; causally independent package from the two touched here)
- `pnpm --filter @kandev/web typecheck` / `lint` / `format:check` — clean (diff is backend-only, no `apps/web/` files touched)
- `pnpm run i18n:ratchet` — "no UI source added or modified"

## Possible Improvements

Low risk: comment- and classification-only changes, no behavior change reachable in production today (the guard still can't fire without the deferred index). The Postgres branch of the new classifier has no dedicated unit test yet — this repo's convention for that (`*_postgres_test.go` against a real Postgres) needs a schema that exists, which is blocked on the same follow-up card that adds the index.

## Checklist

- [x] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->