### PR TITLE
test(backend): catch active-session state drift between SQL and Go

### DIFF
--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -1458,6 +1458,25 @@ const (
 	TaskSessionStateCancelled TaskSessionState = "CANCELLED"
 )
 
+// AllTaskSessionStates is the canonical, exhaustive list of TaskSessionState
+// constants. Code that must cover every state (drift-guard tests, admin
+// tooling) should range over this slice instead of hand-writing its own
+// literal: Go does not enforce switch/slice exhaustiveness (the exhaustive
+// linter is not enabled in this repo), so a hand-written literal silently
+// stops covering new states the moment one is added here. Add a new
+// TaskSessionState constant to this slice in the same change that adds the
+// const.
+var AllTaskSessionStates = []TaskSessionState{
+	TaskSessionStateCreated,
+	TaskSessionStateStarting,
+	TaskSessionStateRunning,
+	TaskSessionStateIdle,
+	TaskSessionStateWaitingForInput,
+	TaskSessionStateCompleted,
+	TaskSessionStateFailed,
+	TaskSessionStateCancelled,
+}
+
 // SessionBranchInfo is a lightweight projection of a session with its worktree branch.
 // Used by the PR watch reconciler to find sessions that may need PR watches.
 type SessionBranchInfo struct {

--- a/apps/backend/internal/task/models/session_state_sets.go
+++ b/apps/backend/internal/task/models/session_state_sets.go
@@ -1,0 +1,23 @@
+package models
+
+// IsActiveSessionState reports whether a session is in the "active" set used by
+// GetActiveTaskSessionByTaskID's SQL filter
+// (internal/task/repository/sqlite/session.go): Created, Starting, Running, and
+// WaitingForInput. TestActiveSessionStateMatchesSQLFilter cross-checks this
+// function against that SQL filter directly, so the two cannot drift silently —
+// edit one without the other and the test fails.
+//
+// This is a different set from its neighbour IsResumableSessionState: active
+// INCLUDES Created (a session not yet picked up still counts as the task's
+// active one) and EXCLUDES Idle (an office session between turns is resumable
+// but not the task's currently active session); resumable is the exact inverse
+// on both points.
+func IsActiveSessionState(state TaskSessionState) bool {
+	switch state {
+	case TaskSessionStateCreated, TaskSessionStateStarting,
+		TaskSessionStateRunning, TaskSessionStateWaitingForInput:
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/backend/internal/task/models/session_state_sets.go
+++ b/apps/backend/internal/task/models/session_state_sets.go
@@ -1,27 +1,17 @@
 package models
 
-// IsActiveSessionState reports whether a session is in the "active" set used by
-// GetActiveTaskSessionByTaskID's SQL filter
-// (internal/task/repository/sqlite/session.go): Created, Starting, Running, and
-// WaitingForInput. TestActiveSessionStateMatchesSQLFilter cross-checks this
-// function against that SQL filter for every state in AllTaskSessionStates, so
-// editing the SQL filter or this switch without updating the other fails that
-// test. That guard only covers the states already in AllTaskSessionStates —
-// adding a new TaskSessionState constant without also adding it there (and,
-// if it should be active, to this switch) is not caught by anything: Go does
-// not enforce switch/slice exhaustiveness.
+// IsTaskLookupActiveSessionState reports whether a session belongs to the active
+// set used by GetActiveTaskSessionByTaskID. The active states are Created,
+// Starting, Running, and WaitingForInput. TestActiveSessionStateMatchesSQLFilter
+// cross-checks this predicate against the SQL filter for every state in
+// AllTaskSessionStates.
 //
 // This is a different set from its neighbour IsResumableSessionState: active
 // INCLUDES Created (a session not yet picked up still counts as the task's
 // active one) and EXCLUDES Idle (an office session between turns is resumable
 // but not the task's currently active session); resumable is the exact inverse
 // on both points.
-//
-// Currently has no production caller: it exists ahead of the pending
-// delegation from office/engine_dispatcher.isActiveDeciderSessionState, which
-// is blocked on PR #3218 merging (see follow-up task
-// d6bb06fb-c97b-40d8-8f5f-b5cfde64873d).
-func IsActiveSessionState(state TaskSessionState) bool {
+func IsTaskLookupActiveSessionState(state TaskSessionState) bool {
 	switch state {
 	case TaskSessionStateCreated, TaskSessionStateStarting,
 		TaskSessionStateRunning, TaskSessionStateWaitingForInput:

--- a/apps/backend/internal/task/models/session_state_sets.go
+++ b/apps/backend/internal/task/models/session_state_sets.go
@@ -4,14 +4,23 @@ package models
 // GetActiveTaskSessionByTaskID's SQL filter
 // (internal/task/repository/sqlite/session.go): Created, Starting, Running, and
 // WaitingForInput. TestActiveSessionStateMatchesSQLFilter cross-checks this
-// function against that SQL filter directly, so the two cannot drift silently —
-// edit one without the other and the test fails.
+// function against that SQL filter for every state in AllTaskSessionStates, so
+// editing the SQL filter or this switch without updating the other fails that
+// test. That guard only covers the states already in AllTaskSessionStates —
+// adding a new TaskSessionState constant without also adding it there (and,
+// if it should be active, to this switch) is not caught by anything: Go does
+// not enforce switch/slice exhaustiveness.
 //
 // This is a different set from its neighbour IsResumableSessionState: active
 // INCLUDES Created (a session not yet picked up still counts as the task's
 // active one) and EXCLUDES Idle (an office session between turns is resumable
 // but not the task's currently active session); resumable is the exact inverse
 // on both points.
+//
+// Currently has no production caller: it exists ahead of the pending
+// delegation from office/engine_dispatcher.isActiveDeciderSessionState, which
+// is blocked on PR #3218 merging (see follow-up task
+// d6bb06fb-c97b-40d8-8f5f-b5cfde64873d).
 func IsActiveSessionState(state TaskSessionState) bool {
 	switch state {
 	case TaskSessionStateCreated, TaskSessionStateStarting,

--- a/apps/backend/internal/task/models/session_state_sets_test.go
+++ b/apps/backend/internal/task/models/session_state_sets_test.go
@@ -14,20 +14,32 @@ func TestIsActiveSessionState(t *testing.T) {
 		TaskSessionStateCancelled:       false,
 	}
 
-	// AllTaskSessionStates is the canonical, exhaustive state list; this length
-	// check trips if a new TaskSessionState constant is added to models.go
-	// without extending AllTaskSessionStates alongside it.
-	if len(AllTaskSessionStates) != 8 {
-		t.Fatalf("len(AllTaskSessionStates) = %d, want 8 (a TaskSessionState constant was added or "+
-			"removed without updating this test's expectations table)", len(AllTaskSessionStates))
+	// AllTaskSessionStates is the canonical list this test ranges over. The checks
+	// below assert it and want cover exactly the same set, with no duplicates — so
+	// extending AllTaskSessionStates without extending want, or a duplicated/dropped
+	// entry silently shrinking coverage, fails here. What this CANNOT catch: a new
+	// TaskSessionState constant added to models.go but never added to
+	// AllTaskSessionStates. Go does not enforce exhaustiveness and the exhaustive
+	// linter is not enabled in this repo.
+	seen := make(map[TaskSessionState]bool, len(AllTaskSessionStates))
+	for _, state := range AllTaskSessionStates {
+		if seen[state] {
+			t.Fatalf("AllTaskSessionStates contains duplicate %q; coverage silently shrinks", state)
+		}
+		seen[state] = true
+		if _, ok := want[state]; !ok {
+			t.Fatalf("no expectation recorded for state %q; add one to this test's want map", state)
+		}
+	}
+	for state := range want {
+		if !seen[state] {
+			t.Fatalf("want has %q but AllTaskSessionStates does not; the canonical list lost a state", state)
+		}
 	}
 
 	for _, state := range AllTaskSessionStates {
 		t.Run(string(state), func(t *testing.T) {
-			wantActive, ok := want[state]
-			if !ok {
-				t.Fatalf("no expectation recorded for state %q; add one to this test's want map", state)
-			}
+			wantActive := want[state]
 			if got := IsActiveSessionState(state); got != wantActive {
 				t.Errorf("IsActiveSessionState(%q) = %v, want %v", state, got, wantActive)
 			}

--- a/apps/backend/internal/task/models/session_state_sets_test.go
+++ b/apps/backend/internal/task/models/session_state_sets_test.go
@@ -2,7 +2,9 @@ package models
 
 import "testing"
 
-func TestIsActiveSessionState(t *testing.T) {
+// TestIsTaskLookupActiveSessionState verifies the active-state contract used by
+// GetActiveTaskSessionByTaskID.
+func TestIsTaskLookupActiveSessionState(t *testing.T) {
 	want := map[TaskSessionState]bool{
 		TaskSessionStateCreated:         true,
 		TaskSessionStateStarting:        true,
@@ -40,8 +42,8 @@ func TestIsActiveSessionState(t *testing.T) {
 	for _, state := range AllTaskSessionStates {
 		t.Run(string(state), func(t *testing.T) {
 			wantActive := want[state]
-			if got := IsActiveSessionState(state); got != wantActive {
-				t.Errorf("IsActiveSessionState(%q) = %v, want %v", state, got, wantActive)
+			if got := IsTaskLookupActiveSessionState(state); got != wantActive {
+				t.Errorf("IsTaskLookupActiveSessionState(%q) = %v, want %v", state, got, wantActive)
 			}
 		})
 	}

--- a/apps/backend/internal/task/models/session_state_sets_test.go
+++ b/apps/backend/internal/task/models/session_state_sets_test.go
@@ -1,0 +1,26 @@
+package models
+
+import "testing"
+
+func TestIsActiveSessionState(t *testing.T) {
+	tests := []struct {
+		state TaskSessionState
+		want  bool
+	}{
+		{TaskSessionStateCreated, true},
+		{TaskSessionStateStarting, true},
+		{TaskSessionStateRunning, true},
+		{TaskSessionStateIdle, false},
+		{TaskSessionStateWaitingForInput, true},
+		{TaskSessionStateCompleted, false},
+		{TaskSessionStateFailed, false},
+		{TaskSessionStateCancelled, false},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.state), func(t *testing.T) {
+			if got := IsActiveSessionState(tc.state); got != tc.want {
+				t.Errorf("IsActiveSessionState(%q) = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/task/models/session_state_sets_test.go
+++ b/apps/backend/internal/task/models/session_state_sets_test.go
@@ -3,23 +3,33 @@ package models
 import "testing"
 
 func TestIsActiveSessionState(t *testing.T) {
-	tests := []struct {
-		state TaskSessionState
-		want  bool
-	}{
-		{TaskSessionStateCreated, true},
-		{TaskSessionStateStarting, true},
-		{TaskSessionStateRunning, true},
-		{TaskSessionStateIdle, false},
-		{TaskSessionStateWaitingForInput, true},
-		{TaskSessionStateCompleted, false},
-		{TaskSessionStateFailed, false},
-		{TaskSessionStateCancelled, false},
+	want := map[TaskSessionState]bool{
+		TaskSessionStateCreated:         true,
+		TaskSessionStateStarting:        true,
+		TaskSessionStateRunning:         true,
+		TaskSessionStateIdle:            false,
+		TaskSessionStateWaitingForInput: true,
+		TaskSessionStateCompleted:       false,
+		TaskSessionStateFailed:          false,
+		TaskSessionStateCancelled:       false,
 	}
-	for _, tc := range tests {
-		t.Run(string(tc.state), func(t *testing.T) {
-			if got := IsActiveSessionState(tc.state); got != tc.want {
-				t.Errorf("IsActiveSessionState(%q) = %v, want %v", tc.state, got, tc.want)
+
+	// AllTaskSessionStates is the canonical, exhaustive state list; this length
+	// check trips if a new TaskSessionState constant is added to models.go
+	// without extending AllTaskSessionStates alongside it.
+	if len(AllTaskSessionStates) != 8 {
+		t.Fatalf("len(AllTaskSessionStates) = %d, want 8 (a TaskSessionState constant was added or "+
+			"removed without updating this test's expectations table)", len(AllTaskSessionStates))
+	}
+
+	for _, state := range AllTaskSessionStates {
+		t.Run(string(state), func(t *testing.T) {
+			wantActive, ok := want[state]
+			if !ok {
+				t.Fatalf("no expectation recorded for state %q; add one to this test's want map", state)
+			}
+			if got := IsActiveSessionState(state); got != wantActive {
+				t.Errorf("IsActiveSessionState(%q) = %v, want %v", state, got, wantActive)
 			}
 		})
 	}

--- a/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestActiveSessionStateMatchesSQLFilter cross-checks GetActiveTaskSessionByTaskID's
-// SQL state filter against models.IsActiveSessionState for every state in
+// SQL state filter against models.IsTaskLookupActiveSessionState for every state in
 // models.AllTaskSessionStates, the package's single canonical state list. Editing
 // the SQL filter without updating the predicate (or vice versa) fails this test
 // instead of only a stale comment — but only for states already present in
@@ -37,7 +37,7 @@ func TestActiveSessionStateMatchesSQLFilter(t *testing.T) {
 			}
 
 			got, err := repo.GetActiveTaskSessionByTaskID(ctx, taskID)
-			wantActive := models.IsActiveSessionState(state)
+			wantActive := models.IsTaskLookupActiveSessionState(state)
 
 			if wantActive {
 				if err != nil {

--- a/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
@@ -1,0 +1,64 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// TestActiveSessionStateMatchesSQLFilter cross-checks GetActiveTaskSessionByTaskID's
+// SQL state filter against models.IsActiveSessionState for every TaskSessionState
+// constant, enumerated literally so a newly added state is a compile-visible
+// omission rather than a silent skip. Editing the SQL filter without updating the
+// predicate (or vice versa) fails this test instead of only a stale comment.
+func TestActiveSessionStateMatchesSQLFilter(t *testing.T) {
+	allStates := []models.TaskSessionState{
+		models.TaskSessionStateCreated,
+		models.TaskSessionStateStarting,
+		models.TaskSessionStateRunning,
+		models.TaskSessionStateIdle,
+		models.TaskSessionStateWaitingForInput,
+		models.TaskSessionStateCompleted,
+		models.TaskSessionStateFailed,
+		models.TaskSessionStateCancelled,
+	}
+
+	for _, state := range allStates {
+		t.Run(string(state), func(t *testing.T) {
+			repo := newRepoForSessionTests(t)
+			ctx := context.Background()
+			taskID := "task-active-state-" + string(state)
+			sessionID := "session-active-state-" + string(state)
+
+			if err := repo.CreateTask(ctx, &models.Task{ID: taskID, Title: "Active state check"}); err != nil {
+				t.Fatalf("CreateTask: %v", err)
+			}
+			if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+				ID:     sessionID,
+				TaskID: taskID,
+				State:  state,
+			}); err != nil {
+				t.Fatalf("CreateTaskSession: %v", err)
+			}
+
+			got, err := repo.GetActiveTaskSessionByTaskID(ctx, taskID)
+			wantActive := models.IsActiveSessionState(state)
+
+			if wantActive {
+				if err != nil {
+					t.Fatalf("GetActiveTaskSessionByTaskID(%q) = %v, want session (state %q is active)", taskID, err, state)
+				}
+				if got == nil || got.ID != sessionID {
+					t.Fatalf("GetActiveTaskSessionByTaskID(%q) returned wrong session: %+v", taskID, got)
+				}
+				return
+			}
+
+			if !errors.Is(err, models.ErrTaskSessionNotFound) {
+				t.Fatalf("GetActiveTaskSessionByTaskID(%q) = (%v, %v), want ErrTaskSessionNotFound (state %q is not active)", taskID, got, err, state)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_active_state_test.go
@@ -9,23 +9,16 @@ import (
 )
 
 // TestActiveSessionStateMatchesSQLFilter cross-checks GetActiveTaskSessionByTaskID's
-// SQL state filter against models.IsActiveSessionState for every TaskSessionState
-// constant, enumerated literally so a newly added state is a compile-visible
-// omission rather than a silent skip. Editing the SQL filter without updating the
-// predicate (or vice versa) fails this test instead of only a stale comment.
+// SQL state filter against models.IsActiveSessionState for every state in
+// models.AllTaskSessionStates, the package's single canonical state list. Editing
+// the SQL filter without updating the predicate (or vice versa) fails this test
+// instead of only a stale comment — but only for states already present in
+// AllTaskSessionStates: Go does not enforce switch/slice exhaustiveness, so a new
+// TaskSessionState constant added to models.go without also being added to
+// AllTaskSessionStates is not caught by this test (or by any linter — the
+// exhaustive linter is not enabled in this repo).
 func TestActiveSessionStateMatchesSQLFilter(t *testing.T) {
-	allStates := []models.TaskSessionState{
-		models.TaskSessionStateCreated,
-		models.TaskSessionStateStarting,
-		models.TaskSessionStateRunning,
-		models.TaskSessionStateIdle,
-		models.TaskSessionStateWaitingForInput,
-		models.TaskSessionStateCompleted,
-		models.TaskSessionStateFailed,
-		models.TaskSessionStateCancelled,
-	}
-
-	for _, state := range allStates {
+	for _, state := range models.AllTaskSessionStates {
 		t.Run(string(state), func(t *testing.T) {
 			repo := newRepoForSessionTests(t)
 			ctx := context.Background()


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3236/3857dbe3170f.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** `GetActiveTaskSessionByTaskID`'s SQL `state IN (...)` filter and the Go code that must agree with it (a dispatcher predicate landing in PR #3218, plus any future caller) have no shared source of truth, just a hand-written comment asking whoever edits one to remember the other. Nothing fails if a future state (e.g. `QUEUED`, `PAUSED`) is added to one side and not the other.
**After this:** A single `taskmodels.IsActiveSessionState` predicate plus a table-driven sqlite test cross-check every known `TaskSessionState` against the live SQL query. Edit the SQL filter without the predicate, or the predicate without the SQL, and a named test fails instead of a comment quietly going stale.
**Who hits this:** Backend contributors editing task-session state handling; low frequency today, but the guard means the next person doesn't have to notice a stale comment by eye.
**Scope:** Standalone chore, split off a review thread on [kdlbs/kandev#3218](https://github.com/kdlbs/kandev/pull/3218#discussion_r3897295867). That PR is still open; a follow-up task exists to wire its dispatcher predicate to call this one once #3218 merges (not part of this PR).
**Not here:** The 18 other duplicated `state IN (...)` SQL literals elsewhere in this codebase, the separate "active-5" (includes `IDLE`) variant used by 6 call sites, and `statussummary.isActiveSessionState` (a third, string-typed definition). Unifying those is a larger cross-subsystem change out of scope for this chore.

A PR review on #3218 flagged that its new `isActiveDeciderSessionState` switch has to be hand-kept in sync with `GetActiveTaskSessionByTaskID`'s SQL filter, with only a comment enforcing it. This adds a shared predicate and a cross-check test so a future state-set change trips a test instead of only a stale comment.

## Important Changes

- Added `taskmodels.IsActiveSessionState(state TaskSessionState) bool` (`apps/backend/internal/task/models/session_state_sets.go`), doc-commented against its neighbour `IsResumableSessionState` (opposite on both `CREATED` and `IDLE`).
- Hoisted `taskmodels.AllTaskSessionStates`, a canonical `[]TaskSessionState` slice next to the state constants, so tests iterate one source of truth instead of separate hand-written literals.
- Added `TestActiveSessionStateMatchesSQLFilter` (`apps/backend/internal/task/repository/sqlite/session_active_state_test.go`): one task/session per state, asserts `GetActiveTaskSessionByTaskID` returns the row iff the predicate says active.
- Added `TestIsActiveSessionState` for the predicate itself, with a set-equality check (not a raw length check) that `AllTaskSessionStates` and the test's expectation table cover exactly the same states with no duplicates — a `len() != 8` check alone would miss a copy-paste duplicate silently dropping a state from coverage.
- Documented, not hidden: a brand-new `TaskSessionState` constant added to `models.go` but never added to `AllTaskSessionStates` is caught by nothing here — Go doesn't enforce switch/slice exhaustiveness and the `exhaustive` linter isn't enabled in this repo. Stated explicitly in the doc comments rather than implied.

## Validation

- `go test ./internal/task/models/... -run 'SessionState' -count=1 -v` — 9 sub-tests pass
- `go test ./internal/task/repository/sqlite/... -run 'ActiveSessionState' -count=1 -v` — 8 sub-tests pass
- Guard proven to fire in three independent directions (each reverted before commit):
  - predicate-side drift (dropped `CREATED` from the switch) → `TestIsActiveSessionState/CREATED` and the sqlite cross-check both fail
  - SQL-side drift (dropped `WAITING_FOR_INPUT` from the `IN (...)` list) → `TestActiveSessionStateMatchesSQLFilter/WAITING_FOR_INPUT` fails
  - canonical-list corruption (replaced `WAITING_FOR_INPUT` with a duplicate `RUNNING`, cardinality unchanged) → `AllTaskSessionStates contains duplicate "RUNNING"; coverage silently shrinks`
- `make -C apps/backend lint` — 0 issues
- `make fmt`, `make typecheck`, `make lint`, `make lint-format` — clean
- `pnpm run i18n:ratchet` (apps/web) — clean, no UI source touched
- `make test` — passes for every package this diff touches; remaining failures are pre-existing and environmental (macOS `/var` symlink issue on ~12 unrelated backend packages, Docker-daemon-unavailable on 3 web tests, host-`make`-version drift on 1 script test), independently reproduced against the merge-base in a scratch worktree
- E2E: not required. Diff is backend-Go-only (`internal/task/models/`, `internal/task/repository/sqlite/`); zero paths under `apps/web/`

## Possible Improvements

Low risk: additive-only change (new file, new exported predicate, new tests), no existing call site touched. `IsActiveSessionState` has no production caller yet — the dispatcher delegation is tracked as a separate follow-up task, blocked on #3218 merging, so it doesn't land in this PR.

## Checklist

- [ ] If this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->