### PR TITLE
fix(office): stop parent tasks waking twice when children finish

### DIFF
--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -1075,13 +1075,23 @@ func (s *Service) queueChildrenCompletedRun(ctx context.Context, parentID string
 		return err
 	}
 
+	// Derived the same way as ParentWakeReconciler's recovery dispatch
+	// (wakeOperationID) so both producers land on the identical operation
+	// id for the same parent + child set. That shared id is what lets
+	// idx_run_idempotency actually dedupe the pair when the reconciler
+	// races this edge-triggered path for the same completion wave.
+	childSetKey, err := s.repo.GetChildSetKey(ctx, parentID)
+	if err != nil {
+		return fmt.Errorf("get child set key: %w", err)
+	}
+
 	children, _, err := s.repo.GetChildSummaries(ctx, parentID)
 	if err != nil {
 		s.logger.Error("get child summaries failed", zap.Error(err))
 		children = nil
 	}
 
-	key := fmt.Sprintf("children_completed:%s", parentID)
+	key := wakeOperationID(parentID, childSetKey)
 	summaries := make([]engine.ChildSummary, 0, len(children))
 	prsByTask := s.lookupChildPRLinks(ctx, children)
 	for _, c := range children {

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -983,7 +983,11 @@ func (s *Service) finalizeDone(ctx context.Context, data *TaskMovedData) error {
 	}
 	if data.ParentID != "" {
 		if err := s.queueChildrenCompletedRun(ctx, data.ParentID); err != nil {
-			s.logger.Error("children completed run failed", zap.Error(err))
+			// Warn, not Error: ParentWakeReconciler is the documented
+			// recovery path for a parent whose wake didn't get queued
+			// here (including a transient GetChildSetKey failure), so
+			// this is expected to self-heal rather than page anyone.
+			s.logger.Warn("children completed run failed", zap.Error(err))
 		}
 	}
 	return nil

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -944,8 +944,8 @@ func (s *Service) queueTaskAssignedRun(
 }
 
 // handleTaskMoved keeps the legacy named-step activity fallback and queues
-// downstream blocker / children-completed runs when a task lands in a
-// terminal step. Canonical task-state activity is written by the task service
+// downstream blocker / children-completed runs when a task enters a terminal
+// step. Canonical task-state activity is written by the task service
 // before task.state_changed is published, so the workflow move path is durable
 // before any WebSocket refetch can run. Stage progression itself is owned by
 // the workflow engine (the orchestrator subscribes to TaskMoved and fires
@@ -968,14 +968,15 @@ func (s *Service) handleTaskMoved(ctx context.Context, event *bus.Event) error {
 			runID, data.SessionID)
 	}
 
-	if categorizeStep(data.ToStepName) == stepCategoryDone {
+	if categorizeStep(data.ToStepName) == stepCategoryDone &&
+		categorizeStep(data.FromStepName) != stepCategoryDone {
 		return s.finalizeDone(ctx, data)
 	}
 	return nil
 }
 
