### PR TITLE
fix: reconcile startup readiness recovery after restart

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2629,8 +2629,7 @@ func (s *Service) launchAfterOnEnterDispatch(
 				zap.String("session_id", sessionID),
 				zap.String("step_name", step.Name),
 				zap.Error(err))
-			s.setSessionWaitingForInput(ctx, taskID, sessionID, session)
-			s.publishSessionWaitingEvent(ctx, taskID, sessionID, step.ID, session)
+			s.parkWorkflowSessionAfterAutoStartFailure(ctx, taskID, sessionID, step.ID)
 		}
 
 	default:
@@ -2752,6 +2751,30 @@ func (s *Service) launchAfterOnEnterDispatch(
 		s.drainQueuedMessageForPromptableSession(ctx, sessionID)
 	}
 
+}
+
+func (s *Service) parkWorkflowSessionAfterAutoStartFailure(
+	ctx context.Context,
+	taskID, sessionID, stepID string,
+) {
+	latest, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		s.logger.Warn("failed to reload session after workflow auto-start failure",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return
+	}
+	if latest == nil || isTerminalSessionState(latest.State) {
+		return
+	}
+
+	s.setSessionWaitingForInput(ctx, taskID, sessionID, latest)
+	latest, err = s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || latest == nil || latest.State != models.TaskSessionStateWaitingForInput {
+		return
+	}
+	s.publishSessionWaitingEvent(ctx, taskID, sessionID, stepID, latest)
 }
 
 // dispatchEngineOwnedOnEnterAction executes an engine-owned on_enter action

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2595,8 +2595,9 @@ func (s *Service) launchAfterOnEnterDispatch(
 		// autoStartStepPrompt sends the prompt directly via PromptTask.
 		effectivePrompt := s.buildWorkflowPrompt(ctx, taskDescription, step, taskID, sessionID, isPassthrough)
 		if err := s.autoStartStepPrompt(ctx, taskID, session, step, effectivePrompt, hasPlanMode, true); err != nil {
-			if errors.Is(err, errSessionReadinessRecoverySuperseded) {
-				s.logger.Info("workflow auto-start readiness recovery was superseded",
+			if errors.Is(err, errSessionReadinessRecoverySuperseded) ||
+				errors.Is(err, errSessionReadinessRecoveryTeardownIncomplete) {
+				s.logger.Info("workflow auto-start readiness recovery preserved its current state",
 					zap.String("task_id", taskID),
 					zap.String("session_id", sessionID))
 				return
@@ -3682,6 +3683,11 @@ func (s *Service) autoStartStepPrompt(
 			return nil
 		}
 		if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
+			requeueTaken()
+			return err
+		}
+		if errors.Is(err, errSessionReadinessRecoverySuperseded) ||
+			errors.Is(err, errSessionReadinessRecoveryTeardownIncomplete) {
 			requeueTaken()
 			return err
 		}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2595,6 +2595,12 @@ func (s *Service) launchAfterOnEnterDispatch(
 		// autoStartStepPrompt sends the prompt directly via PromptTask.
 		effectivePrompt := s.buildWorkflowPrompt(ctx, taskDescription, step, taskID, sessionID, isPassthrough)
 		if err := s.autoStartStepPrompt(ctx, taskID, session, step, effectivePrompt, hasPlanMode, true); err != nil {
+			if errors.Is(err, errSessionReadinessRecoverySuperseded) {
+				s.logger.Info("workflow auto-start readiness recovery was superseded",
+					zap.String("task_id", taskID),
+					zap.String("session_id", sessionID))
+				return
+			}
 			if errors.Is(err, errWorkflowAutoStartSessionTerminalized) {
 				if workflowAutoStartWasCancelled(err) {
 					s.logger.Info("workflow auto-start cancelled before dispatch; not creating replacement",

--- a/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
+++ b/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/queue"
+	"github.com/kandev/kandev/internal/orchestrator/scheduler"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
@@ -140,8 +142,15 @@ func newStartupRecoveryHarness(t *testing.T, promptReady bool) *startupRecoveryH
 	}
 	h.taskRepo = newMockTaskRepo()
 	h.taskRepo.tasks[h.task.ID] = &v1.Task{ID: h.task.ID, State: v1.TaskStateInProgress}
-	h.svc = createTestServiceWithAgent(h.repo, newMockStepGetter(), h.taskRepo, h.agentMgr)
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["blocked-step"] = &wfmodels.WorkflowStep{
+		ID: "blocked-step", WorkflowID: "wf1", Name: "Blocked", Prompt: "continue",
+	}
+	h.svc = createTestServiceWithAgent(h.repo, stepGetter, h.taskRepo, h.agentMgr)
 	h.svc.executor = executor.NewExecutor(h.agentMgr, h.repo, testLogger(), executor.ExecutorConfig{})
+	h.svc.scheduler = scheduler.NewScheduler(
+		queue.NewTaskQueue(10), h.svc.executor, h.taskRepo, testLogger(), scheduler.SchedulerConfig{},
+	)
 	return h
 }
 
@@ -383,6 +392,55 @@ func TestWorkflowAutoStart_ReadinessTimeoutDoesNotPublishWaitingOrCreateReplacem
 			if ok && data[metaKeyNewState] == string(models.TaskSessionStateWaitingForInput) {
 				t.Fatalf("published false WAITING_FOR_INPUT event: %+v", data)
 			}
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestWorkflowAutoStart_ReadinessTimeoutStopFailurePreservesRetryableSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, false)
+		h.agentMgr.stopAgentWithReasonErr = errors.New("runtime still active")
+		h.svc.registerBackgroundWork(h.session.ID, "background-live", "execution-resumed", "work-live")
+		eventBus := &mockEventBus{}
+		h.svc.eventBus = eventBus
+		step := &wfmodels.WorkflowStep{ID: "blocked-step", WorkflowID: "wf1", Name: "Blocked", Prompt: "continue"}
+
+		h.svc.launchAfterOnEnterDispatch(
+			h.ctx, h.task.ID, h.session, step, h.task.Description, false, true, false,
+		)
+
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateStarting {
+			t.Fatalf("session state = %s, want retryable STARTING", persisted.State)
+		}
+		if got := h.taskRepo.stateWrites[h.task.ID]; got != 0 {
+			t.Fatalf("task state writes = %d, want 0 after stop failure", got)
+		}
+		for _, published := range eventBus.published() {
+			if published.Subject != events.TaskSessionStateChanged {
+				continue
+			}
+			data, ok := published.Event.Data.(map[string]interface{})
+			if ok && data[metaKeyNewState] == string(models.TaskSessionStateWaitingForInput) {
+				t.Fatalf("published false WAITING_FOR_INPUT event after stop failure: %+v", data)
+			}
+		}
+		if !h.svc.hasBackgroundTask(h.session.ID, "background-live") {
+			t.Fatal("stop failure retired activity still owned by the live execution")
+		}
+		if h.svc.isExecutionCompleted(h.session.ID, "execution-resumed") {
+			t.Fatal("stop failure terminal-marked a still-live execution")
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 || stopCalls[0].ExecutionID != "execution-resumed" {
+			t.Fatalf("stop calls = %+v, want one attempt for execution-resumed", stopCalls)
 		}
 		h.assertStableIdentity(t)
 	})

--- a/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
+++ b/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
@@ -1,0 +1,355 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type startupRecoveryHarness struct {
+	ctx                     context.Context
+	repo                    *sqliterepo.Repository
+	svc                     *Service
+	agentMgr                *mockAgentManager
+	task                    *models.Task
+	session                 *models.TaskSession
+	launchCalls             atomic.Int32
+	controlTaskUpdatedAt    time.Time
+	controlSessionUpdatedAt time.Time
+}
+
+type successorOnReadyCheckRepo struct {
+	sessionExecutorStore
+	base  *sqliterepo.Repository
+	armed atomic.Bool
+	once  sync.Once
+}
+
+func (r *successorOnReadyCheckRepo) GetExecutorRunningBySessionID(
+	ctx context.Context,
+	sessionID string,
+) (*models.ExecutorRunning, error) {
+	running, err := r.base.GetExecutorRunningBySessionID(ctx, sessionID)
+	if err != nil || running == nil || !r.armed.Load() || running.AgentExecutionID != "execution-resumed" {
+		return running, err
+	}
+	snapshot := *running
+	var replaceErr error
+	r.once.Do(func() {
+		successor := *running
+		successor.AgentExecutionID = "execution-successor"
+		successor.UpdatedAt = time.Now().UTC()
+		replaceErr = r.base.UpsertExecutorRunning(ctx, &successor)
+	})
+	if replaceErr != nil {
+		return nil, replaceErr
+	}
+	return &snapshot, nil
+}
+
+func newStartupRecoveryHarness(t *testing.T, promptReady bool) *startupRecoveryHarness {
+	t.Helper()
+	h := &startupRecoveryHarness{ctx: context.Background()}
+	h.repo = setupTestRepo(t)
+	seedTaskAndSession(t, h.repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	seedTaskAndSession(t, h.repo, "control-task", "control-session", models.TaskSessionStateWaitingForInput)
+
+	var err error
+	h.task, err = h.repo.GetTask(h.ctx, "task1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	h.task.WorkflowStepID = "blocked-step"
+	if err := h.repo.UpdateTask(h.ctx, h.task); err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	controlTask, err := h.repo.GetTask(h.ctx, "control-task")
+	if err != nil {
+		t.Fatalf("get control task: %v", err)
+	}
+	controlTask.WorkflowStepID = "control-step"
+	if err := h.repo.UpdateTask(h.ctx, controlTask); err != nil {
+		t.Fatalf("update control task: %v", err)
+	}
+	h.controlTaskUpdatedAt = controlTask.UpdatedAt
+	controlSession, err := h.repo.GetTaskSession(h.ctx, "control-session")
+	if err != nil {
+		t.Fatalf("get control session: %v", err)
+	}
+	h.controlSessionUpdatedAt = controlSession.UpdatedAt
+	h.session, err = h.repo.GetTaskSession(h.ctx, "session1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	h.session.AgentProfileID = "profile1"
+	if err := h.repo.UpdateTaskSession(h.ctx, h.session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := h.repo.UpsertExecutorRunning(h.ctx, &models.ExecutorRunning{
+		ID:               "running1",
+		SessionID:        h.session.ID,
+		TaskID:           h.task.ID,
+		AgentExecutionID: "execution-before-restart",
+		Status:           models.ExecutorRunningStatusReady,
+		Resumable:        true,
+		ResumeToken:      "resume-token",
+		WorktreePath:     "/tasks/task1",
+		WorktreeBranch:   "feature/task1",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("seed executor row: %v", err)
+	}
+
+	h.agentMgr = &mockAgentManager{
+		repoForExecutionLookup: h.repo,
+		isAgentRunningFn: func(context.Context, string) bool {
+			return false
+		},
+		isAgentReadyFn: func(context.Context, string) bool {
+			return promptReady
+		},
+		launchAgentFunc: func(ctx context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			h.launchCalls.Add(1)
+			running, err := h.repo.GetExecutorRunningBySessionID(ctx, req.SessionID)
+			if err != nil {
+				return nil, err
+			}
+			running.AgentExecutionID = "execution-resumed"
+			running.UpdatedAt = time.Now().UTC()
+			if err := h.repo.UpsertExecutorRunning(ctx, running); err != nil {
+				return nil, err
+			}
+			return &executor.LaunchAgentResponse{AgentExecutionID: "execution-resumed"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[h.task.ID] = &v1.Task{ID: h.task.ID, State: v1.TaskStateInProgress}
+	h.svc = createTestServiceWithAgent(h.repo, newMockStepGetter(), taskRepo, h.agentMgr)
+	h.svc.executor = executor.NewExecutor(h.agentMgr, h.repo, testLogger(), executor.ExecutorConfig{})
+	return h
+}
+
+func (h *startupRecoveryHarness) assertStableIdentity(t *testing.T) {
+	t.Helper()
+	if got := h.launchCalls.Load(); got != 1 {
+		t.Fatalf("LaunchAgent calls = %d, want 1", got)
+	}
+	sessions, err := h.repo.ListTaskSessions(h.ctx, h.task.ID)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != h.session.ID {
+		t.Fatalf("sessions = %+v, want only %s", sessions, h.session.ID)
+	}
+	running, err := h.repo.GetExecutorRunningBySessionID(h.ctx, h.session.ID)
+	if err != nil {
+		t.Fatalf("get executor row: %v", err)
+	}
+	if running.ResumeToken != "resume-token" || running.WorktreePath != "/tasks/task1" ||
+		running.WorktreeBranch != "feature/task1" {
+		t.Fatalf("resume/worktree identity changed: %+v", running)
+	}
+	persistedTask, err := h.repo.GetTask(h.ctx, h.task.ID)
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if persistedTask.WorkflowStepID != "blocked-step" {
+		t.Fatalf("workflow step = %q, want blocked-step", persistedTask.WorkflowStepID)
+	}
+	controlTask, err := h.repo.GetTask(h.ctx, "control-task")
+	if err != nil {
+		t.Fatalf("reload control task: %v", err)
+	}
+	if controlTask.WorkflowStepID != "control-step" || !controlTask.UpdatedAt.Equal(h.controlTaskUpdatedAt) {
+		t.Fatalf("unrelated task changed: %+v", controlTask)
+	}
+	controlSession, err := h.repo.GetTaskSession(h.ctx, "control-session")
+	if err != nil {
+		t.Fatalf("reload control session: %v", err)
+	}
+	if controlSession.State != models.TaskSessionStateWaitingForInput ||
+		!controlSession.UpdatedAt.Equal(h.controlSessionUpdatedAt) {
+		t.Fatalf("unrelated session changed: %+v", controlSession)
+	}
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestEnsureSessionRunning_StartupRecoveryReconcilesReadyExecutionAfterSessionTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, true)
+		if err := h.svc.ensureSessionRunning(h.ctx, h.session.ID, h.session); err != nil {
+			t.Fatalf("ensure session running: %v", err)
+		}
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateWaitingForInput {
+			t.Fatalf("session state = %s, want WAITING_FOR_INPUT", persisted.State)
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestEnsureSessionRunning_StartupRecoveryTerminalizesUnreadyExecutionAfterSessionTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, false)
+		if err := h.svc.ensureSessionRunning(h.ctx, h.session.ID, h.session); err == nil {
+			t.Fatal("expected readiness timeout")
+		}
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateFailed {
+			t.Fatalf("session state = %s, want FAILED", persisted.State)
+		}
+		h.svc.handleAgentBootReady(h.ctx, watcher.AgentEventData{
+			TaskID: h.task.ID, SessionID: h.session.ID, AgentExecutionID: "execution-resumed",
+		})
+		persisted, err = h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session after delayed boot-ready: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateFailed {
+			t.Fatalf("delayed boot-ready changed session state to %s", persisted.State)
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 || stopCalls[0].ExecutionID != "execution-resumed" {
+			t.Fatalf("stop calls = %+v, want one stop for execution-resumed", stopCalls)
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestEnsureSessionRunning_StartupRecoveryDoesNotTouchSuccessorExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, true)
+		wrapped := &successorOnReadyCheckRepo{sessionExecutorStore: h.svc.repo, base: h.repo}
+		h.svc.repo = wrapped
+		launch := h.agentMgr.launchAgentFunc
+		h.agentMgr.launchAgentFunc = func(
+			ctx context.Context,
+			req *executor.LaunchAgentRequest,
+		) (*executor.LaunchAgentResponse, error) {
+			response, err := launch(ctx, req)
+			if err == nil {
+				wrapped.armed.Store(true)
+			}
+			return response, err
+		}
+
+		if err := h.svc.ensureSessionRunning(h.ctx, h.session.ID, h.session); err == nil {
+			t.Fatal("expected readiness timeout after successor superseded the resumed execution")
+		}
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateStarting {
+			t.Fatalf("session state = %s, want successor-owned STARTING", persisted.State)
+		}
+		running, err := h.repo.GetExecutorRunningBySessionID(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload execution: %v", err)
+		}
+		if running.AgentExecutionID != "execution-successor" {
+			t.Fatalf("execution id = %q, want execution-successor", running.AgentExecutionID)
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 0 {
+			t.Fatalf("successor race issued stop calls: %+v", stopCalls)
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestEnsureSessionRunning_StartupRecoveryDoesNotTeardownTerminalSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, true)
+		var transitionOnce sync.Once
+		var transitionErr error
+		h.agentMgr.isAgentReadyFn = func(context.Context, string) bool {
+			transitionOnce.Do(func() {
+				transitionErr = h.repo.UpdateTaskSessionState(
+					h.ctx, h.session.ID, models.TaskSessionStateCancelled, "cancelled concurrently",
+				)
+			})
+			return true
+		}
+
+		if err := h.svc.ensureSessionRunning(h.ctx, h.session.ID, h.session); err == nil {
+			t.Fatal("expected readiness timeout after terminal transition won")
+		}
+		if transitionErr != nil {
+			t.Fatalf("terminal transition: %v", transitionErr)
+		}
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateCancelled {
+			t.Fatalf("session state = %s, want CANCELLED", persisted.State)
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 0 {
+			t.Fatalf("terminal race issued stop calls: %+v", stopCalls)
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestWorkflowAutoStart_ReadinessTimeoutDoesNotPublishWaitingOrCreateReplacement(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, false)
+		eventBus := &mockEventBus{}
+		h.svc.eventBus = eventBus
+		step := &wfmodels.WorkflowStep{ID: "blocked-step", WorkflowID: "wf1", Name: "Blocked", Prompt: "continue"}
+
+		h.svc.launchAfterOnEnterDispatch(
+			h.ctx, h.task.ID, h.session, step, h.task.Description, false, true, false,
+		)
+
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateFailed {
+			t.Fatalf("session state = %s, want FAILED", persisted.State)
+		}
+		for _, published := range eventBus.published() {
+			if published.Subject != events.TaskSessionStateChanged {
+				continue
+			}
+			data, ok := published.Event.Data.(map[string]interface{})
+			if ok && data[metaKeyNewState] == string(models.TaskSessionStateWaitingForInput) {
+				t.Fatalf("published false WAITING_FOR_INPUT event: %+v", data)
+			}
+		}
+		h.assertStableIdentity(t)
+	})
+}

--- a/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
+++ b/apps/backend/internal/orchestrator/startup_recovery_readiness_timeout_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,6 +23,7 @@ type startupRecoveryHarness struct {
 	repo                    *sqliterepo.Repository
 	svc                     *Service
 	agentMgr                *mockAgentManager
+	taskRepo                *mockTaskRepo
 	task                    *models.Task
 	session                 *models.TaskSession
 	launchCalls             atomic.Int32
@@ -136,9 +138,9 @@ func newStartupRecoveryHarness(t *testing.T, promptReady bool) *startupRecoveryH
 			return &executor.LaunchAgentResponse{AgentExecutionID: "execution-resumed"}, nil
 		},
 	}
-	taskRepo := newMockTaskRepo()
-	taskRepo.tasks[h.task.ID] = &v1.Task{ID: h.task.ID, State: v1.TaskStateInProgress}
-	h.svc = createTestServiceWithAgent(h.repo, newMockStepGetter(), taskRepo, h.agentMgr)
+	h.taskRepo = newMockTaskRepo()
+	h.taskRepo.tasks[h.task.ID] = &v1.Task{ID: h.task.ID, State: v1.TaskStateInProgress}
+	h.svc = createTestServiceWithAgent(h.repo, newMockStepGetter(), h.taskRepo, h.agentMgr)
 	h.svc.executor = executor.NewExecutor(h.agentMgr, h.repo, testLogger(), executor.ExecutorConfig{})
 	return h
 }
@@ -234,6 +236,38 @@ func TestEnsureSessionRunning_StartupRecoveryTerminalizesUnreadyExecutionAfterSe
 		h.agentMgr.mu.Unlock()
 		if len(stopCalls) != 1 || stopCalls[0].ExecutionID != "execution-resumed" {
 			t.Fatalf("stop calls = %+v, want one stop for execution-resumed", stopCalls)
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestEnsureSessionRunning_StartupRecoveryStopFailurePreservesRetryableSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, false)
+		h.agentMgr.stopAgentWithReasonErr = errors.New("runtime still active")
+
+		if err := h.svc.ensureSessionRunning(h.ctx, h.session.ID, h.session); err == nil {
+			t.Fatal("expected readiness teardown failure")
+		}
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateStarting {
+			t.Fatalf("session state = %s, want retryable STARTING", persisted.State)
+		}
+		if got := h.taskRepo.updatedStates[h.task.ID]; got == v1.TaskStateFailed {
+			t.Fatal("stop failure marked task FAILED while its execution may still be active")
+		}
+		if got := h.taskRepo.stateWrites[h.task.ID]; got != 0 {
+			t.Fatalf("task state writes = %d, want 0 after stop failure", got)
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 || stopCalls[0].ExecutionID != "execution-resumed" {
+			t.Fatalf("stop calls = %+v, want one attempt for execution-resumed", stopCalls)
 		}
 		h.assertStableIdentity(t)
 	})
@@ -349,6 +383,64 @@ func TestWorkflowAutoStart_ReadinessTimeoutDoesNotPublishWaitingOrCreateReplacem
 			if ok && data[metaKeyNewState] == string(models.TaskSessionStateWaitingForInput) {
 				t.Fatalf("published false WAITING_FOR_INPUT event: %+v", data)
 			}
+		}
+		h.assertStableIdentity(t)
+	})
+}
+
+// @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001.6
+func TestWorkflowAutoStart_ReadinessTimeoutDoesNotReconcileSuccessorExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newStartupRecoveryHarness(t, true)
+		wrapped := &successorOnReadyCheckRepo{sessionExecutorStore: h.svc.repo, base: h.repo}
+		h.svc.repo = wrapped
+		launch := h.agentMgr.launchAgentFunc
+		h.agentMgr.launchAgentFunc = func(
+			ctx context.Context,
+			req *executor.LaunchAgentRequest,
+		) (*executor.LaunchAgentResponse, error) {
+			response, err := launch(ctx, req)
+			if err == nil {
+				wrapped.armed.Store(true)
+			}
+			return response, err
+		}
+		eventBus := &mockEventBus{}
+		h.svc.eventBus = eventBus
+		step := &wfmodels.WorkflowStep{ID: "blocked-step", WorkflowID: "wf1", Name: "Blocked", Prompt: "continue"}
+
+		h.svc.launchAfterOnEnterDispatch(
+			h.ctx, h.task.ID, h.session, step, h.task.Description, false, true, false,
+		)
+
+		persisted, err := h.repo.GetTaskSession(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload session: %v", err)
+		}
+		if persisted.State != models.TaskSessionStateStarting {
+			t.Fatalf("session state = %s, want successor-owned STARTING", persisted.State)
+		}
+		running, err := h.repo.GetExecutorRunningBySessionID(h.ctx, h.session.ID)
+		if err != nil {
+			t.Fatalf("reload execution: %v", err)
+		}
+		if running.AgentExecutionID != "execution-successor" {
+			t.Fatalf("execution id = %q, want execution-successor", running.AgentExecutionID)
+		}
+		for _, published := range eventBus.published() {
+			if published.Subject != events.TaskSessionStateChanged {
+				continue
+			}
+			data, ok := published.Event.Data.(map[string]interface{})
+			if ok && data[metaKeyNewState] == string(models.TaskSessionStateWaitingForInput) {
+				t.Fatalf("published false WAITING_FOR_INPUT event for successor: %+v", data)
+			}
+		}
+		h.agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), h.agentMgr.stopAgentWithReasonArgs...)
+		h.agentMgr.mu.Unlock()
+		if len(stopCalls) != 0 {
+			t.Fatalf("successor race issued stop calls: %+v", stopCalls)
 		}
 		h.assertStableIdentity(t)
 	})

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -111,6 +111,11 @@ var ErrSessionNotPromptable = errors.New("session not promptable")
 // trigger this.
 var errQueuedDispatchSuperseded = errors.New("queued dispatch superseded by a newer one for this session")
 
+// errSessionReadinessRecoverySuperseded marks a timeout recovery attempt that
+// lost ownership to a terminal session or a successor execution. Workflow
+// fallback must not park the new owner based on the old execution's timeout.
+var errSessionReadinessRecoverySuperseded = errors.New("session readiness recovery superseded")
+
 var (
 	// Backend restart recovery can restore the session state before the ACP
 	// stream is promptable again. Keep this above CI's slow-start tail so a
@@ -2531,15 +2536,26 @@ func (s *Service) failOwnedExecutionAfterReadinessTimeout(
 	timeoutErr error,
 ) error {
 	owned, err := s.sessionExecutionIsOwnedAndActive(ctx, session.ID, executionID)
-	if err != nil || !owned {
+	if err != nil {
 		return err
+	}
+	if !owned {
+		return fmt.Errorf("%w for session %s execution %s", errSessionReadinessRecoverySuperseded, session.ID, executionID)
 	}
 	if !s.claimForcedExecutionCleanup(session.ID, executionID) {
-		return fmt.Errorf("execution %s teardown is already owned for session %s", executionID, session.ID)
+		return fmt.Errorf(
+			"%w: execution %s teardown is already owned for session %s",
+			errSessionReadinessRecoverySuperseded,
+			executionID,
+			session.ID,
+		)
 	}
 	owned, err = s.sessionExecutionIsOwnedAndActive(ctx, session.ID, executionID)
-	if err != nil || !owned {
+	if err != nil {
 		return err
+	}
+	if !owned {
+		return fmt.Errorf("%w for session %s execution %s", errSessionReadinessRecoverySuperseded, session.ID, executionID)
 	}
 
 	s.logger.Warn("stopping session-unready execution after resume timeout",
@@ -2547,26 +2563,27 @@ func (s *Service) failOwnedExecutionAfterReadinessTimeout(
 		zap.String("agent_execution_id", executionID),
 		zap.Error(timeoutErr))
 	stopErr := s.executor.StopExecution(ctx, executionID, sessionReadinessRecoveryStopReason, true)
-	if stopErr == nil {
-		s.markExecutionFailed(session.ID, executionID)
-		s.retireExecutionActivityAndPublish(ctx, session.TaskID, session.ID, executionID)
+	if stopErr != nil {
+		return stopErr
 	}
+	s.markExecutionFailed(session.ID, executionID)
+	s.retireExecutionActivityAndPublish(ctx, session.TaskID, session.ID, executionID)
 
 	running, lookupErr := s.repo.GetExecutorRunningBySessionID(ctx, session.ID)
 	if lookupErr != nil {
-		return errors.Join(stopErr, fmt.Errorf("reload execution after readiness teardown: %w", lookupErr))
+		return fmt.Errorf("reload execution after readiness teardown: %w", lookupErr)
 	}
 	if running != nil && running.AgentExecutionID != "" && running.AgentExecutionID != executionID {
-		return stopErr
+		return fmt.Errorf("%w for session %s execution %s", errSessionReadinessRecoverySuperseded, session.ID, executionID)
 	}
 	latest, reloadErr := s.repo.GetTaskSession(ctx, session.ID)
 	if reloadErr != nil {
-		return errors.Join(stopErr, fmt.Errorf("reload session after readiness teardown: %w", reloadErr))
+		return fmt.Errorf("reload session after readiness teardown: %w", reloadErr)
 	}
 	if !isTerminalSessionState(latest.State) {
 		_ = s.handleSessionLaunchFailure(ctx, session.TaskID, session.ID, timeoutErr, latest)
 	}
-	return stopErr
+	return nil
 }
 
 func (s *Service) sessionExecutionMatches(ctx context.Context, sessionID, executionID string) (bool, error) {

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -116,6 +116,11 @@ var errQueuedDispatchSuperseded = errors.New("queued dispatch superseded by a ne
 // fallback must not park the new owner based on the old execution's timeout.
 var errSessionReadinessRecoverySuperseded = errors.New("session readiness recovery superseded")
 
+// errSessionReadinessRecoveryTeardownIncomplete marks a timeout recovery whose
+// exact execution may still be active because runtime teardown failed.
+// Workflow fallback must preserve STARTING instead of parking or replacing it.
+var errSessionReadinessRecoveryTeardownIncomplete = errors.New("session readiness recovery teardown incomplete")
+
 var (
 	// Backend restart recovery can restore the session state before the ACP
 	// stream is promptable again. Keep this above CI's slow-start tail so a
@@ -2564,7 +2569,7 @@ func (s *Service) failOwnedExecutionAfterReadinessTimeout(
 		zap.Error(timeoutErr))
 	stopErr := s.executor.StopExecution(ctx, executionID, sessionReadinessRecoveryStopReason, true)
 	if stopErr != nil {
-		return stopErr
+		return fmt.Errorf("%w: %w", errSessionReadinessRecoveryTeardownIncomplete, stopErr)
 	}
 	s.markExecutionFailed(session.ID, executionID)
 	s.retireExecutionActivityAndPublish(ctx, session.TaskID, session.ID, executionID)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -122,6 +122,7 @@ var (
 const promptFailureCleanupTimeout = 5 * time.Second
 
 const promptReadinessRecoveryStopReason = "prompt readiness recovery"
+const sessionReadinessRecoveryStopReason = "session readiness timeout recovery"
 
 type agentPromptStreamRecoverer interface {
 	RecoverAgentPromptStream(ctx context.Context, sessionID string) error
@@ -2425,7 +2426,8 @@ func (s *Service) attemptColdResume(
 	// when the agent's ACP session initializes — that's what unblocks waitForSessionReady,
 	// no flag-tracking needed.
 	resumeCtx := context.WithoutCancel(ctx)
-	if _, launchErr := s.executor.ResumeSession(resumeCtx, session, true); launchErr != nil {
+	execution, launchErr := s.executor.ResumeSession(resumeCtx, session, true)
+	if launchErr != nil {
 		if errors.Is(launchErr, executor.ErrExecutionAlreadyRunning) {
 			s.recoverAgentPromptStreamIfNeeded(resumeCtx, sessionID)
 			if readyErr := s.waitForAgentPromptReady(resumeCtx, sessionID); readyErr != nil {
@@ -2454,7 +2456,26 @@ func (s *Service) attemptColdResume(
 	// own bounded timeouts (waitForSessionReady's AgentLaunchTimeout launch
 	// budget, and waitForAgentPromptReady's 30s below).
 	if err := s.waitForSessionReady(resumeCtx, sessionID); err != nil {
-		return false, fmt.Errorf("session not ready after resume: %w", err)
+		timeoutErr := fmt.Errorf("session not ready after resume: %w", err)
+		reconciled, reconcileErr := s.reconcilePromptReadySessionAfterReadinessTimeout(
+			resumeCtx, session, execution.AgentExecutionID,
+		)
+		if reconcileErr != nil {
+			s.logger.Warn("failed to reconcile prompt-ready session after readiness timeout",
+				zap.String("session_id", sessionID),
+				zap.String("agent_execution_id", execution.AgentExecutionID),
+				zap.Error(reconcileErr))
+		}
+		if reconciled {
+			return false, nil
+		}
+		cleanupErr := s.failOwnedExecutionAfterReadinessTimeout(
+			resumeCtx, session, execution.AgentExecutionID, timeoutErr,
+		)
+		if cleanupErr != nil {
+			return false, errors.Join(timeoutErr, cleanupErr)
+		}
+		return false, timeoutErr
 	}
 	readyErr := s.waitForAgentPromptReady(resumeCtx, sessionID)
 	if readyErr == nil {
@@ -2462,6 +2483,121 @@ func (s *Service) attemptColdResume(
 		return false, nil
 	}
 	return errors.Is(readyErr, ErrAgentNotReadyForPrompt), fmt.Errorf("agent not ready after resume: %w", readyErr)
+}
+
+func (s *Service) reconcilePromptReadySessionAfterReadinessTimeout(
+	ctx context.Context,
+	session *models.TaskSession,
+	executionID string,
+) (bool, error) {
+	if executionID == "" || s.agentManager == nil {
+		return false, nil
+	}
+	matches, err := s.sessionExecutionMatches(ctx, session.ID, executionID)
+	if err != nil || !matches {
+		return false, err
+	}
+	if !s.agentManager.IsAgentReadyForPrompt(ctx, session.ID) {
+		return false, nil
+	}
+	matches, err = s.sessionExecutionMatches(ctx, session.ID, executionID)
+	if err != nil || !matches {
+		return false, err
+	}
+
+	latest, err := s.repo.GetTaskSession(ctx, session.ID)
+	if err != nil {
+		return false, fmt.Errorf("reload session for readiness reconciliation: %w", err)
+	}
+	if latest.State == models.TaskSessionStateWaitingForInput {
+		return true, nil
+	}
+	if latest.State != models.TaskSessionStateStarting {
+		return false, nil
+	}
+
+	s.setSessionWaitingForInput(ctx, session.TaskID, session.ID, latest)
+	latest, err = s.repo.GetTaskSession(ctx, session.ID)
+	if err != nil {
+		return false, fmt.Errorf("reload reconciled session: %w", err)
+	}
+	return latest.State == models.TaskSessionStateWaitingForInput, nil
+}
+
+func (s *Service) failOwnedExecutionAfterReadinessTimeout(
+	ctx context.Context,
+	session *models.TaskSession,
+	executionID string,
+	timeoutErr error,
+) error {
+	owned, err := s.sessionExecutionIsOwnedAndActive(ctx, session.ID, executionID)
+	if err != nil || !owned {
+		return err
+	}
+	if !s.claimForcedExecutionCleanup(session.ID, executionID) {
+		return fmt.Errorf("execution %s teardown is already owned for session %s", executionID, session.ID)
+	}
+	owned, err = s.sessionExecutionIsOwnedAndActive(ctx, session.ID, executionID)
+	if err != nil || !owned {
+		return err
+	}
+
+	s.logger.Warn("stopping session-unready execution after resume timeout",
+		zap.String("session_id", session.ID),
+		zap.String("agent_execution_id", executionID),
+		zap.Error(timeoutErr))
+	stopErr := s.executor.StopExecution(ctx, executionID, sessionReadinessRecoveryStopReason, true)
+	if stopErr == nil {
+		s.markExecutionFailed(session.ID, executionID)
+		s.retireExecutionActivityAndPublish(ctx, session.TaskID, session.ID, executionID)
+	}
+
+	running, lookupErr := s.repo.GetExecutorRunningBySessionID(ctx, session.ID)
+	if lookupErr != nil {
+		return errors.Join(stopErr, fmt.Errorf("reload execution after readiness teardown: %w", lookupErr))
+	}
+	if running != nil && running.AgentExecutionID != "" && running.AgentExecutionID != executionID {
+		return stopErr
+	}
+	latest, reloadErr := s.repo.GetTaskSession(ctx, session.ID)
+	if reloadErr != nil {
+		return errors.Join(stopErr, fmt.Errorf("reload session after readiness teardown: %w", reloadErr))
+	}
+	if !isTerminalSessionState(latest.State) {
+		_ = s.handleSessionLaunchFailure(ctx, session.TaskID, session.ID, timeoutErr, latest)
+	}
+	return stopErr
+}
+
+func (s *Service) sessionExecutionMatches(ctx context.Context, sessionID, executionID string) (bool, error) {
+	if executionID == "" {
+		return false, nil
+	}
+	running, err := s.repo.GetExecutorRunningBySessionID(ctx, sessionID)
+	if err != nil {
+		return false, err
+	}
+	return running != nil && running.AgentExecutionID == executionID, nil
+}
+
+func (s *Service) sessionExecutionIsOwnedAndActive(
+	ctx context.Context,
+	sessionID, executionID string,
+) (bool, error) {
+	matches, err := s.sessionExecutionMatches(ctx, sessionID, executionID)
+	if err != nil || !matches {
+		return false, err
+	}
+	terminal, err := s.sessionIsTerminal(ctx, sessionID)
+	return !terminal, err
+}
+
+func (s *Service) sessionIsTerminal(ctx context.Context, sessionID string) (bool, error) {
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		return false, err
+	}
+	return session != nil && isTerminalSessionState(session.State), nil
 }
 
 func (s *Service) recoverAgentPromptStreamIfNeeded(ctx context.Context, sessionID string) {

--- a/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
@@ -26,7 +26,7 @@ that environment and does not acquire its own worktree lifecycle.
 
 | Requirement | Design section |
 | --- | --- |
-| `REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001` | [Session identity](#session-identity) |
+| `REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-001` | [Session identity](#session-identity), [Startup readiness convergence](#startup-readiness-convergence) |
 | `REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002` | [Visible recovery errors](#visible-recovery-errors) |
 | `REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-003` | [Explicit branch replacement](#explicit-branch-replacement), [Warning persistence](#warning-persistence) |
 
@@ -98,6 +98,41 @@ workspace preparation succeeds.
 The existing guarded transition to `STARTING`, resume lock, failure rollback,
 and successful token replacement rules remain unchanged. Only **Start fresh**
 can intentionally remove the stored provider identity before launch.
+
+## Startup readiness convergence
+
+Synchronous startup recovery runs before the lifecycle watcher subscribes. This
+ordering remains intentional: lifecycle-token, work-in-progress, and dependency
+reconciliation must finish before watchers, scheduling, and API traffic begin.
+Consequently, a resumed execution can become prompt-ready before its one-shot
+`agent.boot_ready` event has a subscriber.
+
+The cold-resume owner retains the exact execution ID returned by
+`ResumeSession`. If the durable session-readiness wait expires, it reconciles
+that outcome directly instead of relying on event replay:
+
+1. Reload the active `executors_running` identity and require it to match the
+   execution launched by this resume.
+2. If that exact execution is prompt-ready, verify ownership again and use the
+   existing state compare-and-set to park the same `STARTING` session at
+   `WAITING_FOR_INPUT`.
+3. If the exact execution is not prompt-ready, claim teardown ownership, check
+   execution and terminal-session identity again, stop only that execution,
+   retire its activity, and use the existing guarded launch-failure path to
+   settle the old session at `FAILED`.
+
+A terminal session or successor execution supersedes the timeout owner. The
+timeout path neither revives the terminal row nor stops or reconciles the
+successor. It returns an ordinary readiness error rather than the workflow
+terminalization sentinel, so workflow entry cannot create a replacement
+session. Workflow fallback reloads the authoritative row and publishes
+`WAITING_FOR_INPUT` only after that state is durable.
+
+This recovery never synthesizes `agent.boot_ready`: that handler also drains
+queued prompts and would turn reconciliation into a second dispatch source.
+The workflow step, session ID, provider resume token, task environment, and
+worktree remain unchanged. A fresh session remains an explicit user or owner
+operation.
 
 ## Explicit branch replacement
 

--- a/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
@@ -117,16 +117,20 @@ that outcome directly instead of relying on event replay:
    existing state compare-and-set to park the same `STARTING` session at
    `WAITING_FOR_INPUT`.
 3. If the exact execution is not prompt-ready, claim teardown ownership, check
-   execution and terminal-session identity again, stop only that execution,
-   retire its activity, and use the existing guarded launch-failure path to
-   settle the old session at `FAILED`.
+   execution and terminal-session identity again, and stop only that
+   execution. A successful stop retires its activity and uses the existing
+   guarded launch-failure path to settle the old session at `FAILED`. A stop
+   failure returns the readiness and teardown errors while preserving the
+   retryable session state and live-execution activity.
 
 A terminal session or successor execution supersedes the timeout owner. The
 timeout path neither revives the terminal row nor stops or reconciles the
 successor. It returns an ordinary readiness error rather than the workflow
 terminalization sentinel, so workflow entry cannot create a replacement
-session. Workflow fallback reloads the authoritative row and publishes
-`WAITING_FOR_INPUT` only after that state is durable.
+session. An internal supersession marker also prevents workflow fallback from
+parking a successor-owned session. Other workflow fallback reloads the
+authoritative row and publishes `WAITING_FOR_INPUT` only after that state is
+durable.
 
 This recovery never synthesizes `agent.boot_ready`: that handler also drains
 queued prompts and would turn reconciliation into a second dispatch source.

--- a/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
@@ -127,10 +127,10 @@ A terminal session or successor execution supersedes the timeout owner. The
 timeout path neither revives the terminal row nor stops or reconciles the
 successor. It returns an ordinary readiness error rather than the workflow
 terminalization sentinel, so workflow entry cannot create a replacement
-session. An internal supersession marker also prevents workflow fallback from
-parking a successor-owned session. Other workflow fallback reloads the
-authoritative row and publishes `WAITING_FOR_INPUT` only after that state is
-durable.
+session. Internal preserve-state markers also prevent workflow fallback from
+parking a successor-owned session or replacing an execution whose teardown
+failed. Other workflow fallback reloads the authoritative row and publishes
+`WAITING_FOR_INPUT` only after that state is durable.
 
 This recovery never synthesizes `agent.boot_ready`: that handler also drains
 queued prompts and would turn reconciliation into a second dispatch source.


### PR DESCRIPTION
Startup recovery could miss a one-shot boot-ready event and leave a resumed workflow session stuck in STARTING. Reconcile the exact resumed execution directly while preserving terminal, successor, and failed-teardown ownership without creating replacement work.

## Important Changes

- Reconcile a prompt-ready execution after the durable readiness wait expires, preserving the existing session, provider token, worktree, and workflow step.
- Stop and terminalize only the exact unready execution; preserve STARTING and live activity when teardown fails or a successor owns the session.
- Reload authoritative workflow state before publishing WAITING_FOR_INPUT and prevent recovery errors from triggering a fresh fallback launch.

## Validation

- `go test -tags fts5 ./internal/orchestrator -run 'TestEnsureSessionRunning_StartupRecovery|TestWorkflowAutoStart_ReadinessTimeout' -count=1`
- `go test -race -tags fts5 ./internal/orchestrator/... -count=1`
- `golangci-lint run ./... --new-from-rev=625c4ca6b50ff64ba7f9daf7c63d17986d0ffe26 --timeout=5m`
- `python3 scripts/lint-spec-files.py --all`

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3240-bwo7.sprites.app |
| **Commit** | `9baeb41` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->