### PR TITLE
test(workflow): catch quorum guards from silently depending on session identity

### DIFF
--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -451,10 +451,10 @@ func isActiveSessionState(state taskmodels.TaskSessionState) bool {
 // TaskID, CurrentStepID and WorkflowID, all derived from the task row
 // rather than the session (see orchestrator.assembleMachineState).
 //
-// MachineState.SessionID, SessionState and Data are the session-derived
-// fields, so with several live sessions per task "newest" no longer names a
-// specific agent's session. That is latent, not live: none of the three is
-// read by the guard-evaluation path today (Data is written by
+// MachineState.SessionID, SessionState, Data and IsPassthrough are the
+// session-derived fields, so with several live sessions per task "newest" no
+// longer names a specific agent's session. That is latent, not live: none of
+// the four is read by the guard-evaluation path today (Data is written by
 // set_workflow_data through SetSessionMetadataKey and read back into
 // MachineState.Data on every state assembly, but never consumed by guard
 // evaluation), so which session is chosen is unobservable today.

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -443,6 +443,33 @@ func isActiveSessionState(state taskmodels.TaskSessionState) bool {
 // filters by task, so unlike resolveDeciderSessionID (which validates a
 // caller-supplied session id and must check task ownership itself), there
 // is no cross-task session id to smuggle in here.
+//
+// This resolver is deliberately task-scoped, and stays that way after
+// features.officeSessionIdentity gives each participant agent its own
+// session per task. Picking "the newest session" only stays well-defined
+// because EvaluateStepQuorum — its sole caller — reads just CurrentStepID
+// and WorkflowID off the loaded MachineState, and both are derived from the
+// task row rather than the session (see orchestrator.assembleMachineState).
+//
+// MachineState.Data is the one genuinely per-session field: it is populated
+// from session.Metadata["workflow_data"], so with several live sessions per
+// task "newest" would no longer name a specific agent's bag. That is latent,
+// not live — Data currently has no readers anywhere in internal/workflow/
+// (set_workflow_data writes it through SetSessionMetadataKey and nothing
+// reads it back), so which session is chosen is unobservable today.
+//
+// The first caller that genuinely needs per-session state must session-scope
+// its own call — pass the deciding session explicitly, as RecordDecision now
+// does via resolveDeciderSessionID — rather than adding a defensive check
+// here. Guarding this resolver would make a wrong-scoped read look safe and
+// remove the pressure to fix it properly.
+//
+// The invariant this relies on is pinned by
+// TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest
+// (internal/workflow/engine): it evaluates one step through two live
+// sessions carrying different Data and requires an identical snapshot, so a
+// guard that starts reading Data fails there loudly instead of silently
+// resolving another agent's bag through this function.
 func (d *Dispatcher) resolveLatestSessionID(ctx context.Context, taskID string) (string, error) {
 	session, err := d.sessions.GetTaskSessionByTaskID(ctx, taskID)
 	if err != nil {

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -455,8 +455,9 @@ func isActiveSessionState(state taskmodels.TaskSessionState) bool {
 // fields, so with several live sessions per task "newest" no longer names a
 // specific agent's session. That is latent, not live: none of the three is
 // read by the guard-evaluation path today (Data is written by
-// set_workflow_data through SetSessionMetadataKey and never read back), so
-// which session is chosen is unobservable today.
+// set_workflow_data through SetSessionMetadataKey and read back into
+// MachineState.Data on every state assembly, but never consumed by guard
+// evaluation), so which session is chosen is unobservable today.
 //
 // The first caller that genuinely needs per-session state must session-scope
 // its own call — pass the deciding session explicitly, as RecordDecision now

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -447,16 +447,16 @@ func isActiveSessionState(state taskmodels.TaskSessionState) bool {
 // This resolver is deliberately task-scoped, and stays that way after
 // features.officeSessionIdentity gives each participant agent its own
 // session per task. Picking "the newest session" only stays well-defined
-// because EvaluateStepQuorum — its sole caller — reads just CurrentStepID
-// and WorkflowID off the loaded MachineState, and both are derived from the
-// task row rather than the session (see orchestrator.assembleMachineState).
+// because EvaluateStepQuorum — its sole caller — evaluates guards off
+// TaskID, CurrentStepID and WorkflowID, all derived from the task row
+// rather than the session (see orchestrator.assembleMachineState).
 //
-// MachineState.Data is the one genuinely per-session field: it is populated
-// from session.Metadata["workflow_data"], so with several live sessions per
-// task "newest" would no longer name a specific agent's bag. That is latent,
-// not live — Data currently has no readers anywhere in internal/workflow/
-// (set_workflow_data writes it through SetSessionMetadataKey and nothing
-// reads it back), so which session is chosen is unobservable today.
+// MachineState.SessionID, SessionState and Data are the session-derived
+// fields, so with several live sessions per task "newest" no longer names a
+// specific agent's session. That is latent, not live: none of the three is
+// read by the guard-evaluation path today (Data is written by
+// set_workflow_data through SetSessionMetadataKey and never read back), so
+// which session is chosen is unobservable today.
 //
 // The first caller that genuinely needs per-session state must session-scope
 // its own call — pass the deciding session explicitly, as RecordDecision now
@@ -464,12 +464,13 @@ func isActiveSessionState(state taskmodels.TaskSessionState) bool {
 // here. Guarding this resolver would make a wrong-scoped read look safe and
 // remove the pressure to fix it properly.
 //
-// The invariant this relies on is pinned by
+// The invariant is pinned by
 // TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest
 // (internal/workflow/engine): it evaluates one step through two live
-// sessions carrying different Data and requires an identical snapshot, so a
-// guard that starts reading Data fails there loudly instead of silently
-// resolving another agent's bag through this function.
+// sessions carrying different SessionID, SessionState and Data, and requires
+// an identical snapshot — so a guard whose outcome starts depending on any
+// of the three changes that test's result instead of silently resolving
+// another agent's session through this function.
 func (d *Dispatcher) resolveLatestSessionID(ctx context.Context, taskID string) (string, error) {
 	session, err := d.sessions.GetTaskSessionByTaskID(ctx, taskID)
 	if err != nil {

--- a/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"expvar"
+	"reflect"
 	"testing"
 
 	"github.com/kandev/kandev/internal/common/logger"
@@ -487,5 +488,162 @@ func TestEvaluateStepQuorum_DoesNotRecordSlateEmptySideEffects(t *testing.T) {
 	}
 	if entries := logs.FilterMessage("workflow quorum required slate empty").All(); len(entries) != 0 {
 		t.Fatalf("expected no slate-empty warning log from a read-only snapshot, got %d: %+v", len(entries), entries)
+	}
+}
+
+// --- B1 companion: EvaluateStepQuorum must not depend on WHICH session ---
+
+// sessionScopedStateStore mirrors production assembleMachineState
+// (orchestrator/event_handlers_workflow.go): CurrentStepID and WorkflowID are
+// derived from the TASK row and are therefore identical for every session,
+// while SessionID and Data are genuinely per-session — Data being loaded from
+// that session's own metadata["workflow_data"] bag.
+type sessionScopedStateStore struct {
+	step       StepSpec
+	dataBySess map[string]map[string]any
+	loadedData []map[string]any
+	applied    map[string]bool
+}
+
+func (s *sessionScopedStateStore) LoadState(_ context.Context, taskID, sessionID string) (MachineState, error) {
+	data := s.dataBySess[sessionID]
+	s.loadedData = append(s.loadedData, data)
+	return MachineState{
+		TaskID:        taskID,
+		SessionID:     sessionID,
+		WorkflowID:    "wf",
+		CurrentStepID: "review",
+		Data:          data,
+	}, nil
+}
+func (s *sessionScopedStateStore) LoadStep(_ context.Context, _, _ string) (StepSpec, error) {
+	return s.step, nil
+}
+func (s *sessionScopedStateStore) LoadNextStep(_ context.Context, _ string, _ int) (StepSpec, error) {
+	return StepSpec{ID: "approval", Position: 2}, nil
+}
+func (s *sessionScopedStateStore) LoadPreviousStep(_ context.Context, _ string, _ int) (StepSpec, error) {
+	return StepSpec{}, nil
+}
+func (s *sessionScopedStateStore) ApplyTransition(_ context.Context, _, _, _, _ string, _ Trigger) error {
+	return nil
+}
+func (s *sessionScopedStateStore) ApplyTransitionIfAtStep(
+	_ context.Context, _, _, _, _ string, _ Trigger,
+) (bool, error) {
+	return false, nil
+}
+func (s *sessionScopedStateStore) PersistData(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}
+func (s *sessionScopedStateStore) IsOperationApplied(_ context.Context, op string) (bool, error) {
+	return s.applied[op], nil
+}
+func (s *sessionScopedStateStore) MarkOperationApplied(_ context.Context, op string) error {
+	s.applied[op] = true
+	return nil
+}
+
+// TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest pins the
+// invariant that lets engine_dispatcher's resolveLatestSessionID stay
+// task-scoped ("the task's most recent session, any state") once
+// features.officeSessionIdentity gives each participant agent its own
+// session per task and a task therefore has SEVERAL live sessions.
+//
+// Today EvaluateStepQuorum reads only CurrentStepID and WorkflowID off the
+// loaded MachineState, and both are task-derived, so which session the
+// resolver happens to pick cannot change the answer. MachineState.Data is
+// the one genuinely per-session field, and nothing in internal/workflow/
+// reads it.
+//
+// If a guard ever starts reading Data, that stops being true silently: the
+// resolver would hand the engine whichever agent's bag happened to be
+// newest, and a decision could be evaluated against another agent's state
+// with nothing failing. This test makes that regression loud. The fix at
+// that point is to session-scope the CALL SITE — pass the deciding session,
+// as RecordDecision does via resolveDeciderSessionID — not to add a
+// defensive check inside the task-scoped resolver, which would only make a
+// wrong-scoped read look safe.
+func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) {
+	newStore := func() *sessionScopedStateStore {
+		return &sessionScopedStateStore{
+			step: StepSpec{
+				ID: "review", WorkflowID: "wf", Position: 1,
+				Events: map[Trigger][]Action{
+					TriggerOnTurnComplete: {
+						{Kind: ActionMoveToNext, Guard: approvedGuard("reviewer")},
+					},
+				},
+			},
+			// The two live sessions carry DIFFERENT per-session bags, so a
+			// guard that started reading Data would diverge between them.
+			dataBySess: map[string]map[string]any{
+				"sess-runner":   {"owner": "runner", "attempts": 3},
+				"sess-reviewer": {"owner": "reviewer", "attempts": 1},
+			},
+			applied: map[string]bool{},
+		}
+	}
+	parts := fakeParticipants{list: []ParticipantInfo{
+		{ID: "p1", Role: "reviewer", DecisionRequired: true, AgentProfileID: "rev-A"},
+	}}
+	newDecisions := func() *fakeDecisionStore {
+		d := newFakeDecisionStore()
+		d.byKey[dkey("task-1", "review")] = []DecisionInfo{{ParticipantID: "p1", Decision: DecisionApproved}}
+		return d
+	}
+
+	runnerStore := newStore()
+	fromRunner, err := New(runnerStore, MapRegistry{},
+		WithDecisionStore(newDecisions()), WithParticipantStore(parts)).
+		EvaluateStepQuorum(context.Background(), "task-1", "sess-runner")
+	if err != nil {
+		t.Fatalf("EvaluateStepQuorum(sess-runner): %v", err)
+	}
+
+	reviewerStore := newStore()
+	fromReviewer, err := New(reviewerStore, MapRegistry{},
+		WithDecisionStore(newDecisions()), WithParticipantStore(parts)).
+		EvaluateStepQuorum(context.Background(), "task-1", "sess-reviewer")
+	if err != nil {
+		t.Fatalf("EvaluateStepQuorum(sess-reviewer): %v", err)
+	}
+
+	// Guard against a vacuous pass: if the fake ever stops handing the two
+	// runs genuinely different per-session bags, the comparison below proves
+	// nothing. Assert the divergence actually reached the engine.
+	if len(runnerStore.loadedData) != 1 || len(reviewerStore.loadedData) != 1 {
+		t.Fatalf("expected exactly one LoadState per run, got %d and %d",
+			len(runnerStore.loadedData), len(reviewerStore.loadedData))
+	}
+	if reflect.DeepEqual(runnerStore.loadedData[0], reviewerStore.loadedData[0]) {
+		t.Fatalf("test is vacuous: both sessions loaded the same Data %v", runnerStore.loadedData[0])
+	}
+
+	// The snapshot must be identical despite that divergence.
+	if fromRunner.StepID != fromReviewer.StepID {
+		t.Errorf("StepID differs by session: %q vs %q", fromRunner.StepID, fromReviewer.StepID)
+	}
+	if fromRunner.ReevaluationBlocked != fromReviewer.ReevaluationBlocked {
+		t.Errorf("ReevaluationBlocked differs by session: %v vs %v",
+			fromRunner.ReevaluationBlocked, fromReviewer.ReevaluationBlocked)
+	}
+	if len(fromRunner.Guards) != len(fromReviewer.Guards) {
+		t.Fatalf("guard count differs by session: %d vs %d",
+			len(fromRunner.Guards), len(fromReviewer.Guards))
+	}
+	for i := range fromRunner.Guards {
+		if fromRunner.Guards[i] != fromReviewer.Guards[i] {
+			t.Errorf("guard %d differs by session:\n  runner:   %#v\n  reviewer: %#v",
+				i, fromRunner.Guards[i], fromReviewer.Guards[i])
+		}
+	}
+
+	// Sanity: the snapshot is non-trivial, so the equality above has content.
+	if fromRunner.StepID != "review" || len(fromRunner.Guards) != 1 {
+		t.Fatalf("expected a one-guard snapshot at step review, got %#v", fromRunner)
+	}
+	if !fromRunner.Guards[0].Satisfied {
+		t.Fatalf("expected the quorum guard to be satisfied, got %#v", fromRunner.Guards[0])
 	}
 }

--- a/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
@@ -555,20 +555,21 @@ func (s *sessionScopedStateStore) MarkOperationApplied(_ context.Context, op str
 // features.officeSessionIdentity gives each participant agent its own
 // session per task and a task therefore has SEVERAL live sessions.
 //
-// Today EvaluateStepQuorum reads only CurrentStepID and WorkflowID off the
-// loaded MachineState, and both are task-derived, so which session the
-// resolver happens to pick cannot change the answer. MachineState.Data is
-// the one genuinely per-session field, and nothing in internal/workflow/
-// reads it.
+// Today EvaluateStepQuorum's guard evaluation reads TaskID, CurrentStepID
+// and WorkflowID off the loaded MachineState, all task-derived, so which
+// session the resolver happens to pick cannot change the answer. SessionID,
+// SessionState and Data are the session-derived fields, and none of them is
+// read by guard evaluation.
 //
-// If a guard ever starts reading Data, that stops being true silently: the
-// resolver would hand the engine whichever agent's bag happened to be
-// newest, and a decision could be evaluated against another agent's state
-// with nothing failing. This test makes that regression loud. The fix at
-// that point is to session-scope the CALL SITE — pass the deciding session,
-// as RecordDecision does via resolveDeciderSessionID — not to add a
-// defensive check inside the task-scoped resolver, which would only make a
-// wrong-scoped read look safe.
+// If a guard ever starts reading SessionID, SessionState or Data, that
+// stops being true silently: the resolver would hand the engine whichever
+// agent's state happened to be newest, and a decision could be evaluated
+// against another agent's state with nothing failing. This test makes that
+// regression loud. The fix at that point is to session-scope the CALL SITE
+// — pass the deciding session, as RecordDecision does via
+// resolveDeciderSessionID — not to add a defensive check inside the
+// task-scoped resolver, which would only make a wrong-scoped read look
+// safe.
 func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) {
 	newStore := func() *sessionScopedStateStore {
 		return &sessionScopedStateStore{

--- a/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
@@ -496,28 +496,34 @@ func TestEvaluateStepQuorum_DoesNotRecordSlateEmptySideEffects(t *testing.T) {
 // sessionScopedStateStore mirrors production assembleMachineState
 // (orchestrator/event_handlers_workflow.go): CurrentStepID and WorkflowID are
 // derived from the TASK row and are therefore identical for every session,
-// while SessionID, SessionState and Data are genuinely per-session — Data
-// being loaded from that session's own metadata["workflow_data"] bag.
+// while SessionID, SessionState, Data and IsPassthrough are genuinely
+// per-session — Data being loaded from that session's own
+// metadata["workflow_data"] bag.
 type sessionScopedStateStore struct {
-	step         StepSpec
-	dataBySess   map[string]map[string]any
-	stateBySess  map[string]string
-	loadedData   []map[string]any
-	loadedStates []string
-	applied      map[string]bool
+	step              StepSpec
+	dataBySess        map[string]map[string]any
+	stateBySess       map[string]string
+	passthroughBySess map[string]bool
+	loadedData        []map[string]any
+	loadedStates      []string
+	loadedPassthrough []bool
+	applied           map[string]bool
 }
 
 func (s *sessionScopedStateStore) LoadState(_ context.Context, taskID, sessionID string) (MachineState, error) {
 	data := s.dataBySess[sessionID]
 	sessionState := s.stateBySess[sessionID]
+	isPassthrough := s.passthroughBySess[sessionID]
 	s.loadedData = append(s.loadedData, data)
 	s.loadedStates = append(s.loadedStates, sessionState)
+	s.loadedPassthrough = append(s.loadedPassthrough, isPassthrough)
 	return MachineState{
 		TaskID:        taskID,
 		SessionID:     sessionID,
 		WorkflowID:    "wf",
 		CurrentStepID: "review",
 		SessionState:  sessionState,
+		IsPassthrough: isPassthrough,
 		Data:          data,
 	}, nil
 }
@@ -558,10 +564,11 @@ func (s *sessionScopedStateStore) MarkOperationApplied(_ context.Context, op str
 // Today EvaluateStepQuorum's guard evaluation reads TaskID, CurrentStepID
 // and WorkflowID off the loaded MachineState, all task-derived, so which
 // session the resolver happens to pick cannot change the answer. SessionID,
-// SessionState and Data are the session-derived fields, and none of them is
-// read by guard evaluation.
+// SessionState, Data and IsPassthrough are the session-derived fields, and
+// none of them is read by guard evaluation.
 //
-// If a guard ever starts reading SessionID, SessionState or Data, that
+// If a guard ever starts reading SessionID, SessionState, Data or
+// IsPassthrough, that
 // stops being true silently: the resolver would hand the engine whichever
 // agent's state happened to be newest, and a decision could be evaluated
 // against another agent's state with nothing failing. This test makes that
@@ -591,6 +598,10 @@ func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) 
 			stateBySess: map[string]string{
 				"sess-runner":   "RUNNING",
 				"sess-reviewer": "WAITING_FOR_INPUT",
+			},
+			passthroughBySess: map[string]bool{
+				"sess-runner":   true,
+				"sess-reviewer": false,
 			},
 			applied: map[string]bool{},
 		}
@@ -637,6 +648,14 @@ func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) 
 	if runnerStore.loadedStates[0] == reviewerStore.loadedStates[0] {
 		t.Fatalf("test is vacuous: both sessions loaded the same SessionState %q", runnerStore.loadedStates[0])
 	}
+	if len(runnerStore.loadedPassthrough) != 1 || len(reviewerStore.loadedPassthrough) != 1 {
+		t.Fatalf("expected exactly one LoadState per run, got %d and %d passthrough values",
+			len(runnerStore.loadedPassthrough), len(reviewerStore.loadedPassthrough))
+	}
+	if runnerStore.loadedPassthrough[0] == reviewerStore.loadedPassthrough[0] {
+		t.Fatalf("test is vacuous: both sessions loaded the same IsPassthrough value %v",
+			runnerStore.loadedPassthrough[0])
+	}
 
 	// The snapshot must be identical despite that divergence.
 	if fromRunner.StepID != fromReviewer.StepID {
@@ -651,7 +670,7 @@ func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) 
 			len(fromRunner.Guards), len(fromReviewer.Guards))
 	}
 	for i := range fromRunner.Guards {
-		if fromRunner.Guards[i] != fromReviewer.Guards[i] {
+		if !reflect.DeepEqual(fromRunner.Guards[i], fromReviewer.Guards[i]) {
 			t.Errorf("guard %d differs by session:\n  runner:   %#v\n  reviewer: %#v",
 				i, fromRunner.Guards[i], fromReviewer.Guards[i])
 		}

--- a/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_reevaluation_test.go
@@ -496,23 +496,28 @@ func TestEvaluateStepQuorum_DoesNotRecordSlateEmptySideEffects(t *testing.T) {
 // sessionScopedStateStore mirrors production assembleMachineState
 // (orchestrator/event_handlers_workflow.go): CurrentStepID and WorkflowID are
 // derived from the TASK row and are therefore identical for every session,
-// while SessionID and Data are genuinely per-session — Data being loaded from
-// that session's own metadata["workflow_data"] bag.
+// while SessionID, SessionState and Data are genuinely per-session — Data
+// being loaded from that session's own metadata["workflow_data"] bag.
 type sessionScopedStateStore struct {
-	step       StepSpec
-	dataBySess map[string]map[string]any
-	loadedData []map[string]any
-	applied    map[string]bool
+	step         StepSpec
+	dataBySess   map[string]map[string]any
+	stateBySess  map[string]string
+	loadedData   []map[string]any
+	loadedStates []string
+	applied      map[string]bool
 }
 
 func (s *sessionScopedStateStore) LoadState(_ context.Context, taskID, sessionID string) (MachineState, error) {
 	data := s.dataBySess[sessionID]
+	sessionState := s.stateBySess[sessionID]
 	s.loadedData = append(s.loadedData, data)
+	s.loadedStates = append(s.loadedStates, sessionState)
 	return MachineState{
 		TaskID:        taskID,
 		SessionID:     sessionID,
 		WorkflowID:    "wf",
 		CurrentStepID: "review",
+		SessionState:  sessionState,
 		Data:          data,
 	}, nil
 }
@@ -575,11 +580,16 @@ func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) 
 					},
 				},
 			},
-			// The two live sessions carry DIFFERENT per-session bags, so a
-			// guard that started reading Data would diverge between them.
+			// The two live sessions carry DIFFERENT per-session bags and
+			// states, so a guard that started reading either would diverge
+			// between them.
 			dataBySess: map[string]map[string]any{
 				"sess-runner":   {"owner": "runner", "attempts": 3},
 				"sess-reviewer": {"owner": "reviewer", "attempts": 1},
+			},
+			stateBySess: map[string]string{
+				"sess-runner":   "RUNNING",
+				"sess-reviewer": "WAITING_FOR_INPUT",
 			},
 			applied: map[string]bool{},
 		}
@@ -610,14 +620,21 @@ func TestEvaluateStepQuorum_InsensitiveToWhichLiveSessionIsNewest(t *testing.T) 
 	}
 
 	// Guard against a vacuous pass: if the fake ever stops handing the two
-	// runs genuinely different per-session bags, the comparison below proves
-	// nothing. Assert the divergence actually reached the engine.
+	// runs genuinely different per-session bags and states, the comparison
+	// below proves nothing. Assert the divergence actually reached the engine.
 	if len(runnerStore.loadedData) != 1 || len(reviewerStore.loadedData) != 1 {
 		t.Fatalf("expected exactly one LoadState per run, got %d and %d",
 			len(runnerStore.loadedData), len(reviewerStore.loadedData))
 	}
 	if reflect.DeepEqual(runnerStore.loadedData[0], reviewerStore.loadedData[0]) {
 		t.Fatalf("test is vacuous: both sessions loaded the same Data %v", runnerStore.loadedData[0])
+	}
+	if len(runnerStore.loadedStates) != 1 || len(reviewerStore.loadedStates) != 1 {
+		t.Fatalf("expected exactly one LoadState per run, got %d and %d states",
+			len(runnerStore.loadedStates), len(reviewerStore.loadedStates))
+	}
+	if runnerStore.loadedStates[0] == reviewerStore.loadedStates[0] {
+		t.Fatalf("test is vacuous: both sessions loaded the same SessionState %q", runnerStore.loadedStates[0])
 	}
 
 	// The snapshot must be identical despite that divergence.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3255/bed31ea7ffed.html)
<!-- kandev-pr-walkthrough-end -->

Nothing currently depends on session identity in the quorum guard-evaluation path, but nothing said so or checked it: the invariant that `resolveLatestSessionID` stays task-scoped lived only in engineers' heads. This closes that gap with a documented invariant and a mutation-proven regression test.

**Today:** `resolveLatestSessionID`'s task-scoped behavior (safe for guard evaluation, ambiguous for the per-session `MachineState.Data` bag) is undocumented, and no test would catch a future change that made guard evaluation read session-specific state.
**After this:** A doc comment on `resolveLatestSessionID` states the invariant explicitly, and a new regression test fails if `EvaluateStepQuorum`'s guards ever start reading session-derived fields, so the result depends on which sibling session happens to be newest.
**Who hits this:** Backend engineers touching `internal/workflow/engine` guard/quorum evaluation or `internal/office/engine_dispatcher` session resolution.
**Scope:** Residual test/doc slice of the office-session-identity work (B1 session-per-agent + B4 decision session binding), which landed flag-gated behind `features.officeSessionIdentity` in #3211. Standalone otherwise — the flag stays off.
**Not here:** No production code changes. The live-scoped `uniq_office_task_session` index and duplicate session-row cleanup are explicitly out of scope — the 63 duplicate `(task, agent)` pairs found in the live DB are terminal-row history (163 terminal / 18 live / zero concurrent), not identity corruption.

## Validation

- `make fmt` — no changes
- `make typecheck` — clean
- `make test` — `internal/workflow/engine` and `internal/office/engine_dispatcher` pass in full; the one failing package, `internal/worktree`, fails identically on `origin/main` (pre-existing sandbox-contention class, unrelated to this diff)
- `go test ./internal/workflow/engine/... ./internal/office/engine_dispatcher/... -run 'TestEvaluateStepQuorum|TestDispatcher_RecordDecision|TestRecordAgentDecision' -v` — 18/18 pass
- `make lint` — 0 issues (`golangci-lint run ./...`, web eslint, harness, spec, architecture lints)
- `make lint-format` — clean
- `cd apps/web && pnpm run i18n:ratchet` — clean (no UI source touched)
- New test is mutation-proven: injecting a mutant into `evaluateGuardStateReadOnly` to read session-specific state made the new test fail as designed, then the mutant was reverted

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->