-// finalizeDone resolves blockers and notifies parents when a task lands
-// in a terminal step. Both side-effects route through the engine via
+// finalizeDone resolves blockers and notifies parents when a task enters
+// a terminal step. Both side-effects route through the engine via
 // dispatchEngineTrigger (on_blocker_resolved / on_children_completed).
 func (s *Service) finalizeDone(ctx context.Context, data *TaskMovedData) error {
 	if err := s.queueBlockersResolvedRuns(ctx, data.TaskID); err != nil {

--- a/apps/backend/internal/office/service/event_subscribers_children_completed_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_children_completed_test.go
@@ -1,0 +1,34 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+func TestTaskMovedTerminalToTerminalDoesNotWakeParent(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	dispatcher := &fakeDispatcher{}
+	svc.SetWorkflowEngineDispatcher(dispatcher)
+
+	adoptOffice(t, svc, "ws-1")
+	seedStuckParent(t, svc, "ws-1", "parent-1", "worker-1")
+
+	event := bus.NewEvent(events.TaskMoved, "test", map[string]string{
+		"task_id":                   "parent-1-child-0",
+		"workspace_id":              "ws-1",
+		"from_step_name":            "Cancelled",
+		"to_step_name":              "Done",
+		"assignee_agent_profile_id": "worker-1",
+		"parent_id":                 "parent-1",
+	})
+	if err := eb.Publish(context.Background(), events.TaskMoved, event); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+
+	if calls := dispatcher.Calls(); len(calls) != 0 {
+		t.Fatalf("terminal-to-terminal move dispatched a parent wake: %#v", calls)
+	}
+}

--- a/apps/backend/internal/office/service/scheduler_wake_reconciler.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -230,6 +231,22 @@ func (h *ParentWakeReconciler) recordReceipt(
 }
 
 func wakeOperationID(parentTaskID, childSetKey string) string {
-	sum := sha256.Sum256([]byte(parentTaskID + "\x00" + childSetKey))
+	// A completion wave is identified by the child IDs, not by the terminal
+	// state each child reached. A terminal-to-terminal edit (for example,
+	// CANCELLED to COMPLETED) must not create a new parent wake. The receipt
+	// keeps the full state-aware key for recovery, so strip only the state
+	// suffix when deriving the operation identity.
+	childIDs := make([]string, 0)
+	for _, child := range strings.Split(childSetKey, ",") {
+		if child == "" {
+			continue
+		}
+		if separator := strings.LastIndexByte(child, ':'); separator >= 0 {
+			child = child[:separator]
+		}
+		childIDs = append(childIDs, child)
+	}
+	canonicalChildSet := strings.Join(childIDs, ",")
+	sum := sha256.Sum256([]byte(parentTaskID + "\x00" + canonicalChildSet))
 	return fmt.Sprintf("task_children_completed:%s:%s", parentTaskID, hex.EncodeToString(sum[:]))
 }

--- a/apps/backend/internal/office/service/scheduler_wake_reconciler_identity_test.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler_identity_test.go
@@ -1,0 +1,23 @@
+package service
+
+import "testing"
+
+func TestWakeOperationID_IgnoresTerminalStateChanges(t *testing.T) {
+	parentID := "parent-1"
+	first := wakeOperationID(parentID, "child-1:CANCELLED,child-2:COMPLETED")
+	second := wakeOperationID(parentID, "child-1:COMPLETED,child-2:COMPLETED")
+
+	if first != second {
+		t.Fatalf("terminal state edit changed operation id: first=%q second=%q", first, second)
+	}
+}
+
+func TestWakeOperationID_ChangesWhenChildSetChanges(t *testing.T) {
+	parentID := "parent-1"
+	first := wakeOperationID(parentID, "child-1:COMPLETED")
+	second := wakeOperationID(parentID, "child-1:COMPLETED,child-2:COMPLETED")
+
+	if first == second {
+		t.Fatalf("new child set reused operation id %q", first)
+	}
+}

--- a/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/service"
 )
@@ -321,4 +322,63 @@ func TestParentWakeReconciler_UnresolvedAndPausedDoNotStarveHealthyParent(t *tes
 		}
 	}
 	t.Fatalf("zz-healthy-parent was never dispatched across 3 ticks behind 10 sticky candidates: %#v", dispatcher.Calls())
+}
+
+// TestWakeOperationID_UnifiedAcrossEdgeAndReconcilerPaths is the regression
+// test for the duplicate on_children_completed wake race: the edge-triggered
+// path (queueChildrenCompletedRun, fired off task.moved) and the
+// level-triggered ParentWakeReconciler can both dispatch a wake for the same
+// parent within one window. Before the fix they derived different operation
+// ids ("children_completed:<parent>" vs the sha256-based
+// "task_children_completed:<parent>:<hash>"), so idx_run_idempotency could
+// never dedupe them and both runs executed. Both producers must now derive
+// the identical operation id for the same parent + child set so the shared
+// idempotency key (and therefore the DB's unique index) actually collapses
+// the second dispatch.
+func TestWakeOperationID_UnifiedAcrossEdgeAndReconcilerPaths(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+	dispatcher := &fakeDispatcher{}
+	svc.SetWorkflowEngineDispatcher(dispatcher)
+
+	adoptOffice(t, svc, "ws-1")
+	seedStuckParent(t, svc, "ws-1", "parent-1", "worker-1")
+
+	// Edge-triggered path: a child lands in Done, firing
+	// finalizeDone -> queueChildrenCompletedRun for parent-1.
+	moveEvent := bus.NewEvent("task.moved", "test", map[string]string{
+		"task_id":                   "parent-1-child-0",
+		"workspace_id":              "ws-1",
+		"from_step_id":              "step-1",
+		"to_step_id":                "step-done",
+		"to_step_name":              "Done",
+		"from_step_name":            "In Progress",
+		"assignee_agent_profile_id": "worker-1",
+		"parent_id":                 "parent-1",
+	})
+	if err := eb.Publish(ctx, "task.moved", moveEvent); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+
+	// Level-triggered path: one reconciler tick sweeping the same
+	// still-stuck parent (the edge dispatch above never writes a receipt
+	// or a run row — fakeDispatcher only records the call — so
+	// ListStuckParents still finds parent-1).
+	handler := service.NewParentWakeReconciler(service.NewSchedulerIntegration(svc, 0))
+	if err := handler.Tick(ctx); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	calls := dispatcher.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("want 2 dispatcher calls (edge + reconciler), got %d: %#v", len(calls), calls)
+	}
+	edgeOpID, reconcilerOpID := calls[0].opID, calls[1].opID
+	if edgeOpID == "" || reconcilerOpID == "" {
+		t.Fatalf("expected non-empty operation ids, got edge=%q reconciler=%q", edgeOpID, reconcilerOpID)
+	}
+	if edgeOpID != reconcilerOpID {
+		t.Fatalf("edge and reconciler paths derived different operation ids for the same parent+child-set: edge=%q reconciler=%q",
+			edgeOpID, reconcilerOpID)
+	}
 }

