### PR TITLE
fix(workflow): recognize reviewer decisions from agents who also hold the approver seat

### DIFF
--- a/apps/backend/internal/workflow/engine/quorum.go
+++ b/apps/backend/internal/workflow/engine/quorum.go
@@ -902,8 +902,10 @@ func (e *Engine) evaluateGuardStateReadOnly(
 // slate construction the quorum evaluator itself uses — so role
 // resolution and slate membership can never disagree about who
 // participates, per AC-57's "exactly once, in the engine" mandate.
-// Approver is checked before reviewer, matching the existing
-// approver-wins precedence in office/dashboard/decisions.go's
+// When the caller holds both seats, the seat whose StepID equals stepID
+// wins, since that is the seat the current step's guard actually reads
+// decisions against. If both seats sit at stepID, or neither does,
+// approver wins, matching the precedence in office/dashboard/decisions.go's
 // resolveDeciderRole (AC-4). Returns ErrParticipantNotFound when the
 // agent occupies neither seat.
 func (e *Engine) ResolveParticipantRole(
@@ -916,6 +918,8 @@ func (e *Engine) ResolveParticipantRole(
 	if state, stateErr := e.store.LoadState(ctx, taskID, ""); stateErr == nil {
 		workflowID = state.WorkflowID
 	}
+
+	var matches []roleSeat
 	for _, r := range []wfmodels.ParticipantRole{
 		wfmodels.ParticipantRoleApprover,
 		wfmodels.ParticipantRoleReviewer,
@@ -924,20 +928,33 @@ func (e *Engine) ResolveParticipantRole(
 		if seatsErr != nil {
 			return "", "", fmt.Errorf("resolve participant role: %w", seatsErr)
 		}
-		if id, ok := seatIDFor(seats, agentProfileID); ok {
-			return string(r), id, nil
+		if seat, ok := seatFor(seats, agentProfileID); ok {
+			matches = append(matches, roleSeat{role: string(r), seat: seat})
 		}
 	}
-	return "", "", ErrParticipantNotFound
+	if len(matches) == 0 {
+		return "", "", ErrParticipantNotFound
+	}
+	for _, m := range matches {
+		if m.seat.StepID == stepID {
+			return m.role, m.seat.ID, nil
+		}
+	}
+	return matches[0].role, matches[0].seat.ID, nil
 }
 
-// seatIDFor scans seats for one occupied by agentProfileID, returning its
-// AC-50 canonical seat id.
-func seatIDFor(seats []ParticipantInfo, agentProfileID string) (string, bool) {
+// roleSeat pairs a resolved role with the seat matched under it.
+type roleSeat struct {
+	role string
+	seat ParticipantInfo
+}
+
+// seatFor scans seats for one occupied by agentProfileID.
+func seatFor(seats []ParticipantInfo, agentProfileID string) (ParticipantInfo, bool) {
 	for _, s := range seats {
 		if s.AgentProfileID == agentProfileID {
-			return s.ID, true
+			return s, true
 		}
 	}
-	return "", false
+	return ParticipantInfo{}, false
 }

--- a/apps/backend/internal/workflow/engine/quorum.go
+++ b/apps/backend/internal/workflow/engine/quorum.go
@@ -929,16 +929,14 @@ func (e *Engine) ResolveParticipantRole(
 			return "", "", fmt.Errorf("resolve participant role: %w", seatsErr)
 		}
 		if seat, ok := seatFor(seats, agentProfileID); ok {
+			if seat.StepID == stepID {
+				return string(r), seat.ID, nil
+			}
 			matches = append(matches, roleSeat{role: string(r), seat: seat})
 		}
 	}
 	if len(matches) == 0 {
 		return "", "", ErrParticipantNotFound
-	}
-	for _, m := range matches {
-		if m.seat.StepID == stepID {
-			return m.role, m.seat.ID, nil
-		}
 	}
 	return matches[0].role, matches[0].seat.ID, nil
 }

--- a/apps/backend/internal/workflow/engine/quorum.go
+++ b/apps/backend/internal/workflow/engine/quorum.go
@@ -920,13 +920,17 @@ func (e *Engine) ResolveParticipantRole(
 	}
 
 	var matches []roleSeat
+	var firstSeatsErr error
 	for _, r := range []wfmodels.ParticipantRole{
 		wfmodels.ParticipantRoleApprover,
 		wfmodels.ParticipantRoleReviewer,
 	} {
 		seats, seatsErr := e.requiredSeatsForWorkflow(ctx, stepID, taskID, workflowID, string(r))
 		if seatsErr != nil {
-			return "", "", fmt.Errorf("resolve participant role: %w", seatsErr)
+			if firstSeatsErr == nil {
+				firstSeatsErr = seatsErr
+			}
+			continue
 		}
 		if seat, ok := seatFor(seats, agentProfileID); ok {
 			if seat.StepID == stepID {
@@ -934,6 +938,9 @@ func (e *Engine) ResolveParticipantRole(
 			}
 			matches = append(matches, roleSeat{role: string(r), seat: seat})
 		}
+	}
+	if firstSeatsErr != nil {
+		return "", "", fmt.Errorf("resolve participant role: %w", firstSeatsErr)
 	}
 	if len(matches) == 0 {
 		return "", "", ErrParticipantNotFound

--- a/apps/backend/internal/workflow/engine/quorum_agent_resolver_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_agent_resolver_test.go
@@ -263,6 +263,27 @@ func TestResolveParticipantRole_ApproverAtStepSkipsReviewerResolverError(t *test
 	}
 }
 
+// TestResolveParticipantRole_ReviewerAtStepDefersApproverResolverError is the
+// inverse of the approver-at-step case: an unrelated approver resolver error
+// must not hide a valid reviewer seat at the step being evaluated.
+func TestResolveParticipantRole_ReviewerAtStepDefersApproverResolverError(t *testing.T) {
+	boom := errors.New("boom")
+	participants := scopedParticipants{perTask: []ParticipantInfo{
+		{ID: "seat-approver", TaskID: "task-1", StepID: "other-step", Role: "approver", AgentProfileID: "agent-b", DecisionRequired: true},
+		{ID: "seat-reviewer", TaskID: "task-1", StepID: "review", Role: "reviewer", AgentProfileID: "agent-a", DecisionRequired: true},
+	}}
+	resolver := &perIDErrResolver{errFor: map[string]error{"agent-b": boom}}
+	eng := quorumEngineWithResolver(newFakeDecisionStore(), participants, resolver)
+
+	role, participantID, err := eng.ResolveParticipantRole(context.Background(), "task-1", "review", "agent-a")
+	if err != nil {
+		t.Fatalf("ResolveParticipantRole: %v", err)
+	}
+	if role != "reviewer" || participantID != "seat-reviewer" {
+		t.Errorf("role/participantID = %q/%q, want reviewer/seat-reviewer", role, participantID)
+	}
+}
+
 func TestComputeGuardOutcome_ContinuesEvaluatingAfterDroppingUnresolvedSeat(t *testing.T) {
 	parts := scopedParticipants{template: []ParticipantInfo{
 		{ID: "p1", StepID: "review", Role: "reviewer", AgentProfileID: "rev-A", DecisionRequired: true},

--- a/apps/backend/internal/workflow/engine/quorum_agent_resolver_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_agent_resolver_test.go
@@ -227,6 +227,42 @@ func TestComputeGuardOutcome_ResolverErrorSurfacesAsEvaluationError(t *testing.T
 // held one resolvable and one unresolved-agent seat still fires once the
 // resolvable seat approves, instead of waiting forever on a seat that can
 // never decide.
+// perIDErrResolver errors only for the agent profile ids listed in errFor,
+// resolving every other id as present.
+type perIDErrResolver struct {
+	errFor map[string]error
+}
+
+func (r *perIDErrResolver) AgentProfileExists(_ context.Context, agentProfileID string) (bool, error) {
+	if err, ok := r.errFor[agentProfileID]; ok {
+		return false, err
+	}
+	return true, nil
+}
+
+// TestResolveParticipantRole_ApproverAtStepSkipsReviewerResolverError is the
+// regression test for FINDING R1-A: when the caller's approver seat already
+// sits at stepID, that seat is both matches[0] and the step-preferred
+// answer, so the reviewer slate must never be built. A resolver error on the
+// reviewer seat's agent profile would otherwise fail the whole resolution.
+func TestResolveParticipantRole_ApproverAtStepSkipsReviewerResolverError(t *testing.T) {
+	boom := errors.New("boom")
+	participants := scopedParticipants{perTask: []ParticipantInfo{
+		{ID: "seat-approver", TaskID: "task-1", StepID: "review", Role: "approver", AgentProfileID: "agent-a", DecisionRequired: true},
+		{ID: "seat-reviewer", TaskID: "task-1", StepID: "other-step", Role: "reviewer", AgentProfileID: "agent-b", DecisionRequired: true},
+	}}
+	resolver := &perIDErrResolver{errFor: map[string]error{"agent-b": boom}}
+	eng := quorumEngineWithResolver(newFakeDecisionStore(), participants, resolver)
+
+	role, participantID, err := eng.ResolveParticipantRole(context.Background(), "task-1", "review", "agent-a")
+	if err != nil {
+		t.Fatalf("ResolveParticipantRole: %v", err)
+	}
+	if role != "approver" || participantID != "seat-approver" {
+		t.Errorf("role/participantID = %q/%q, want approver/seat-approver", role, participantID)
+	}
+}
+
 func TestComputeGuardOutcome_ContinuesEvaluatingAfterDroppingUnresolvedSeat(t *testing.T) {
 	parts := scopedParticipants{template: []ParticipantInfo{
 		{ID: "p1", StepID: "review", Role: "reviewer", AgentProfileID: "rev-A", DecisionRequired: true},

--- a/apps/backend/internal/workflow/engine/quorum_role_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_role_test.go
@@ -195,3 +195,24 @@ func TestResolveParticipantRole_StepPreferredTransitionFires(t *testing.T) {
 		t.Fatalf("unexpected transition endpoints: %#v", result)
 	}
 }
+
+// TestResolveParticipantRole_NeitherSeatAtStep_ApproverWins is AC-4's
+// fallback case: a caller holding both seats, with neither seat's StepID
+// matching the step being queried, still resolves under approver-wins —
+// the step-preference added for the Review re-entry bug only kicks in
+// when the approver seat itself sits at the queried step.
+func TestResolveParticipantRole_NeitherSeatAtStep_ApproverWins(t *testing.T) {
+	participants := scopedParticipants{perTask: []ParticipantInfo{
+		{ID: "seat-reviewer", TaskID: "task-1", StepID: "review-1", Role: "reviewer", AgentProfileID: "agent-a", DecisionRequired: true},
+		{ID: "seat-approver", TaskID: "task-1", StepID: "approval-1", Role: "approver", AgentProfileID: "agent-a", DecisionRequired: true},
+	}}
+	eng := quorumEngine(nil, participants)
+
+	role, participantID, err := eng.ResolveParticipantRole(context.Background(), "task-1", "review-2", "agent-a")
+	if err != nil {
+		t.Fatalf("ResolveParticipantRole: %v", err)
+	}
+	if role != "approver" || participantID != "seat-approver" {
+		t.Errorf("role/participantID = %q/%q, want approver/seat-approver", role, participantID)
+	}
+}

--- a/apps/backend/internal/workflow/engine/quorum_role_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_role_test.go
@@ -133,3 +133,65 @@ func TestResolveParticipantRole_StoreErrorWrapped(t *testing.T) {
 		t.Fatalf("err = %v, want wrapped store error", err)
 	}
 }
+
+// TestResolveParticipantRole_StepPreferredOverApproverWins is the
+// regression test for the Review re-entry bug: a caller holding both
+// seats at different steps must resolve under the role whose seat sits
+// at the step actually being evaluated, not under approver-wins. The
+// approver seat was cast once the task first reached Approval and
+// persists across the Review re-entry that follows an Approval
+// rejection, so both rows coexist by the time this resolves at "review".
+func TestResolveParticipantRole_StepPreferredOverApproverWins(t *testing.T) {
+	participants := scopedParticipants{perTask: []ParticipantInfo{
+		{ID: "seat-reviewer", TaskID: "task-1", StepID: "review", Role: "reviewer", AgentProfileID: "agent-a", DecisionRequired: true},
+		{ID: "seat-approver", TaskID: "task-1", StepID: "approval", Role: "approver", AgentProfileID: "agent-a", DecisionRequired: true},
+	}}
+	eng := quorumEngine(nil, participants)
+
+	role, participantID, err := eng.ResolveParticipantRole(context.Background(), "task-1", "review", "agent-a")
+	if err != nil {
+		t.Fatalf("ResolveParticipantRole: %v", err)
+	}
+	if role != "reviewer" || participantID != "seat-reviewer" {
+		t.Errorf("role/participantID = %q/%q, want reviewer/seat-reviewer", role, participantID)
+	}
+}
+
+// TestResolveParticipantRole_StepPreferredTransitionFires proves the
+// second half of the DoD: resolving under the step-preferred role and
+// recording the decision under the resolved seat actually satisfies the
+// reviewer quorum guard and fires Review -> Approval, where it used to
+// park forever because the decision was misfiled against a seat absent
+// from the reviewer slate.
+func TestResolveParticipantRole_StepPreferredTransitionFires(t *testing.T) {
+	store := quorumStore(&TransitionGuard{
+		WaitForQuorum: &WaitForQuorumGuard{Role: "reviewer", Threshold: QuorumAllApprove},
+	})
+	decisions := newFakeDecisionStore()
+	participants := scopedParticipants{perTask: []ParticipantInfo{
+		{ID: "seat-reviewer", TaskID: "task-1", StepID: "review", Role: "reviewer", AgentProfileID: "agent-a", DecisionRequired: true},
+		{ID: "seat-approver", TaskID: "task-1", StepID: "approval", Role: "approver", AgentProfileID: "agent-a", DecisionRequired: true},
+	}}
+	eng := New(store, MapRegistry{}, WithDecisionStore(decisions), WithParticipantStore(participants))
+
+	role, participantID, err := eng.ResolveParticipantRole(context.Background(), "task-1", "review", "agent-a")
+	if err != nil {
+		t.Fatalf("ResolveParticipantRole: %v", err)
+	}
+	if role != "reviewer" || participantID != "seat-reviewer" {
+		t.Fatalf("role/participantID = %q/%q, want reviewer/seat-reviewer", role, participantID)
+	}
+
+	result, err := eng.RecordParticipantDecision(context.Background(), "sess-1", DecisionInfo{
+		TaskID: "task-1", StepID: "review", ParticipantID: participantID, Decision: DecisionApproved,
+	})
+	if err != nil {
+		t.Fatalf("RecordParticipantDecision: %v", err)
+	}
+	if !result.Transitioned {
+		t.Fatalf("expected the resolved reviewer decision to satisfy quorum and transition: %#v", result)
+	}
+	if result.FromStepID != "review" || result.ToStepID != "approval" {
+		t.Fatalf("unexpected transition endpoints: %#v", result)
+	}
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3270/22f0f4a17498.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** when a reviewer who also holds the approver seat sends a task back to Review after rejecting it at Approval, their Review decision gets filed under `approver` instead of `reviewer`. The reviewer quorum never sees the decision, so the task never advances back to Approval — it sits stuck at Review.

**After this:** the decision is filed against whichever seat sits at the task's current step. A reviewer-at-Review decision is recorded as `reviewer`, the quorum guard fires, and Review → Approval proceeds normally.

**Who hits this:** any workspace where the same agent profile holds both the approver and reviewer seats (small teams, thin workspaces) and a task cycles Review → Approval → (rejected) → Review again.

**Scope:** standalone backend fix, no siblings.

**Not here:** the human decision path (`resolveDeciderRole` in `internal/office/dashboard/decisions.go`) is intentionally left step-blind/approver-wins; this only touches the agent-facing resolver.

`Engine.ResolveParticipantRole` looped a fixed role order (approver, then reviewer) and returned on the first seat match, so a caller holding both seats always resolved to `approver` regardless of which step they were deciding at. It now collects matches in that same order but prefers the match whose seat sits at the step actually being evaluated, falling back to approver-wins only when neither seat is at the current step.

## Validation

- `go test ./internal/workflow/engine/... -count=1` — pass, including two new regression tests (`TestResolveParticipantRole_StepPreferredOverApproverWins`, `TestResolveParticipantRole_StepPreferredTransitionFires`) that fail against the pre-fix code and pass against the fix.
- `go test ./internal/workflow/... -count=1` — pass.
- `golangci-lint run ./...` (backend) — 0 issues.
- `gofmt -l` on the changed files — clean.
- `make fmt`, `make typecheck`, `make lint` (backend/web/harness/specs/architecture), `make lint-format`, `pnpm run i18n:ratchet` — all green.
- Falsification: copied the new test files onto the pre-fix `quorum.go` at the merge-base commit in a scratch worktree — both new regression tests fail there, confirming they exercise the fix and aren't tautologies.
- A handful of unrelated backend packages (worktree management, launcher, agent runtime lifecycle) fail intermittently on this host due to disk-space contention from many concurrent checkouts sharing one machine — confirmed pre-existing by reproducing the same failures against the merge-base commit in a scratch worktree, before this diff exists. Nothing in `internal/workflow/...` is affected.

## Possible Improvements

Low risk: the change only reorders which of two roles a provably-attached participant resolves to; the "not a participant" rejection path (`ErrParticipantNotFound`) is unchanged.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Backend-only fix, no public-facing surface.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->