### PR TITLE
fix(backend): stop a subtask's PR from binding to unrelated tasks and archiving them

### DIFF
--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -673,6 +673,7 @@ func startAgentInfrastructure(
 		services.GitHub.SetTaskIssueStore(taskStoreAdapter)
 		services.GitHub.SetTaskRepositoryBaseBranchUpdater(taskStoreAdapter)
 		services.GitHub.SetTaskSessionChecker(&taskSessionCheckerAdapter{repo: repos.Task})
+		services.GitHub.SetWorkspaceGroupOwnerResolver(repos.Task)
 		log.Info("GitHub service configured for orchestrator (PR auto-detection enabled)")
 
 	}

--- a/apps/backend/internal/github/models.go
+++ b/apps/backend/internal/github/models.go
@@ -476,6 +476,17 @@ type PRWatch struct {
 	UpdatedAt       time.Time  `json:"updated_at" db:"updated_at"`
 }
 
+// TaskPR "source" values, recording which write path created the
+// association. Empty ("") is the default for rows written before this
+// column existed and is never backfilled.
+const (
+	// TaskPRSourceWatch is a PR observed via push detection or discovered by
+	// a PR watch (branch-based association).
+	TaskPRSourceWatch = "watch"
+	// TaskPRSourceURLLink is a PR the user explicitly linked by URL.
+	TaskPRSourceURLLink = "url_link"
+)
+
 // TaskPR associates a PR with a task. RepositoryID identifies which task
 // repository this PR belongs to (multi-repo tasks can have one PR per repo).
 // Empty for legacy rows persisted before multi-repo support.
@@ -523,6 +534,11 @@ type TaskPR struct {
 	LastSyncedAt            *time.Time `json:"last_synced_at,omitempty" db:"last_synced_at"`
 	DetachedAt              *time.Time `json:"-" db:"detached_at"`
 	UpdatedAt               time.Time  `json:"updated_at" db:"updated_at"`
+
+	// Source records which write path created this association: see
+	// TaskPRSourceWatch / TaskPRSourceURLLink. Empty on rows written before
+	// this column existed; never backfilled.
+	Source string `json:"source" db:"source"`
 
 	// --- PR outcome attribution (five nullable columns, never backfilled) ---
 	//

--- a/apps/backend/internal/github/poller.go
+++ b/apps/backend/internal/github/poller.go
@@ -231,13 +231,14 @@ func (p *Poller) tryBatchedPRWatchCheck(ctx context.Context, watches []*PRWatch)
 		if r.Watch.PRNumber == 0 {
 			continue
 		}
+		effectiveTaskID := p.service.resolveEffectiveAssociationTaskID(ctx, r.Watch.TaskID, r.Watch.RepositoryID)
 		pr := r.Status.PR
 		if pr != nil && (pr.State == prStateMerged || pr.State == prStateClosed) {
-			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
+			p.publishPRStatusEvent(ctx, r.Watch, effectiveTaskID, r.Status)
 			continue
 		}
 		if r.Changed {
-			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
+			p.publishPRStatusEvent(ctx, r.Watch, effectiveTaskID, r.Status)
 		}
 	}
 	return true
@@ -281,10 +282,19 @@ func (p *Poller) checkSinglePRWatch(ctx context.Context, watch *PRWatch) {
 		return
 	}
 
+	// A numbered watch found its PR before this fix existed (or before the
+	// discovering session's own group redirect took effect) keeps the
+	// observing member's task_id forever — watches are never re-pointed once
+	// they have a PR (see apps/backend/CLAUDE.md's "PR status sync coverage").
+	// Resolve the effective owner here, the same way associatePRWithTask does
+	// for the association write, so the background poller keeps syncing the
+	// owner's github_task_prs row instead of silently updating nothing.
+	effectiveTaskID := p.service.resolveEffectiveAssociationTaskID(ctx, watch.TaskID, watch.RepositoryID)
+
 	// Always sync latest PR state to the task-PR record.
-	if syncErr := p.service.SyncTaskPR(ctx, watch.TaskID, status); syncErr != nil {
+	if syncErr := p.service.SyncTaskPR(ctx, effectiveTaskID, status); syncErr != nil {
 		p.logger.Error("failed to sync task PR",
-			zap.String("task_id", watch.TaskID), zap.Error(syncErr))
+			zap.String("task_id", effectiveTaskID), zap.Error(syncErr))
 		return // Keep watch so the next cycle can retry
 	}
 	// When the tracked PR is merged or closed, reset the watch back to the
@@ -293,13 +303,13 @@ func (p *Poller) checkSinglePRWatch(ctx context.Context, watch *PRWatch) {
 	// closes #1 and opens #2 as a replacement) without requiring manual
 	// intervention. The watch is only deleted when its owning session is gone.
 	if status.PR != nil && (status.PR.State == prStateMerged || status.PR.State == prStateClosed) {
-		p.publishPRStatusEvent(ctx, watch, status)
+		p.publishPRStatusEvent(ctx, watch, effectiveTaskID, status)
 		hold, holdErr := p.service.ShouldHoldTerminalPRWatch(
-			ctx, watch.TaskID, watch.RepositoryID, watch.PRNumber, status.PR.State,
+			ctx, effectiveTaskID, watch.RepositoryID, watch.PRNumber, status.PR.State,
 		)
 		if holdErr != nil {
 			p.logger.Warn("failed to check terminal PR automation",
-				zap.String("task_id", watch.TaskID), zap.Error(holdErr))
+				zap.String("task_id", effectiveTaskID), zap.Error(holdErr))
 			return
 		}
 		if hold {
@@ -321,7 +331,7 @@ func (p *Poller) checkSinglePRWatch(ctx context.Context, watch *PRWatch) {
 		return
 	}
 
-	p.publishPRStatusEvent(ctx, watch, status)
+	p.publishPRStatusEvent(ctx, watch, effectiveTaskID, status)
 }
 
 // detectPRForWatch searches GitHub for a PR on the watch's branch.
@@ -383,13 +393,13 @@ func (p *Poller) detectPRForWatch(ctx context.Context, watch *PRWatch) {
 		zap.Int("pr_number", pr.Number))
 }
 