--- a/apps/backend/internal/runs/repository/sqlite/idempotency_violation.go
+++ b/apps/backend/internal/runs/repository/sqlite/idempotency_violation.go
@@ -1,0 +1,38 @@
+package sqlite
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// runIdempotencyIndexName is the unique index enforcing at most one runs row
+// per non-null idempotency_key (internal/office/repository/sqlite/base.go,
+// idx_run_idempotency).
+const runIdempotencyIndexName = "idx_run_idempotency"
+
+// sqliteRunIdempotencyViolationMessage is the substring go-sqlite3 puts in a
+// UNIQUE-constraint error for this index. SQLite exposes no typed access to
+// the violated index's name, only the column ("UNIQUE constraint failed:
+// runs.idempotency_key"); that column is unique to idx_run_idempotency on
+// this table, so matching it attributes the violation correctly rather than
+// to the table's primary key.
+const sqliteRunIdempotencyViolationMessage = "UNIQUE constraint failed: runs.idempotency_key"
+
+// IsIdempotencyKeyUniqueViolation reports whether err is a violation of
+// idx_run_idempotency specifically, not any unique violation. On PostgreSQL
+// it inspects the typed pgconn.PgError's constraint name; on SQLite (no
+// typed access to the constraint name) it matches the message documented
+// above. Mirrors isExternalIDUniqueViolation
+// (internal/task/repository/sqlite/task_external_id.go).
+func IsIdempotencyKeyUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505" && pgErr.ConstraintName == runIdempotencyIndexName
+	}
+	return strings.Contains(err.Error(), sqliteRunIdempotencyViolationMessage)
+}

--- a/apps/backend/internal/runs/service/service.go
+++ b/apps/backend/internal/runs/service/service.go
@@ -12,6 +12,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,18 @@ import (
 	"github.com/kandev/kandev/internal/runs/commentkeys"
 	runssqlite "github.com/kandev/kandev/internal/runs/repository/sqlite"
 )
+
+// errIdempotencyKeyConflict signals that insertRun's CreateRun failed
+// because idx_run_idempotency rejected a duplicate idempotency_key —
+// distinct from the earlier CheckIdempotencyKey miss, which only looks
+// within IdempotencyWindowHours. Two independent producers deriving the
+// same operation id for the same event can both pass that windowed check
+// before either commits (or the colliding row can simply be older than the
+// window); the unique index is what actually stops the second insert.
+// QueueRun treats this the same as a windowed dedupe hit: QueueOutcomeDeduped,
+// not an error, so the losing producer's caller doesn't abort or log a
+// spurious failure for what is really a no-op.
+var errIdempotencyKeyConflict = errors.New("idempotency key conflict")
 
 // RunQueueAdapter is the interface the workflow engine uses to enqueue
 // runs from queue_run actions. Phase 2 final's parallel agent
