### PR TITLE
fix(web): normalize structured task confirmations

### DIFF
--- a/apps/web/components/confirmation/action-confirm-popover.test.tsx
+++ b/apps/web/components/confirmation/action-confirm-popover.test.tsx
@@ -60,13 +60,20 @@ describe("ActionConfirmPopover", () => {
 
   it("supports a wider bounded surface without changing the default width", async () => {
     render(<Harness />);
-    expect(screen.getByRole("dialog").className).toContain("w-64");
+    const defaultDialog = screen.getByRole("dialog");
+    expect(defaultDialog.className).toContain("w-64");
+    expect(
+      defaultDialog.querySelector<HTMLElement>('[data-slot="popover-description"]')?.className,
+    ).not.toContain("text-pretty");
 
     cleanup();
     render(<Harness size="wide" />);
     const wideDialog = screen.getByRole("dialog");
     expect(wideDialog.className).toContain("w-72");
     expect(wideDialog.className).toContain("max-w-[calc(100vw-1rem)]");
+    expect(
+      wideDialog.querySelector<HTMLElement>('[data-slot="popover-description"]')?.className,
+    ).toContain("text-pretty");
   });
 
   it("closes before invoking an unresolved confirmation and returns focus on cancel", async () => {

--- a/apps/web/components/confirmation/action-confirm-popover.tsx
+++ b/apps/web/components/confirmation/action-confirm-popover.tsx
@@ -216,7 +216,12 @@ function ActionConfirmPopoverContent({
       <PopoverHeader>
         <PopoverTitle id={titleId}>{title}</PopoverTitle>
         {description ? (
-          <PopoverDescription id={descriptionId}>{description}</PopoverDescription>
+          <PopoverDescription
+            id={descriptionId}
+            className={size === "wide" ? "text-pretty" : undefined}
+          >
+            {description}
+          </PopoverDescription>
         ) : null}
       </PopoverHeader>
       <div className="flex justify-end gap-2">

--- a/apps/web/components/task/session-delete-description.tsx
+++ b/apps/web/components/task/session-delete-description.tsx
@@ -5,18 +5,33 @@ import { useTranslation } from "react-i18next";
 export function SessionDeleteDescription({
   isPrimary,
   isOnlySession,
+  structured = false,
 }: {
   isPrimary: boolean;
   isOnlySession: boolean;
+  structured?: boolean;
 }) {
   const { t } = useTranslation();
+  const primaryNotice = isPrimary && !isOnlySession;
+  const onlySessionNotice = isOnlySession;
+
+  if (structured) {
+    return (
+      <>
+        <p>{t("task:thisWillPermanentlyDeleteTheConversation")}</p>
+        {primaryNotice && <p className="font-medium">{t("task:thisIsThePrimarySessionAnother")}</p>}
+        {onlySessionNotice && <p className="font-medium">{t("task:thisIsTheOnlySessionFor")}</p>}
+      </>
+    );
+  }
+
   return (
     <>
       <span>{t("task:thisWillPermanentlyDeleteTheConversation")}</span>
-      {isPrimary && !isOnlySession && (
+      {primaryNotice && (
         <span className="mt-2 block font-medium">{t("task:thisIsThePrimarySessionAnother")}</span>
       )}
-      {isOnlySession && (
+      {onlySessionNotice && (
         <span className="mt-2 block font-medium">{t("task:thisIsTheOnlySessionFor")}</span>
       )}
     </>

--- a/apps/web/components/task/session-delete-description.tsx
+++ b/apps/web/components/task/session-delete-description.tsx
@@ -13,14 +13,13 @@ export function SessionDeleteDescription({
 }) {
   const { t } = useTranslation();
   const primaryNotice = isPrimary && !isOnlySession;
-  const onlySessionNotice = isOnlySession;
 
   if (structured) {
     return (
       <>
         <p>{t("task:thisWillPermanentlyDeleteTheConversation")}</p>
         {primaryNotice && <p className="font-medium">{t("task:thisIsThePrimarySessionAnother")}</p>}
-        {onlySessionNotice && <p className="font-medium">{t("task:thisIsTheOnlySessionFor")}</p>}
+        {isOnlySession && <p className="font-medium">{t("task:thisIsTheOnlySessionFor")}</p>}
       </>
     );
   }
@@ -31,7 +30,7 @@ export function SessionDeleteDescription({
       {primaryNotice && (
         <span className="mt-2 block font-medium">{t("task:thisIsThePrimarySessionAnother")}</span>
       )}
-      {onlySessionNotice && (
+      {isOnlySession && (
         <span className="mt-2 block font-medium">{t("task:thisIsTheOnlySessionFor")}</span>
       )}
     </>

--- a/apps/web/components/task/session-tab-menu.test.tsx
+++ b/apps/web/components/task/session-tab-menu.test.tsx
@@ -26,6 +26,12 @@ describe("DeleteSessionDialog", () => {
     expect(dialog.textContent).toContain("permanently delete the conversation history");
     expect(dialog.textContent).toContain("task workspace and its files are kept");
     expect(dialog.textContent).toContain("only session for this task");
+    const description = dialog.querySelector('[data-slot="alert-dialog-description"]');
+    expect(description).not.toBeNull();
+    expect(description?.id).toBe(dialog.getAttribute("aria-describedby"));
+    expect(description?.classList.contains("min-w-0")).toBe(true);
+    expect(description?.classList.contains("text-left")).toBe(true);
+    expect(description?.querySelectorAll("p")).toHaveLength(2);
     // No uncommitted/unpushed warning belongs on session deletion.
     expect(dialog.textContent).not.toContain("uncommitted");
     expect(dialog.textContent).not.toContain("unpushed");

--- a/apps/web/components/task/session-tab-menu.tsx
+++ b/apps/web/components/task/session-tab-menu.tsx
@@ -53,8 +53,12 @@ export function DeleteSessionDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>{t("task:deleteSession")}</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div>
-              <SessionDeleteDescription isPrimary={isPrimary} isOnlySession={sessionCount === 1} />
+            <div className="min-w-0 space-y-2 text-left">
+              <SessionDeleteDescription
+                isPrimary={isPrimary}
+                isOnlySession={sessionCount === 1}
+                structured
+              />
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/web/components/task/task-detach-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-detach-confirm-dialog.test.tsx
@@ -70,17 +70,25 @@ describe("task detach confirmation adapters", () => {
   });
 
   it("keeps task-switcher detachment on its existing modal branch", async () => {
+    const longTaskTitle = `Child task ${"x".repeat(180)}`;
     render(
       <TaskDetachTargetConfirmDialog
-        target={{ id: "child", title: "Child task", workspaceMode: "inherit_parent" }}
+        target={{ id: "child", title: longTaskTitle, workspaceMode: "inherit_parent" }}
         detachingTaskId={null}
         onDismiss={vi.fn()}
         onConfirm={vi.fn()}
       />,
     );
 
-    await waitFor(() =>
-      expect(screen.getByRole("alertdialog", { name: "Detach task from parent?" })).not.toBeNull(),
-    );
+    await waitFor(() => {
+      const dialog = screen.getByRole("alertdialog", { name: "Detach task from parent?" });
+      const description = dialog.querySelector('[data-slot="alert-dialog-description"]');
+      expect(description).not.toBeNull();
+      expect(description?.id).toBe(dialog.getAttribute("aria-describedby"));
+      expect(description?.classList.contains("min-w-0")).toBe(true);
+      expect(description?.classList.contains("text-left")).toBe(true);
+      expect(description?.querySelectorAll("p")).toHaveLength(3);
+      expect(description?.textContent).toContain(longTaskTitle);
+    });
   });
 });

--- a/apps/web/components/task/task-detach-confirm-dialog.tsx
+++ b/apps/web/components/task/task-detach-confirm-dialog.tsx
@@ -28,13 +28,32 @@ export type TaskDetachConfirmationCopyProps = {
 function TaskDetachDescription({
   taskTitle,
   sharesParentWorkspace,
-}: TaskDetachConfirmationCopyProps): ReactNode {
+  structured = false,
+}: TaskDetachConfirmationCopyProps & { structured?: boolean }): ReactNode {
   const { t } = useTranslation();
+  const title = taskTitle || t("task:thisTask2");
+
+  if (structured) {
+    return (
+      <>
+        <p className="break-words">
+          {t("task:detachWillBecomeTopLevel", {
+            taskTitle: title,
+          })}
+        </p>
+        <p>{t("task:detachingChangesTheHierarchyOnlyAccess")}</p>
+        {sharesParentWorkspace && (
+          <p className="font-medium text-foreground">{t("task:thisTaskSharesItsParentS")}</p>
+        )}
+      </>
+    );
+  }
+
   return (
     <span className="block space-y-2">
       <span className="block">
         {t("task:detachWillBecomeTopLevel", {
-          taskTitle: taskTitle || t("task:thisTask2"),
+          taskTitle: title,
         })}
       </span>
       <span className="block">{t("task:detachingChangesTheHierarchyOnlyAccess")}</span>
@@ -208,10 +227,11 @@ export function TaskDetachConfirmDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>{t(DETACH_TASK_FROM_PARENT_KEY)}</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div>
+            <div className="min-w-0 space-y-2 text-left">
               <TaskDetachDescription
                 taskTitle={taskTitle}
                 sharesParentWorkspace={sharesParentWorkspace}
+                structured
               />
             </div>
           </AlertDialogDescription>

--- a/apps/web/components/task/task-reset-env-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-reset-env-confirm-dialog.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TaskResetEnvConfirmDialog } from "./task-reset-env-confirm-dialog";
+
+afterEach(cleanup);
+
+describe("TaskResetEnvConfirmDialog", () => {
+  it("renders structured warning copy through one left-aligned description", () => {
+    render(
+      <TaskResetEnvConfirmDialog open onOpenChange={vi.fn()} hasWorktreePath onConfirm={vi.fn()} />,
+    );
+
+    const dialog = screen.getByRole("alertdialog", { name: "Reset environment?" });
+    const description = dialog.querySelector('[data-slot="alert-dialog-description"]');
+    expect(description).not.toBeNull();
+    expect(description?.id).toBe(dialog.getAttribute("aria-describedby"));
+    expect(description?.classList.contains("min-w-0")).toBe(true);
+    expect(description?.classList.contains("text-left")).toBe(true);
+    expect(description?.querySelectorAll("p")).toHaveLength(2);
+    expect(description?.textContent).toContain("Any uncommitted or unpushed changes");
+  });
+});

--- a/apps/web/components/task/task-reset-env-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-reset-env-confirm-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TaskResetEnvConfirmDialog } from "./task-reset-env-confirm-dialog";
@@ -19,5 +19,52 @@ describe("TaskResetEnvConfirmDialog", () => {
     expect(description?.classList.contains("text-left")).toBe(true);
     expect(description?.querySelectorAll("p")).toHaveLength(2);
     expect(description?.textContent).toContain("Any uncommitted or unpushed changes");
+  });
+
+  it("requires acknowledgment and passes the push-branch choice to confirmation", () => {
+    const onConfirm = vi.fn();
+    render(
+      <TaskResetEnvConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        hasWorktreePath
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirm = screen.getByTestId("reset-env-confirm") as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /push the current branch to its remote before resetting/i,
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /I understand any uncommitted changes will be lost/i,
+      }),
+    );
+
+    expect(confirm.disabled).toBe(false);
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledWith({ pushBranch: true });
+  });
+
+  it("locks both choices and confirmation while resetting", () => {
+    render(
+      <TaskResetEnvConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        hasWorktreePath
+        isResetting
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect((checkbox as HTMLButtonElement).disabled).toBe(true);
+    }
+    expect((screen.getByTestId("reset-env-confirm") as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/apps/web/components/task/task-reset-env-confirm-dialog.tsx
+++ b/apps/web/components/task/task-reset-env-confirm-dialog.tsx
@@ -49,7 +49,7 @@ export function TaskResetEnvConfirmDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>{t("task:resetEnvironment")}</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-2">
+            <div className="min-w-0 space-y-2 text-left">
               <p>{t("task:thisTearsDownTheCurrentContainer")}</p>
               <p className="text-destructive">{t("task:anyUncommittedOrUnpushedChangesIn")}</p>
             </div>

--- a/docs/plans/surface-text-hierarchy/plan.md
+++ b/docs/plans/surface-text-hierarchy/plan.md
@@ -106,7 +106,7 @@ the final composition.
 - [x] [Task 01: Standardize surface typography primitives](task-01-standardize-surface-typography-primitives.md) (completed)
 - [x] [Task 02: Normalize structured app confirmations](task-02-normalize-structured-app-confirmations.md) (completed)
 - [x] [Task 03: Refine task cleanup confirmations](task-03-refine-task-cleanup-confirmations.md) (completed)
-- [ ] [Task 04: Normalize structured task confirmations](task-04-normalize-structured-task-confirmations.md)
+- [x] [Task 04: Normalize structured task confirmations](task-04-normalize-structured-task-confirmations.md) (completed)
 - [ ] [Task 05: Add responsive text hierarchy E2E](task-05-add-responsive-text-hierarchy-e2e.md)
 
 ## Risks

--- a/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
+++ b/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
@@ -104,3 +104,7 @@ pnpm run i18n:check
 - Focused verification passed with 3 test files and 11 tests. Web typecheck,
   focused ESLint with `--max-warnings 0`, `pnpm run i18n:check`, targeted
   Prettier, and `git diff --check` also passed on the integrated stack.
+- Exact-head E2E integration exposed that the archive-only wide popover had
+  lost its specified pretty prose wrapping. The wide size contract now applies
+  `text-pretty` to its description while the default popover remains unchanged;
+  the shared popover and archive confirmation suites pass 20 tests.

--- a/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
+++ b/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
@@ -1,7 +1,7 @@
 ---
 id: "04-normalize-structured-task-confirmations"
 title: "Normalize structured task confirmations"
-status: pending
+status: completed
 wave: 2
 depends_on:
   - "01-standardize-surface-typography-primitives"
@@ -93,4 +93,14 @@ pnpm run i18n:check
 
 ## Results
 
-Pending implementation.
+- RED: Focused assertions failed against the pre-change wrapperless fragments
+  and spans because the three dialogs lacked the required semantic paragraph
+  structure, left alignment, containment, and single description boundary.
+- GREEN: Session deletion, task detachment, and environment reset now render
+  structured paragraphs inside one `min-w-0 text-left` AlertDialog description;
+  compact popover and inline descriptions remain unchanged.
+- Added a shared session-delete description renderer plus focused coverage for
+  all three surfaces, including a 180-character dynamic task title.
+- Focused verification passed with 3 test files and 9 tests. Web typecheck,
+  focused ESLint with `--max-warnings 0`, `pnpm run i18n:check`, targeted
+  Prettier, and `git diff --check` also passed on the integrated stack.

--- a/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
+++ b/docs/plans/surface-text-hierarchy/task-04-normalize-structured-task-confirmations.md
@@ -101,6 +101,6 @@ pnpm run i18n:check
   compact popover and inline descriptions remain unchanged.
 - Added a shared session-delete description renderer plus focused coverage for
   all three surfaces, including a 180-character dynamic task title.
-- Focused verification passed with 3 test files and 9 tests. Web typecheck,
+- Focused verification passed with 3 test files and 11 tests. Web typecheck,
   focused ESLint with `--max-warnings 0`, `pnpm run i18n:check`, targeted
   Prettier, and `git diff --check` also passed on the integrated stack.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3234/ab38cf43f7f7.html)
<!-- kandev-pr-walkthrough-end -->

Structured confirmation copy was visually flat and fragile around long dynamic values. Session deletion, task detachment, and environment reset now use semantic paragraph grouping, readable spacing, left alignment, and explicit width containment while preserving behavior. The archive-only wide popover also preserves the approved pretty prose wrapping without changing the default compact popover.

## Validation

- Exact post-restack head: `ec053d98462c8a27a64623a52bcdfff1477c0c58`.
- `pnpm --filter @kandev/web test -- components/confirmation/action-confirm-popover.test.tsx components/task/task-archive-confirmation.test.tsx components/task/session-tab-menu.test.tsx components/task/task-detach-confirm-dialog.test.tsx components/task/task-reset-env-confirm-dialog.test.tsx` (5 files, 31 tests).
- `pnpm --filter @kandev/web run typecheck`.
- Focused ESLint with `--max-warnings 0` across affected component and test files.
- `pnpm run i18n:check`.
- Targeted Prettier, `git diff --check`, and `python3 scripts/lint-spec-files.py --all`.
- Fresh production-bundle Playwright passed on the exact head: archive, session deletion, and task detachment 3/3 in desktop Chromium; session deletion and task detachment 2/2 in Pixel 5 mobile Chrome; environment reset 1/1 in the real-container project.
- Browser-computed archive-popover evidence confirms `text-wrap: pretty`. All six privacy-safe synthetic captures were independently inspected, losslessly compressed with pixels preserved, and published in parentless media commit `d399def60cafc223a6e8f2f0fabd50e3736bbe1a`; pinned raw URLs returned HTTP 200 and matched the published hashes.
- Public docs are unaffected; the implementation plan and Task 04 results are current.

## Screenshots

<!-- kandev-screenshots-start -->

| Surface | Evidence |
| --- | --- |
| Archive confirmation popover (desktop) | ![Wide archive confirmation popover with readable wrapped prose](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/archive-popover-desktop.png) |
| Session deletion (desktop) | ![Structured session deletion confirmation on desktop](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/session-delete-desktop.png) |
| Session deletion (mobile) | ![Structured session deletion confirmation on a Pixel 5](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/session-delete-mobile.png) |
| Task detachment (desktop) | ![Structured task detachment confirmation on desktop](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/task-detach-desktop.png) |
| Task detachment (mobile) | ![Structured task detachment confirmation on a Pixel 5](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/task-detach-mobile.png) |
| Environment reset (desktop) | ![Structured environment reset warning on desktop](https://raw.githubusercontent.com/kdlbs/kandev/5180ac869138d4df86ad08ceef4bbe6e47dc6561/environment-reset-desktop.png) |

<!-- kandev-screenshots-end -->

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
