### PR TITLE
fix: preserve selected agent tab across reloads

### DIFF
--- a/apps/web/components/task/dockview-session-tab-sync.test.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.test.ts
@@ -21,6 +21,7 @@ type SessionTabSyncPanel = {
 
 type SessionTabSyncApi = {
   panels: SessionTabSyncPanel[];
+  groups: Array<{ activePanel: { id: string } | null }>;
   getPanel: (id: string) => SessionTabSyncPanel | null;
   onDidActivePanelChange: (callback: (panel: { id: string } | null) => void) => {
     dispose: ReturnType<typeof vi.fn<() => void>>;
@@ -33,8 +34,12 @@ type SessionTabSyncStore = {
     taskSessions: {
       items: Record<string, { id: string; task_id: string }>;
     };
+    taskSessionsByTask: {
+      itemsByTaskId: Record<string, Array<{ id: string }>>;
+    };
     environmentIdBySessionId: Record<string, string>;
     setActiveSession: ReturnType<typeof vi.fn<(taskId: string, sessionId: string) => void>>;
+    setActiveSessionAuto: ReturnType<typeof vi.fn<(taskId: string, sessionId: string) => void>>;
   };
 };
 
@@ -45,6 +50,12 @@ function makeSessionTabSyncHarness(args: {
   activeSessionId: string;
   otherSessionId: string;
   includeOtherEnv?: boolean;
+  includeOtherInTaskList?: boolean;
+  otherEnvironmentId?: string;
+  otherSessionTaskId?: string;
+  restoredSessionId?: string;
+  restoredSessionIds?: string[];
+  restoredPanelIds?: string[];
 }) {
   let activePanelChange: ((panel: { id: string } | null) => void) | null = null;
   const activePanelSetActive = vi.fn(() => {
@@ -57,6 +68,12 @@ function makeSessionTabSyncHarness(args: {
   ];
   const api: SessionTabSyncApi = {
     panels,
+    groups: (
+      args.restoredPanelIds ??
+      (args.restoredSessionIds ?? [args.restoredSessionId ?? args.activeSessionId]).map(
+        (sessionId) => `session:${sessionId}`,
+      )
+    ).map((panelId) => ({ activePanel: { id: panelId } })),
     getPanel: (id: string) => panels.find((panel) => panel.id === id) ?? null,
     onDidActivePanelChange: (callback: (panel: { id: string } | null) => void) => {
       activePanelChange = callback;
@@ -64,9 +81,12 @@ function makeSessionTabSyncHarness(args: {
     },
   };
   const setActiveSession = vi.fn();
+  const setActiveSessionAuto = vi.fn();
   const environmentIdBySessionId = {
     [args.activeSessionId]: "env-A",
-    ...(args.includeOtherEnv === false ? {} : { [args.otherSessionId]: "env-A" }),
+    ...(args.includeOtherEnv === false
+      ? {}
+      : { [args.otherSessionId]: args.otherEnvironmentId ?? "env-A" }),
   };
   const appStore: SessionTabSyncStore = {
     getState: () => ({
@@ -77,11 +97,23 @@ function makeSessionTabSyncHarness(args: {
       taskSessions: {
         items: {
           [args.activeSessionId]: { id: args.activeSessionId, task_id: args.activeTaskId },
-          [args.otherSessionId]: { id: args.otherSessionId, task_id: args.activeTaskId },
+          [args.otherSessionId]: {
+            id: args.otherSessionId,
+            task_id: args.otherSessionTaskId ?? args.activeTaskId,
+          },
+        },
+      },
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          [args.activeTaskId]: [
+            { id: args.activeSessionId },
+            ...(args.includeOtherInTaskList === false ? [] : [{ id: args.otherSessionId }]),
+          ],
         },
       },
       environmentIdBySessionId,
       setActiveSession,
+      setActiveSessionAuto,
     }),
   };
 
@@ -89,6 +121,7 @@ function makeSessionTabSyncHarness(args: {
     api,
     appStore,
     setActiveSession,
+    setActiveSessionAuto,
     activePanelSetActive,
     otherPanelSetActive,
     fireActivePanelChange: (panelId: string | null) => {
@@ -97,12 +130,26 @@ function makeSessionTabSyncHarness(args: {
   };
 }
 
-function makeDefaultSessionTabSyncHarness(args?: { includeOtherEnv?: boolean }) {
+function makeDefaultSessionTabSyncHarness(args?: {
+  includeOtherEnv?: boolean;
+  includeOtherInTaskList?: boolean;
+  otherEnvironmentId?: string;
+  otherSessionTaskId?: string;
+  restoredSessionId?: string;
+  restoredSessionIds?: string[];
+  restoredPanelIds?: string[];
+}) {
   return makeSessionTabSyncHarness({
     activeTaskId: TASK_ID,
     activeSessionId: ACTIVE_SESSION_ID,
     otherSessionId: OTHER_SESSION_ID,
     includeOtherEnv: args?.includeOtherEnv,
+    includeOtherInTaskList: args?.includeOtherInTaskList,
+    otherEnvironmentId: args?.otherEnvironmentId,
+    otherSessionTaskId: args?.otherSessionTaskId,
+    restoredSessionId: args?.restoredSessionId,
+    restoredSessionIds: args?.restoredSessionIds,
+    restoredPanelIds: args?.restoredPanelIds,
   });
 }
 
@@ -113,20 +160,20 @@ function startSessionTabSync(harness: SessionTabSyncHarness) {
   );
 }
 
-describe("setupSessionTabSync", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    clearSessionTabUserActivationIntentsForTest();
-    useDockviewStore.setState({ isRestoringLayout: false });
-  });
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  clearSessionTabUserActivationIntentsForTest();
+  useDockviewStore.setState({ isRestoringLayout: false, currentLayoutEnvId: "env-A" });
+});
 
-  afterEach(() => {
-    clearSessionTabUserActivationIntentsForTest();
-    useDockviewStore.setState({ isRestoringLayout: false });
-    vi.useRealTimers();
-  });
+afterEach(() => {
+  clearSessionTabUserActivationIntentsForTest();
+  useDockviewStore.setState({ isRestoringLayout: false });
+  vi.useRealTimers();
+});
 
+describe("setupSessionTabSync automatic activation", () => {
   it("does not pin a session when Dockview activates another session panel without user intent", () => {
     const harness = makeDefaultSessionTabSyncHarness();
 
@@ -136,7 +183,85 @@ describe("setupSessionTabSync", () => {
     expect(harness.setActiveSession).not.toHaveBeenCalled();
     expect(harness.activePanelSetActive).toHaveBeenCalledTimes(1);
   });
+});
 
+describe("setupSessionTabSync restored selection", () => {
+  // @covers AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6
+  it("adopts the restored secondary Agent tab without creating a user pin", () => {
+    const harness = makeDefaultSessionTabSyncHarness({ restoredSessionId: OTHER_SESSION_ID });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).toHaveBeenCalledWith(TASK_ID, OTHER_SESSION_ID);
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
+  });
+
+  it("uses the Agent-group selection when another group has global focus", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      restoredPanelIds: ["files", OTHER_SESSION_PANEL_ID],
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).toHaveBeenCalledWith(TASK_ID, OTHER_SESSION_ID);
+  });
+
+  it("keeps the boot fallback when the restored session has no environment", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      includeOtherEnv: false,
+      restoredSessionId: OTHER_SESSION_ID,
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("keeps the boot fallback for a restored session from another task", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      otherSessionTaskId: "task-B",
+      restoredSessionId: OTHER_SESSION_ID,
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("keeps the boot fallback when the restored session is not current", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      includeOtherInTaskList: false,
+      restoredSessionId: OTHER_SESSION_ID,
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("keeps the boot fallback for a restored session from another environment", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      otherEnvironmentId: "env-B",
+      restoredSessionId: OTHER_SESSION_ID,
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("keeps the boot fallback when multiple Agent groups have a selected session", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      restoredSessionIds: [ACTIVE_SESSION_ID, OTHER_SESSION_ID],
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+});
+
+describe("setupSessionTabSync explicit activation", () => {
   it("pins the session when the active panel change follows explicit session-tab user intent", () => {
     const harness = makeDefaultSessionTabSyncHarness();
 

--- a/apps/web/components/task/dockview-session-tab-sync.test.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.test.ts
@@ -44,6 +44,9 @@ type SessionTabSyncStore = {
 };
 
 type SessionTabSyncHarness = ReturnType<typeof makeSessionTabSyncHarness>;
+type SessionTabSyncDisposable = { dispose: () => void };
+
+const activeDisposables: SessionTabSyncDisposable[] = [];
 
 function makeSessionTabSyncHarness(args: {
   activeTaskId: string;
@@ -154,9 +157,11 @@ function makeDefaultSessionTabSyncHarness(args?: {
 }
 
 function startSessionTabSync(harness: SessionTabSyncHarness) {
-  setupSessionTabSync(
-    harness.api as unknown as DockviewReadyEvent["api"],
-    harness.appStore as unknown as StoreApi<AppState>,
+  activeDisposables.push(
+    setupSessionTabSync(
+      harness.api as unknown as DockviewReadyEvent["api"],
+      harness.appStore as unknown as StoreApi<AppState>,
+    ),
   );
 }
 
@@ -168,6 +173,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const disposable of activeDisposables.splice(0)) disposable.dispose();
   clearSessionTabUserActivationIntentsForTest();
   useDockviewStore.setState({ isRestoringLayout: false });
   vi.useRealTimers();
@@ -258,6 +264,28 @@ describe("setupSessionTabSync restored selection", () => {
     startSessionTabSync(harness);
 
     expect(harness.setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("adopts the only valid restored session when another selected panel is stale", () => {
+    const harness = makeDefaultSessionTabSyncHarness({
+      restoredSessionIds: ["missing-session", OTHER_SESSION_ID],
+    });
+
+    startSessionTabSync(harness);
+
+    expect(harness.setActiveSessionAuto).toHaveBeenCalledWith(TASK_ID, OTHER_SESSION_ID);
+  });
+
+  it("adopts the restored selection after late environment layout restoration", () => {
+    const harness = makeDefaultSessionTabSyncHarness();
+    useDockviewStore.setState({ currentLayoutEnvId: null });
+    startSessionTabSync(harness);
+
+    harness.api.groups = [{ activePanel: { id: OTHER_SESSION_PANEL_ID } }];
+    useDockviewStore.setState({ isRestoringLayout: true, currentLayoutEnvId: "env-A" });
+    useDockviewStore.setState({ isRestoringLayout: false });
+
+    expect(harness.setActiveSessionAuto).toHaveBeenCalledWith(TASK_ID, OTHER_SESSION_ID);
   });
 });
 

--- a/apps/web/components/task/dockview-session-tab-sync.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.ts
@@ -20,6 +20,29 @@ function isDifferentSessionPanel(panelId: string, activeSessionId: string | null
   return panelId.startsWith("session:") && panelId !== `session:${activeSessionId}`;
 }
 
+function adoptRestoredSessionTabSelection(
+  api: DockviewReadyEvent["api"],
+  appStore: StoreApi<AppState>,
+): void {
+  const selectedSessionIds = api.groups.flatMap((group) => {
+    const panelId = group.activePanel?.id;
+    return panelId?.startsWith("session:") ? [panelId.slice("session:".length)] : [];
+  });
+  if (selectedSessionIds.length !== 1) return;
+
+  const state = appStore.getState();
+  const sessionId = selectedSessionIds[0];
+  if (!state.tasks.activeTaskId || sessionId === state.tasks.activeSessionId) return;
+  if (state.taskSessions.items[sessionId]?.task_id !== state.tasks.activeTaskId) return;
+  const currentSessions = state.taskSessionsByTask.itemsByTaskId[state.tasks.activeTaskId] ?? [];
+  if (!currentSessions.some((session) => session.id === sessionId)) return;
+  const currentEnvironmentId = useDockviewStore.getState().currentLayoutEnvId;
+  if (!currentEnvironmentId || state.environmentIdBySessionId[sessionId] !== currentEnvironmentId) {
+    return;
+  }
+  state.setActiveSessionAuto(state.tasks.activeTaskId, sessionId);
+}
+
 /**
  * Sync `activeSessionId` in the store when the user explicitly activates a
  * session tab. Dockview can also activate panels internally while restoring
@@ -27,6 +50,7 @@ function isDifferentSessionPanel(panelId: string, activeSessionId: string | null
  * session or they create an app-level feedback loop.
  */
 export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: StoreApi<AppState>) {
+  adoptRestoredSessionTabSelection(api, appStore);
   return api.onDidActivePanelChange((panel) => {
     if (!panel) return;
     const isRestoring = useDockviewStore.getState().isRestoringLayout;

--- a/apps/web/components/task/dockview-session-tab-sync.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.ts
@@ -24,23 +24,28 @@ function adoptRestoredSessionTabSelection(
   api: DockviewReadyEvent["api"],
   appStore: StoreApi<AppState>,
 ): void {
+  const state = appStore.getState();
+  const activeTaskId = state.tasks.activeTaskId;
+  const currentEnvironmentId = useDockviewStore.getState().currentLayoutEnvId;
+  if (!activeTaskId || !currentEnvironmentId) return;
+
+  const currentSessionIds = new Set<string>(
+    (state.taskSessionsByTask.itemsByTaskId[activeTaskId] ?? []).map((session) => session.id),
+  );
   const selectedSessionIds = api.groups.flatMap((group) => {
     const panelId = group.activePanel?.id;
-    return panelId?.startsWith("session:") ? [panelId.slice("session:".length)] : [];
+    if (!panelId?.startsWith("session:")) return [];
+    const sessionId = panelId.slice("session:".length);
+    if (state.taskSessions.items[sessionId]?.task_id !== activeTaskId) return [];
+    if (!currentSessionIds.has(sessionId)) return [];
+    if (state.environmentIdBySessionId[sessionId] !== currentEnvironmentId) return [];
+    return [sessionId];
   });
   if (selectedSessionIds.length !== 1) return;
 
-  const state = appStore.getState();
   const sessionId = selectedSessionIds[0];
-  if (!state.tasks.activeTaskId || sessionId === state.tasks.activeSessionId) return;
-  if (state.taskSessions.items[sessionId]?.task_id !== state.tasks.activeTaskId) return;
-  const currentSessions = state.taskSessionsByTask.itemsByTaskId[state.tasks.activeTaskId] ?? [];
-  if (!currentSessions.some((session) => session.id === sessionId)) return;
-  const currentEnvironmentId = useDockviewStore.getState().currentLayoutEnvId;
-  if (!currentEnvironmentId || state.environmentIdBySessionId[sessionId] !== currentEnvironmentId) {
-    return;
-  }
-  state.setActiveSessionAuto(state.tasks.activeTaskId, sessionId);
+  if (sessionId === state.tasks.activeSessionId) return;
+  state.setActiveSessionAuto(activeTaskId, sessionId);
 }
 
 /**
@@ -51,7 +56,12 @@ function adoptRestoredSessionTabSelection(
  */
 export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: StoreApi<AppState>) {
   adoptRestoredSessionTabSelection(api, appStore);
-  return api.onDidActivePanelChange((panel) => {
+  const unsubscribeLayoutRestore = useDockviewStore.subscribe((state, previousState) => {
+    if (previousState.isRestoringLayout && !state.isRestoringLayout) {
+      adoptRestoredSessionTabSelection(api, appStore);
+    }
+  });
+  const activePanelDisposable = api.onDidActivePanelChange((panel) => {
     if (!panel) return;
     const isRestoring = useDockviewStore.getState().isRestoringLayout;
     if (isDebug()) {
@@ -104,4 +114,10 @@ export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: St
     }
     state.setActiveSession(target.taskId, target.sessionId);
   });
+  return {
+    dispose: () => {
+      unsubscribeLayoutRestore();
+      activePanelDisposable.dispose();
+    },
+  };
 }

--- a/apps/web/e2e/tests/session/multi-session-ux.spec.ts
+++ b/apps/web/e2e/tests/session/multi-session-ux.spec.ts
@@ -142,6 +142,74 @@ test.describe("Multi-session UX", () => {
     });
   });
 
+  // @covers AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6
+  test("reload restores the selected Agent tab", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { task, session } = await createTaskAndNavigate(
+      testPage,
+      apiClient,
+      seedData,
+      "Agent Tab Reload Focus Task",
+    );
+    const { sessions: initialSessions } = await apiClient.listTaskSessions(task.id);
+    const primarySessionId = initialSessions[0]?.id;
+    if (!primarySessionId) throw new Error("expected a primary session");
+
+    await session.openNewSessionDialog();
+    await session.newSessionPromptInput().fill("/e2e:simple-message");
+    await session.newSessionStartButton().click();
+
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return sessions.find((item) => item.id !== primarySessionId)?.id ?? "";
+        },
+        { message: "Waiting for the secondary session" },
+      )
+      .not.toBe("");
+    const { sessions } = await apiClient.listTaskSessions(task.id);
+    const secondarySessionId = sessions.find((item) => item.id !== primarySessionId)?.id;
+    if (!secondarySessionId) throw new Error("expected a secondary session");
+
+    const secondaryTab = session.sessionTabBySessionId(secondarySessionId);
+    await expect(secondaryTab).toBeVisible();
+    await secondaryTab.click();
+    const secondaryTabWrapper = testPage.locator(".dv-tab", { has: secondaryTab });
+    await expect(secondaryTabWrapper).toHaveClass(/dv-active-tab/);
+
+    await expect
+      .poll(() =>
+        testPage.evaluate(() => {
+          const persist = (window as Window & { __persistDockviewLayout__?: () => void })
+            .__persistDockviewLayout__;
+          if (!persist) return false;
+          persist();
+          return true;
+        }),
+      )
+      .toBe(true);
+
+    await testPage.reload();
+    await session.waitForLoad();
+
+    const restoredSecondaryTab = session.sessionTabBySessionId(secondarySessionId);
+    await expect(restoredSecondaryTab).toBeVisible();
+    await expect(testPage.locator(".dv-tab", { has: restoredSecondaryTab })).toHaveClass(
+      /dv-active-tab/,
+    );
+    await expect(session.activeChat()).toBeVisible();
+    await prCapture.screenshot("agent-tab-reload-focus", {
+      caption: "The selected secondary Agent tab remains active after a full page reload",
+    });
+  });
+
   test("+ dropdown shows sessions with correct numbering", async ({
     testPage,
     apiClient,

--- a/docs/plans/agent-tab-reload-focus/plan.md
+++ b/docs/plans/agent-tab-reload-focus/plan.md
@@ -1,0 +1,106 @@
+---
+created: 2026-09-01
+status: done
+requirements:
+  - REQ-UI-TASK-AGENT-TAB-RECONCILIATION-001
+system_design:
+  - ../../specs/ui/system-design/task-agent-tab-reconciliation.md
+legacy_specs: []
+---
+
+# Implementation Plan: Agent Tab Reload Focus
+
+## Overview
+
+Restore the selected current Agent tab after a desktop task reload. First, add
+a failing unit regression for saved selection adoption. Then implement the
+frontend correction and prove the full reload flow in Chromium.
+
+## Confirmed root cause
+
+A user tab selection updates the in-memory task store. A full reload replaces
+that state with the backend boot payload, which selects the primary session.
+The Dockview layout retains the selected secondary tab in `sessionStorage`.
+However, the session-tab event guard treats restored activation as an automatic
+event and redirects it to the boot-selected session.
+
+## Scope
+
+### In scope
+
+- Restore one valid current Agent selection from the environment Dockview layout.
+- Align the task store through automatic session selection without a user pin.
+- Keep the existing explicit-intent guard for later Dockview activation events.
+- Add focused unit and desktop Chromium reload regressions.
+
+### Out of scope
+
+- Backend boot-session selection and session lifecycle behavior.
+- New persisted settings, URL state, API fields, or database changes.
+- Saved layout geometry and valid non-Agent focus behavior.
+- Phone and tablet composition, controls, and selection behavior.
+
+## Technical approach
+
+Add a restoration helper near `setupSessionTabSync`. The helper will inspect
+the restored Dockview groups before the normal listener is registered. It will
+accept only one group-selected `session:<id>` that belongs to the active task,
+current session list, and current environment.
+
+Call `setActiveSessionAuto` for a valid restored selection. This call updates
+the effective session and `lastSessionByTaskId` without creating a user pin.
+Keep `setActiveSession` limited to explicit pointer or keyboard intent.
+
+When saved selection data is stale or ambiguous, keep the boot-selected
+session. Do not change the existing fallback or activate a different panel.
+
+## Tests
+
+- `AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.2` remains covered by the existing
+  session-tab activation and synchronization unit tests.
+- `AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6` gains focused cases in
+  `apps/web/components/task/dockview-session-tab-sync.test.ts`.
+- The unit regression covers valid secondary selection, user-pin isolation,
+  stale selection, cross-task selection, cross-environment selection, and
+  ambiguous selection.
+
+## E2E tests
+
+- Add a Chromium scenario to
+  `apps/web/e2e/tests/session/multi-session-ux.spec.ts` for
+  `AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6`.
+- Create two current sessions, select the secondary Agent tab, flush the saved
+  Dockview layout, and reload the task.
+- Verify that the secondary tab remains active and its conversation remains
+  visible after hydration.
+
+No mobile Playwright change is required. Phone and tablet do not mount the
+desktop Dockview workbench, and this repair changes no shared mobile state or
+interaction.
+
+## Work orders
+
+- [x] [Task 01: Restore Agent tab focus after reload](task-01-restore-agent-tab-focus.md)
+
+## Verification results
+
+Passed:
+
+```text
+cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx
+Vitest: 45 tests passed in 4 files.
+
+cd apps/web && pnpm run typecheck
+TypeScript: passed.
+
+cd apps/web && CAPTURE_PR_ASSETS=true pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab"
+Playwright: 1 Chromium test passed.
+```
+
+## Risks
+
+- An unvalidated saved session ID can restore a deleted or unrelated session.
+- Calling `setActiveSession` would create a false user pin during boot.
+- Selecting from global Dockview focus alone can lose the Agent-group selection
+  when a valid non-Agent panel owns global focus.
+- A broad event exception can reintroduce automatic session pinning.

--- a/docs/plans/agent-tab-reload-focus/plan.md
+++ b/docs/plans/agent-tab-reload-focus/plan.md
@@ -43,9 +43,10 @@ event and redirects it to the boot-selected session.
 ## Technical approach
 
 Add a restoration helper near `setupSessionTabSync`. The helper will inspect
-the restored Dockview groups before the normal listener is registered. It will
-accept only one group-selected `session:<id>` that belongs to the active task,
-current session list, and current environment.
+the restored Dockview groups before the normal listener is registered and
+whenever a delayed environment-layout restoration completes. It will filter
+out invalid selections, then accept only one group-selected `session:<id>` that
+belongs to the active task, current session list, and current environment.
 
 Call `setActiveSessionAuto` for a valid restored selection. This call updates
 the effective session and `lastSessionByTaskId` without creating a user pin.
@@ -88,13 +89,19 @@ Passed:
 
 ```text
 cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx
-Vitest: 45 tests passed in 4 files.
+Vitest: 47 tests passed in 4 files.
 
 cd apps/web && pnpm run typecheck
 TypeScript: passed.
 
 cd apps/web && CAPTURE_PR_ASSETS=true pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab"
 Playwright: 1 Chromium test passed.
+
+python3 scripts/lint-spec-files.py --all
+Specification lint: passed.
+
+git diff --check
+Whitespace validation: passed.
 ```
 
 ## Risks

--- a/docs/plans/agent-tab-reload-focus/task-01-restore-agent-tab-focus.md
+++ b/docs/plans/agent-tab-reload-focus/task-01-restore-agent-tab-focus.md
@@ -1,0 +1,92 @@
+---
+id: "01-restore-agent-tab-focus"
+title: "Restore Agent tab focus after reload"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-TASK-AGENT-TAB-RECONCILIATION-001
+acceptance_criteria:
+  - AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.2
+  - AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6
+system_design:
+  - ../../specs/ui/system-design/task-agent-tab-reconciliation.md
+---
+
+# Task 01: Restore Agent Tab Focus After Reload
+
+## Summary
+
+Adopt one valid restored Agent selection before normal Dockview tab-event
+synchronization starts. Keep the current safety guard and prove the task reload
+flow through the desktop UI.
+
+## In scope
+
+- Add a focused failing unit regression for restored Agent selection.
+- Resolve one valid group-selected current session after environment layout restore.
+- Apply the restored session through `setActiveSessionAuto`.
+- Add a desktop Chromium regression to the existing multi-session specification.
+
+## Out of scope
+
+- Backend boot payload changes.
+- New persistence, URL parameters, API contracts, or store fields.
+- Changes to saved layout geometry or non-Agent panel focus.
+- Mobile and tablet UI changes.
+
+## Acceptance
+
+- A valid selected secondary Agent panel becomes the effective session after reload without creating a user pin.
+- Stale, cross-task, cross-environment, and ambiguous saved selections keep the normal boot fallback.
+- The selected secondary Agent tab and its conversation remain visible after a full desktop task reload.
+
+## Verification
+
+```bash
+cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab"
+git diff --check
+```
+
+Make sure that Playwright discovers and executes one Chromium scenario.
+
+## Files likely touched
+
+- `apps/web/components/task/dockview-desktop-layout.tsx`
+- `apps/web/components/task/dockview-session-tab-sync.ts`
+- `apps/web/components/task/dockview-session-tab-sync.test.ts`
+- `apps/web/e2e/tests/session/multi-session-ux.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Dockview can keep one selected panel per group while another group owns global focus.
+- Restored session panels can be stale before current membership validation.
+- Event-order changes can reintroduce automatic user pins.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/ui/requirements/task-agent-tab-reconciliation.md`
+- `docs/specs/ui/system-design/task-agent-tab-reconciliation.md`
+- Existing Dockview restore, activation-intent, and multi-session test patterns.
+
+## Results
+
+Completed.
+
+- Added restored Agent-selection adoption before normal Dockview tab-event synchronization.
+- Validated current task membership and environment ownership before changing the active session.
+- Used `setActiveSessionAuto` so page restoration does not create a user pin.
+- Added unit coverage for valid, stale, cross-task, cross-environment, and ambiguous layouts.
+- Added a desktop Chromium reload regression and captured the restored secondary-tab state.
+- Verification passed: 45 focused unit tests, TypeScript typecheck, and one Chromium E2E test.

--- a/docs/plans/agent-tab-reload-focus/task-01-restore-agent-tab-focus.md
+++ b/docs/plans/agent-tab-reload-focus/task-01-restore-agent-tab-focus.md
@@ -45,9 +45,9 @@ flow through the desktop UI.
 ## Verification
 
 ```bash
-cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps/web && pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab"
+(cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx)
+(cd apps/web && pnpm run typecheck)
+(cd apps/web && pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab")
 git diff --check
 ```
 
@@ -84,9 +84,12 @@ None.
 
 Completed.
 
-- Added restored Agent-selection adoption before normal Dockview tab-event synchronization.
+- Added restored Agent-selection adoption before normal Dockview tab-event synchronization
+  and after delayed environment-layout restoration.
 - Validated current task membership and environment ownership before changing the active session.
+- Filtered stale selected panels before deciding whether the valid selection is ambiguous.
 - Used `setActiveSessionAuto` so page restoration does not create a user pin.
-- Added unit coverage for valid, stale, cross-task, cross-environment, and ambiguous layouts.
+- Added unit coverage for valid, stale, cross-task, cross-environment, ambiguous,
+  mixed stale-and-valid, and delayed-restoration layouts.
 - Added a desktop Chromium reload regression and captured the restored secondary-tab state.
-- Verification passed: 45 focused unit tests, TypeScript typecheck, and one Chromium E2E test.
+- Verification passed: 47 focused unit tests, TypeScript typecheck, and one Chromium E2E test.

--- a/docs/specs/ui/requirements/task-agent-tab-reconciliation.md
+++ b/docs/specs/ui/requirements/task-agent-tab-reconciliation.md
@@ -44,8 +44,10 @@ task workbench becomes usable.
   existing session controls without mounting desktop workbench tabs.
 - **AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6:** When a desktop user selects an
   Agent tab and reloads the same task, the selected current session shall remain
-  the effective active session and Agent tab. If that session is no longer
-  current, Kandev shall use the normal active-session fallback.
+  the effective active session and Agent tab without creating a user pin. The
+  restored selection must belong to the active task and current environment.
+  If the selection is invalid or ambiguous, Kandev shall use the normal
+  active-session fallback.
 
 ### REQ-UI-TASK-AGENT-TAB-RECONCILIATION-002: Agent Tab Rename Isolation
 

--- a/docs/specs/ui/requirements/task-agent-tab-reconciliation.md
+++ b/docs/specs/ui/requirements/task-agent-tab-reconciliation.md
@@ -42,6 +42,10 @@ task workbench becomes usable.
 - **AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.5:** Phone and tablet task surfaces
   shall continue to project the same task session membership through their
   existing session controls without mounting desktop workbench tabs.
+- **AC-UI-TASK-AGENT-TAB-RECONCILIATION-001.6:** When a desktop user selects an
+  Agent tab and reloads the same task, the selected current session shall remain
+  the effective active session and Agent tab. If that session is no longer
+  current, Kandev shall use the normal active-session fallback.
 
 ### REQ-UI-TASK-AGENT-TAB-RECONCILIATION-002: Agent Tab Rename Isolation
 

--- a/docs/specs/ui/system-design/task-agent-tab-reconciliation.md
+++ b/docs/specs/ui/system-design/task-agent-tab-reconciliation.md
@@ -37,8 +37,9 @@ the user's current Agent-tab selection and projects it into task state.
   Agent panels, ensures the active session panel, and adds current sibling
   session panels without activating them.
 - `setupReadyDockview` restores the environment layout before it registers the
-  normal session-tab event listener. It adopts one valid restored Agent
-  selection through the automatic session-selection action.
+  normal session-tab event listener. It calls `setupSessionTabSync`, which
+  adopts one valid restored Agent selection initially and after a delayed
+  environment layout restoration completes.
 - `SessionTab` owns the fine-pointer Agent-tab context menu and attaches the
   shared Dockview maximize handler to the tab surface.
 - `TabRenameInput` owns the inline editor's pointer and keyboard event boundary.
@@ -91,6 +92,12 @@ Before normal tab-event synchronization starts, the UI resolves the selected
 Agent panel from the restored group state. It validates that panel against the
 active task, current session list, and current environment.
 
+If session-to-environment metadata arrives after Dockview is ready, the
+environment switch restores that saved layout later. Session-tab
+synchronization repeats the same adoption when the restore flag clears. Stale
+and unrelated selected panels are filtered before the UI decides whether the
+remaining valid selection is ambiguous.
+
 When one valid restored Agent selection exists, the UI applies it with
 `setActiveSessionAuto`. This action aligns the application store with the
 restored layout without creating a user pin. The existing explicit-intent guard
@@ -131,6 +138,7 @@ and verifies that native text selection remains active while the Dockview group
 stays unmaximized. Mobile coverage is unchanged because phone and tablet do not
 mount the affected Dockview tab surface.
 
-A restoration unit test covers a valid secondary Agent selection and invalid
-saved selections. A desktop Playwright regression selects the secondary Agent
-tab, reloads the task, and verifies that the same session remains active.
+A restoration unit test covers a valid secondary Agent selection, invalid
+saved selections, mixed stale and valid selections, and delayed environment
+layout restoration. A desktop Playwright regression selects the secondary
+Agent tab, reloads the task, and verifies that the same session remains active.

--- a/docs/specs/ui/system-design/task-agent-tab-reconciliation.md
+++ b/docs/specs/ui/system-design/task-agent-tab-reconciliation.md
@@ -12,8 +12,8 @@ requirements:
 
 This design makes desktop Agent-tab reconciliation depend on both task session
 state and Dockview readiness. The task system remains authoritative for session
-membership and the active session. This UI design only projects that state into
-the desktop workbench.
+membership and the normal active-session fallback. The desktop workbench owns
+the user's current Agent-tab selection and projects it into task state.
 
 ## Requirement mapping
 
@@ -36,6 +36,9 @@ the desktop workbench.
 - `runAutoSessionTabEffect` reads the current application state, removes stale
   Agent panels, ensures the active session panel, and adds current sibling
   session panels without activating them.
+- `setupReadyDockview` restores the environment layout before it registers the
+  normal session-tab event listener. It adopts one valid restored Agent
+  selection through the automatic session-selection action.
 - `SessionTab` owns the fine-pointer Agent-tab context menu and attaches the
   shared Dockview maximize handler to the tab surface.
 - `TabRenameInput` owns the inline editor's pointer and keyboard event boundary.
@@ -64,6 +67,11 @@ No new API, persisted value, or store field is required. The existing
 `taskSessionsByTask.itemsByTaskId` collection is the session-membership source.
 The existing Dockview store `api` value is the readiness source.
 
+The environment-scoped Dockview layout already stores the selected panel for
+each group in browser `sessionStorage`. A restored `session:<id>` value is a
+selection hint. It is not session-membership authority. The UI accepts the hint
+only when the session belongs to the active task and current environment.
+
 ## Control flow
 
 1. Route loading and application-store hydration can finish before or after
@@ -77,6 +85,17 @@ The existing Dockview store `api` value is the readiness source.
    valid non-Agent focus, and adds all sibling session panels as inactive tabs.
 6. Later membership or active-session changes use the same path.
 
+During a full reload, the boot payload supplies the normal primary-session
+fallback. The workbench then restores the environment-scoped Dockview layout.
+Before normal tab-event synchronization starts, the UI resolves the selected
+Agent panel from the restored group state. It validates that panel against the
+active task, current session list, and current environment.
+
+When one valid restored Agent selection exists, the UI applies it with
+`setActiveSessionAuto`. This action aligns the application store with the
+restored layout without creating a user pin. The existing explicit-intent guard
+continues to reject unrelated Dockview activation events.
+
 The readiness change is an event source, not a second copy of session state.
 The effect always reads current application state when it runs.
 
@@ -86,6 +105,11 @@ A null Dockview API is a temporary no-op. API readiness causes deterministic
 reconciliation, so recovery does not depend on a timer, route retry, or page
 reload. A session that disappears before readiness is not materialized because
 the effect reads the latest session list.
+
+The UI ignores a restored Agent selection when it is stale, cross-task,
+cross-environment, or ambiguous. The boot-selected active session remains the
+fallback. This rule prevents saved layout data from overriding current task
+membership.
 
 ## Responsive behavior
 
@@ -106,3 +130,7 @@ Playwright regression enters Agent-tab rename mode, double-clicks the input,
 and verifies that native text selection remains active while the Dockview group
 stays unmaximized. Mobile coverage is unchanged because phone and tablet do not
 mount the affected Dockview tab surface.
+
+A restoration unit test covers a valid secondary Agent selection and invalid
+saved selections. A desktop Playwright regression selects the secondary Agent
+tab, reloads the task, and verifies that the same session remains active.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3250/fcdcbb76578f.html)
<!-- kandev-pr-walkthrough-end -->

Reloading a multi-session task reset the focused Agent tab to the primary session. The desktop workbench now adopts a valid environment-scoped restored selection without creating a user pin.

## Validation

- `cd apps/web && pnpm exec vitest run components/task/dockview-session-tab-sync.test.ts components/task/dockview-layout-restore.test.ts components/task/dockview-session-tab-activation.test.ts components/task/dockview-session-tabs.hook.test.tsx`
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && CAPTURE_PR_ASSETS=true pnpm e2e:run --host tests/session/multi-session-ux.spec.ts -- --grep "reload restores the selected Agent tab"`
- `python3 scripts/lint-spec-files.py --all`
- `git diff --check`
- Public documentation is unchanged because this corrects existing task-tab behavior without changing commands, configuration, or terminology.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![The selected secondary Agent tab remains active after reload](https://raw.githubusercontent.com/kdlbs/kandev/7fe1ad1e965c06d3d825da5a1b95f6d98c799ab4/agent-tab-reload-focus.png)
<!-- kandev-screenshots-end -->