@@ -207,6 +220,11 @@ func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) (QueueOutco
 
 	row, err := s.insertRun(ctx, agentInstanceID, req, payload)
 	if err != nil {
+		if errors.Is(err, errIdempotencyKeyConflict) {
+			s.log.Debug("run skipped (idempotency index race)",
+				zap.String("key", req.IdempotencyKey))
+			return QueueOutcomeDeduped, nil
+		}
 		return "", err
 	}
 
@@ -241,6 +259,9 @@ func (s *Service) insertRun(
 		RequestedAt:    time.Now().UTC(),
 	}
 	if err := s.repo.CreateRun(ctx, row); err != nil {
+		if runssqlite.IsIdempotencyKeyUniqueViolation(err) {
+			return nil, errIdempotencyKeyConflict
+		}
 		return nil, fmt.Errorf("enqueue run: %w", err)
 	}
 	return row, nil

--- a/apps/backend/internal/runs/service/service.go
+++ b/apps/backend/internal/runs/service/service.go
@@ -31,12 +31,12 @@ import (
 // because idx_run_idempotency rejected a duplicate idempotency_key —
 // distinct from the earlier CheckIdempotencyKey miss, which only looks
 // within IdempotencyWindowHours. Two independent producers deriving the
-// same operation id for the same event can both pass that windowed check
+// same operation id for the same event can both pass that fast-path check
 // before either commits (or the colliding row can simply be older than the
 // window); the unique index is what actually stops the second insert.
-// QueueRun treats this the same as a windowed dedupe hit: QueueOutcomeDeduped,
-// not an error, so the losing producer's caller doesn't abort or log a
-// spurious failure for what is really a no-op.
+// QueueRun treats this as a durable dedupe hit: QueueOutcomeDeduped, not an
+// error, so the losing producer's caller does not abort or log a spurious
+// failure for what is really a no-op.
 var errIdempotencyKeyConflict = errors.New("idempotency key conflict")
 
 // RunQueueAdapter is the interface the workflow engine uses to enqueue
@@ -56,9 +56,8 @@ type QueueOutcome string
 const (
 	// QueueOutcomeQueued means a new runs row was inserted.
 	QueueOutcomeQueued QueueOutcome = "queued"
-	// QueueOutcomeDeduped means an existing row with the same
-	// IdempotencyKey already exists within the dedupe window, so nothing
-	// was inserted.
+	// QueueOutcomeDeduped means an existing row with the same IdempotencyKey
+	// already exists in the durable idempotency index, so nothing was inserted.
 	QueueOutcomeDeduped QueueOutcome = "deduped"
 	// QueueOutcomeCoalesced means the request was merged into an existing
 	// queued row for the same agent + reason within the coalescing
@@ -77,8 +76,9 @@ const (
 //     action. Empty when the queue_run did not originate from the
 //     engine (legacy office paths).
 //   - Reason: the run reason (task_assigned, task_comment, …).
-//   - IdempotencyKey: when non-empty, the run is suppressed if a row
-//     with the same key landed in the last 24 hours.
+//   - IdempotencyKey: when non-empty, the run is suppressed if the durable
+//     queue identity already exists. QueueRun first checks recent rows, then
+//     relies on the unique index to close races and preserve that identity.
 //   - Payload: structured JSON-encoded payload. Must be a non-nil map
 //     when set; serialised before insert. QueueRun adds the resolved
 //     task / workflow / agent envelope before persisting.
@@ -97,9 +97,9 @@ type QueueRunRequest struct {
 // coalesced_count and replacing the payload.
 const CoalesceWindowSeconds = 5
 
-// IdempotencyWindowHours is the deduplication window. Requests with a
-// non-empty IdempotencyKey are suppressed if the same key was used
-// within this window.
+// IdempotencyWindowHours is the lookback used by the fast duplicate query.
+// The runs table's unique idempotency index remains durable for every
+// persisted key, including rows older than this window.
 const IdempotencyWindowHours = 24
 
 // signalBuffer sizes the in-process channel used for event-driven
@@ -166,7 +166,7 @@ func (s *Service) SubscribeSignal() <-chan struct{} { return s.signalCh }
 // QueueRun implements RunQueueAdapter. The flow is:
 //  1. Resolve agent_profile_id (from the request field, payload fallback,
 //     or a wired resolver).
-//  2. Idempotency check (24h) on req.IdempotencyKey if set.
+//  2. Recent idempotency check on req.IdempotencyKey if set.
 //  3. Coalescing (5s window for same agent + reason).
 //  4. Insert into runs table.
 //  5. Publish OfficeRunQueued.

--- a/apps/backend/internal/runs/service/service.go
+++ b/apps/backend/internal/runs/service/service.go
@@ -220,6 +220,12 @@ func (s *Service) QueueRun(ctx context.Context, req QueueRunRequest) (QueueOutco
 
 	row, err := s.insertRun(ctx, agentInstanceID, req, payload)
 	if err != nil {
+		// idx_run_idempotency has no time bound, so a conflict here can
+		// come from a row older than IdempotencyWindowHours, not just the
+		// windowed race CheckIdempotencyKey guards against above. Either
+		// way the existing row is definitionally the same operation this
+		// key identifies, so treat it as a no-op dedupe rather than a hard
+		// error (see errIdempotencyKeyConflict's doc comment).
 		if errors.Is(err, errIdempotencyKeyConflict) {
 			s.log.Debug("run skipped (idempotency index race)",
 				zap.String("key", req.IdempotencyKey))

--- a/apps/backend/internal/runs/service/service_postgres_test.go
+++ b/apps/backend/internal/runs/service/service_postgres_test.go
@@ -1,0 +1,93 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events/bus"
+	officesqlite "github.com/kandev/kandev/internal/office/repository/sqlite"
+	runsservice "github.com/kandev/kandev/internal/runs/service"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// TestPostgresQueueRun_DedupesOnIdempotencyIndexRace is the PostgreSQL twin
+// of TestQueueRun_DedupesOnIdempotencyIndexRace: SQLite and PostgreSQL
+// classify unique-violation errors completely differently (typed
+// pgconn.PgError with a constraint name vs. SQLite's message-substring
+// match — see runssqlite.IsIdempotencyKeyUniqueViolation), so the SQLite
+// path passing is not evidence the PostgreSQL path does. Without this test
+// a Postgres deployment could silently fail to recognize the
+// idx_run_idempotency violation, fall through to insertRun's generic error
+// wrap, and reproduce the exact "spurious ERROR on the losing producer"
+// bug the fix exists to remove. Skips unless KANDEV_TEST_POSTGRES_DSN is
+// set.
+func TestPostgresQueueRun_DedupesOnIdempotencyIndexRace(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	// runs is created by the office repo's own schema init, but that init
+	// references the tasks table, so the task repository's schema must
+	// run first — mirroring production boot order (see failure_postgres_test.go).
+	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+	officeRepo, err := officesqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init office repo: %v", err)
+	}
+
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "console"})
+	eb := bus.NewMemoryEventBus(log)
+	svc := runsservice.New(officeRepo.RunsRepository(), eb, log, nil)
+	repo := officeRepo.RunsRepository()
+	ctx := context.Background()
+
+	const key = "task_children_completed:parent-1:0541818c598576d27d09bff86195037f87910dbf34f0420f6a99dc468aa1dfc7"
+
+	outcome, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_children_completed",
+		IdempotencyKey: key,
+		Payload:        map[string]any{"agent_profile_id": "a1", "task_id": "t1"},
+	})
+	if err != nil {
+		t.Fatalf("queue first run: %v", err)
+	}
+	if outcome != runsservice.QueueOutcomeQueued {
+		t.Fatalf("first outcome = %q, want %q", outcome, runsservice.QueueOutcomeQueued)
+	}
+
+	var firstRunID string
+	if err := repo.Reader().GetContext(ctx, &firstRunID,
+		repo.Reader().Rebind(`SELECT id FROM runs WHERE idempotency_key = ?`), key); err != nil {
+		t.Fatalf("look up first run id: %v", err)
+	}
+	// Push the first row outside CheckIdempotencyKey's 24h window so the
+	// racing insert reaches idx_run_idempotency instead of being caught
+	// by the earlier check — the exact gap a true concurrent race falls
+	// into (both producers pass the check before either commits).
+	if err := repo.SetRunRequestedAtForTest(ctx, firstRunID, time.Now().UTC().Add(-25*time.Hour)); err != nil {
+		t.Fatalf("age first run past the idempotency window: %v", err)
+	}
+
+	second, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_children_completed",
+		IdempotencyKey: key,
+		Payload:        map[string]any{"agent_profile_id": "a1", "task_id": "t1"},
+	})
+	if err != nil {
+		t.Fatalf("queue racing run: %v", err)
+	}
+	if second != runsservice.QueueOutcomeDeduped {
+		t.Fatalf("racing outcome = %q, want %q", second, runsservice.QueueOutcomeDeduped)
+	}
+
+	var count int
+	if err := repo.Reader().GetContext(ctx, &count,
+		repo.Reader().Rebind(`SELECT COUNT(*) FROM runs WHERE idempotency_key = ?`), key); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("runs with idempotency_key %q = %d, want 1", key, count)
+	}
+}