-func (p *Poller) publishPRStatusEvent(ctx context.Context, watch *PRWatch, status *PRStatus) {
+func (p *Poller) publishPRStatusEvent(ctx context.Context, watch *PRWatch, taskID string, status *PRStatus) {
 	if p.eventBus == nil {
 		return
 	}
 	evt := &PRFeedbackEvent{
 		SessionID:      watch.SessionID,
-		TaskID:         watch.TaskID,
+		TaskID:         taskID,
 		PRNumber:       watch.PRNumber,
 		Owner:          watch.Owner,
 		Repo:           watch.Repo,

--- a/apps/backend/internal/github/poller.go
+++ b/apps/backend/internal/github/poller.go
@@ -231,7 +231,9 @@ func (p *Poller) tryBatchedPRWatchCheck(ctx context.Context, watches []*PRWatch)
 		if r.Watch.PRNumber == 0 {
 			continue
 		}
-		effectiveTaskID := p.service.resolveEffectiveAssociationTaskID(ctx, r.Watch.TaskID, r.Watch.RepositoryID)
+		effectiveTaskID := p.service.reconcileTaskPROwnership(
+			ctx, r.Watch.SessionID, r.Watch.TaskID, r.Watch.RepositoryID, r.Watch.PRNumber,
+		)
 		pr := r.Status.PR
 		if pr != nil && (pr.State == prStateMerged || pr.State == prStateClosed) {
 			p.publishPRStatusEvent(ctx, r.Watch, effectiveTaskID, r.Status)
@@ -289,7 +291,9 @@ func (p *Poller) checkSinglePRWatch(ctx context.Context, watch *PRWatch) {
 	// Resolve the effective owner here, the same way associatePRWithTask does
 	// for the association write, so the background poller keeps syncing the
 	// owner's github_task_prs row instead of silently updating nothing.
-	effectiveTaskID := p.service.resolveEffectiveAssociationTaskID(ctx, watch.TaskID, watch.RepositoryID)
+	effectiveTaskID := p.service.reconcileTaskPROwnership(
+		ctx, watch.SessionID, watch.TaskID, watch.RepositoryID, watch.PRNumber,
+	)
 
 	// Always sync latest PR state to the task-PR record.
 	if syncErr := p.service.SyncTaskPR(ctx, effectiveTaskID, status); syncErr != nil {
@@ -379,7 +383,10 @@ func (p *Poller) detectPRForWatch(ctx context.Context, watch *PRWatch) {
 		return
 	}
 
-	if _, assocErr := p.service.AssociatePRWithTask(ctx, watch.TaskID, watch.RepositoryID, pr); assocErr != nil {
+	if _, assocErr := p.service.associatePRWithTaskForSession(
+		ctx, watch.WorkspaceID, watch.SessionID, watch.TaskID, watch.RepositoryID, pr,
+		false, false, TaskPRSourceWatch,
+	); assocErr != nil {
 		p.logger.Error("failed to associate detected PR with task",
 			zap.String("task_id", watch.TaskID),
 			zap.Int("pr_number", pr.Number),

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -101,27 +101,39 @@ type TaskRepositoryBaseBranchUpdater interface {
 	) error
 }
 
+// WorkspaceGroupOwnerResolver resolves the workspace-group owner task for a
+// task that may be a non-owner member sharing another task's worktree
+// (inherit_parent / shared_group). It mirrors
+// internal/orchestrator.resolveEffectivePushTaskID's lookup so that a
+// watch-sourced association write is redirected to the same task an
+// orchestrator-side watch would have redirected to — see
+// resolveEffectiveAssociationTaskID for the full rationale.
+type WorkspaceGroupOwnerResolver interface {
+	GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID string) (string, error)
+}
+
 // Service coordinates GitHub integration operations.
 type Service struct {
-	mu                       sync.Mutex
-	connectionMutationLocks  [64]sync.Mutex
-	client                   Client
-	authMethod               string
-	secrets                  SecretProvider
-	secretManager            SecretManager
-	connectionSecrets        ConnectionSecretStore
-	personalConnections      *StorePersonalConnectionRepository
-	resolver                 *CredentialResolver
-	appRegistrationRuntimes  map[string]*githubAppRuntime
-	appRegistrationLifecycle *AppRegistrationLifecycleService
-	credentialBroker         *CredentialBroker
-	store                    *Store
-	eventBus                 bus.EventBus
-	logger                   *logger.Logger
-	taskDeleter              TaskDeleter
-	taskRepositoryUpdater    TaskRepositoryBaseBranchUpdater
-	comparisonTargetObserver ComparisonTargetObserver
-	taskIssueStore           TaskIssueStore
+	mu                          sync.Mutex
+	connectionMutationLocks     [64]sync.Mutex
+	client                      Client
+	authMethod                  string
+	secrets                     SecretProvider
+	secretManager               SecretManager
+	connectionSecrets           ConnectionSecretStore
+	personalConnections         *StorePersonalConnectionRepository
+	resolver                    *CredentialResolver
+	appRegistrationRuntimes     map[string]*githubAppRuntime
+	appRegistrationLifecycle    *AppRegistrationLifecycleService
+	credentialBroker            *CredentialBroker
+	store                       *Store
+	eventBus                    bus.EventBus
+	logger                      *logger.Logger
+	taskDeleter                 TaskDeleter
+	taskRepositoryUpdater       TaskRepositoryBaseBranchUpdater
+	comparisonTargetObserver    ComparisonTargetObserver
+	taskIssueStore              TaskIssueStore
+	workspaceGroupOwnerResolver WorkspaceGroupOwnerResolver
 	// cascadeTaskDeleter is the cascade-delete entry point used by the
 	// watch reset flow. It is distinct from taskDeleter (which only deletes
 	// a single task by ID) because reset must walk the task tree and clean
@@ -288,6 +300,15 @@ func (s *Service) SetTaskDeleter(d TaskDeleter) { s.taskDeleter = d }
 // SetTaskRepositoryBaseBranchUpdater wires best-effort task base projection.
 func (s *Service) SetTaskRepositoryBaseBranchUpdater(updater TaskRepositoryBaseBranchUpdater) {
 	s.taskRepositoryUpdater = updater
+}
+
+// SetWorkspaceGroupOwnerResolver wires the workspace-group owner lookup used
+// by resolveEffectiveAssociationTaskID to redirect watch-sourced association
+// writes away from a non-owner shared-worktree member. Optional — when unset,
+// the redirect is a no-op and association writes keep their pre-existing
+// (potentially member-attributed) behavior.
+func (s *Service) SetWorkspaceGroupOwnerResolver(r WorkspaceGroupOwnerResolver) {
+	s.workspaceGroupOwnerResolver = r
 }
 
 // SetCascadeTaskDeleter wires the cascade-delete dependency used by the

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -112,6 +112,13 @@ type WorkspaceGroupOwnerResolver interface {
 	GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID string) (string, error)
 }
 
+// WorkspaceGroupOwnerSessionResolver resolves the owner for the exact group
+// bound to an observing session. It prevents a task with multiple active group
+// memberships from selecting an unrelated owner by task ID alone.
+type WorkspaceGroupOwnerSessionResolver interface {
+	GetWorkspaceGroupOwnerTaskIDForSession(ctx context.Context, taskID, sessionID string) (string, error)
+}
+
 // Service coordinates GitHub integration operations.
 type Service struct {
 	mu                          sync.Mutex

--- a/apps/backend/internal/github/service_pr_feedback_sync.go
+++ b/apps/backend/internal/github/service_pr_feedback_sync.go
@@ -53,13 +53,14 @@ func (s *Service) persistPRFeedbackState(ctx context.Context, workspaceID string
 		if tp == nil || tp.TaskID == "" {
 			continue
 		}
-		if _, dup := seen[tp.TaskID]; dup {
+		effectiveTaskID := s.reconcileTaskPROwnership(ctx, "", tp.TaskID, tp.RepositoryID, pr.Number)
+		if _, dup := seen[effectiveTaskID]; dup {
 			continue
 		}
-		seen[tp.TaskID] = struct{}{}
-		if syncErr := s.SyncTaskPR(ctx, tp.TaskID, status); syncErr != nil {
+		seen[effectiveTaskID] = struct{}{}
+		if syncErr := s.SyncTaskPR(ctx, effectiveTaskID, status); syncErr != nil {
 			s.logger.Debug("task PR sync from PR feedback failed",
-				zap.String("task_id", tp.TaskID), zap.Int("pr_number", pr.Number), zap.Error(syncErr))
+				zap.String("task_id", effectiveTaskID), zap.Int("pr_number", pr.Number), zap.Error(syncErr))
 		}
 	}
 }

--- a/apps/backend/internal/github/service_pr_unwatched.go
+++ b/apps/backend/internal/github/service_pr_unwatched.go
@@ -97,10 +97,32 @@ func (s *Service) syncUnwatchedTaskPRGroup(ctx context.Context, workspaceID stri
 		return
 	}
 	live := s.fetchUnwatchedTaskPRs(ctx, resolved, group)
+	seen := make(map[string]struct{}, len(group))
 	for _, tp := range group {
+		if tp == nil || tp.TaskID == "" {
+			continue
+		}
 		status := live[prStatusCacheKey(tp.Owner, tp.Repo, tp.PRNumber)]
 		if status == nil || status.PR == nil {
 			continue
+		}
+		effectiveTaskID := s.reconcileTaskPROwnership(ctx, "", tp.TaskID, tp.RepositoryID, tp.PRNumber)
+		seenKey := fmt.Sprintf("%s\x00%s\x00%d", effectiveTaskID, tp.RepositoryID, tp.PRNumber)
+		if _, duplicate := seen[seenKey]; duplicate {
+			continue
+		}
+		seen[seenKey] = struct{}{}
+		if effectiveTaskID != tp.TaskID {
+			ownerTP, loadErr := s.store.GetTaskPRByRepoAndNumber(ctx, effectiveTaskID, tp.RepositoryID, tp.PRNumber)
+			if loadErr != nil {
+				s.logger.Debug("load reconciled owner task PR failed",
+					zap.String("task_id", effectiveTaskID), zap.Int("pr_number", tp.PRNumber), zap.Error(loadErr))
+				continue
+			}
+			if ownerTP == nil {
+				continue
+			}
+			tp = ownerTP
 		}
 		if syncErr := s.reconcileTaskPRLifecycle(ctx, tp, status); syncErr != nil {
 			s.logger.Debug("unwatched task PR reconcile failed",

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -1578,6 +1578,14 @@ func (s *Service) triggerPRStatusSync(ctx context.Context, watch *PRWatch, taskI
 	if watch == nil || strings.TrimSpace(watch.WorkspaceID) == "" {
 		return nil, ErrGitHubWorkspaceRequired
 	}
+	// taskID is derived from the watch (callers fetch watches by task_id), so
+	// a numbered watch that found its PR before this fix existed still carries
+	// the observing member's task_id — watches are never re-pointed once they
+	// have a PR (see apps/backend/CLAUDE.md's "PR status sync coverage").
+	// Resolve the effective owner the same way associatePRWithTask does for
+	// the association write, so an on-demand sync keeps landing on the
+	// owner's github_task_prs row instead of silently updating nothing.
+	taskID = s.resolveEffectiveAssociationTaskID(ctx, taskID, watch.RepositoryID)
 	resolved, err := s.resolveAutomationClient(ctx, watch.WorkspaceID, watch.Owner, watch.Repo)
 	if err != nil {
 		return nil, err

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -306,7 +306,7 @@ func (s *Service) AssociatePRWithTask(ctx context.Context, taskID, repositoryID 
 	// pr here comes from branch-search discovery (poller.detectPRForWatch) or
 	// a batched status result of unknown populated-ness — never assert
 	// outcomeFieldsPopulated for this wrapper's callers (AC-11).
-	return s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, false, false)
+	return s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, false, false, TaskPRSourceWatch)
 }
 
 // AssociatePRWithTaskForWorkspace is the workspace-scoped variant of
@@ -317,7 +317,7 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 	if strings.TrimSpace(workspaceID) == "" {
 		return nil, ErrGitHubWorkspaceRequired
 	}
-	return s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, false, false)
+	return s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, false, false, TaskPRSourceWatch)
 }
 
 // associatePRWithTask creates the task-PR association. outcomeFieldsPopulated
@@ -325,9 +325,13 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 // direct GetPR-based callers in this file set it true; the two public
 // wrappers above always pass false, preserving their existing callers'
 // behavior exactly, because a branch-search or batched-status pr may not
-// carry real observations for these fields (AC-11).
+// carry real observations for these fields (AC-11). source is only applied
+// when this call creates a brand-new row (see TaskPRSourceWatch /
+// TaskPRSourceURLLink) — an existing or restored row keeps its original
+// source classification (no backfill).
 func (s *Service) associatePRWithTask(
-	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR, restoreDetached, outcomeFieldsPopulated bool,
+	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR,
+	restoreDetached, outcomeFieldsPopulated bool, source string,
 ) (*TaskPR, error) {
 	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
 		return nil, err
@@ -388,6 +392,7 @@ func (s *Service) associatePRWithTask(
 		CreatedAt:    pr.CreatedAt,
 		MergedAt:     pr.MergedAt,
 		ClosedAt:     pr.ClosedAt,
+		Source:       source,
 	}
 	// ReplaceTaskPR upserts the row matching (task, repository, pr_number)
 	// and resolves the five outcome-attribution columns itself, inside its
@@ -447,7 +452,7 @@ func (s *Service) AssociateExistingPRByURL(ctx context.Context, taskID, reposito
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR: %w", err)
 	}
-	tp, err := s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, true, true)
+	tp, err := s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, true, true, TaskPRSourceURLLink)
 	if err != nil {
 		return nil, fmt.Errorf("associate PR with task: %w", err)
 	}
@@ -477,7 +482,7 @@ func (s *Service) AssociateExistingPRByURLForWorkspace(
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR: %w", err)
 	}
-	tp, err := s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, true, true)
+	tp, err := s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, true, true, TaskPRSourceURLLink)
 	if err != nil {
 		return nil, fmt.Errorf("associate PR with task: %w", err)
 	}
@@ -522,7 +527,7 @@ func (s *Service) AssociatePRByURL(ctx context.Context, sessionID, taskID, repos
 	}
 
 	// Associate PR with task (persists + publishes WS event)
-	if _, assocErr := s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, true, true); assocErr != nil {
+	if _, assocErr := s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, true, true, TaskPRSourceWatch); assocErr != nil {
 		s.logger.Error("failed to associate PR with task after creation",
 			zap.String("task_id", taskID), zap.Error(assocErr))
 	}
@@ -557,7 +562,7 @@ func (s *Service) AssociatePRByURLForWorkspace(
 	); err != nil {
 		return fmt.Errorf("create PR watch: %w", err)
 	}
-	if _, err := s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, true, true); err != nil {
+	if _, err := s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, true, true, TaskPRSourceWatch); err != nil {
 		return fmt.Errorf("associate PR with task: %w", err)
 	}
 	return nil

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -320,6 +320,83 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 	return s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, false, false, TaskPRSourceWatch)
 }
 
+// resolveEffectiveAssociationTaskID redirects a watch-sourced association
+// write to the workspace-group owner task, independently of whatever
+// producer called in. It exists as defense-in-depth alongside
+// internal/orchestrator's resolveEffectivePushTaskID: that helper redirects
+// every watch/association call site the orchestrator package controls, but
+// Review Round 2 (F4) found a fifth orchestrator producer it had missed, and
+// F5 found that redirect alone does nothing for github_pr_watches rows that
+// already carry a member task_id from before the fix existed — those stale
+// watches keep feeding poller.go's AssociatePRWithTask(watch.TaskID, ...)
+// forever, since nothing ever rewrites a watch's task_id. Applying the same
+// redirect again at this single private write funnel closes both gaps at
+// once: it does not matter which orchestrator producer supplied taskID, or
+// whether the watch driving it predates this fix, because every watch-sourced
+// write is re-checked here before it lands.
+//
+// Only applied to source == TaskPRSourceWatch. TaskPRSourceURLLink
+// (AssociateExistingPRByURL/ForWorkspace) is a deliberate cross-task action —
+// the user explicitly chose to link a specific PR to the task whose card they
+// were viewing, independent of worktree sharing — and must never be
+// silently rerouted to a different task.
+//
+// Falls back to taskID unchanged (matching resolveEffectivePushTaskID's own
+// fallback semantics) whenever the redirect can't be safely applied: no
+// resolver wired, taskID empty, no group/no distinct owner, the lookup
+// errors, the owner task can't be loaded or is archived, or the owner
+// doesn't hold repositoryID itself (redirecting would just make
+// validateTaskRepositoryID reject the owner and drop the association, which
+// is worse than leaving it under the observing task — the same reasoning
+// Round 2 applied to resolveEffectivePushTaskID's own repository check).
+func (s *Service) resolveEffectiveAssociationTaskID(ctx context.Context, taskID, repositoryID string) string {
+	if taskID == "" {
+		return taskID
+	}
+	resolver := s.workspaceGroupOwnerResolver
+	if resolver == nil {
+		return taskID
+	}
+	ownerTaskID, err := resolver.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	if err != nil || ownerTaskID == "" || ownerTaskID == taskID {
+		return taskID
+	}
+	store := s.getTaskIssueStore()
+	if store == nil {
+		return taskID
+	}
+	ownerTask, err := store.GetTask(ctx, ownerTaskID)
+	if err != nil || ownerTask == nil || ownerTask.ArchivedAt != nil {
+		return taskID
+	}
+	if repositoryID != "" && !s.associationOwnerHoldsRepository(ctx, store, ownerTaskID, repositoryID) {
+		return taskID
+	}
+	s.logger.Info("redirecting watch-sourced PR association to workspace group owner",
+		zap.String("from_task_id", taskID),
+		zap.String("to_task_id", ownerTaskID),
+		zap.String("repository_id", repositoryID))
+	return ownerTaskID
+}
+
+// associationOwnerHoldsRepository reports whether taskID has a
+// task_repositories row for repositoryID. Used by
+// resolveEffectiveAssociationTaskID to avoid redirecting into a write that
+// validateTaskRepositoryID would reject and associatePRWithTask would then
+// silently drop.
+func (s *Service) associationOwnerHoldsRepository(ctx context.Context, store TaskIssueStore, taskID, repositoryID string) bool {
+	taskRepos, err := store.ListTaskRepositories(ctx, taskID)
+	if err != nil {
+		return false
+	}
+	for _, tr := range taskRepos {
+		if tr != nil && tr.RepositoryID == repositoryID {
+			return true
+		}
+	}
+	return false
+}
+
 // associatePRWithTask creates the task-PR association. outcomeFieldsPopulated
 // tells it whether pr came from a full single-PR fetch (AC-10) — only the
 // direct GetPR-based callers in this file set it true; the two public
@@ -328,11 +405,16 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 // carry real observations for these fields (AC-11). source is only applied
 // when this call creates a brand-new row (see TaskPRSourceWatch /
 // TaskPRSourceURLLink) — an existing or restored row keeps its original
-// source classification (no backfill).
+// source classification (no backfill). taskID is redirected to the
+// workspace-group owner before anything else runs when source is
+// TaskPRSourceWatch — see resolveEffectiveAssociationTaskID.
 func (s *Service) associatePRWithTask(
 	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR,
 	restoreDetached, outcomeFieldsPopulated bool, source string,
 ) (*TaskPR, error) {
+	if source == TaskPRSourceWatch {
+		taskID = s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
+	}
 	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -54,6 +54,7 @@ func (s *Service) createPRWatch(
 	if existing != nil {
 		return existing, nil // already watching this (session, repo, branch)
 	}
+	taskID = s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 	w := &PRWatch{
 		WorkspaceID:  workspaceID,
 		SessionID:    sessionID,
@@ -271,6 +272,7 @@ func (s *Service) ensurePRWatch(
 	if existing != nil {
 		return existing, nil
 	}
+	taskID = s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 	w := &PRWatch{
 		WorkspaceID:  workspaceID,
 		SessionID:    sessionID,
@@ -341,7 +343,7 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 // were viewing, independent of worktree sharing — and must never be
 // silently rerouted to a different task.
 //
-// Falls back to taskID unchanged (matching resolveEffectivePushTaskID's own
+// Falls back to taskID unchanged (matching the orchestrator resolver's
 // fallback semantics) whenever the redirect can't be safely applied: no
 // resolver wired, taskID empty, no group/no distinct owner, the lookup
 // errors, the owner task can't be loaded or is archived, or the owner
@@ -349,7 +351,9 @@ func (s *Service) AssociatePRWithTaskForWorkspace(
 // validateTaskRepositoryID reject the owner and drop the association, which
 // is worse than leaving it under the observing task — the same reasoning
 // Round 2 applied to resolveEffectivePushTaskID's own repository check).
-func (s *Service) resolveEffectiveAssociationTaskID(ctx context.Context, taskID, repositoryID string) string {
+func (s *Service) resolveEffectiveAssociationTaskIDForSession(
+	ctx context.Context, sessionID, taskID, repositoryID string,
+) string {
 	if taskID == "" {
 		return taskID
 	}
@@ -357,7 +361,18 @@ func (s *Service) resolveEffectiveAssociationTaskID(ctx context.Context, taskID,
 	if resolver == nil {
 		return taskID
 	}
-	ownerTaskID, err := resolver.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	var ownerTaskID string
+	var err error
+	if sessionID != "" {
+		if sessionResolver, ok := any(resolver).(WorkspaceGroupOwnerSessionResolver); ok {
+			ownerTaskID, err = sessionResolver.GetWorkspaceGroupOwnerTaskIDForSession(ctx, taskID, sessionID)
+		} else {
+			// Keep compatibility with older adapters and focused test doubles.
+			ownerTaskID, err = resolver.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+		}
+	} else {
+		ownerTaskID, err = resolver.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	}
 	if err != nil || ownerTaskID == "" || ownerTaskID == taskID {
 		return taskID
 	}
@@ -397,6 +412,36 @@ func (s *Service) associationOwnerHoldsRepository(ctx context.Context, store Tas
 	return false
 }
 
+// reconcileTaskPROwnership repairs an active member-owned row before a
+// watch-sourced sync writes the effective owner. The store operation is
+// atomic and does not publish an intermediate member event, so one upstream
+// observation produces one owner-scoped update.
+func (s *Service) reconcileTaskPROwnership(
+	ctx context.Context, sessionID, memberTaskID, repositoryID string, prNumber int,
+) string {
+	ownerTaskID := s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, memberTaskID, repositoryID)
+	if ownerTaskID == "" || ownerTaskID == memberTaskID || prNumber == 0 || s.store == nil {
+		return ownerTaskID
+	}
+	reconciler, ok := any(s.store).(TaskPROwnershipReconciler)
+	if !ok {
+		return ownerTaskID
+	}
+	if _, err := reconciler.ReconcileTaskPROwnership(
+		ctx, memberTaskID, ownerTaskID, repositoryID, prNumber,
+	); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("failed to reconcile legacy member task PR",
+				zap.String("member_task_id", memberTaskID),
+				zap.String("owner_task_id", ownerTaskID),
+				zap.String("repository_id", repositoryID),
+				zap.Int("pr_number", prNumber),
+				zap.Error(err))
+		}
+	}
+	return ownerTaskID
+}
+
 // associatePRWithTask creates the task-PR association. outcomeFieldsPopulated
 // tells it whether pr came from a full single-PR fetch (AC-10) — only the
 // direct GetPR-based callers in this file set it true; the two public
@@ -412,8 +457,20 @@ func (s *Service) associatePRWithTask(
 	ctx context.Context, workspaceID, taskID, repositoryID string, pr *PR,
 	restoreDetached, outcomeFieldsPopulated bool, source string,
 ) (*TaskPR, error) {
+	return s.associatePRWithTaskForSession(ctx, workspaceID, "", taskID, repositoryID, pr,
+		restoreDetached, outcomeFieldsPopulated, source)
+}
+
+func (s *Service) associatePRWithTaskForSession(
+	ctx context.Context, workspaceID, sessionID, taskID, repositoryID string, pr *PR,
+	restoreDetached, outcomeFieldsPopulated bool, source string,
+) (*TaskPR, error) {
+	originalTaskID := taskID
 	if source == TaskPRSourceWatch {
-		taskID = s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
+		taskID = s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, taskID, repositoryID)
+		if taskID != originalTaskID {
+			s.reconcileTaskPROwnership(ctx, sessionID, originalTaskID, repositoryID, pr.Number)
+		}
 	}
 	if err := s.validateTaskRepositoryID(ctx, taskID, repositoryID); err != nil {
 		return nil, err
@@ -607,14 +664,14 @@ func (s *Service) AssociatePRByURL(ctx context.Context, sessionID, taskID, repos
 	// its only sync handle (get-or-create, never re-pointed on a hit), so it
 	// must agree with the association's task_id or the redirected owner's
 	// row never syncs.
-	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
+	effectiveTaskID := s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 	if _, watchErr := s.CreatePRWatch(ctx, sessionID, effectiveTaskID, repositoryID, owner, repo, prNumber, branch); watchErr != nil {
 		s.logger.Error("failed to create PR watch after PR creation",
 			zap.String("session_id", sessionID), zap.Error(watchErr))
 	}
 
 	// Associate PR with task (persists + publishes WS event)
-	if _, assocErr := s.associatePRWithTask(ctx, "", effectiveTaskID, repositoryID, pr, true, true, TaskPRSourceWatch); assocErr != nil {
+	if _, assocErr := s.associatePRWithTaskForSession(ctx, "", sessionID, taskID, repositoryID, pr, true, true, TaskPRSourceWatch); assocErr != nil {
 		s.logger.Error("failed to associate PR with task after creation",
 			zap.String("task_id", effectiveTaskID), zap.Error(assocErr))
 	}
@@ -648,13 +705,13 @@ func (s *Service) AssociatePRByURLForWorkspace(
 	// its only sync handle (get-or-create, never re-pointed on a hit), so it
 	// must agree with the association's task_id or the redirected owner's
 	// row never syncs.
-	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
+	effectiveTaskID := s.resolveEffectiveAssociationTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 	if _, err := s.CreatePRWatchForWorkspace(
 		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, owner, repo, prNumber, branch,
 	); err != nil {
 		return fmt.Errorf("create PR watch: %w", err)
 	}
-	if _, err := s.associatePRWithTask(ctx, workspaceID, effectiveTaskID, repositoryID, pr, true, true, TaskPRSourceWatch); err != nil {
+	if _, err := s.associatePRWithTaskForSession(ctx, workspaceID, sessionID, taskID, repositoryID, pr, true, true, TaskPRSourceWatch); err != nil {
 		return fmt.Errorf("associate PR with task: %w", err)
 	}
 	return nil
@@ -1518,7 +1575,8 @@ func (s *Service) detectPRForWatchOnce(
 	// re-hits `gh` on every on-demand sync, and the frontend re-syncs every 5s
 	// while no PR is found — flooding the logs with identical failures.
 	if watch.LastCheckedAt != nil && time.Since(*watch.LastCheckedAt) < PRSyncFreshnessWindow {
-		return s.store.GetTaskPRByRepository(ctx, taskID, watch.RepositoryID)
+		effectiveTaskID := s.reconcileTaskPROwnership(ctx, watch.SessionID, watch.TaskID, watch.RepositoryID, watch.PRNumber)
+		return s.store.GetTaskPRByRepository(ctx, effectiveTaskID, watch.RepositoryID)
 	}
 
 	// Snapshot the negative-cache generation BEFORE the fetch so an
@@ -1564,9 +1622,12 @@ func (s *Service) detectPRForWatchOnce(
 			zap.String("watch_id", watch.ID), zap.Int("pr_number", pr.Number), zap.Error(err))
 		return nil, fmt.Errorf("update PR watch: %w", err)
 	}
-	if _, assocErr := s.AssociatePRWithTaskForWorkspace(ctx, watch.WorkspaceID, taskID, watch.RepositoryID, pr); assocErr != nil {
+	if _, assocErr := s.associatePRWithTaskForSession(
+		ctx, watch.WorkspaceID, watch.SessionID, watch.TaskID, watch.RepositoryID, pr,
+		false, false, TaskPRSourceWatch,
+	); assocErr != nil {
 		s.logger.Error("failed to associate PR with task during sync",
-			zap.String("task_id", taskID), zap.Int("pr_number", pr.Number), zap.Error(assocErr))
+			zap.String("task_id", watch.TaskID), zap.Int("pr_number", pr.Number), zap.Error(assocErr))
 		return nil, fmt.Errorf("associate PR: %w", assocErr)
 	}
 	// Also fetch status so the first response includes review/check state
@@ -1585,7 +1646,11 @@ func (s *Service) triggerPRStatusSync(ctx context.Context, watch *PRWatch, taskI
 	// Resolve the effective owner the same way associatePRWithTask does for
 	// the association write, so an on-demand sync keeps landing on the
 	// owner's github_task_prs row instead of silently updating nothing.
-	taskID = s.resolveEffectiveAssociationTaskID(ctx, taskID, watch.RepositoryID)
+	rawTaskID := taskID
+	if watch.TaskID != "" {
+		rawTaskID = watch.TaskID
+	}
+	taskID = s.reconcileTaskPROwnership(ctx, watch.SessionID, rawTaskID, watch.RepositoryID, watch.PRNumber)
 	resolved, err := s.resolveAutomationClient(ctx, watch.WorkspaceID, watch.Owner, watch.Repo)
 	if err != nil {
 		return nil, err
@@ -1647,7 +1712,10 @@ func (s *Service) triggerPRStatusSync(ctx context.Context, watch *PRWatch, taskI
 			// created. AssociatePRWithTask publishes the creation event; the
 			// following SyncTaskPR may publish again if status fields changed.
 			// That double event is harmless because clients re-fetch state.
-			if _, assocErr := s.AssociatePRWithTask(bgCtx, taskID, watch.RepositoryID, status.PR); assocErr != nil {
+			if _, assocErr := s.associatePRWithTaskForSession(
+				bgCtx, watch.WorkspaceID, watch.SessionID, rawTaskID, watch.RepositoryID, status.PR,
+				false, false, TaskPRSourceWatch,
+			); assocErr != nil {
 				return nil, assocErr
 			}
 		}

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -603,15 +603,20 @@ func (s *Service) AssociatePRByURL(ctx context.Context, sessionID, taskID, repos
 	if branch == "" {
 		branch = pr.HeadBranch
 	}
-	if _, watchErr := s.CreatePRWatch(ctx, sessionID, taskID, repositoryID, owner, repo, prNumber, branch); watchErr != nil {
+	// Resolved once and reused for both writes below: the watch's task_id is
+	// its only sync handle (get-or-create, never re-pointed on a hit), so it
+	// must agree with the association's task_id or the redirected owner's
+	// row never syncs.
+	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
+	if _, watchErr := s.CreatePRWatch(ctx, sessionID, effectiveTaskID, repositoryID, owner, repo, prNumber, branch); watchErr != nil {
 		s.logger.Error("failed to create PR watch after PR creation",
 			zap.String("session_id", sessionID), zap.Error(watchErr))
 	}
 
 	// Associate PR with task (persists + publishes WS event)
-	if _, assocErr := s.associatePRWithTask(ctx, "", taskID, repositoryID, pr, true, true, TaskPRSourceWatch); assocErr != nil {
+	if _, assocErr := s.associatePRWithTask(ctx, "", effectiveTaskID, repositoryID, pr, true, true, TaskPRSourceWatch); assocErr != nil {
 		s.logger.Error("failed to associate PR with task after creation",
-			zap.String("task_id", taskID), zap.Error(assocErr))
+			zap.String("task_id", effectiveTaskID), zap.Error(assocErr))
 	}
 }
 
@@ -639,12 +644,17 @@ func (s *Service) AssociatePRByURLForWorkspace(
 	if branch == "" {
 		branch = pr.HeadBranch
 	}
+	// Resolved once and reused for both writes below: the watch's task_id is
+	// its only sync handle (get-or-create, never re-pointed on a hit), so it
+	// must agree with the association's task_id or the redirected owner's
+	// row never syncs.
+	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, taskID, repositoryID)
 	if _, err := s.CreatePRWatchForWorkspace(
-		ctx, workspaceID, sessionID, taskID, repositoryID, owner, repo, prNumber, branch,
+		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, owner, repo, prNumber, branch,
 	); err != nil {
 		return fmt.Errorf("create PR watch: %w", err)
 	}
-	if _, err := s.associatePRWithTask(ctx, workspaceID, taskID, repositoryID, pr, true, true, TaskPRSourceWatch); err != nil {
+	if _, err := s.associatePRWithTask(ctx, workspaceID, effectiveTaskID, repositoryID, pr, true, true, TaskPRSourceWatch); err != nil {
 		return fmt.Errorf("associate PR with task: %w", err)
 	}
 	return nil

--- a/apps/backend/internal/github/service_pr_watch_batched.go
+++ b/apps/backend/internal/github/service_pr_watch_batched.go
@@ -307,7 +307,7 @@ func (s *Service) applyBatchedNumberedWatch(
 	// Resolve the effective owner here, the same way associatePRWithTask does
 	// for the association write, so this loop keeps syncing the owner's
 	// github_task_prs row instead of silently updating nothing.
-	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, w.TaskID, w.RepositoryID)
+	effectiveTaskID := s.reconcileTaskPROwnership(ctx, w.SessionID, w.TaskID, w.RepositoryID, w.PRNumber)
 
 	// Gap-fill: a numbered watch can exist even when its exact task_pr row was
 	// never created. This targeted read is unconditional because the common
@@ -322,7 +322,10 @@ func (s *Service) applyBatchedNumberedWatch(
 			zap.Int("pr_number", w.PRNumber), zap.Error(err))
 		return PRWatchSyncResult{Watch: w, Status: status, Found: true, SyncFailed: true}
 	} else if existing == nil && status.PR != nil {
-		if _, assocErr := s.AssociatePRWithTaskForWorkspace(ctx, w.WorkspaceID, w.TaskID, w.RepositoryID, status.PR); assocErr != nil {
+		if _, assocErr := s.associatePRWithTaskForSession(
+			ctx, w.WorkspaceID, w.SessionID, w.TaskID, w.RepositoryID, status.PR,
+			false, false, TaskPRSourceWatch,
+		); assocErr != nil {
 			s.logger.Error("failed to associate numbered PR with task",
 				zap.String("task_id", w.TaskID), zap.Int("pr_number", w.PRNumber), zap.Error(assocErr))
 			return PRWatchSyncResult{Watch: w, Status: status, Found: true, SyncFailed: true}
@@ -435,7 +438,10 @@ func (s *Service) applyBatchedSearchingWatch(
 			zap.String("watch_id", w.ID), zap.Int("pr_number", status.PR.Number), zap.Error(err))
 		return PRWatchSyncResult{Watch: w, Status: status, Found: true}
 	}
-	if _, err := s.AssociatePRWithTaskForWorkspace(ctx, w.WorkspaceID, w.TaskID, w.RepositoryID, status.PR); err != nil {
+	if _, err := s.associatePRWithTaskForSession(
+		ctx, w.WorkspaceID, w.SessionID, w.TaskID, w.RepositoryID, status.PR,
+		false, false, TaskPRSourceWatch,
+	); err != nil {
 		s.logger.Error("failed to associate detected PR with task",
 			zap.String("task_id", w.TaskID), zap.Int("pr_number", status.PR.Number), zap.Error(err))
 		return PRWatchSyncResult{Watch: w, Status: status, Found: true}

--- a/apps/backend/internal/github/service_pr_watch_batched.go
+++ b/apps/backend/internal/github/service_pr_watch_batched.go
@@ -300,6 +300,15 @@ func (s *Service) applyBatchedNumberedWatch(
 	if err := s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, commentAt, status.ChecksState, status.ReviewState); err != nil {
 		s.logger.Error("failed to update PR watch timestamps", zap.String("id", w.ID), zap.Error(err))
 	}
+	// A numbered watch found its PR before this fix existed (or before the
+	// discovering session's own group redirect took effect) keeps the
+	// observing member's task_id forever — watches are never re-pointed once
+	// they have a PR (see apps/backend/CLAUDE.md's "PR status sync coverage").
+	// Resolve the effective owner here, the same way associatePRWithTask does
+	// for the association write, so this loop keeps syncing the owner's
+	// github_task_prs row instead of silently updating nothing.
+	effectiveTaskID := s.resolveEffectiveAssociationTaskID(ctx, w.TaskID, w.RepositoryID)
+
 	// Gap-fill: a numbered watch can exist even when its exact task_pr row was
 	// never created. This targeted read is unconditional because the common
 	// existing-row path is cheap, and the missing-row path must repair before
@@ -307,9 +316,9 @@ func (s *Service) applyBatchedNumberedWatch(
 	// creation event; the following SyncTaskPR may publish a second event when
 	// status fields changed. That double event is harmless because clients
 	// re-fetch the task PR state.
-	if existing, err := s.store.GetTaskPRByRepoAndNumber(ctx, w.TaskID, w.RepositoryID, w.PRNumber); err != nil {
+	if existing, err := s.store.GetTaskPRByRepoAndNumber(ctx, effectiveTaskID, w.RepositoryID, w.PRNumber); err != nil {
 		s.logger.Error("failed to load exact task PR",
-			zap.String("task_id", w.TaskID), zap.String("repository_id", w.RepositoryID),
+			zap.String("task_id", effectiveTaskID), zap.String("repository_id", w.RepositoryID),
 			zap.Int("pr_number", w.PRNumber), zap.Error(err))
 		return PRWatchSyncResult{Watch: w, Status: status, Found: true, SyncFailed: true}
 	} else if existing == nil && status.PR != nil {
@@ -319,8 +328,8 @@ func (s *Service) applyBatchedNumberedWatch(
 			return PRWatchSyncResult{Watch: w, Status: status, Found: true, SyncFailed: true}
 		}
 	}
-	if syncErr := s.SyncTaskPR(ctx, w.TaskID, status); syncErr != nil {
-		s.logger.Error("failed to sync task PR", zap.String("task_id", w.TaskID), zap.Error(syncErr))
+	if syncErr := s.SyncTaskPR(ctx, effectiveTaskID, status); syncErr != nil {
+		s.logger.Error("failed to sync task PR", zap.String("task_id", effectiveTaskID), zap.Error(syncErr))
 		// SyncFailed=true so poller skips publishing PR feedback while the
 		// task_pr row is still stale — old applyPRStatus path early-returned
 		// on this error for the same reason.
@@ -330,7 +339,7 @@ func (s *Service) applyBatchedNumberedWatch(
 	// same branch can be detected without manual intervention.
 	if status.PR != nil && (status.PR.State == prStateMerged || status.PR.State == prStateClosed) {
 		hold, holdErr := s.ShouldHoldTerminalPRWatch(
-			ctx, w.TaskID, w.RepositoryID, w.PRNumber, status.PR.State,
+			ctx, effectiveTaskID, w.RepositoryID, w.PRNumber, status.PR.State,
 		)
 		if holdErr != nil {
 			s.logger.Error("failed to check terminal PR automation", zap.String("id", w.ID), zap.Error(holdErr))

--- a/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
+++ b/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
@@ -1,0 +1,255 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+// multiTaskIssueStore is a TaskIssueStore fake keyed by task ID, unlike the
+// single-task fakeTaskIssueStore in service_task_issue_test.go. F5's redirect
+// tests need two distinct tasks resolvable at once: the observing task
+// (validated before any redirect decision is made) and the workspace-group
+// owner (validated by resolveEffectiveAssociationTaskID itself) — a
+// single-task fake can't represent both without one lookup spuriously
+// failing.
+type multiTaskIssueStore struct {
+	tasks map[string]*taskmodels.Task
+	repos map[string][]*taskmodels.TaskRepository
+}
+
+func newMultiTaskIssueStore() *multiTaskIssueStore {
+	return &multiTaskIssueStore{
+		tasks: make(map[string]*taskmodels.Task),
+		repos: make(map[string][]*taskmodels.TaskRepository),
+	}
+}
+
+func (m *multiTaskIssueStore) addTask(task *taskmodels.Task, repositoryIDs ...string) {
+	m.tasks[task.ID] = task
+	repos := make([]*taskmodels.TaskRepository, 0, len(repositoryIDs))
+	for _, repoID := range repositoryIDs {
+		repos = append(repos, &taskmodels.TaskRepository{ID: "tr-" + task.ID + "-" + repoID, TaskID: task.ID, RepositoryID: repoID})
+	}
+	m.repos[task.ID] = repos
+}
+
+func (m *multiTaskIssueStore) GetTask(_ context.Context, taskID string) (*taskmodels.Task, error) {
+	task, ok := m.tasks[taskID]
+	if !ok {
+		return nil, errors.New("task not found")
+	}
+	return task, nil
+}
+
+func (m *multiTaskIssueStore) ListTaskRepositories(_ context.Context, taskID string) ([]*taskmodels.TaskRepository, error) {
+	task, ok := m.tasks[taskID]
+	if !ok {
+		return nil, errors.New("task not found")
+	}
+	return m.repos[task.ID], nil
+}
+
+func (m *multiTaskIssueStore) GetRepository(_ context.Context, _ string) (*taskmodels.Repository, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *multiTaskIssueStore) UpdateTaskMetadata(
+	_ context.Context, _ string, _ map[string]interface{},
+) (*taskmodels.Task, error) {
+	return nil, errors.New("not implemented")
+}
+
+// fakeWorkspaceGroupOwnerResolver is a WorkspaceGroupOwnerResolver fake for
+// resolveEffectiveAssociationTaskID's tests — a fixed answer (or error) is
+// enough since the redirect logic itself, not the lookup, is under test.
+type fakeWorkspaceGroupOwnerResolver struct {
+	ownerTaskID string
+	err         error
+}
+
+func (f *fakeWorkspaceGroupOwnerResolver) GetWorkspaceGroupOwnerTaskID(_ context.Context, _ string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.ownerTaskID, nil
+}
+
+// TestAssociatePRWithTask_RedirectsWatchSourcedToWorkspaceGroupOwner covers
+// Review Round 2's F5 finding: a github_pr_watches row that already carries a
+// member task's ID (whether written before this fix existed, or by any
+// orchestrator producer a future change might miss) keeps feeding
+// poller.go's AssociatePRWithTask(watch.TaskID, ...) forever, since nothing
+// ever rewrites a watch's stored task_id. Redirecting again at this single
+// private write funnel closes that gap independently of which caller or
+// which stale row supplied taskID.
+func TestAssociatePRWithTask_RedirectsWatchSourcedToWorkspaceGroupOwner(t *testing.T) {
+	_, svc, _, store := setupPollerTest(t)
+
+	issueStore := newMultiTaskIssueStore()
+	issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-canonical")
+	svc.SetTaskIssueStore(issueStore)
+	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+
+	ctx := context.Background()
+	pr := &PR{
+		Number: 42, RepoOwner: "org", RepoName: "repo",
+		HTMLURL: "https://github.com/org/repo/pull/42",
+	}
+
+	tp, err := svc.AssociatePRWithTask(ctx, "member1", "repo-canonical", pr)
+	if err != nil {
+		t.Fatalf("AssociatePRWithTask: %v", err)
+	}
+	if tp.TaskID != "owner1" {
+		t.Fatalf("TaskPR.TaskID = %q, want owner1 (the group owner)", tp.TaskID)
+	}
+
+	ownerRows, err := store.ListTaskPRsByTask(ctx, "owner1")
+	if err != nil {
+		t.Fatalf("list owner PR associations: %v", err)
+	}
+	if len(ownerRows) != 1 {
+		t.Fatalf("got %d PR associations for owner1, want 1: %+v", len(ownerRows), ownerRows)
+	}
+
+	memberRows, err := store.ListTaskPRsByTask(ctx, "member1")
+	if err != nil {
+		t.Fatalf("list member PR associations: %v", err)
+	}
+	if len(memberRows) != 0 {
+		t.Fatalf("got %d PR associations for member1, want 0 (redirected, not duplicated): %+v", len(memberRows), memberRows)
+	}
+}
+
+// TestAssociatePRWithTask_FallsBackToObservingTask covers STEP 1b's
+// fail-safe requirement for resolveEffectiveAssociationTaskID: every way the
+// redirect can't be safely applied must leave the association under the
+// observing task rather than silently dropping it (a redirect into a task
+// validateTaskRepositoryID then rejects) or panicking on a missing
+// dependency.
+func TestAssociatePRWithTask_FallsBackToObservingTask(t *testing.T) {
+	tests := []struct {
+		name    string
+		wire    func(svc *Service, issueStore *multiTaskIssueStore)
+		wantErr bool
+	}{
+		{
+			name: "no resolver wired",
+			wire: func(_ *Service, issueStore *multiTaskIssueStore) {
+				issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+			},
+		},
+		{
+			name: "resolver errors",
+			wire: func(svc *Service, issueStore *multiTaskIssueStore) {
+				issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+				svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{err: errors.New("lookup failed")})
+			},
+		},
+		{
+			name: "owner task not found",
+			wire: func(svc *Service, issueStore *multiTaskIssueStore) {
+				// Only member1 is registered — GetTask("owner1") fails.
+				issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+				svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+			},
+		},
+		{
+			name: "owner archived",
+			wire: func(svc *Service, issueStore *multiTaskIssueStore) {
+				issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+				archivedAt := time.Now().UTC()
+				issueStore.addTask(&taskmodels.Task{ID: "owner1", ArchivedAt: &archivedAt}, "repo-canonical")
+				svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+			},
+		},
+		{
+			name: "owner does not hold repository",
+			wire: func(svc *Service, issueStore *multiTaskIssueStore) {
+				issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+				issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-other")
+				svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, svc, _, store := setupPollerTest(t)
+			issueStore := newMultiTaskIssueStore()
+			tc.wire(svc, issueStore)
+			svc.SetTaskIssueStore(issueStore)
+
+			ctx := context.Background()
+			pr := &PR{
+				Number: 42, RepoOwner: "org", RepoName: "repo",
+				HTMLURL: "https://github.com/org/repo/pull/42",
+			}
+
+			tp, err := svc.AssociatePRWithTask(ctx, "member1", "repo-canonical", pr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("AssociatePRWithTask: want error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AssociatePRWithTask: %v (association must not be silently dropped)", err)
+			}
+			if tp.TaskID != "member1" {
+				t.Fatalf("TaskPR.TaskID = %q, want member1 (redirect unsafe, fall back to observing task)", tp.TaskID)
+			}
+			rows, err := store.ListTaskPRsByTask(ctx, "member1")
+			if err != nil {
+				t.Fatalf("list member PR associations: %v", err)
+			}
+			if len(rows) != 1 {
+				t.Fatalf("got %d PR associations for member1, want 1: %+v", len(rows), rows)
+			}
+		})
+	}
+}
+
+// TestAssociateExistingPRByURL_DoesNotRedirectURLLinkSource covers the F5
+// scope boundary: TaskPRSourceURLLink (AssociateExistingPRByURL) is a
+// deliberate cross-task action — the user explicitly chose to link a specific
+// PR to the task whose card they were viewing — and must never be silently
+// rerouted, even when a workspace-group redirect would otherwise apply for a
+// watch-sourced write on the same task/repository pair. The resolver here
+// points at a task the fake store has no record of, so if the guard were
+// ever removed, the resulting redirect would surface as a hard error instead
+// of a silent misattribution.
+func TestAssociateExistingPRByURL_DoesNotRedirectURLLinkSource(t *testing.T) {
+	_, svc, mockClient, store := setupPollerTest(t)
+
+	issueStore := newMultiTaskIssueStore()
+	issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+	svc.SetTaskIssueStore(issueStore)
+	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+
+	mockClient.AddPR(&PR{
+		Number: 42, RepoOwner: "org", RepoName: "repo",
+		HTMLURL: "https://github.com/org/repo/pull/42", HeadBranch: "feature-x", BaseBranch: "main",
+	})
+
+	ctx := context.Background()
+	tp, err := svc.AssociateExistingPRByURL(ctx, "member1", "repo-canonical", "https://github.com/org/repo/pull/42")
+	if err != nil {
+		t.Fatalf("AssociateExistingPRByURL: %v", err)
+	}
+	if tp.TaskID != "member1" {
+		t.Fatalf("TaskPR.TaskID = %q, want member1 (URL-link source must never redirect)", tp.TaskID)
+	}
+
+	rows, err := store.ListTaskPRsByTask(ctx, "member1")
+	if err != nil {
+		t.Fatalf("list member PR associations: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d PR associations for member1, want 1: %+v", len(rows), rows)
+	}
+}

--- a/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
+++ b/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
 )
 
@@ -381,5 +383,82 @@ func TestCheckSinglePRWatch_LegacyMemberWatchSyncsOwnersTaskPR(t *testing.T) {
 	}
 	if len(memberRows) != 0 {
 		t.Fatalf("got %d PR associations for member1, want 0 (sync must not create a stranded row under the observing member): %+v", len(memberRows), memberRows)
+	}
+}
+
+func TestCheckSinglePRWatch_MovesLegacyMemberTaskPRToOwner(t *testing.T) {
+	poller, svc, mockClient, store := setupPollerTest(t)
+	ctx := context.Background()
+
+	issueStore := newMultiTaskIssueStore()
+	issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+	issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-canonical")
+	svc.SetTaskIssueStore(issueStore)
+	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+
+	now := time.Now().UTC()
+	mergedAt := now.Add(-time.Hour)
+	mockClient.AddPR(&PR{
+		Number: 42, Title: "Feature PR", State: prStateMerged,
+		HeadSHA: "abc123", HeadBranch: "feature-branch", BaseBranch: "main",
+		RepoOwner: "owner", RepoName: "repo", MergedAt: &mergedAt,
+	})
+	watch := &PRWatch{
+		SessionID: "sess-legacy", TaskID: "member1", RepositoryID: "repo-canonical",
+		Owner: "owner", Repo: "repo", PRNumber: 42, Branch: "feature-branch",
+	}
+	if err := store.CreatePRWatch(ctx, withTestWorkspace(watch)); err != nil {
+		t.Fatalf("create PR watch: %v", err)
+	}
+	legacy := &TaskPR{
+		TaskID: "member1", RepositoryID: "repo-canonical", Owner: "owner", Repo: "repo", PRNumber: 42,
+		PRURL: "https://github.com/owner/repo/pull/42", PRTitle: "Feature PR",
+		HeadBranch: "feature-branch", BaseBranch: "main", State: "open", CreatedAt: now.Add(-2 * time.Hour),
+	}
+	if err := store.CreateTaskPR(ctx, legacy); err != nil {
+		t.Fatalf("create legacy member task PR: %v", err)
+	}
+
+	seen := make(chan *TaskPR, 2)
+	sub, err := svc.eventBus.Subscribe(events.GitHubTaskPRUpdated, func(_ context.Context, event *bus.Event) error {
+		if tp, ok := event.Data.(*TaskPR); ok {
+			seen <- tp
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("subscribe to task PR updates: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	poller.checkSinglePRWatch(ctx, watch)
+
+	select {
+	case eventPR := <-seen:
+		if eventPR.TaskID != "owner1" {
+			t.Fatalf("updated event task ID = %q, want owner1", eventPR.TaskID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no owner task PR update event published")
+	}
+	select {
+	case eventPR := <-seen:
+		t.Fatalf("unexpected second task PR update for %q", eventPR.TaskID)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ownerPR, err := store.GetTaskPRByRepoAndNumber(ctx, "owner1", "repo-canonical", 42)
+	if err != nil {
+		t.Fatalf("get owner task PR: %v", err)
+	}
+	if ownerPR == nil || ownerPR.State != prStateMerged {
+		t.Fatalf("owner task PR = %+v, want merged owner row", ownerPR)
+	}
+	memberRows, err := store.ListTaskPRsByTask(ctx, "member1")
+	if err != nil {
+		t.Fatalf("list member task PRs: %v", err)
+	}
+	if len(memberRows) != 0 {
+		t.Fatalf("member task PRs = %+v, want no active legacy member row", memberRows)
 	}
 }

--- a/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
+++ b/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
@@ -228,6 +228,11 @@ func TestAssociateExistingPRByURL_DoesNotRedirectURLLinkSource(t *testing.T) {
 
 	issueStore := newMultiTaskIssueStore()
 	issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+	// owner1 must hold repo-canonical too — otherwise resolveEffectiveAssociationTaskID
+	// falls back to the observing task on its own (GetTask("owner1") errors), and the
+	// no-redirect assertion below would pass even if the source==TaskPRSourceWatch
+	// guard this test exists to cover were removed.
+	issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-canonical")
 	svc.SetTaskIssueStore(issueStore)
 	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
 
@@ -302,5 +307,79 @@ func TestAssociatePRByURL_WatchAndAssociationAgreeOnRedirectedOwner(t *testing.T
 	}
 	if len(memberWatches) != 0 {
 		t.Fatalf("got %d PR watches for member1, want 0 (watch must not be stranded under the observing member task): %+v", len(memberWatches), memberWatches)
+	}
+}
+
+// TestCheckSinglePRWatch_LegacyMemberWatchSyncsOwnersTaskPR covers a watch
+// that already carries a member task's ID — either written before this fix
+// existed, or (per apps/backend/CLAUDE.md's "PR status sync coverage") any
+// numbered watch, since a watch that has found a PR is never re-pointed once
+// created. Before this fix, poller.checkSinglePRWatch called
+// SyncTaskPR(ctx, watch.TaskID, ...) directly, so a legacy member-attributed
+// watch would look up the owner's github_task_prs row under the wrong task
+// ID, find nothing, and silently no-op forever — freezing the owner's PR
+// status at whatever it was when the redirect fix shipped. The watch itself
+// must stay under the member (watches are never re-pointed); only the sync
+// target is resolved.
+func TestCheckSinglePRWatch_LegacyMemberWatchSyncsOwnersTaskPR(t *testing.T) {
+	poller, svc, mockClient, store := setupPollerTest(t)
+	ctx := context.Background()
+
+	issueStore := newMultiTaskIssueStore()
+	issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-canonical")
+	svc.SetTaskIssueStore(issueStore)
+	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+
+	mockClient.AddPR(&PR{
+		Number: 42, Title: "Feature PR", State: prStateMerged,
+		HeadSHA: "abc123", HeadBranch: "feature-branch",
+		RepoOwner: "owner", RepoName: "repo",
+	})
+
+	// The watch itself keeps the observing member's task_id — simulating
+	// either a pre-fix row or one that predates the discovering session's own
+	// group membership. Never re-pointed; see CreatePRWatch's get-or-create
+	// semantics.
+	watch := &PRWatch{
+		SessionID: "sess-legacy", TaskID: "member1", RepositoryID: "repo-canonical",
+		Owner: "owner", Repo: "repo", PRNumber: 42, Branch: "feature-branch",
+	}
+	if err := store.CreatePRWatch(ctx, withTestWorkspace(watch)); err != nil {
+		t.Fatalf("create PR watch: %v", err)
+	}
+
+	// The association already correctly landed under the owner (e.g. via
+	// AssociatePRByURL or CheckSessionPR's own redirect).
+	if err := store.CreateTaskPR(ctx, &TaskPR{
+		TaskID: "owner1", RepositoryID: "repo-canonical",
+		Owner: "owner", Repo: "repo", PRNumber: 42,
+		PRURL: "https://github.com/owner/repo/pull/42", PRTitle: "Feature PR",
+		HeadBranch: "feature-branch", BaseBranch: "main", State: "open",
+	}); err != nil {
+		t.Fatalf("create task PR: %v", err)
+	}
+
+	poller.checkSinglePRWatch(ctx, watch)
+
+	ownerTP, err := store.GetTaskPRByRepoAndNumber(ctx, "owner1", "repo-canonical", 42)
+	if err != nil {
+		t.Fatalf("get owner task PR: %v", err)
+	}
+	if ownerTP == nil {
+		t.Fatal("expected owner1's task PR to still exist")
+	}
+	if ownerTP.State != prStateMerged {
+		t.Errorf("owner1 TaskPR.State = %q, want %q (sync must land on the owner despite the watch's stale task_id)", ownerTP.State, prStateMerged)
+	}
+	if ownerTP.LastSyncedAt == nil {
+		t.Error("expected owner1's TaskPR.LastSyncedAt to be set by the sync")
+	}
+
+	memberRows, err := store.ListTaskPRsByTask(ctx, "member1")
+	if err != nil {
+		t.Fatalf("list member PR associations: %v", err)
+	}
+	if len(memberRows) != 0 {
+		t.Fatalf("got %d PR associations for member1, want 0 (sync must not create a stranded row under the observing member): %+v", len(memberRows), memberRows)
 	}
 }

--- a/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
+++ b/apps/backend/internal/github/service_pr_watch_workspace_group_redirect_test.go
@@ -253,3 +253,54 @@ func TestAssociateExistingPRByURL_DoesNotRedirectURLLinkSource(t *testing.T) {
 		t.Fatalf("got %d PR associations for member1, want 1: %+v", len(rows), rows)
 	}
 }
+
+// TestAssociatePRByURL_WatchAndAssociationAgreeOnRedirectedOwner covers
+// Review Round 3's F-A finding: AssociatePRByURL created the PR watch under
+// the raw, unredirected observing task, then associated under the
+// workspace-group owner two lines later. createPRWatch is get-or-create and
+// never re-points task_id on a hit, so the watch was permanently stuck under
+// the member while the association correctly redirected to the owner. Every
+// subsequent poller/batched sync call keys off watch.TaskID, which then
+// resolved to zero rows for the owner and silently never synced. Both the
+// watch and the association must land under the same (redirected) task.
+func TestAssociatePRByURL_WatchAndAssociationAgreeOnRedirectedOwner(t *testing.T) {
+	_, svc, mockClient, store := setupPollerTest(t)
+
+	issueStore := newMultiTaskIssueStore()
+	issueStore.addTask(&taskmodels.Task{ID: "member1"}, "repo-canonical")
+	issueStore.addTask(&taskmodels.Task{ID: "owner1"}, "repo-canonical")
+	svc.SetTaskIssueStore(issueStore)
+	svc.SetWorkspaceGroupOwnerResolver(&fakeWorkspaceGroupOwnerResolver{ownerTaskID: "owner1"})
+
+	mockClient.AddPR(&PR{
+		Number: 42, RepoOwner: "org", RepoName: "repo",
+		HTMLURL: "https://github.com/org/repo/pull/42", HeadBranch: "feature-x", BaseBranch: "main",
+	})
+
+	ctx := context.Background()
+	svc.AssociatePRByURL(ctx, "session-1", "member1", "repo-canonical", "https://github.com/org/repo/pull/42", "")
+
+	ownerAssociations, err := store.ListTaskPRsByTask(ctx, "owner1")
+	if err != nil {
+		t.Fatalf("list owner PR associations: %v", err)
+	}
+	if len(ownerAssociations) != 1 {
+		t.Fatalf("got %d PR associations for owner1, want 1: %+v", len(ownerAssociations), ownerAssociations)
+	}
+
+	ownerWatches, err := store.ListPRWatchesByTask(ctx, "owner1")
+	if err != nil {
+		t.Fatalf("list owner PR watches: %v", err)
+	}
+	if len(ownerWatches) != 1 {
+		t.Fatalf("got %d PR watches for owner1, want 1 (watch must be created under the same redirected task as the association): %+v", len(ownerWatches), ownerWatches)
+	}
+
+	memberWatches, err := store.ListPRWatchesByTask(ctx, "member1")
+	if err != nil {
+		t.Fatalf("list member PR watches: %v", err)
+	}
+	if len(memberWatches) != 0 {
+		t.Fatalf("got %d PR watches for member1, want 0 (watch must not be stranded under the observing member task): %+v", len(memberWatches), memberWatches)
+	}
+}

--- a/apps/backend/internal/github/service_task_pr_detach_test.go
+++ b/apps/backend/internal/github/service_task_pr_detach_test.go
@@ -193,7 +193,7 @@ func TestAssociatePRWithTaskExplicitLinkRestoresDetachedAssociation(t *testing.T
 		Title: "fresh title", HeadBranch: "fresh-branch", BaseBranch: "develop", AuthorLogin: "bob",
 		State: "closed", MergeableState: "dirty", Additions: 8, Deletions: 3,
 	}
-	associated, err := svc.associatePRWithTask(ctx, row.WorkspaceID, row.TaskID, row.RepositoryID, freshPR, true, true)
+	associated, err := svc.associatePRWithTask(ctx, row.WorkspaceID, row.TaskID, row.RepositoryID, freshPR, true, true, TaskPRSourceURLLink)
 	if err != nil {
 		t.Fatalf("explicitly associate PR: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestAssociatePRWithTaskExplicitLinkOnAlreadyMergedDetachedPRPopulatesOutcom
 		ChangedFiles: 12, ChangedFilesObserved: true,
 		MergedByLogin: "carlosflorencio",
 	}
-	associated, err := svc.associatePRWithTask(ctx, row.WorkspaceID, row.TaskID, row.RepositoryID, mergedPR, true, true)
+	associated, err := svc.associatePRWithTask(ctx, row.WorkspaceID, row.TaskID, row.RepositoryID, mergedPR, true, true, TaskPRSourceURLLink)
 	if err != nil {
 		t.Fatalf("explicitly associate PR: %v", err)
 	}

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -152,6 +152,7 @@ const createTablesSQL = `
 		merged_by_login TEXT,
 		closed_by_login TEXT,
 		auto_merge_observed_at DATETIME,
+		source TEXT NOT NULL DEFAULT '',
 		UNIQUE(task_id, repository_id, pr_number)
 	);
 
@@ -612,6 +613,9 @@ func (s *Store) initSchemaUpgrades() error {
 	if err := s.addTaskPRMergeQueueColumns(); err != nil {
 		return err
 	}
+	if err := s.addTaskPRSourceColumn(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -644,6 +648,28 @@ func (s *Store) addTaskPRMergeQueueColumns() error {
 		if _, err := s.db.Exec(stmt); err != nil && !dbutil.IsDuplicateColumnError(err) {
 			return fmt.Errorf("add github_task_prs.%s: %w", column.name, err)
 		}
+	}
+	return nil
+}
+
+// addTaskPRSourceColumn adds github_task_prs.source, which records which
+// write path created the association ("watch" or "url_link"; empty for rows
+// written before this column existed). It joins taskPRColumns like the
+// outcome-attribution columns above, so a driver-level ALTER failure here
+// must also abort startup rather than surface as a scan error on the next
+// read. Only dbutil.IsDuplicateColumnError is tolerated, per ADR 0027; no
+// backfill runs against existing rows.
+func (s *Store) addTaskPRSourceColumn() error {
+	cols, err := s.tableColumns("github_task_prs")
+	if err != nil {
+		return fmt.Errorf("read github_task_prs columns: %w", err)
+	}
+	if _, ok := cols["source"]; ok {
+		return nil
+	}
+	if _, err := s.db.Exec(`ALTER TABLE github_task_prs ADD COLUMN source TEXT NOT NULL DEFAULT ''`); err != nil &&
+		!dbutil.IsDuplicateColumnError(err) {
+		return fmt.Errorf("add github_task_prs.source: %w", err)
 	}
 	return nil
 }
@@ -1433,13 +1459,15 @@ func (s *Store) migratePRTablesForMultiRepo() error {
 			merged_by_login TEXT,
 			closed_by_login TEXT,
 			auto_merge_observed_at DATETIME,
+			source TEXT NOT NULL DEFAULT '',
 			UNIQUE(task_id, repository_id, pr_number)
 		)`,
-		// The five outcome-attribution columns are selected directly, not
-		// via COALESCE: addTaskPROutcomeColumns runs earlier in
-		// initSchemaUpgrades, before this data-migration step, so the old
-		// table being rebuilt here already has them (fail-loud — startup
-		// would have aborted otherwise).
+		// The five outcome-attribution columns and source are selected
+		// directly, not via COALESCE: addTaskPROutcomeColumns and
+		// addTaskPRSourceColumn both run earlier in initSchemaUpgrades,
+		// before this data-migration step, so the old table being rebuilt
+		// here already has them (fail-loud — startup would have aborted
+		// otherwise).
 		`INSERT INTO github_task_prs_new (
 			id, workspace_id, task_id, repository_id, owner, repo, pr_number, pr_url, pr_title,
 			head_branch, base_branch, head_sha, author_login, state, review_state, checks_state,
@@ -1448,7 +1476,7 @@ func (s *Store) migratePRTablesForMultiRepo() error {
 			merge_queue_last_removal_reason, merge_queue_last_removal_before_sha,
 			review_count, pending_review_count, comment_count,
 			additions, deletions, created_at, merged_at, closed_at, last_synced_at, detached_at, updated_at,
-			is_draft, changed_files, merged_by_login, closed_by_login, auto_merge_observed_at
+			is_draft, changed_files, merged_by_login, closed_by_login, auto_merge_observed_at, source
 		) SELECT
 			id, COALESCE(workspace_id, ''), task_id, COALESCE(repository_id, ''), owner, repo, pr_number, pr_url, pr_title,
 			head_branch, base_branch, COALESCE(head_sha, ''), author_login, state, review_state, checks_state,
@@ -1457,7 +1485,7 @@ func (s *Store) migratePRTablesForMultiRepo() error {
 			COALESCE(merge_queue_last_removal_reason, ''), COALESCE(merge_queue_last_removal_before_sha, ''),
 			review_count, pending_review_count, comment_count,
 			additions, deletions, created_at, merged_at, closed_at, last_synced_at, detached_at, updated_at,
-			is_draft, changed_files, merged_by_login, closed_by_login, auto_merge_observed_at
+			is_draft, changed_files, merged_by_login, closed_by_login, auto_merge_observed_at, source
 		FROM github_task_prs`,
 	)
 }
@@ -1790,7 +1818,8 @@ const taskPRColumns = `id, workspace_id, task_id, repository_id, owner, repo, pr
 	created_at, merged_at, closed_at, last_synced_at, detached_at, updated_at,
 	is_draft, changed_files, merged_by_login, closed_by_login, auto_merge_observed_at,
 	head_sha, merge_queue_entry_id, merge_queue_entry_head_sha, merge_queue_last_removal_id,
-	merge_queue_last_removed_at, merge_queue_last_removal_reason, merge_queue_last_removal_before_sha`
+	merge_queue_last_removed_at, merge_queue_last_removal_reason, merge_queue_last_removal_before_sha,
+	source`
 
 // taskPRColumnsQualified is taskPRColumns with each column qualified by the
 // `gtp` alias, for queries that join github_task_prs against another table.
@@ -1802,7 +1831,8 @@ const taskPRColumnsQualified = `gtp.id, gtp.workspace_id, gtp.task_id, gtp.repos
 	gtp.created_at, gtp.merged_at, gtp.closed_at, gtp.last_synced_at, gtp.detached_at, gtp.updated_at,
 	gtp.is_draft, gtp.changed_files, gtp.merged_by_login, gtp.closed_by_login, gtp.auto_merge_observed_at,
 	gtp.head_sha, gtp.merge_queue_entry_id, gtp.merge_queue_entry_head_sha, gtp.merge_queue_last_removal_id,
-	gtp.merge_queue_last_removed_at, gtp.merge_queue_last_removal_reason, gtp.merge_queue_last_removal_before_sha`
+	gtp.merge_queue_last_removed_at, gtp.merge_queue_last_removal_reason, gtp.merge_queue_last_removal_before_sha,
+	gtp.source`
 
 type taskPRWriter interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
@@ -1844,6 +1874,7 @@ func taskPRValues(tp *TaskPR) []any {
 		tp.MergedByLogin, tp.ClosedByLogin, tp.AutoMergeObservedAt, tp.HeadSHA,
 		tp.MergeQueueEntryID, tp.MergeQueueEntryHeadSHA, tp.MergeQueueLastRemovalID,
 		tp.MergeQueueLastRemovedAt, tp.MergeQueueLastRemovalReason, tp.MergeQueueLastRemovalBeforeSHA,
+		tp.Source,
 	}
 }
 

--- a/apps/backend/internal/github/store_task_pr_ownership.go
+++ b/apps/backend/internal/github/store_task_pr_ownership.go
@@ -1,0 +1,244 @@
+package github
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// TaskPROwnershipReconciler moves or detaches an old watch-sourced association
+// when a session now resolves to a different workspace-group owner. The
+// operation is kept in the store so the TaskPR row and its task-scoped
+// automation state change together, without publishing an intermediate event.
+type TaskPROwnershipReconciler interface {
+	ReconcileTaskPROwnership(
+		ctx context.Context, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+	) (bool, error)
+}
+
+type taskPROwnerState int
+
+const (
+	taskPROwnerAbsent taskPROwnerState = iota
+	taskPROwnerActive
+	taskPROwnerDetached
+)
+
+// ReconcileTaskPROwnership repairs a legacy member-owned TaskPR for one exact
+// watch-derived PR. If an active owner row exists, the member row becomes a
+// detached tombstone. If no owner row exists, the row and its automation state
+// move to the owner in one transaction. Explicit URL links are not changed.
+// The bool reports whether an active member row was reconciled.
+func (s *Store) ReconcileTaskPROwnership(
+	ctx context.Context, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+) (bool, error) {
+	if !validTaskPROwnershipArgs(s, memberTaskID, ownerTaskID, prNumber) {
+		return false, nil
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	memberID, source, found, err := findTaskPRMemberTx(ctx, tx, memberTaskID, repositoryID, prNumber)
+	if err != nil {
+		return false, err
+	}
+	if !found || source == TaskPRSourceURLLink {
+		return false, nil
+	}
+
+	ownerState, err := findTaskPROwnerStateTx(ctx, tx, ownerTaskID, repositoryID, prNumber)
+	if err != nil {
+		return false, err
+	}
+	if ownerState == taskPROwnerActive {
+		if err := reconcileExistingOwnerTaskPRTx(ctx, tx, memberID, memberTaskID, ownerTaskID, repositoryID, prNumber); err != nil {
+			return false, err
+		}
+		return true, tx.Commit()
+	}
+	if ownerState == taskPROwnerDetached {
+		// A detached owner tombstone is an explicit opt-out. Do not resurrect
+		// it through a watch, but still remove the active duplicate member row.
+		if err := detachTaskPROwnershipRowTx(ctx, tx, memberID, memberTaskID, repositoryID, prNumber); err != nil {
+			return false, err
+		}
+		return true, tx.Commit()
+	}
+
+	if err := moveTaskPROwnershipTx(ctx, tx, memberID, memberTaskID, ownerTaskID, repositoryID, prNumber); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+func validTaskPROwnershipArgs(s *Store, memberTaskID, ownerTaskID string, prNumber int) bool {
+	return s != nil && memberTaskID != "" && ownerTaskID != "" && memberTaskID != ownerTaskID && prNumber != 0
+}
+
+func findTaskPRMemberTx(
+	ctx context.Context, tx *sqlx.Tx, memberTaskID, repositoryID string, prNumber int,
+) (string, string, bool, error) {
+	var memberID, source string
+	err := tx.QueryRowxContext(ctx, `
+		SELECT id, source
+		FROM github_task_prs
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ? AND detached_at IS NULL
+		LIMIT 1`, memberTaskID, repositoryID, prNumber).Scan(&memberID, &source)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if source == TaskPRSourceURLLink {
+		return memberID, source, true, nil
+	}
+	if err != nil {
+		return "", "", false, fmt.Errorf("load member task PR: %w", err)
+	}
+	return memberID, source, true, nil
+}
+
+func reconcileExistingOwnerTaskPRTx(
+	ctx context.Context, tx *sqlx.Tx, memberID, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+) error {
+	if err := copyTaskPROwnershipStateTx(ctx, tx, memberTaskID, ownerTaskID, repositoryID, prNumber); err != nil {
+		return err
+	}
+	return detachTaskPROwnershipRowTx(ctx, tx, memberID, memberTaskID, repositoryID, prNumber)
+}
+
+func findTaskPROwnerStateTx(
+	ctx context.Context, tx *sqlx.Tx, ownerTaskID, repositoryID string, prNumber int,
+) (taskPROwnerState, error) {
+	var ownerID string
+	err := tx.QueryRowxContext(ctx, `
+		SELECT id
+		FROM github_task_prs
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ? AND detached_at IS NULL
+		LIMIT 1`, ownerTaskID, repositoryID, prNumber).Scan(&ownerID)
+	if err == nil {
+		return taskPROwnerActive, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return taskPROwnerAbsent, fmt.Errorf("load owner task PR: %w", err)
+	}
+	err = tx.QueryRowxContext(ctx, `
+		SELECT id
+		FROM github_task_prs
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?
+		LIMIT 1`, ownerTaskID, repositoryID, prNumber).Scan(&ownerID)
+	if err == nil {
+		return taskPROwnerDetached, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return taskPROwnerAbsent, nil
+	}
+	return taskPROwnerAbsent, fmt.Errorf("load owner task PR tombstone: %w", err)
+}
+
+func moveTaskPROwnershipTx(
+	ctx context.Context, tx *sqlx.Tx, memberID, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+) error {
+	if err := copyTaskPROwnershipStateTx(ctx, tx, memberTaskID, ownerTaskID, repositoryID, prNumber); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `
+		UPDATE github_task_prs
+		SET task_id = ?, updated_at = ?
+		WHERE id = ? AND task_id = ? AND repository_id = ? AND pr_number = ? AND detached_at IS NULL`,
+		ownerTaskID, time.Now().UTC(), memberID, memberTaskID, repositoryID, prNumber)
+	if err != nil {
+		return fmt.Errorf("move task PR to owner: %w", err)
+	}
+	if rows, rowsErr := result.RowsAffected(); rowsErr != nil {
+		return fmt.Errorf("inspect moved task PR: %w", rowsErr)
+	} else if rows != 1 {
+		return fmt.Errorf("move task PR to owner: affected %d rows", rows)
+	}
+	return moveTaskPROwnershipStateTx(ctx, tx, memberTaskID, ownerTaskID, repositoryID, prNumber)
+}
+
+func detachTaskPROwnershipRowTx(
+	ctx context.Context, tx *sqlx.Tx, memberID, memberTaskID, repositoryID string, prNumber int,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE github_task_prs
+		SET detached_at = ?, updated_at = ?
+		WHERE id = ? AND task_id = ? AND repository_id = ? AND pr_number = ? AND detached_at IS NULL`,
+		time.Now().UTC(), time.Now().UTC(), memberID, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("detach duplicate task PR: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM github_task_pr_automation_options
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("remove duplicate task PR automation options: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM github_task_ci_pr_state
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("remove duplicate task PR automation state: %w", err)
+	}
+	return nil
+}
+
+func copyTaskPROwnershipStateTx(
+	ctx context.Context, tx *sqlx.Tx, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO github_task_pr_automation_options (
+			task_id, repository_id, pr_number, auto_fix_enabled, auto_merge_enabled,
+			prompt_on_review_requested, prompt_on_merged, prompt_on_closed, created_at, updated_at
+		)
+		SELECT ?, repository_id, pr_number, auto_fix_enabled, auto_merge_enabled,
+			prompt_on_review_requested, prompt_on_merged, prompt_on_closed, created_at, updated_at
+		FROM github_task_pr_automation_options
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`,
+		ownerTaskID, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("copy task PR automation options: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO github_task_ci_pr_state (
+			task_id, repository_id, pr_number, last_fix_signature, last_fix_checkpoint_json,
+			last_fix_enqueued_at, last_fix_session_id, auto_fix_round_count, auto_fix_exhausted_at,
+			last_merge_signature, last_merge_attempt_at, last_merge_result, merge_retry_pending,
+			last_queue_attempt_head_sha, last_queue_fix_event_id, last_queue_removal_cause,
+			review_request_initialized, last_review_requested, last_observed_pr_state,
+			last_lifecycle_event, last_lifecycle_prompt_at, last_lifecycle_session_id,
+			last_error, last_error_kind, created_at, updated_at
+		)
+		SELECT ?, repository_id, pr_number, last_fix_signature, last_fix_checkpoint_json,
+			last_fix_enqueued_at, last_fix_session_id, auto_fix_round_count, auto_fix_exhausted_at,
+			last_merge_signature, last_merge_attempt_at, last_merge_result, merge_retry_pending,
+			last_queue_attempt_head_sha, last_queue_fix_event_id, last_queue_removal_cause,
+			review_request_initialized, last_review_requested, last_observed_pr_state,
+			last_lifecycle_event, last_lifecycle_prompt_at, last_lifecycle_session_id,
+			last_error, last_error_kind, created_at, updated_at
+		FROM github_task_ci_pr_state
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`,
+		ownerTaskID, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("copy task PR automation state: %w", err)
+	}
+	return nil
+}
+
+func moveTaskPROwnershipStateTx(
+	ctx context.Context, tx *sqlx.Tx, memberTaskID, ownerTaskID, repositoryID string, prNumber int,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM github_task_pr_automation_options
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("remove moved task PR automation options: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM github_task_ci_pr_state
+		WHERE task_id = ? AND repository_id = ? AND pr_number = ?`, memberTaskID, repositoryID, prNumber); err != nil {
+		return fmt.Errorf("remove moved task PR automation state: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/github/store_task_pr_source_test.go
+++ b/apps/backend/internal/github/store_task_pr_source_test.go
@@ -1,0 +1,149 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTaskPRSourceFreshSchemaRoundTrips(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	for _, source := range []string{TaskPRSourceWatch, TaskPRSourceURLLink} {
+		t.Run(source, func(t *testing.T) {
+			id := "source-" + source
+			if err := store.CreateTaskPR(ctx, &TaskPR{
+				ID: id, WorkspaceID: "ws-source", TaskID: id, RepositoryID: id,
+				Owner: "acme", Repo: "demo", PRNumber: 42,
+				PRURL: "https://github.com/acme/demo/pull/42", PRTitle: "Source",
+				HeadBranch: "feature/source", BaseBranch: "main", AuthorLogin: "alice",
+				State: "open", CreatedAt: now, Source: source,
+			}); err != nil {
+				t.Fatalf("create task PR: %v", err)
+			}
+			got, err := store.GetTaskPRByID(ctx, id)
+			if err != nil {
+				t.Fatalf("get task PR: %v", err)
+			}
+			if got == nil || got.Source != source {
+				t.Fatalf("stored source = %q, want %q; row = %+v", sourceOfTaskPR(got), source, got)
+			}
+		})
+	}
+}
+
+func TestTaskPRSourceLegacyConstraintRebuildPreservesValuesAndReplay(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO workspaces (id) VALUES ('ws-source');
+		INSERT INTO tasks (id, workspace_id) VALUES
+			('task-legacy-watch', 'ws-source'),
+			('task-legacy-empty', 'ws-source')`); err != nil {
+		t.Fatalf("seed legacy tasks: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		DROP TABLE github_task_prs;
+		CREATE TABLE github_task_prs (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL DEFAULT '',
+			task_id TEXT NOT NULL,
+			repository_id TEXT NOT NULL DEFAULT '',
+			owner TEXT NOT NULL,
+			repo TEXT NOT NULL,
+			pr_number INTEGER NOT NULL,
+			pr_url TEXT NOT NULL,
+			pr_title TEXT NOT NULL,
+			head_branch TEXT NOT NULL,
+			base_branch TEXT NOT NULL,
+			head_sha TEXT NOT NULL DEFAULT '',
+			author_login TEXT NOT NULL,
+			state TEXT NOT NULL DEFAULT 'open',
+			review_state TEXT NOT NULL DEFAULT '',
+			checks_state TEXT NOT NULL DEFAULT '',
+			mergeable_state TEXT NOT NULL DEFAULT '',
+			merge_queue_state TEXT NOT NULL DEFAULT '',
+			merge_queue_position INTEGER,
+			merge_queue_entry_id TEXT NOT NULL DEFAULT '',
+			merge_queue_entry_head_sha TEXT NOT NULL DEFAULT '',
+			merge_queue_estimated_time_to_merge_seconds INTEGER,
+			merge_queue_last_removal_id TEXT NOT NULL DEFAULT '',
+			merge_queue_last_removed_at DATETIME,
+			merge_queue_last_removal_reason TEXT NOT NULL DEFAULT '',
+			merge_queue_last_removal_before_sha TEXT NOT NULL DEFAULT '',
+			review_count INTEGER DEFAULT 0,
+			pending_review_count INTEGER DEFAULT 0,
+			required_reviews INTEGER,
+			comment_count INTEGER DEFAULT 0,
+			unresolved_review_threads INTEGER DEFAULT 0,
+			checks_total INTEGER DEFAULT 0,
+			checks_passing INTEGER DEFAULT 0,
+			additions INTEGER DEFAULT 0,
+			deletions INTEGER DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			merged_at DATETIME,
+			closed_at DATETIME,
+			last_synced_at DATETIME,
+			detached_at DATETIME,
+			updated_at DATETIME NOT NULL,
+			is_draft BOOLEAN,
+			changed_files INTEGER,
+			merged_by_login TEXT,
+			closed_by_login TEXT,
+			auto_merge_observed_at DATETIME,
+			source TEXT NOT NULL DEFAULT '',
+			UNIQUE(task_id, pr_number)
+		);
+		INSERT INTO github_task_prs (
+			id, workspace_id, task_id, repository_id, owner, repo, pr_number, pr_url,
+			pr_title, head_branch, base_branch, author_login, state, created_at, updated_at, source
+		) VALUES
+			('legacy-watch', 'ws-source', 'task-legacy-watch', 'repo-watch', 'acme', 'demo', 1,
+			 'https://github.com/acme/demo/pull/1', 'Watch', 'feature/watch', 'main', 'alice', 'open', ?, ?, 'watch'),
+			('legacy-empty', 'ws-source', 'task-legacy-empty', 'repo-empty', 'acme', 'demo', 2,
+			 'https://github.com/acme/demo/pull/2', 'Legacy', 'feature/legacy', 'main', 'alice', 'open', ?, ?, '')
+	`, now, now, now, now); err != nil {
+		t.Fatalf("seed legacy task PR table: %v", err)
+	}
+
+	reopened, err := NewStore(store.db, store.ro)
+	if err != nil {
+		t.Fatalf("reopen store for source migration: %v", err)
+	}
+	assertTaskPRSource := func(t *testing.T, id, want string) {
+		t.Helper()
+		got, err := reopened.GetTaskPRByID(ctx, id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if got == nil || got.Source != want {
+			t.Fatalf("%s source = %q, want %q; row = %+v", id, sourceOfTaskPR(got), want, got)
+		}
+	}
+	assertTaskPRSource(t, "legacy-watch", TaskPRSourceWatch)
+	assertTaskPRSource(t, "legacy-empty", "")
+
+	replayed, err := NewStore(reopened.db, reopened.ro)
+	if err != nil {
+		t.Fatalf("replay source migration: %v", err)
+	}
+	for id, want := range map[string]string{"legacy-watch": TaskPRSourceWatch, "legacy-empty": ""} {
+		got, err := replayed.GetTaskPRByID(ctx, id)
+		if err != nil {
+			t.Fatalf("get %s after replay: %v", id, err)
+		}
+		if got == nil || got.Source != want {
+			t.Fatalf("%s source after replay = %q, want %q", id, sourceOfTaskPR(got), want)
+		}
+	}
+}
+
+func sourceOfTaskPR(tp *TaskPR) string {
+	if tp == nil {
+		return "<nil>"
+	}
+	return tp.Source
+}

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -345,7 +345,7 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 	// the push (a subtask sharing a parent's worktree still has its own
 	// session row). Only the write destination below is redirected.
 	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
-	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID)
+	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, identity.repositoryID)
 	if identity.provider == gitlabProviderName {
 		s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, effectiveTaskID, repositoryName, branch, identity)
 		return
@@ -364,10 +364,23 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 // unrelated tasks (the group owner plus whichever subtasks happened to be
 // running when the push landed). Falls back to the original taskID — leaving
 // the pre-fix behavior for that call — when there is no active group, the
-// repo doesn't support group lookups, the lookup fails, or the resolved owner
+// repo doesn't support group lookups, the lookup fails, the resolved owner
 // task can't be loaded or is archived (an archived owner is not a valid
-// association target).
-func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID string) string {
+// association target), or the owner task doesn't hold repositoryID itself
+// (redirecting would make the downstream write get rejected by
+// validateTaskRepositoryID and dropped — see associatePRWithTask — which is
+// worse than leaving the association under the observing task). repositoryID
+// may be "" (identity couldn't be resolved yet); the ownership check is
+// skipped in that case, matching validateTaskRepositoryID's own no-op on an
+// empty repositoryID.
+//
+// This is the single boundary every watch-creation and association call site
+// routes through — dispatchPushDetection, ensureSessionPRWatch,
+// CheckSessionPR, and buildTaskBranchList (feeding the poller's
+// reconcileWatches) — so no member-attributed github_pr_watches row is ever
+// created and the poller's own AssociatePRWithTask(watch.TaskID, ...) writes
+// under the already-redirected task.
+func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID, repositoryID string) string {
 	if taskID == "" {
 		return taskID
 	}
@@ -383,10 +396,30 @@ func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID string)
 	if err != nil || ownerTask == nil || ownerTask.ArchivedAt != nil {
 		return taskID
 	}
+	if repositoryID != "" && !s.taskHoldsRepository(ctx, store, ownerTaskID, repositoryID) {
+		return taskID
+	}
 	s.logger.Info("redirecting push-detected PR/MR association to workspace group owner",
 		zap.String("from_task_id", taskID),
 		zap.String("to_task_id", ownerTaskID))
 	return ownerTaskID
+}
+
+// taskHoldsRepository reports whether taskID has a task_repositories row for
+// repositoryID. Used by resolveEffectivePushTaskID to avoid redirecting into
+// a write that validateTaskRepositoryID would reject and associatePRWithTask
+// would then silently drop.
+func (s *Service) taskHoldsRepository(ctx context.Context, store repoStore, taskID, repositoryID string) bool {
+	taskRepos, err := store.ListTaskRepositories(ctx, taskID)
+	if err != nil {
+		return false
+	}
+	for _, tr := range taskRepos {
+		if tr != nil && tr.RepositoryID == repositoryID {
+			return true
+		}
+	}
+	return false
 }
 
 type pushRepositoryIdentity struct {

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -335,17 +335,58 @@ func (s *Service) trackPushAndAssociatePR(ctx context.Context, data watcher.GitE
 // called verbatim for every non-GitLab (including unknown/legacy-empty
 // provider) repository — this passes the shared repository identity into the
 // existing provider-specific path. Extracted from trackPushAndAssociatePR to
-// keep that function inside the statement budget.
+// keep that function inside the statement budget. The taskID the write lands
+// under may be redirected away from the observing task; see
+// resolveEffectivePushTaskID.
 func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, repositoryName, branch string) {
+	// Identity (owner/name/repositoryID) MUST resolve against the observing
+	// task, not the redirected one: the physical checkout, session, and
+	// task_repositories rows belong to whichever task's session actually saw
+	// the push (a subtask sharing a parent's worktree still has its own
+	// session row). Only the write destination below is redirected.
 	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
+	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID)
 	if identity.provider == gitlabProviderName {
-		s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
+		s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, effectiveTaskID, repositoryName, branch, identity)
 		return
 	}
 	if s.githubService == nil {
 		return
 	}
-	s.detectPushAndAssociatePRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
+	s.detectPushAndAssociatePRWithIdentity(ctx, sessionID, effectiveTaskID, repositoryName, branch, identity)
+}
+
+// resolveEffectivePushTaskID redirects a push-detected PR/MR association from
+// the observing task to its workspace-group owner task. A subtask sharing its
+// parent's worktree via inherit_parent/shared_group workspace modes observes
+// the SAME branch pushes as every other member of the group, so writing the
+// association under the observing task's own ID binds one PR/MR to several
+// unrelated tasks (the group owner plus whichever subtasks happened to be
+// running when the push landed). Falls back to the original taskID — leaving
+// the pre-fix behavior for that call — when there is no active group, the
+// repo doesn't support group lookups, the lookup fails, or the resolved owner
+// task can't be loaded or is archived (an archived owner is not a valid
+// association target).
+func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID string) string {
+	if taskID == "" {
+		return taskID
+	}
+	store, ok := s.repo.(repoStore)
+	if !ok {
+		return taskID
+	}
+	ownerTaskID, err := store.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	if err != nil || ownerTaskID == "" || ownerTaskID == taskID {
+		return taskID
+	}
+	ownerTask, err := s.repo.GetTask(ctx, ownerTaskID)
+	if err != nil || ownerTask == nil || ownerTask.ArchivedAt != nil {
+		return taskID
+	}
+	s.logger.Info("redirecting push-detected PR/MR association to workspace group owner",
+		zap.String("from_task_id", taskID),
+		zap.String("to_task_id", ownerTaskID))
+	return ownerTaskID
 }
 
 type pushRepositoryIdentity struct {

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -376,10 +376,11 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 //
 // This is the single boundary every watch-creation and association call site
 // routes through — dispatchPushDetection, ensureSessionPRWatch,
-// CheckSessionPR, and buildTaskBranchList (feeding the poller's
-// reconcileWatches) — so no member-attributed github_pr_watches row is ever
-// created and the poller's own AssociatePRWithTask(watch.TaskID, ...) writes
-// under the already-redirected task.
+// CheckSessionPR, buildTaskBranchList (feeding the poller's
+// reconcileWatches), and resetPRWatchForBranchSwitch — so no
+// member-attributed github_pr_watches row is ever created and the poller's
+// own AssociatePRWithTask(watch.TaskID, ...) writes under the
+// already-redirected task.
 func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID, repositoryID string) string {
 	if taskID == "" {
 		return taskID
@@ -1126,8 +1127,9 @@ func (s *Service) resetPRWatchForBranchSwitch(ctx context.Context, taskID, sessi
 	if workspaceID == "" {
 		return
 	}
+	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
 	if _, err := s.githubService.EnsurePRWatchForWorkspace(
-		ctx, workspaceID, sessionID, taskID, repositoryID, owner, repoName, newBranch,
+		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, owner, repoName, newBranch,
 	); err != nil {
 		s.logger.Error("failed to add PR watch after branch switch",
 			zap.String("session_id", sessionID), zap.String("new_branch", newBranch),

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -345,7 +345,7 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 	// the push (a subtask sharing a parent's worktree still has its own
 	// session row). Only the write destination below is redirected.
 	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
-	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, identity.repositoryID)
+	effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sessionID, taskID, identity.repositoryID)
 	if identity.provider == gitlabProviderName {
 		s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, effectiveTaskID, repositoryName, branch, identity)
 		return
@@ -381,7 +381,13 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 // member-attributed github_pr_watches row is ever created and the poller's
 // own AssociatePRWithTask(watch.TaskID, ...) writes under the
 // already-redirected task.
-func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID, repositoryID string) string {
+type sessionWorkspaceGroupOwnerResolver interface {
+	GetWorkspaceGroupOwnerTaskIDForSession(ctx context.Context, taskID, sessionID string) (string, error)
+}
+
+func (s *Service) resolveEffectivePushTaskIDForSession(
+	ctx context.Context, sessionID, taskID, repositoryID string,
+) string {
 	if taskID == "" {
 		return taskID
 	}
@@ -389,7 +395,18 @@ func (s *Service) resolveEffectivePushTaskID(ctx context.Context, taskID, reposi
 	if !ok {
 		return taskID
 	}
-	ownerTaskID, err := store.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	var ownerTaskID string
+	var err error
+	if sessionID != "" {
+		if sessionResolver, ok := any(store).(sessionWorkspaceGroupOwnerResolver); ok {
+			ownerTaskID, err = sessionResolver.GetWorkspaceGroupOwnerTaskIDForSession(ctx, taskID, sessionID)
+		} else {
+			// Keep compatibility with repository test doubles and older adapters.
+			ownerTaskID, err = store.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+		}
+	} else {
+		ownerTaskID, err = store.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	}
 	if err != nil || ownerTaskID == "" || ownerTaskID == taskID {
 		return taskID
 	}
@@ -1127,7 +1144,7 @@ func (s *Service) resetPRWatchForBranchSwitch(ctx context.Context, taskID, sessi
 	if workspaceID == "" {
 		return
 	}
-	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
+	effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 	if _, err := s.githubService.EnsurePRWatchForWorkspace(
 		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, owner, repoName, newBranch,
 	); err != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_git_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_test.go
@@ -449,6 +449,12 @@ func TestHandleBranchSwitched_RedirectsToWorkspaceGroupOwner(t *testing.T) {
 	if err := testRepo.UpdateTaskSession(ctx, session); err != nil {
 		t.Fatalf("link session to environment: %v", err)
 	}
+	if _, err := testRepo.DB().Exec(
+		`UPDATE task_workspace_groups SET materialized_environment_id = ? WHERE id = ?`,
+		"env-s1", "group1",
+	); err != nil {
+		t.Fatalf("bind workspace group to environment: %v", err)
+	}
 
 	svc := createTestService(testRepo, newMockStepGetter(), newMockTaskRepo())
 	ghSvc := &mockGitHubService{}

--- a/apps/backend/internal/orchestrator/event_handlers_git_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/office/costs/modelsdev"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // Regression: when the agent renames or switches branches inside a session,
@@ -381,6 +382,93 @@ func TestHandleBranchSwitched_AlreadyWatchedBranchIsNoop(t *testing.T) {
 	}
 	if ghSvc.ensureWatchCalls != 0 {
 		t.Errorf("EnsurePRWatch called %d times, want 0", ghSvc.ensureWatchCalls)
+	}
+}
+
+// TestHandleBranchSwitched_RedirectsToWorkspaceGroupOwner covers Review Round
+// 2's F4 finding: resetPRWatchForBranchSwitch was a fifth watch-creation call
+// site that read taskID straight off the observing branch-switch event
+// instead of routing through resolveEffectivePushTaskID, so a shared-worktree
+// subtask that switched branches got its own member-attributed watch for the
+// new branch — reproducing the "one PR bound to several tasks" defect on
+// every branch switch, independent of dispatchPushDetection/
+// ensureSessionPRWatch/CheckSessionPR/buildTaskBranchList already routing
+// through the redirect (see event_handlers_github_multi_branch_assoc_test.go).
+func TestHandleBranchSwitched_RedirectsToWorkspaceGroupOwner(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	testRepo := setupTestRepo(t)
+	seedSession(t, testRepo, "t1", "s1", "step1")
+
+	if err := testRepo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, testRepo, "group1", "parent1", "parent1", "t1")
+
+	rObj := &models.Repository{
+		ID: "repo1", WorkspaceID: "ws1", Name: "myrepo",
+		SourceType: "provider", Provider: "github",
+		ProviderOwner: "myorg", ProviderName: "myrepo",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := testRepo.CreateRepository(ctx, rObj); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	if err := testRepo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID: "tr1", TaskID: "t1", RepositoryID: "repo1",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task repository: %v", err)
+	}
+	// The owner shares the same physical checkout as its members (that's the
+	// whole premise of inherit_parent/shared_group), so it holds repo1 too —
+	// this is what makes the redirect eligible under the F2 ownership guard.
+	seedGroupOwnerTaskRepository(t, testRepo, "parent1", "repo1", "feature/a")
+	if err := testRepo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: "env-s1", TaskID: "t1", ExecutorType: "worktree",
+		WorkspacePath: "/tmp", Status: models.TaskEnvironmentStatusReady,
+		Repos: []*models.TaskEnvironmentRepo{
+			{
+				ID: "wt-s1", WorktreeID: "wtree-s1", RepositoryID: "repo1",
+				WorktreeBranch: "feature/a", CreatedAt: now,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("create environment: %v", err)
+	}
+	session, err := testRepo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	session.TaskEnvironmentID = "env-s1"
+	session.RepositoryID = "repo1"
+	if err := testRepo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("link session to environment: %v", err)
+	}
+
+	svc := createTestService(testRepo, newMockStepGetter(), newMockTaskRepo())
+	ghSvc := &mockGitHubService{}
+	svc.SetGitHubService(ghSvc)
+
+	// switchBranch hardcodes TaskID "t1" / SessionID "s1" / RepositoryName
+	// "myrepo" — the observing subtask's own identity, exactly like a real
+	// inherit_parent/shared_group member that shares the owner's worktree.
+	switchBranch(t, svc, "feature/a", "feature/b")
+
+	if ghSvc.ensureWatchCalls != 1 {
+		t.Fatalf("EnsurePRWatch called %d times, want 1", ghSvc.ensureWatchCalls)
+	}
+	if ghSvc.lastEnsureWatchTaskID != "parent1" {
+		t.Fatalf("EnsurePRWatchForWorkspace taskID = %q, want parent1 (the group owner)", ghSvc.lastEnsureWatchTaskID)
+	}
+	for _, c := range ghSvc.ensureWatchLog {
+		if c.TaskID == "t1" {
+			t.Fatalf("subtask t1 got its own watch after branch switch, want zero: %+v", ghSvc.ensureWatchLog)
+		}
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -1019,6 +1019,12 @@ func (s *Service) backfillRepoProvider(store repoStore, repo *models.Repository)
 // AND the session worktree for that repo has no branch (rare; ensures
 // backwards compatibility with single-repo callers that pass the resolved
 // branch directly).
+//
+// The watch's task_id is redirected via resolveEffectivePushTaskID, same as
+// push detection: this runs on every session start, so without the redirect
+// a subtask sharing its parent's worktree gets its own member-attributed
+// watch here even when push detection itself is fixed — the watch the
+// poller then associates the PR under (see poller.go's detectPRForWatch).
 func (s *Service) ensureSessionPRWatch(ctx context.Context, taskID, sessionID, fallbackBranch string) {
 	if s.githubService == nil {
 		return
@@ -1029,8 +1035,9 @@ func (s *Service) ensureSessionPRWatch(ctx context.Context, taskID, sessionID, f
 	}
 	targets := s.resolveSessionWatchTargets(ctx, taskID, sessionID, fallbackBranch)
 	for _, t := range targets {
+		effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, t.RepositoryID)
 		if _, err := s.githubService.EnsurePRWatchForWorkspace(
-			ctx, workspaceID, sessionID, taskID, t.RepositoryID, t.Owner, t.Repo, t.Branch,
+			ctx, workspaceID, sessionID, effectiveTaskID, t.RepositoryID, t.Owner, t.Repo, t.Branch,
 		); err != nil {
 			s.logger.Warn("failed to ensure PR watch for session",
 				zap.String("session_id", sessionID),
@@ -1359,13 +1366,26 @@ func (s *Service) CheckSessionPR(ctx context.Context, taskID, sessionID string) 
 		return false, nil
 	}
 
-	// Check if a PR is already associated with this task
-	existing, err := s.githubService.GetTaskPR(ctx, taskID)
+	// The watch/association write destination is redirected the same way as
+	// push detection (resolveEffectivePushTaskID): this is the frontend's
+	// on-demand alternative to that same detection, so without the redirect a
+	// user opening a shared-worktree subtask reproduces the multi-binding on
+	// demand. Resolved first, ahead of resolveTaskRepo/branch below, so the
+	// already-associated short-circuit only needs a repositoryID lookup, not
+	// a full owner/repo/branch resolution.
+	repositoryID := s.resolvePrimaryTaskRepositoryID(ctx, taskID)
+	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
+
+	// Check if a PR is already associated with the effective task.
+	existing, err := s.githubService.GetTaskPR(ctx, effectiveTaskID)
 	if err == nil && existing != nil {
 		return true, nil
 	}
 
-	// Resolve the GitHub owner/repo from the task's repository
+	// Resolve the GitHub owner/repo from the task's repository. This, and
+	// branch resolution below, stay keyed off the observing taskID: the
+	// physical checkout and task_repositories rows belong to whichever task's
+	// session the frontend is checking, same as dispatchPushDetection.
 	owner, repoName := s.resolveTaskRepo(ctx, taskID)
 	if owner == "" || repoName == "" {
 		return false, nil
@@ -1377,13 +1397,12 @@ func (s *Service) CheckSessionPR(ctx context.Context, taskID, sessionID string) 
 	}
 
 	// Ensure a PR watch exists so the background poller will keep checking
-	repositoryID := s.resolvePrimaryTaskRepositoryID(ctx, taskID)
 	workspaceID := s.taskWorkspaceID(ctx, taskID)
 	if workspaceID == "" {
 		return false, github.ErrGitHubWorkspaceRequired
 	}
 	if _, watchErr := s.githubService.EnsurePRWatchForWorkspace(
-		ctx, workspaceID, sessionID, taskID, repositoryID, owner, repoName, branch,
+		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, owner, repoName, branch,
 	); watchErr != nil {
 		s.logger.Warn("failed to ensure PR watch during check",
 			zap.String("session_id", sessionID),
@@ -1398,8 +1417,8 @@ func (s *Service) CheckSessionPR(ctx context.Context, taskID, sessionID string) 
 		return false, nil
 	}
 
-	// Found a PR — associate it with the task
-	s.associatePRFromPushScoped(ctx, workspaceID, sessionID, taskID, owner, repoName, repositoryID, branch, pr)
+	// Found a PR — associate it with the effective task.
+	s.associatePRFromPushScoped(ctx, workspaceID, sessionID, effectiveTaskID, owner, repoName, repositoryID, branch, pr)
 	return true, nil
 }
 
@@ -1426,6 +1445,11 @@ func (s *Service) ResolveBranchForSession(ctx context.Context, taskID, sessionID
 // TaskBranchInfo per (session, repository) that doesn't already have a PR
 // watch. Multi-repo: previously dedup was keyed by sessionID, which silently
 // dropped non-primary repos as soon as the primary one got a watch.
+//
+// TaskID is redirected via resolveEffectivePushTaskID before the caller
+// (poller.reconcileWatches) creates the watch, same as ensureSessionPRWatch:
+// this is the third and last producer that would otherwise write a
+// member-attributed watch for a shared-worktree subtask.
 func (s *Service) buildTaskBranchList(ctx context.Context, store repoStore) ([]github.TaskBranchInfo, error) {
 	sessions, err := store.ListSessionsWithBranches(ctx)
 	if err != nil {
@@ -1448,9 +1472,10 @@ func (s *Service) buildTaskBranchList(ctx context.Context, store repoStore) ([]g
 			if watchedKeys[watchedSessionRepoKey(sess.SessionID, t.RepositoryID, t.Branch)] {
 				continue
 			}
+			effectiveTaskID := s.resolveEffectivePushTaskID(ctx, sess.TaskID, t.RepositoryID)
 			result = append(result, github.TaskBranchInfo{
 				WorkspaceID:  sess.WorkspaceID,
-				TaskID:       sess.TaskID,
+				TaskID:       effectiveTaskID,
 				SessionID:    sess.SessionID,
 				RepositoryID: t.RepositoryID,
 				Owner:        t.Owner,

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -1035,7 +1035,7 @@ func (s *Service) ensureSessionPRWatch(ctx context.Context, taskID, sessionID, f
 	}
 	targets := s.resolveSessionWatchTargets(ctx, taskID, sessionID, fallbackBranch)
 	for _, t := range targets {
-		effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, t.RepositoryID)
+		effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sessionID, taskID, t.RepositoryID)
 		if _, err := s.githubService.EnsurePRWatchForWorkspace(
 			ctx, workspaceID, sessionID, effectiveTaskID, t.RepositoryID, t.Owner, t.Repo, t.Branch,
 		); err != nil {
@@ -1374,7 +1374,7 @@ func (s *Service) CheckSessionPR(ctx context.Context, taskID, sessionID string) 
 	// already-associated short-circuit only needs a repositoryID lookup, not
 	// a full owner/repo/branch resolution.
 	repositoryID := s.resolvePrimaryTaskRepositoryID(ctx, taskID)
-	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
+	effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 
 	// Check if a PR is already associated with the effective task.
 	existing, err := s.githubService.GetTaskPR(ctx, effectiveTaskID)
@@ -1472,7 +1472,7 @@ func (s *Service) buildTaskBranchList(ctx context.Context, store repoStore) ([]g
 			if watchedKeys[watchedSessionRepoKey(sess.SessionID, t.RepositoryID, t.Branch)] {
 				continue
 			}
-			effectiveTaskID := s.resolveEffectivePushTaskID(ctx, sess.TaskID, t.RepositoryID)
+			effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sess.SessionID, sess.TaskID, t.RepositoryID)
 			result = append(result, github.TaskBranchInfo{
 				WorkspaceID:  sess.WorkspaceID,
 				TaskID:       effectiveTaskID,

--- a/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
@@ -211,6 +211,11 @@ func TestGitHubPushAssociationRedirectsToWorkspaceGroupOwner(t *testing.T) {
 	}
 	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
 	seedGitHubPushAssocFixture(t, repo, "feature-x")
+	// The owner shares the same physical checkout as its members (that's the
+	// whole premise of inherit_parent/shared_group), so it holds repo1 too —
+	// this is what makes the redirect below eligible under the F2 ownership
+	// guard, not just the group membership.
+	seedGroupOwnerTaskRepository(t, repo, "parent1", "repo1", "feature-x")
 
 	mockClient := github.NewMockClient()
 	mockClient.AddPR(&github.PR{
@@ -298,5 +303,169 @@ func TestGitHubPushAssociationRedirectsToWorkspaceGroupOwner(t *testing.T) {
 	}
 	if ghSvc.lastAssociateTaskID != "solo1" {
 		t.Fatalf("AssociatePRWithTask taskID = %q, want solo1 (no group, no redirect)", ghSvc.lastAssociateTaskID)
+	}
+}
+
+// seedGroupOwnerTaskRepository gives the workspace-group owner task its own
+// task_repositories row for repoID, matching the real inherit_parent/
+// shared_group scenario where the owner is checked out at the same physical
+// repository its members share. Without this, resolveEffectivePushTaskID's F2
+// fallback (the owner doesn't hold the repository) would fire and every
+// redirect-focused test below would silently degrade into the ungrouped-task
+// no-redirect path instead of exercising the redirect itself.
+func seedGroupOwnerTaskRepository(t *testing.T, repo *sqliterepo.Repository, taskID, repoID, checkoutBranch string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := repo.CreateTaskRepository(context.Background(), &models.TaskRepository{
+		ID: "tr-" + taskID, TaskID: taskID, RepositoryID: repoID, CheckoutBranch: checkoutBranch,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create owner task repository: %v", err)
+	}
+}
+
+// TestEnsureSessionPRWatchRedirectsToWorkspaceGroupOwner covers Review Round
+// 1's F1 finding: resolveEffectivePushTaskID was only ever called from
+// dispatchPushDetection. ensureSessionPRWatch runs on every session start (see
+// task_operations.go's four call sites) and, before this fix, always created
+// its watch under the observing subtask's own taskID — so a shared-worktree
+// subtask got its own member-attributed watch the moment its session started,
+// independent of whether a push had even happened yet.
+func TestEnsureSessionPRWatchRedirectsToWorkspaceGroupOwner(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	seedSession(t, repo, "t1", "s1", "step1")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
+	seedGitHubPushAssocFixture(t, repo, "feature-x")
+	seedGroupOwnerTaskRepository(t, repo, "parent1", "repo1", "feature-x")
+
+	ghSvc := &mockGitHubService{client: github.NewMockClient()}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.SetGitHubService(ghSvc)
+
+	svc.ensureSessionPRWatch(ctx, "t1", "s1", "feature-x")
+
+	if ghSvc.ensureWatchCalls == 0 {
+		t.Fatalf("expected EnsurePRWatchForWorkspace to be called")
+	}
+	if ghSvc.lastEnsureWatchTaskID != "parent1" {
+		t.Fatalf("EnsurePRWatchForWorkspace taskID = %q, want parent1 (the group owner)", ghSvc.lastEnsureWatchTaskID)
+	}
+	for _, c := range ghSvc.ensureWatchLog {
+		if c.TaskID == "t1" {
+			t.Fatalf("subtask t1 got its own watch, want zero: %+v", ghSvc.ensureWatchLog)
+		}
+	}
+}
+
+// TestCheckSessionPRRedirectsToWorkspaceGroupOwner covers the second F1 gap:
+// CheckSessionPR is the frontend's on-demand alternative to push detection
+// (triggered by the user clicking "check for PR"), and before this fix wrote
+// both the watch and the association under the observing subtask's own
+// taskID, reproducing the multi-binding defect on demand instead of only on a
+// push.
+func TestCheckSessionPRRedirectsToWorkspaceGroupOwner(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	seedSession(t, repo, "t1", "s1", "step1")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
+	seedGitHubPushAssocFixture(t, repo, "feature-x")
+	seedGroupOwnerTaskRepository(t, repo, "parent1", "repo1", "feature-x")
+
+	mockClient := github.NewMockClient()
+	mockClient.AddPR(&github.PR{
+		Number: 9, Title: "On-demand check PR", HTMLURL: "https://github.com/myorg/kandev/pull/9",
+		RepoOwner: "myorg", RepoName: "kandev", HeadBranch: "feature-x", BaseBranch: "main",
+	})
+	ghSvc := &mockGitHubService{client: mockClient}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.SetGitHubService(ghSvc)
+
+	found, err := svc.CheckSessionPR(ctx, "t1", "s1")
+	if err != nil {
+		t.Fatalf("CheckSessionPR: %v", err)
+	}
+	if !found {
+		t.Fatalf("CheckSessionPR: expected a PR to be found")
+	}
+
+	if ghSvc.lastEnsureWatchTaskID != "parent1" {
+		t.Fatalf("EnsurePRWatchForWorkspace taskID = %q, want parent1 (the group owner)", ghSvc.lastEnsureWatchTaskID)
+	}
+	if ghSvc.lastAssociateTaskID != "parent1" {
+		t.Fatalf("AssociatePRWithTask taskID = %q, want parent1 (the group owner)", ghSvc.lastAssociateTaskID)
+	}
+	for _, c := range ghSvc.associateLog {
+		if c.TaskID == "t1" {
+			t.Fatalf("subtask t1 got its own association, want zero: %+v", ghSvc.associateLog)
+		}
+	}
+}
+
+// TestPushAssociationFallsBackWhenOwnerLacksRepository covers Review Round 1's
+// F2 finding: resolveEffectivePushTaskID must not redirect to a workspace
+// group owner that doesn't hold the observing task's repository in its own
+// task_repositories, since the downstream validateTaskRepositoryID guard would
+// then reject the write and the association would be dropped silently —
+// contradicting the "never drop the association silently" design principle.
+// The write must fall back to the observing task instead.
+func TestPushAssociationFallsBackWhenOwnerLacksRepository(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	seedSession(t, repo, "t1", "s1", "step1")
+	// Parent owns the group but was never seeded with repo1 in its own
+	// task_repositories — e.g. it added the group after the member already
+	// had its own repository wired up.
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
+	seedGitHubPushAssocFixture(t, repo, "feature-x")
+
+	mockClient := github.NewMockClient()
+	mockClient.AddPR(&github.PR{
+		Number: 10, Title: "Fallback PR", HTMLURL: "https://github.com/myorg/kandev/pull/10",
+		RepoOwner: "myorg", RepoName: "kandev", HeadBranch: "feature-x", BaseBranch: "main",
+	})
+	ghSvc := &mockGitHubService{client: mockClient}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.SetGitHubService(ghSvc)
+
+	svc.dispatchPushDetection(ctx, "s1", "t1", "", "feature-x")
+
+	if ghSvc.lastCreateWatchTaskID != "t1" {
+		t.Fatalf("CreatePRWatch taskID = %q, want t1 (owner lacks repository, fall back to observing task)",
+			ghSvc.lastCreateWatchTaskID)
+	}
+	if ghSvc.lastAssociateTaskID != "t1" {
+		t.Fatalf("AssociatePRWithTask taskID = %q, want t1 (owner lacks repository, fall back to observing task)",
+			ghSvc.lastAssociateTaskID)
+	}
+	if len(ghSvc.associateLog) != 1 {
+		t.Fatalf("expected exactly one association (not silently dropped), got %+v", ghSvc.associateLog)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // seedGitHubPushAssocFixture creates the repository, task_repository
@@ -133,5 +134,169 @@ func TestGitHubPushAssociationPassesRepositoryID(t *testing.T) {
 	}
 	if ghSvc.lastAssociateRepositoryID != "repo1" {
 		t.Fatalf("AssociatePRWithTask repositoryID = %q, want repo1", ghSvc.lastAssociateRepositoryID)
+	}
+}
+
+// seedWorkspaceGroup creates the task_workspace_groups /
+// task_workspace_group_members rows the workspace-group redirect reads. Those
+// tables are created by internal/office/repository/sqlite's schema init, not
+// this package's own — office's init never runs against an
+// orchestrator-package test DB, so the fixture creates them directly, the
+// same way internal/task/repository/sqlite/task_environment_test.go does for
+// its own package's group-binding tests. Only the columns the redirect query
+// actually reads (or that a foreign key requires) are populated.
+func seedWorkspaceGroup(t *testing.T, repo *sqliterepo.Repository, groupID, ownerTaskID string, memberTaskIDs ...string) {
+	t.Helper()
+	if _, err := repo.DB().Exec(`
+		CREATE TABLE IF NOT EXISTS task_workspace_groups (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL DEFAULT '',
+			owner_task_id TEXT NOT NULL,
+			materialized_kind TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS task_workspace_group_members (
+			workspace_group_id TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			released_at TIMESTAMP,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (workspace_group_id, task_id)
+		);
+	`); err != nil {
+		t.Fatalf("create workspace group tables: %v", err)
+	}
+	if _, err := repo.DB().Exec(
+		`INSERT INTO task_workspace_groups (id, owner_task_id) VALUES (?, ?)`, groupID, ownerTaskID,
+	); err != nil {
+		t.Fatalf("seed workspace group: %v", err)
+	}
+	for _, taskID := range memberTaskIDs {
+		if _, err := repo.DB().Exec(
+			`INSERT INTO task_workspace_group_members (workspace_group_id, task_id) VALUES (?, ?)`,
+			groupID, taskID,
+		); err != nil {
+			t.Fatalf("seed workspace group member %s: %v", taskID, err)
+		}
+	}
+}
+
+// TestGitHubPushAssociationRedirectsToWorkspaceGroupOwner covers the "one PR
+// gets bound to several tasks" defect: a subtask sharing its parent's
+// worktree via inherit_parent/shared_group workspace modes observes the same
+// git-status push as the parent, since they share one physical checkout. Push
+// detection must file the resulting watch/association under the group's
+// owner task, not the subtask that happened to be running when the push
+// landed — otherwise one PR ends up bound to every task in the group.
+func TestGitHubPushAssociationRedirectsToWorkspaceGroupOwner(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	// seedSession creates the shared ws1/wf1 fixture plus the subtask's own
+	// task+session — its checkout, task_repository row, and
+	// session.RepositoryID all key off t1, exactly like a real
+	// inherit_parent/shared_group subtask that actually observed the push.
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	// The owner task lives in the same workspace/workflow; created directly
+	// (not via seedSession/seedTaskWithoutSession, which would try to
+	// recreate the ws1/wf1 rows seedSession already inserted above).
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
+	seedGitHubPushAssocFixture(t, repo, "feature-x")
+
+	mockClient := github.NewMockClient()
+	mockClient.AddPR(&github.PR{
+		Number: 7, Title: "Shared worktree PR", HTMLURL: "https://github.com/myorg/kandev/pull/7",
+		RepoOwner: "myorg", RepoName: "kandev", HeadBranch: "feature-x", BaseBranch: "main",
+	})
+	ghSvc := &mockGitHubService{client: mockClient}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.SetGitHubService(ghSvc)
+
+	svc.dispatchPushDetection(ctx, "s1", "t1", "", "feature-x")
+
+	if ghSvc.lastCreateWatchTaskID != "parent1" {
+		t.Fatalf("CreatePRWatch taskID = %q, want parent1 (the group owner)", ghSvc.lastCreateWatchTaskID)
+	}
+	if ghSvc.lastAssociateTaskID != "parent1" {
+		t.Fatalf("AssociatePRWithTask taskID = %q, want parent1 (the group owner)", ghSvc.lastAssociateTaskID)
+	}
+	for _, c := range ghSvc.associateLog {
+		if c.TaskID == "t1" {
+			t.Fatalf("subtask t1 got its own association, want zero: %+v", ghSvc.associateLog)
+		}
+	}
+
+	// Stable across a second push-detection run: rerunning must not flip the
+	// attribution back to the observing subtask.
+	svc.dispatchPushDetection(ctx, "s1", "t1", "", "feature-x")
+	if ghSvc.lastCreateWatchTaskID != "parent1" {
+		t.Fatalf("second run: CreatePRWatch taskID = %q, want parent1", ghSvc.lastCreateWatchTaskID)
+	}
+	if ghSvc.lastAssociateTaskID != "parent1" {
+		t.Fatalf("second run: AssociatePRWithTask taskID = %q, want parent1", ghSvc.lastAssociateTaskID)
+	}
+	for _, c := range ghSvc.associateLog {
+		if c.TaskID == "t1" {
+			t.Fatalf("subtask t1 got its own association after second run, want zero: %+v", ghSvc.associateLog)
+		}
+	}
+
+	// Negative control: a task with no workspace group keeps its own
+	// attribution — the redirect must not fire for ordinary, ungrouped tasks.
+	// Created directly (not via seedSession, which would try to recreate the
+	// shared ws1/wf1 rows already inserted above).
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "solo1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Solo", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create solo task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "s-solo", TaskID: "solo1", State: models.TaskSessionStateRunning,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create solo session: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID: "repo-solo", WorkspaceID: "ws1", Name: "kandev",
+		SourceType: "provider", Provider: "github",
+		ProviderOwner: "myorg", ProviderName: "kandev",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create solo repository: %v", err)
+	}
+	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID: "tr-solo", TaskID: "solo1", RepositoryID: "repo-solo", CheckoutBranch: "solo-branch",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create solo task repository: %v", err)
+	}
+	soloSession, _ := repo.GetTaskSession(ctx, "s-solo")
+	soloSession.RepositoryID = "repo-solo"
+	if err := repo.UpdateTaskSession(ctx, soloSession); err != nil {
+		t.Fatalf("update solo session: %v", err)
+	}
+	mockClient.AddPR(&github.PR{
+		Number: 8, Title: "Solo PR", HTMLURL: "https://github.com/myorg/kandev/pull/8",
+		RepoOwner: "myorg", RepoName: "kandev", HeadBranch: "solo-branch", BaseBranch: "main",
+	})
+
+	svc.dispatchPushDetection(ctx, "s-solo", "solo1", "", "solo-branch")
+
+	if ghSvc.lastCreateWatchTaskID != "solo1" {
+		t.Fatalf("CreatePRWatch taskID = %q, want solo1 (no group, no redirect)", ghSvc.lastCreateWatchTaskID)
+	}
+	if ghSvc.lastAssociateTaskID != "solo1" {
+		t.Fatalf("AssociatePRWithTask taskID = %q, want solo1 (no group, no redirect)", ghSvc.lastAssociateTaskID)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_multi_branch_assoc_test.go
@@ -153,6 +153,7 @@ func seedWorkspaceGroup(t *testing.T, repo *sqliterepo.Repository, groupID, owne
 			workspace_id TEXT NOT NULL DEFAULT '',
 			owner_task_id TEXT NOT NULL,
 			materialized_kind TEXT NOT NULL DEFAULT '',
+			materialized_environment_id TEXT NOT NULL DEFAULT '',
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -67,18 +67,20 @@ type mockGitHubService struct {
 	lastAssociateRepositoryID   string
 	lastCreateWatchWorkspaceID  string
 	lastAssociateWorkspaceID    string
-	// lastCreateWatchTaskID/lastAssociateTaskID capture the taskID each
-	// ForWorkspace call actually wrote under, so tests can pin the
-	// workspace-group redirect (resolveEffectivePushTaskID) at the write
+	// lastCreateWatchTaskID/lastAssociateTaskID/lastEnsureWatchTaskID capture
+	// the taskID each ForWorkspace call actually wrote under, so tests can pin
+	// the workspace-group redirect (resolveEffectivePushTaskID) at the write
 	// funnel instead of only inferring it from call counts.
 	lastCreateWatchTaskID string
 	lastAssociateTaskID   string
-	// createWatchLog/associateLog record every call (not just the last), so
-	// multi-branch tests can assert each branch got its own watch/association
-	// scoped to the right repository, rather than only inspecting whichever
-	// call happened to run last.
+	lastEnsureWatchTaskID string
+	// createWatchLog/associateLog/ensureWatchLog record every call (not just
+	// the last), so multi-branch tests can assert each branch got its own
+	// watch/association scoped to the right repository, rather than only
+	// inspecting whichever call happened to run last.
 	createWatchLog []repoBranchCall
 	associateLog   []repoBranchCall
+	ensureWatchLog []repoBranchCall
 
 	// Review PR reservation tracking.
 	reserveCalls   int
@@ -377,9 +379,11 @@ func (m *mockGitHubService) MergePRForAutomation(
 	m.mergeExpectedHeadSHA = expectedHeadSHA
 	return m.MergePR(ctx, owner, repo, number, method)
 }
-func (m *mockGitHubService) EnsurePRWatch(_ context.Context, _, _, _, _, _, branch string) (*github.PRWatch, error) {
+func (m *mockGitHubService) EnsurePRWatch(_ context.Context, _, taskID, repositoryID, _, _, branch string) (*github.PRWatch, error) {
 	m.ensureWatchCalls++
 	m.ensureWatchBranch = branch
+	m.lastEnsureWatchTaskID = taskID
+	m.ensureWatchLog = append(m.ensureWatchLog, repoBranchCall{TaskID: taskID, RepositoryID: repositoryID, Branch: branch})
 	return &github.PRWatch{}, nil
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -12,10 +12,11 @@ import (
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
-// repoBranchCall records one (repositoryID, branch) pair observed by a
-// mockGitHubService call, so multi-branch tests can assert per-call scoping
-// instead of only the most recent call's arguments.
+// repoBranchCall records one (taskID, repositoryID, branch) triple observed
+// by a mockGitHubService call, so multi-branch tests can assert per-call
+// scoping instead of only the most recent call's arguments.
 type repoBranchCall struct {
+	TaskID       string
 	RepositoryID string
 	Branch       string
 }
@@ -66,6 +67,12 @@ type mockGitHubService struct {
 	lastAssociateRepositoryID   string
 	lastCreateWatchWorkspaceID  string
 	lastAssociateWorkspaceID    string
+	// lastCreateWatchTaskID/lastAssociateTaskID capture the taskID each
+	// ForWorkspace call actually wrote under, so tests can pin the
+	// workspace-group redirect (resolveEffectivePushTaskID) at the write
+	// funnel instead of only inferring it from call counts.
+	lastCreateWatchTaskID string
+	lastAssociateTaskID   string
 	// createWatchLog/associateLog record every call (not just the last), so
 	// multi-branch tests can assert each branch got its own watch/association
 	// scoped to the right repository, rather than only inspecting whichever
@@ -411,11 +418,12 @@ func (m *mockGitHubService) ListPRWatchesBySession(_ context.Context, _ string) 
 	}
 	return []*github.PRWatch{m.prWatch}, nil
 }
-func (m *mockGitHubService) CreatePRWatch(_ context.Context, _, _, repositoryID, _, _ string, _ int, branch string) (*github.PRWatch, error) {
+func (m *mockGitHubService) CreatePRWatch(_ context.Context, _, taskID, repositoryID, _, _ string, _ int, branch string) (*github.PRWatch, error) {
 	m.createWatchCalls++
 	m.createWatchBranch = branch
 	m.lastCreateWatchRepositoryID = repositoryID
-	m.createWatchLog = append(m.createWatchLog, repoBranchCall{RepositoryID: repositoryID, Branch: branch})
+	m.lastCreateWatchTaskID = taskID
+	m.createWatchLog = append(m.createWatchLog, repoBranchCall{TaskID: taskID, RepositoryID: repositoryID, Branch: branch})
 	return &github.PRWatch{}, nil
 }
 func (m *mockGitHubService) CreatePRWatchForWorkspace(
@@ -424,14 +432,15 @@ func (m *mockGitHubService) CreatePRWatchForWorkspace(
 	m.lastCreateWatchWorkspaceID = workspaceID
 	return m.CreatePRWatch(ctx, sessionID, taskID, repositoryID, owner, repo, prNumber, branch)
 }
-func (m *mockGitHubService) AssociatePRWithTask(_ context.Context, _, repositoryID string, pr *github.PR) (*github.TaskPR, error) {
+func (m *mockGitHubService) AssociatePRWithTask(_ context.Context, taskID, repositoryID string, pr *github.PR) (*github.TaskPR, error) {
 	m.associateCalls++
 	m.lastAssociateRepositoryID = repositoryID
+	m.lastAssociateTaskID = taskID
 	branch := ""
 	if pr != nil {
 		branch = pr.HeadBranch
 	}
-	m.associateLog = append(m.associateLog, repoBranchCall{RepositoryID: repositoryID, Branch: branch})
+	m.associateLog = append(m.associateLog, repoBranchCall{TaskID: taskID, RepositoryID: repositoryID, Branch: branch})
 	return &github.TaskPR{}, nil
 }
 func (m *mockGitHubService) AssociatePRWithTaskForWorkspace(

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
@@ -223,6 +223,15 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 	if projectPath == "" || repositoryID == "" {
 		return false, nil
 	}
+
+	// The watch/association write destination is redirected the same way as
+	// push detection (resolveEffectivePushTaskID): this on-demand entry point
+	// is the frontend's manual alternative to that same detection path, so
+	// without the redirect, checking from a shared-worktree subtask would
+	// write gitlab_task_mrs/gitlab_mr_watches under the member instead of the
+	// workspace-group owner, reproducing the multi-binding on demand.
+	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
+
 	branch := strings.TrimSpace(s.resolvePRWatchBranch(ctx, taskID, sessionID, ""))
 	if branch == "" {
 		return false, nil
@@ -234,8 +243,8 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 	// to (repositoryID, branch) rather than "any MR linked to the task", so a
 	// multi-repo/multi-branch task's on-demand check for one branch isn't
 	// short-circuited by a sibling branch's already-linked MR.
-	if existing := s.gitlabTaskMRFor(ctx, taskID, repositoryID, branch); existing != nil {
-		s.ensureWatchForLinkedMR(ctx, sessionID, taskID, repositoryID, existing)
+	if existing := s.gitlabTaskMRFor(ctx, effectiveTaskID, repositoryID, branch); existing != nil {
+		s.ensureWatchForLinkedMR(ctx, sessionID, effectiveTaskID, repositoryID, existing)
 		return true, nil
 	}
 
@@ -248,13 +257,13 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 	// match) before searching, so the background poller keeps checking this
 	// branch even when no MR is open yet — mirrors CheckSessionPR's
 	// EnsurePRWatchForWorkspace-before-lookup ordering.
-	if _, err := s.gitlabMRLinkService.EnsureMRWatch(ctx, sessionID, taskID, repositoryID, projectPath, 0, branch); err != nil {
+	if _, err := s.gitlabMRLinkService.EnsureMRWatch(ctx, sessionID, effectiveTaskID, repositoryID, projectPath, 0, branch); err != nil {
 		s.logger.Warn("failed to ensure MR watch during check",
 			zap.String("session_id", sessionID), zap.Error(err))
 	}
 
 	assoc, err := s.gitlabMRLinkService.AutoLinkMRForBranch(
-		ctx, workspaceID, sessionID, taskID, repositoryID, projectPath, branch,
+		ctx, workspaceID, sessionID, effectiveTaskID, repositoryID, projectPath, branch,
 	)
 	// A real service/store error (e.g. an unconfigured GitLab connection) is
 	// a backend problem, not "no MR is open on this branch" — propagate it

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
@@ -230,7 +230,7 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 	// without the redirect, checking from a shared-worktree subtask would
 	// write gitlab_task_mrs/gitlab_mr_watches under the member instead of the
 	// workspace-group owner, reproducing the multi-binding on demand.
-	effectiveTaskID := s.resolveEffectivePushTaskID(ctx, taskID, repositoryID)
+	effectiveTaskID := s.resolveEffectivePushTaskIDForSession(ctx, sessionID, taskID, repositoryID)
 
 	branch := strings.TrimSpace(s.resolvePRWatchBranch(ctx, taskID, sessionID, ""))
 	if branch == "" {

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
@@ -20,8 +20,15 @@ type fakeGitLabMRLinkService struct {
 	// lastAutoLinkRepositoryID records the repositoryID argument of the most
 	// recent AutoLinkMRForBranch call, so multi-repo tests can assert scoping.
 	lastAutoLinkRepositoryID string
+	// lastAutoLinkTaskID records the taskID argument of the most recent
+	// AutoLinkMRForBranch call, so workspace-group redirect tests can assert
+	// which task the write actually landed under.
+	lastAutoLinkTaskID string
 
 	ensureWatchCalls int
+	// lastEnsureWatchTaskID records the taskID argument of the most recent
+	// EnsureMRWatch call, mirroring lastAutoLinkTaskID above.
+	lastEnsureWatchTaskID string
 
 	taskMRs map[string][]*gitlab.TaskMR
 
@@ -35,6 +42,7 @@ func (f *fakeGitLabMRLinkService) AutoLinkMRForBranch(
 	f.mu.Lock()
 	f.autoLinkCalls++
 	f.lastAutoLinkRepositoryID = repositoryID
+	f.lastAutoLinkTaskID = taskID
 	fn := f.autoLinkFunc
 	f.mu.Unlock()
 	if fn != nil {
@@ -44,10 +52,11 @@ func (f *fakeGitLabMRLinkService) AutoLinkMRForBranch(
 }
 
 func (f *fakeGitLabMRLinkService) EnsureMRWatch(
-	_ context.Context, _, _, _, _ string, _ int, _ string,
+	_ context.Context, _, taskID, _, _ string, _ int, _ string,
 ) (*gitlab.MRWatch, error) {
 	f.mu.Lock()
 	f.ensureWatchCalls++
+	f.lastEnsureWatchTaskID = taskID
 	f.mu.Unlock()
 	return &gitlab.MRWatch{}, nil
 }

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_workspace_group_redirect_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_workspace_group_redirect_test.go
@@ -64,7 +64,11 @@ func TestCheckSessionMRRedirectsToWorkspaceGroupOwner(t *testing.T) {
 	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
 	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
 	fake.autoLinkFunc = func(_ context.Context, _, _, taskID, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
-		return &gitlab.TaskMR{TaskID: taskID, RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 3, HeadBranch: branch}, nil
+		tm := &gitlab.TaskMR{TaskID: taskID, RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 3, HeadBranch: branch}
+		fake.mu.Lock()
+		fake.taskMRs[taskID] = append(fake.taskMRs[taskID], tm)
+		fake.mu.Unlock()
+		return tm, nil
 	}
 	svc.SetGitLabMRLinkService(fake)
 

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_workspace_group_redirect_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_workspace_group_redirect_test.go
@@ -1,0 +1,114 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/gitlab"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestCheckSessionMRRedirectsToWorkspaceGroupOwner covers Review Round 3's F-B
+// finding: CheckSessionMR is GitLab's on-demand counterpart to CheckSessionPR
+// (redirected in an earlier round), but was never itself redirected. Before
+// this fix it always wrote the MR watch and association under the observing
+// subtask's own taskID, reproducing the "one PR/MR gets bound to several
+// tasks" defect on demand for GitLab in exactly the same way CheckSessionPR
+// once did for GitHub.
+func TestCheckSessionMRRedirectsToWorkspaceGroupOwner(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	// seedSession creates the shared ws1/wf1 fixture plus the subtask's own
+	// task+session, checked out at repo1/feat/a, exactly like a real
+	// inherit_parent/shared_group subtask sharing its parent's worktree.
+	seedSession(t, repo, "t1", "s1", "step1")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "parent1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", Description: "Test", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	seedWorkspaceGroup(t, repo, "group1", "parent1", "parent1", "t1")
+
+	repoObj := &models.Repository{
+		ID: "repo1", WorkspaceID: "ws1", Name: "myproj",
+		SourceType: "provider", Provider: gitlabProviderName,
+		ProviderOwner: "group", ProviderName: "myproj",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := repo.CreateRepository(ctx, repoObj); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID: "tr1", TaskID: "t1", RepositoryID: "repo1", CheckoutBranch: "feat/a",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task repository: %v", err)
+	}
+	session, _ := repo.GetTaskSession(ctx, "s1")
+	session.RepositoryID = "repo1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+	// The owner shares the same physical checkout as its members (the whole
+	// premise of inherit_parent/shared_group), so it holds repo1 too — this is
+	// what makes the redirect eligible under resolveEffectivePushTaskID's
+	// ownership guard, not just group membership.
+	seedGroupOwnerTaskRepository(t, repo, "parent1", "repo1", "feat/a")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
+	fake.autoLinkFunc = func(_ context.Context, _, _, taskID, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		return &gitlab.TaskMR{TaskID: taskID, RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 3, HeadBranch: branch}, nil
+	}
+	svc.SetGitLabMRLinkService(fake)
+
+	found, err := svc.CheckSessionMR(ctx, "t1", "s1")
+	if err != nil {
+		t.Fatalf("CheckSessionMR: %v", err)
+	}
+	if !found {
+		t.Fatalf("CheckSessionMR: expected a merge request to be found")
+	}
+
+	if fake.lastEnsureWatchTaskID != "parent1" {
+		t.Fatalf("EnsureMRWatch taskID = %q, want parent1 (the group owner)", fake.lastEnsureWatchTaskID)
+	}
+	if fake.lastAutoLinkTaskID != "parent1" {
+		t.Fatalf("AutoLinkMRForBranch taskID = %q, want parent1 (the group owner)", fake.lastAutoLinkTaskID)
+	}
+	if len(fake.taskMRs["t1"]) != 0 {
+		t.Fatalf("subtask t1 got its own association, want zero: %+v", fake.taskMRs["t1"])
+	}
+}
+
+// TestCheckSessionMR_NoGroupKeepsOwnAttribution is the negative control for
+// TestCheckSessionMRRedirectsToWorkspaceGroupOwner: an ordinary, ungrouped
+// task must keep writing its watch/association under its own taskID — the
+// redirect must only fire for actual workspace-group members.
+func TestCheckSessionMR_NoGroupKeepsOwnAttribution(t *testing.T) {
+	svc, fake := seedGitLabSessionWithRepo(t)
+	fake.autoLinkFunc = func(_ context.Context, _, _, taskID, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		return &gitlab.TaskMR{TaskID: taskID, RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 4, HeadBranch: branch}, nil
+	}
+
+	found, err := svc.CheckSessionMR(context.Background(), "t1", "s1")
+	if err != nil {
+		t.Fatalf("CheckSessionMR: %v", err)
+	}
+	if !found {
+		t.Fatalf("CheckSessionMR: expected a merge request to be found")
+	}
+
+	if fake.lastEnsureWatchTaskID != "t1" {
+		t.Fatalf("EnsureMRWatch taskID = %q, want t1 (no group, no redirect)", fake.lastEnsureWatchTaskID)
+	}
+	if fake.lastAutoLinkTaskID != "t1" {
+		t.Fatalf("AutoLinkMRForBranch taskID = %q, want t1 (no group, no redirect)", fake.lastAutoLinkTaskID)
+	}
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -272,6 +272,9 @@ type repoStore interface {
 	UpdateTaskEnvironmentRepo(ctx context.Context, repo *models.TaskEnvironmentRepo) error
 	// Session history + plan (for context handover)
 	GetTaskPlan(ctx context.Context, taskID string) (*models.TaskPlan, error)
+	// GetWorkspaceGroupOwnerTaskID resolves push-detected PR/MR associations
+	// to the workspace-group owner task; see resolveEffectivePushTaskID.
+	GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID string) (string, error)
 }
 
 // sessionExecutorStore is the minimal repository interface needed by the orchestrator service.

--- a/apps/backend/internal/task/repository/sqlite/workspace_group.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_group.go
@@ -8,14 +8,23 @@ import (
 
 // GetWorkspaceGroupOwnerTaskID returns the owner task ID of the active
 // (non-released) workspace group taskID belongs to, or "" if taskID is not a
-// member of any active group (including the common case where it is itself
-// the owner). task_workspace_groups/task_workspace_group_members are created
-// by internal/office/repository/sqlite (see createWorkspaceGroupTables), not
-// by this package's own schema init; both packages operate on the same
-// physical SQLite database, and session.go's bindReadySharedGroupEnvironment
-// already reads these tables directly for the same reason — avoiding an
+// member of any active group. The owner itself has its own 'owner'-role
+// member row (AddWorkspaceGroupMember is called for the owner too), so
+// calling this with the owner's own taskID returns that same ID rather than
+// "" — callers redirecting a write compare the result against their input
+// taskID rather than against "" to detect that no-op case.
+// task_workspace_groups/task_workspace_group_members are created by
+// internal/office/repository/sqlite (see createWorkspaceGroupTables), not by
+// this package's own schema init; both packages operate on the same physical
+// SQLite database, and session.go's bindReadySharedGroupEnvironment already
+// reads these tables directly for the same reason — avoiding an
 // internal/office import into internal/task/repository/sqlite (and, via it,
 // into internal/orchestrator).
+//
+// ORDER BY makes the choice deterministic when a task is (unreleased-)member
+// of more than one active group at once — AddWorkspaceGroupMember does not
+// constrain a task to a single group, and without an explicit order the
+// LIMIT 1 pick depends on SQLite's query plan. Earliest membership wins.
 func (r *Repository) GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID string) (string, error) {
 	var ownerTaskID string
 	err := r.ro.GetContext(ctx, &ownerTaskID, r.ro.Rebind(`
@@ -23,6 +32,7 @@ func (r *Repository) GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID st
 		FROM task_workspace_groups g
 		JOIN task_workspace_group_members m ON m.workspace_group_id = g.id
 		WHERE m.task_id = ? AND m.released_at IS NULL
+		ORDER BY m.created_at, g.id
 		LIMIT 1
 	`), taskID)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/apps/backend/internal/task/repository/sqlite/workspace_group.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_group.go
@@ -1,0 +1,35 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// GetWorkspaceGroupOwnerTaskID returns the owner task ID of the active
+// (non-released) workspace group taskID belongs to, or "" if taskID is not a
+// member of any active group (including the common case where it is itself
+// the owner). task_workspace_groups/task_workspace_group_members are created
+// by internal/office/repository/sqlite (see createWorkspaceGroupTables), not
+// by this package's own schema init; both packages operate on the same
+// physical SQLite database, and session.go's bindReadySharedGroupEnvironment
+// already reads these tables directly for the same reason — avoiding an
+// internal/office import into internal/task/repository/sqlite (and, via it,
+// into internal/orchestrator).
+func (r *Repository) GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID string) (string, error) {
+	var ownerTaskID string
+	err := r.ro.GetContext(ctx, &ownerTaskID, r.ro.Rebind(`
+		SELECT g.owner_task_id
+		FROM task_workspace_groups g
+		JOIN task_workspace_group_members m ON m.workspace_group_id = g.id
+		WHERE m.task_id = ? AND m.released_at IS NULL
+		LIMIT 1
+	`), taskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return ownerTaskID, nil
+}

--- a/apps/backend/internal/task/repository/sqlite/workspace_group.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_group.go
@@ -43,3 +43,58 @@ func (r *Repository) GetWorkspaceGroupOwnerTaskID(ctx context.Context, taskID st
 	}
 	return ownerTaskID, nil
 }
+
+// GetWorkspaceGroupOwnerTaskIDForSession resolves the owner for the workspace
+// group that owns the observing session's materialized environment. A task can
+// retain active membership in more than one group, so the task-only lookup is
+// not safe when a session identifies the exact shared checkout.
+func (r *Repository) GetWorkspaceGroupOwnerTaskIDForSession(
+	ctx context.Context, taskID, sessionID string,
+) (string, error) {
+	if taskID == "" || sessionID == "" {
+		return "", nil
+	}
+	var environmentID string
+	err := r.ro.GetContext(ctx, &environmentID, r.ro.Rebind(`
+		SELECT COALESCE(task_environment_id, '')
+		FROM task_sessions
+		WHERE id = ? AND task_id = ?
+		LIMIT 1
+	`), sessionID, taskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	// Sessions created before a shared environment is materialized do not yet
+	// carry an exact group identity. Preserve the existing task-only behavior
+	// until that binding is available; once an environment is present, the
+	// exact join below prevents a different active membership from winning.
+	if environmentID == "" {
+		return r.GetWorkspaceGroupOwnerTaskID(ctx, taskID)
+	}
+	var ownerTaskID string
+	err = r.ro.GetContext(ctx, &ownerTaskID, r.ro.Rebind(`
+		SELECT g.owner_task_id
+		FROM task_sessions s
+		JOIN task_workspace_groups g
+		  ON g.materialized_environment_id = s.task_environment_id
+		JOIN task_workspace_group_members m
+		  ON m.workspace_group_id = g.id
+		 AND m.task_id = s.task_id
+		 AND m.released_at IS NULL
+		WHERE s.id = ?
+		  AND s.task_id = ?
+		  AND s.task_environment_id <> ''
+		ORDER BY g.id
+		LIMIT 1
+	`), sessionID, taskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return ownerTaskID, nil
+}

--- a/apps/backend/internal/task/repository/sqlite/workspace_group_test.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_group_test.go
@@ -1,0 +1,133 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// seedWorkspaceGroupOwnerFixture creates the task_workspace_groups /
+// task_workspace_group_members rows GetWorkspaceGroupOwnerTaskID reads. Those
+// tables are owned by internal/office/repository/sqlite's schema init, which
+// never runs against this package's own test DB (see
+// TestCreateTaskSessionWithSharedGroupWorkspaceBindingElectsOneMaterializer for
+// the same convention), so the fixture creates the columns the query actually
+// touches directly.
+func seedWorkspaceGroupOwnerFixture(t *testing.T, repo *Repository) {
+	t.Helper()
+	if _, err := repo.db.Exec(`
+		CREATE TABLE IF NOT EXISTS task_workspace_groups (
+			id TEXT PRIMARY KEY,
+			owner_task_id TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS task_workspace_group_members (
+			workspace_group_id TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			role TEXT NOT NULL DEFAULT 'member',
+			released_at TIMESTAMP,
+			created_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (workspace_group_id, task_id)
+		);
+	`); err != nil {
+		t.Fatalf("create workspace group tables: %v", err)
+	}
+}
+
+func insertWorkspaceGroupMember(
+	t *testing.T, repo *Repository, groupID, ownerTaskID, memberTaskID string, createdAt time.Time,
+) {
+	t.Helper()
+	if _, err := repo.db.Exec(
+		`INSERT OR IGNORE INTO task_workspace_groups (id, owner_task_id) VALUES (?, ?)`,
+		groupID, ownerTaskID,
+	); err != nil {
+		t.Fatalf("seed workspace group %s: %v", groupID, err)
+	}
+	if _, err := repo.db.Exec(
+		`INSERT INTO task_workspace_group_members (workspace_group_id, task_id, created_at) VALUES (?, ?, ?)`,
+		groupID, memberTaskID, createdAt,
+	); err != nil {
+		t.Fatalf("seed workspace group member %s/%s: %v", groupID, memberTaskID, err)
+	}
+}
+
+// TestGetWorkspaceGroupOwnerTaskIDPicksEarliestMembershipDeterministically
+// covers the F3 finding from Review Round 1: the query's LIMIT 1 had no
+// ORDER BY, so when a task is an (unreleased) member of more than one active
+// workspace group, the redirect target picked by SQLite's query plan could
+// change across a re-sync, breaking AC-2's requirement that the redirect
+// target stay stable. Earliest membership (by created_at) must win, and the
+// result must not depend on the order the groups happen to be inserted in.
+func TestGetWorkspaceGroupOwnerTaskIDPicksEarliestMembershipDeterministically(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, "ws-group-owner")
+	for _, taskID := range []string{"member1", "owner-early", "owner-late"} {
+		if err := repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: "ws-group-owner", Title: taskID}); err != nil {
+			t.Fatalf("create task %s: %v", taskID, err)
+		}
+	}
+	seedWorkspaceGroupOwnerFixture(t, repo)
+
+	earlier := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	// Insert the LATER membership first so a naive LIMIT-1-no-ORDER-BY query
+	// (or one that happens to favor insertion/rowid order) would be tempted
+	// to return the wrong owner.
+	insertWorkspaceGroupMember(t, repo, "group-late", "owner-late", "member1", later)
+	insertWorkspaceGroupMember(t, repo, "group-early", "owner-early", "member1", earlier)
+
+	ownerTaskID, err := repo.GetWorkspaceGroupOwnerTaskID(ctx, "member1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceGroupOwnerTaskID: %v", err)
+	}
+	if ownerTaskID != "owner-early" {
+		t.Fatalf("owner task ID = %q, want owner-early (earliest membership)", ownerTaskID)
+	}
+
+	// Re-running must not flip the answer even though the physical row order
+	// on disk hasn't changed — pins that the result is genuinely determined by
+	// the ORDER BY clause, not incidental query-plan behavior.
+	ownerTaskID2, err := repo.GetWorkspaceGroupOwnerTaskID(ctx, "member1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceGroupOwnerTaskID (second run): %v", err)
+	}
+	if ownerTaskID2 != "owner-early" {
+		t.Fatalf("second run: owner task ID = %q, want owner-early", ownerTaskID2)
+	}
+}
+
+// TestGetWorkspaceGroupOwnerTaskIDIgnoresReleasedMembership pins the existing
+// released_at filter alongside the new ordering, so the F3 fix didn't
+// accidentally widen the query to include stale memberships.
+func TestGetWorkspaceGroupOwnerTaskIDIgnoresReleasedMembership(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, "ws-group-owner-released")
+	for _, taskID := range []string{"member1", "owner-active"} {
+		if err := repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: "ws-group-owner-released", Title: taskID}); err != nil {
+			t.Fatalf("create task %s: %v", taskID, err)
+		}
+	}
+	seedWorkspaceGroupOwnerFixture(t, repo)
+
+	now := time.Now().UTC()
+	insertWorkspaceGroupMember(t, repo, "group-active", "owner-active", "member1", now)
+	if _, err := repo.db.Exec(
+		`UPDATE task_workspace_group_members SET released_at = ? WHERE workspace_group_id = 'group-active' AND task_id = 'member1'`,
+		now,
+	); err != nil {
+		t.Fatalf("release membership: %v", err)
+	}
+
+	ownerTaskID, err := repo.GetWorkspaceGroupOwnerTaskID(ctx, "member1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceGroupOwnerTaskID: %v", err)
+	}
+	if ownerTaskID != "" {
+		t.Fatalf("owner task ID = %q, want empty (only membership is released)", ownerTaskID)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/workspace_group_test.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_group_test.go
@@ -131,3 +131,42 @@ func TestGetWorkspaceGroupOwnerTaskIDIgnoresReleasedMembership(t *testing.T) {
 		t.Fatalf("owner task ID = %q, want empty (only membership is released)", ownerTaskID)
 	}
 }
+
+func TestGetWorkspaceGroupOwnerTaskIDForSessionUsesBoundEnvironment(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, "ws-group-session-owner")
+	for _, taskID := range []string{"member1", "owner-early", "owner-late"} {
+		if err := repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: "ws-group-session-owner", Title: taskID}); err != nil {
+			t.Fatalf("create task %s: %v", taskID, err)
+		}
+	}
+	seedWorkspaceGroupOwnerFixture(t, repo)
+	if _, err := repo.db.Exec(`ALTER TABLE task_workspace_groups ADD COLUMN materialized_environment_id TEXT NOT NULL DEFAULT ''`); err != nil {
+		t.Fatalf("add materialized environment column: %v", err)
+	}
+
+	insertWorkspaceGroupMember(t, repo, "group-early", "owner-early", "member1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	insertWorkspaceGroupMember(t, repo, "group-late", "owner-late", "member1", time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	if _, err := repo.db.Exec(`UPDATE task_workspace_groups SET materialized_environment_id = CASE id WHEN 'group-early' THEN 'env-early' ELSE 'env-late' END`); err != nil {
+		t.Fatalf("seed materialized environments: %v", err)
+	}
+	if _, err := repo.db.Exec(`INSERT INTO task_sessions (id, task_id, task_environment_id, started_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"session-late", "member1", "env-late", time.Now().UTC(), time.Now().UTC()); err != nil {
+		t.Fatalf("seed bound session: %v", err)
+	}
+
+	resolver, ok := any(repo).(interface {
+		GetWorkspaceGroupOwnerTaskIDForSession(context.Context, string, string) (string, error)
+	})
+	if !ok {
+		t.Fatal("Repository does not implement session-bound workspace owner resolution")
+	}
+	ownerTaskID, err := resolver.GetWorkspaceGroupOwnerTaskIDForSession(ctx, "member1", "session-late")
+	if err != nil {
+		t.Fatalf("GetWorkspaceGroupOwnerTaskIDForSession: %v", err)
+	}
+	if ownerTaskID != "owner-late" {
+		t.Fatalf("owner task ID = %q, want owner-late for the session-bound group", ownerTaskID)
+	}
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3248/d0387e5811ae.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** When a subtask's agent session runs inside its parent task's shared worktree (the normal shape for `inherit_parent`/shared-group workspaces), every git push or on-demand branch check that session observes gets attributed to the *subtask's own task*, not the task that actually owns the checkout. The same open PR ends up bound to several tasks at once — each can render a different review state for the same PR — and if the "Archive task when its PR merges" automation is on, merging the PR archives every bound task, including subtasks whose own work is still unfinished. This already destroyed real work: PR #3215 merging on 2026-08-31 archived two mid-flight tasks that had no connection to it.
**After this:** Every producer that can create a PR watch or write a `github_task_prs` association (push detection, on-demand check, branch switch, poller reconcile, and the GitHub/GitLab "link PR by URL" flows) resolves the workspace-group owner before writing, so a subtask's session can no longer create its own binding for a PR it doesn't own. Rows also record which code path created them (`watch` vs `url_link`) so a future duplicate can be traced.
**Who hits this:** Anyone whose subtasks or follow-up tasks share a parent's worktree — routine whenever a task is created with `workspace_mode: inherit_parent` or against an existing checkout.
**Scope:** standalone fix, no sibling PRs.
**Not here:** A structurally different case — two *independently created* tasks that each check out the same PR's branch in their *own separate* worktrees (PR #2496) — still double-binds, because there's no worktree-ownership relationship to redirect through; deciding which task should own that PR is a product judgment, not a mechanical fix, so it's filed as a follow-up Kandev task rather than folded in here.

A subtask's git-watcher session runs inside its parent task's shared worktree, so every push or branch check it observes gets bound to the subtask's own task record — one PR can end up attributed to several tasks with divergent review state, and merging it can archive tasks whose work isn't done. This redirects every watch/association write to the task that owns the shared worktree, so a subtask's session never creates its own binding.

## Important Changes

- Redirect every PR-watch and PR-association write (push detection, on-demand session check, branch switch, the poller's reconcile pass, and the GitHub/GitLab "link PR by URL" flows) to the task that owns the shared worktree, with a fail-safe fallback to the observing task when the owner can't be resolved, is archived, or doesn't hold the repository — an association is never silently dropped.
- Add a `source` column (`watch` / `url_link`) to `github_task_prs` so a duplicate binding can be traced back to the code path that created it.
- Detach the collateral rows already found live in the DB and re-enable the "Archive task when its PR merges" automation, which had been disabled to disarm the archive trap while this fix was in flight.

## Validation

- `make -C apps/backend test` (targeted: `internal/github`, `internal/orchestrator`, `internal/task/repository/sqlite`, `internal/backendapp` — all green; full suite — 12 packages fail identically pre- and post-rebase, and identically at `git merge-base HEAD origin/main`, all in the documented macOS `/var`-symlink class, none overlapping this diff's touched packages)
- `make -C apps/backend lint` and `golangci-lint run ./... --new-from-rev=<merge-base>` — 0 issues
- `make typecheck test lint`, `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — clean; this PR is backend-only (zero files under `apps/web/`), and the two web/e2e-script test failures hit while running the full suite (`lib/http-git-server.test.ts`, `e2e/scripts/run-e2e.test.ts`) were independently reproduced in isolation as environmental — the Docker daemon isn't running in this sandbox — not caused by this diff or the rebase
- Live-DB acceptance query (`select pr_number, count(distinct task_id) ... having n>1`) returns zero rows for every case this PR covers; PR #2496 ("Route B", see Not Here above) intentionally still appears
- New/updated Go tests assert on **which task** the row lands on, not merely that *an* association exists: `TestGitHubPushAssociationRedirectsToWorkspaceGroupOwner`, `TestEnsureSessionPRWatchRedirectsToWorkspaceGroupOwner`, `TestCheckSessionPRRedirectsToWorkspaceGroupOwner`, `TestHandleBranchSwitched_RedirectsToWorkspaceGroupOwner`, `TestCheckSessionMRRedirectsToWorkspaceGroupOwner`, `TestAssociatePRWithTask_RedirectsWatchSourcedToWorkspaceGroupOwner`, `TestAssociatePRByURL_WatchAndAssociationAgreeOnRedirectedOwner`, plus fallback and negative-control siblings for each

## Possible Improvements

Low risk: a read-only lookup plus a nullable provenance column, no new concurrent-write paths. Pre-existing member-attributed `github_pr_watches` rows aren't backfilled — the funnel-level redirect corrects the association the next time each is used, deliberately, since a migration would need the identical resolution logic anyway.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->