### PR TITLE
test: stabilize reset prompt admission race

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow_reset_quiescence_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_reset_quiescence_test.go
@@ -351,6 +351,13 @@ func TestResetAgentContext_SerializesPromptAdmission(t *testing.T) {
 		}
 	}
 	releaseCancel()
+	if promptTimedOut {
+		select {
+		case promptErr = <-promptDone:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for reset-blocked prompt admission")
+		}
+	}
 	select {
 	case resetOK := <-resetDone:
 		if !resetOK {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_reset_quiescence_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_reset_quiescence_test.go
@@ -293,7 +293,9 @@ func TestResetAgentContext_ResetMarkerPrecedesLifecycleCancellationWait(t *testi
 // before its final guarded claim, then starts reset while that claim is paused.
 // If reset wins the shared guard, the marker rejects the prompt while reset is
 // waiting on cancellation. If the prompt wins, reset must observe that turn
-// and cancel it before replacing the provider session.
+// and cancel it before replacing the provider session. Cancellation entry alone
+// does not identify the winner: a successful prompt can release the guard and
+// be descheduled before it reports its result.
 func TestResetAgentContext_SerializesPromptAdmission(t *testing.T) {
 	ctx := context.Background()
 	svc, repo, manager, session := newActiveResetTestService(t)
@@ -334,21 +336,19 @@ func TestResetAgentContext_SerializesPromptAdmission(t *testing.T) {
 	releaseGuard()
 
 	var promptErr error
-	resetWonGuard := false
+	promptTimedOut := false
 	select {
 	case promptErr = <-promptDone:
 	case <-cancelEntered:
-		// Reset won the admission guard and is now waiting for its internal
-		// cancellation. The prompt must observe the still-published marker.
-		resetWonGuard = true
+		// Reset is waiting for its internal cancellation. If it won the guard,
+		// the prompt must observe the marker without waiting for cancellation.
+		// A nil result is also valid when the prompt won but reported after reset
+		// reached CancelAgent.
 		select {
 		case promptErr = <-promptDone:
 		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for reset-blocked prompt admission")
+			promptTimedOut = true
 		}
-	}
-	if resetWonGuard && !errors.Is(promptErr, ErrSessionResetInProgress) {
-		t.Fatalf("prompt admission after reset won guard = %v, want %v", promptErr, ErrSessionResetInProgress)
 	}
 	releaseCancel()
 	select {
@@ -360,7 +360,10 @@ func TestResetAgentContext_SerializesPromptAdmission(t *testing.T) {
 		t.Fatal("timed out waiting for context reset")
 	}
 
-	if !resetWonGuard && promptErr != nil && !errors.Is(promptErr, ErrSessionResetInProgress) {
+	if promptTimedOut {
+		t.Fatal("timed out waiting for reset-blocked prompt admission")
+	}
+	if promptErr != nil && !errors.Is(promptErr, ErrSessionResetInProgress) {
 		t.Fatalf("prompt admission error = %v, want reset sentinel or successful claim", promptErr)
 	}
 	// A prompt that won the guard must have been visible as the active turn to


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3241/94bd5947e983.html)
<!-- kandev-pr-walkthrough-end -->

## Overview

Stabilizes `TestResetAgentContext_SerializesPromptAdmission`, which QA
reproduced failing under `-race -count=100` after the shared-guard ordering
fix in #3169 merged.

## Motivation

The test used receipt of `cancelEntered` as proof that reset won the shared
admission guard. That signal only proves reset reached its internal
cancellation wait, not that it won the guard: a successful prompt can release
the guard and then be descheduled before it sends its result on `promptDone`.
In that interleaving the test incorrectly treated the run as "reset won" and
asserted the prompt error must be `ErrSessionResetInProgress`, then called
`t.Fatal` when the prompt had actually succeeded — before joining the reset
goroutine, which also produced a secondary `sql: database is closed` teardown
error.

## Changes

- `apps/backend/internal/orchestrator/event_handlers_workflow_reset_quiescence_test.go`:
  - Stop inferring the guard winner from `cancelEntered` alone. Accept either
    valid outcome (prompt won and returned an error/nil, or reset won and the
    prompt observes `ErrSessionResetInProgress`).
  - Retain the bounded assertion that a reset-blocked prompt resolves before
    cancellation release, now via an explicit `promptTimedOut` flag instead of
    an inline `t.Fatal` that could fire before reset is joined.
  - Move the reset-sentinel assertion after `resetDone` is joined, so the test
    never fails without cleanly synchronizing with the reset goroutine first.
  - Updated the doc comment to document why `cancelEntered` alone can't
    identify the winner.

No production code changed; this is a deterministic test-harness fix. No
timeout was increased, no retry wrapper was added, and no assertion was
weakened — the missed-admission bound is still enforced, just after correctly
distinguishing the two valid orderings.

## Testing

- `go test ./internal/orchestrator -run '^TestResetAgentContext_SerializesPromptAdmission$' -count=100` — PASS
- `go test -race ./internal/orchestrator -run '^TestResetAgentContext_SerializesPromptAdmission$' -count=100` — PASS (previously reproduced 3 failures out of 100 before this fix)
- `go test ./internal/orchestrator` — PASS
- `golangci-lint run ./... --new-from-rev=<merge-base> --timeout=5m` — 0 issues
- `gofmt -l` on changed file — clean
- `git diff --check` — clean

## Breaking Changes

None.

## Related Issues

Follow-up to #3169 (merged). QA on that PR's exact head reproduced this
secondary race; see task evidence for repro details.


## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->