--- a/apps/backend/internal/runs/service/service_test.go
+++ b/apps/backend/internal/runs/service/service_test.go
@@ -565,6 +565,69 @@ func TestQueueRun_DistinctIdempotencyKeyStillQueuesAfterDedup(t *testing.T) {
 	}
 }
 
+// TestQueueRun_DedupesOnIdempotencyIndexRace pins the fix for the duplicate
+// on_children_completed wake race: idx_run_idempotency (unique on
+// idempotency_key with no time bound) can reject an insert even when
+// CheckIdempotencyKey's 24h-windowed lookup found no duplicate — for
+// example when two independent producers derive the same operation id and
+// race the insert, or (as reproduced deterministically here) when the
+// colliding row is older than the window. Before the fix insertRun wrapped
+// that unique-constraint violation in a generic "enqueue run" error, which
+// aborted the losing producer's step actions and logged a spurious ERROR
+// instead of being treated as an idempotent no-op.
+func TestQueueRun_DedupesOnIdempotencyIndexRace(t *testing.T) {
+	svc, _, repo := newTestServiceWithRepo(t)
+	ctx := context.Background()
+
+	const key = "task_children_completed:parent-1:0541818c598576d27d09bff86195037f87910dbf34f0420f6a99dc468aa1dfc7"
+
+	outcome, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_children_completed",
+		IdempotencyKey: key,
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue first run: %v", err)
+	}
+	if outcome != runsservice.QueueOutcomeQueued {
+		t.Fatalf("first outcome = %q, want %q", outcome, runsservice.QueueOutcomeQueued)
+	}
+
+	var firstRunID string
+	if err := repo.Reader().GetContext(ctx, &firstRunID,
+		`SELECT id FROM runs WHERE idempotency_key = ?`, key); err != nil {
+		t.Fatalf("look up first run id: %v", err)
+	}
+	// Push the first row outside CheckIdempotencyKey's 24h window so the
+	// racing insert reaches idx_run_idempotency instead of being caught
+	// by the earlier check — the exact gap a true concurrent race falls
+	// into (both producers pass the check before either commits).
+	if err := repo.SetRunRequestedAtForTest(ctx, firstRunID, time.Now().UTC().Add(-25*time.Hour)); err != nil {
+		t.Fatalf("age first run past the idempotency window: %v", err)
+	}
+
+	second, err := svc.QueueRun(ctx, runsservice.QueueRunRequest{
+		Reason:         "task_children_completed",
+		IdempotencyKey: key,
+		Payload:        agentInPayload("a1"),
+	})
+	if err != nil {
+		t.Fatalf("queue racing run: %v", err)
+	}
+	if second != runsservice.QueueOutcomeDeduped {
+		t.Fatalf("racing outcome = %q, want %q", second, runsservice.QueueOutcomeDeduped)
+	}
+
+	var count int
+	if err := repo.Reader().GetContext(ctx, &count,
+		`SELECT COUNT(*) FROM runs WHERE idempotency_key = ?`, key); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("runs with idempotency_key %q = %d, want 1", key, count)
+	}
+}
+
 // TestQueueRun_Coalescing pins that two requests for the same
 // (agent, reason) inside the 5s window collapse onto a single row
 // with coalesced_count = 2 instead of producing two queued rows.

--- a/apps/backend/internal/workflow/engine/adapters.go
+++ b/apps/backend/internal/workflow/engine/adapters.go
@@ -27,9 +27,8 @@ type QueueOutcome string
 const (
 	// QueueOutcomeQueued means a new runs row was inserted.
 	QueueOutcomeQueued QueueOutcome = "queued"
-	// QueueOutcomeDeduped means an existing row with the same
-	// IdempotencyKey already exists within the dedupe window, so nothing
-	// was inserted.
+	// QueueOutcomeDeduped means an existing row with the same IdempotencyKey
+	// already exists in the durable queue identity, so nothing was inserted.
 	QueueOutcomeDeduped QueueOutcome = "deduped"
 	// QueueOutcomeCoalesced means the request was merged into an existing
 	// queued row for the same agent + reason within the coalescing

--- a/docs/decisions/0004-task-model-unification.md
+++ b/docs/decisions/0004-task-model-unification.md
@@ -82,7 +82,7 @@ The first-transition-wins, idempotent-by-`OperationID`, `EvaluateOnly`-mode cont
 
 Two entry paths:
 
-- **Engine-emitted runs** — every `queue_run` action lands here. Coalescing (5s window for same agent + reason), per-agent serialisation (one claimed run per agent), idempotency (24h dedup window), cooldown (per-agent), and atomic task checkout (one agent per task at a time) all apply. The scheduler claims runs and dispatches via `runtime.Launch`.
+- **Engine-emitted runs** — every `queue_run` action lands here. Coalescing (5s window for same agent + reason), per-agent serialisation (one claimed run per agent), idempotency (a 24h lookup plus a durable unique key), cooldown (per-agent), and atomic task checkout (one agent per task at a time) all apply. The scheduler claims runs and dispatches via `runtime.Launch`.
 - **User-initiated launches** — a user clicking Start on a kanban task bypasses the queue and calls `runtime.Launch` directly. The queue's coalescing isn't appropriate when latency matters and the user explicitly chose timing.
 
 `run_events` (the audit log we already have) keeps its current shape. Per-run streaming via `office.run.event_appended.<run_id>` works unchanged. The WS event subjects (`office.run.queued`, `office.run.processed`, `office.run.event_appended.*`) keep the `office.` prefix for now to preserve frontend stability — they're string constants we can rename later if we want.

--- a/docs/specs/office/requirements/scheduler.md
+++ b/docs/specs/office/requirements/scheduler.md
@@ -37,7 +37,7 @@ queue](../../tasks/requirements/run-scheduling.md) and
 - **AC-OFFICE-SCHEDULER-001.4:** Office recovery is maintenance, not part of every five-second queue drain. When no workspace has adopted Office, it skips the task scan.
 - **AC-OFFICE-SCHEDULER-001.5:** The shared runs scheduler and cron loop stop and join before database cleanup during graceful shutdown.
 - **AC-OFFICE-SCHEDULER-001.6:** Has a `source` discriminator (see table below) plus a typed payload.
-- **AC-OFFICE-SCHEDULER-001.7:** Carries an `idempotency_key` for source-level dedup within a 24-hour window.
+- **AC-OFFICE-SCHEDULER-001.7:** Carries an `idempotency_key`. The queue uses a 24-hour lookup for recent duplicates and a durable unique key for persisted identities.
 - **AC-OFFICE-SCHEDULER-001.8:** Is coalesced into an in-flight run when one exists for the same agent (claim-time merge).
 
 ## System design

--- a/docs/specs/office/system-design/scheduler-01.md
+++ b/docs/specs/office/system-design/scheduler-01.md
@@ -47,7 +47,7 @@ Office supplies autonomous run producers and Office-specific maintenance. The pe
 A SQLite-persisted queue of "wake this agent up" requests. Every periodic, event-driven, and reactive trigger flows through this queue before becoming an agent run. Each request:
 
 - Has a `source` discriminator (see table below) plus a typed payload.
-- Carries an `idempotency_key` for source-level dedup within a 24-hour window.
+- Carries an `idempotency_key` for source-level dedup. The queue checks recent rows within 24 hours and the persisted key remains unique for its lifetime.
 - Is coalesced into an in-flight run when one exists for the same agent (claim-time merge).
 - Produces exactly one `runs` row on successful claim; the run is the execution record, the wakeup-request is the dispatch record.
 

--- a/docs/specs/office/system-design/scheduler-02.md
+++ b/docs/specs/office/system-design/scheduler-02.md
@@ -293,7 +293,7 @@ Survives a kandev process restart: all `agent_wakeup_requests` rows including `q
 
 Does NOT survive (reconstructed on next tick): in-memory claim leases - a `claimed` wakeup whose process died is picked up by the staleness/recovery path; the scheduler's claim query is the source of truth. The unstarted-task recovery sweep suppresses duplicates with its `NOT EXISTS` check on `runs`: any queued, claimed, or finished run of any age blocks redispatch, while failed and cancelled runs do not.
 
-Retention: idempotency-key dedup window 24 hours; summary cap 8 KB per row; routine run history retained for inspection (no automatic prune in scope here); catch-up cap (default 25) drops missed routine ticks beyond it (not recorded individually).
+Retention: the idempotency lookup window is 24 hours, while persisted idempotency keys remain unique; summary cap 8 KB per row; routine run history retained for inspection (no automatic prune in scope here); catch-up cap (default 25) drops missed routine ticks beyond it (not recorded individually).
 
 The scheduler reads all `queued` and unexpired-retry wakeup requests on boot and resumes processing them.
 

--- a/docs/specs/tasks/system-design/model-unification.md
+++ b/docs/specs/tasks/system-design/model-unification.md
@@ -184,7 +184,8 @@ A reviewer rejecting a Review:
 
 `office_runs` is renamed `runs`. Universal queue for engine-emitted
 launches. Every `queue_run` action creates a row. Coalescing (5s
-window for same agent + reason), idempotency (24h dedup window),
+window for same agent + reason), idempotency (a 24h lookup plus a durable
+unique key),
 per-agent serialisation (one claimed run per agent), cooldown
 (per-agent, default 10s), and atomic task checkout (one agent per
 task at a time) all apply — same machinery as today's office_runs.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3271/666a10ab2839.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** When several child tasks of an office-managed parent finish close together, the parent can receive two separate `on_children_completed` wake runs for the same completion wave instead of one.
**After this:** The two producers that can wake a parent for the same completion (the normal completion-triggered path, and the reconciler safety net from #3103) compute the same dedupe key, so the database's existing unique index actually catches and collapses the duplicate.
**Who hits this:** Any office-managed task whose children finish in a tight window, most likely a stalled/recovered parent the reconciler already sweeps.
**Scope:** Standalone fix.
**Not here:** A third wake producer, `cascadeChildrenCompleted` (the Kanban dashboard status-change path), still uses its own key format and can still race the reconciler — filed as follow-up task `7a3799d0-d589-4ee1-af45-f0a0b146e0ba` since the remedy is a contract change (either the cascade key or the reconciler's key format, or a shared claim table).

No UI changes in this diff — screenshots not applicable.

The normal completion-triggered path (`event_subscribers.go:queueChildrenCompletedRun`) and the reconciler (`scheduler_wake_reconciler.go:wakeOperationID`) derived different operation ids for the same parent and child set, so the `idx_run_idempotency` unique index never recognized the two runs as duplicates and both executed for one completion wave.

## Important Changes

- Edge-triggered wake now derives its operation id via the reconciler's `wakeOperationID(parentID, childSetKey)` instead of a parent-only key, so both producers land on the same id.
- New `IsIdempotencyKeyUniqueViolation` classifier (typed `pgconn.PgError` constraint check on Postgres, message-substring match on SQLite, mirroring the existing `isExternalIDUniqueViolation`) maps a unique-index collision on insert to `QueueOutcomeDeduped` instead of a hard error.
- Also fixes a related latent bug: the old edge-triggered key was constant per parent forever, and the engine's operation-applied ledger is permanent, so the edge path could only ever deliver `on_children_completed` once per parent, ever — a second delegation wave was silently dropped rather than deduped.

## Validation

- `go test -race -tags fts5 ./internal/office/... ./internal/runs/... ./internal/workflow/...` → all `ok`
- `KANDEV_TEST_POSTGRES_DSN=... go test ./internal/runs/service/... -run TestPostgresQueueRun_DedupesOnIdempotencyIndexRace -tags fts5 -v` → `PASS`, against a local ephemeral Postgres 15
- `golangci-lint run ./...` → `0 issues`
- `make typecheck`, `make lint`, `make lint-format`, `pnpm run i18n:ratchet` → all clean
- Test proven non-tautological: temporarily reverting the operation-id unification made `TestWakeOperationID_UnifiedAcrossEdgeAndReconcilerPaths` fail with the old mismatched keys; restored before commit
- Unrelated pre-existing failures (`internal/worktree`, `internal/task/service`, and others) reproduce identically against a scratch worktree at this branch's merge-base — confirmed environmental (shared-host temp-directory contention across ~50 concurrent task worktrees), not introduced by this diff

## Possible Improvements

Low risk: this only changes how a wake's operation id is derived and adds a dedupe classifier on insert; it changes no transaction, rollback, or scheduling behavior. The `cascadeChildrenCompleted` producer noted above is the main residual gap, tracked separately.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->