### PR TITLE
refactor(office): stop hand-syncing the dispatcher's active-state list with the SQL filter

### DIFF
--- a/apps/backend/internal/office/engine_dispatcher/dispatcher.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher.go
@@ -393,10 +393,8 @@ func (d *Dispatcher) resolveActiveSessionID(ctx context.Context, taskID string) 
 // unresolvable active session already gets, rather than rejecting the
 // decision outright.
 //
-// The active-state set mirrors GetActiveTaskSessionByTaskID's own query
-// (internal/task/repository/sqlite/session.go) — there is no shared
-// models-level predicate for that set, so this local copy must be kept in
-// sync with it.
+// The active-state set is taskmodels.IsTaskLookupActiveSessionState, the same
+// predicate GetActiveTaskSessionByTaskID's own query is cross-checked against.
 func (d *Dispatcher) resolveDeciderSessionID(ctx context.Context, taskID, sessionID string) (string, error) {
 	session, err := d.sessions.GetTaskSession(ctx, sessionID)
 	if err != nil {
@@ -410,7 +408,7 @@ func (d *Dispatcher) resolveDeciderSessionID(ctx context.Context, taskID, sessio
 		d.logSessionUnresolvable(taskID, sessionID, "foreign")
 		return "", nil
 	}
-	if !isActiveSessionState(session.State) {
+	if !taskmodels.IsTaskLookupActiveSessionState(session.State) {
 		d.logSessionUnresolvable(taskID, sessionID, "terminal")
 		return "", nil
 	}
@@ -422,18 +420,6 @@ func (d *Dispatcher) logSessionUnresolvable(taskID, sessionID, reason string) {
 		zap.String("task_id", taskID),
 		zap.String("supplied_session_id", sessionID),
 		zap.String("reason", reason))
-}
-
-func isActiveSessionState(state taskmodels.TaskSessionState) bool {
-	switch state {
-	case taskmodels.TaskSessionStateCreated,
-		taskmodels.TaskSessionStateStarting,
-		taskmodels.TaskSessionStateRunning,
-		taskmodels.TaskSessionStateWaitingForInput:
-		return true
-	default:
-		return false
-	}
 }
 
 // resolveLatestSessionID returns the F38 "any session" id (the task's

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
@@ -362,7 +362,7 @@ func TestDispatcher_RecordDecision_ForeignSessionFallsBackToUnresolvable(t *test
 	}
 }
 
-// TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable
+// TestDispatcher_RecordDecision_NonActiveSessionFallsBackToUnresolvable
 // covers the other session_unresolvable case: a supplied session that
 // belongs to the right task but is not in an active state. The table is
 // derived from taskmodels.AllTaskSessionStates filtered by

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
@@ -364,17 +364,18 @@ func TestDispatcher_RecordDecision_ForeignSessionFallsBackToUnresolvable(t *test
 
 // TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable
 // covers the other session_unresolvable case: a supplied session that
-// belongs to the right task but is in a terminal (non-active) state. Table
-// covers every terminal state; exhaustiveness against the full
-// TaskSessionState set is proved once, per-state, by
-// TestIsTaskLookupActiveSessionState.
+// belongs to the right task but is not in an active state. The table is
+// derived from taskmodels.AllTaskSessionStates filtered by
+// !IsTaskLookupActiveSessionState, so it cannot fall out of sync with the
+// active-state set the same way the removed hand-written switch could.
 func TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable(t *testing.T) {
-	terminalStates := []taskmodels.TaskSessionState{
-		taskmodels.TaskSessionStateCompleted,
-		taskmodels.TaskSessionStateFailed,
-		taskmodels.TaskSessionStateCancelled,
+	var nonActiveStates []taskmodels.TaskSessionState
+	for _, state := range taskmodels.AllTaskSessionStates {
+		if !taskmodels.IsTaskLookupActiveSessionState(state) {
+			nonActiveStates = append(nonActiveStates, state)
+		}
 	}
-	for _, state := range terminalStates {
+	for _, state := range nonActiveStates {
 		t.Run(string(state), func(t *testing.T) {
 			eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
 			sessions := &fakeSessions{
@@ -391,8 +392,11 @@ func TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable(t *tes
 			if err != nil {
 				t.Fatalf("RecordDecision: %v, want success (session_unresolvable, not an error)", err)
 			}
+			if !eng.decisionCalled {
+				t.Fatal("engine RecordParticipantDecision not invoked")
+			}
 			if eng.decisionSession != "" {
-				t.Errorf("session id = %q, want blank: terminal session must not be forwarded", eng.decisionSession)
+				t.Errorf("session id = %q, want blank: non-active session must not be forwarded", eng.decisionSession)
 			}
 		})
 	}

--- a/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
+++ b/apps/backend/internal/office/engine_dispatcher/dispatcher_decisions_test.go
@@ -364,25 +364,37 @@ func TestDispatcher_RecordDecision_ForeignSessionFallsBackToUnresolvable(t *test
 
 // TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable
 // covers the other session_unresolvable case: a supplied session that
-// belongs to the right task but is in a terminal (non-active) state.
+// belongs to the right task but is in a terminal (non-active) state. Table
+// covers every terminal state; exhaustiveness against the full
+// TaskSessionState set is proved once, per-state, by
+// TestIsTaskLookupActiveSessionState.
 func TestDispatcher_RecordDecision_TerminalSessionFallsBackToUnresolvable(t *testing.T) {
-	eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
-	sessions := &fakeSessions{
-		byID: map[string]*taskmodels.TaskSession{
-			"sess-done": {ID: "sess-done", TaskID: "task-1", State: taskmodels.TaskSessionStateCompleted},
-		},
+	terminalStates := []taskmodels.TaskSessionState{
+		taskmodels.TaskSessionStateCompleted,
+		taskmodels.TaskSessionStateFailed,
+		taskmodels.TaskSessionStateCancelled,
 	}
-	d := New(eng, sessions, logger.Default())
+	for _, state := range terminalStates {
+		t.Run(string(state), func(t *testing.T) {
+			eng := &fakeEngine{decisionResult: engine.RecordDecisionResult{DecisionID: "decision-1"}}
+			sessions := &fakeSessions{
+				byID: map[string]*taskmodels.TaskSession{
+					"sess-done": {ID: "sess-done", TaskID: "task-1", State: state},
+				},
+			}
+			d := New(eng, sessions, logger.Default())
 
-	_, err := d.RecordDecision(context.Background(), RecordDecisionInput{
-		TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
-		Decision: "approved", SessionID: "sess-done",
-	})
-	if err != nil {
-		t.Fatalf("RecordDecision: %v, want success (session_unresolvable, not an error)", err)
-	}
-	if eng.decisionSession != "" {
-		t.Errorf("session id = %q, want blank: terminal session must not be forwarded", eng.decisionSession)
+			_, err := d.RecordDecision(context.Background(), RecordDecisionInput{
+				TaskID: "task-1", StepID: "review", ParticipantID: "participant-1",
+				Decision: "approved", SessionID: "sess-done",
+			})
+			if err != nil {
+				t.Fatalf("RecordDecision: %v, want success (session_unresolvable, not an error)", err)
+			}
+			if eng.decisionSession != "" {
+				t.Errorf("session id = %q, want blank: terminal session must not be forwarded", eng.decisionSession)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3274/8928fff34ec0.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** whoever touches `resolveDeciderSessionID`'s active-session check has to remember to hand-edit two other copies of the same four-state set (the SQL `IN (...)` filter and the shared `taskmodels` predicate), or the copies silently drift apart.
**After this:** the dispatcher delegates to the one shared predicate (`taskmodels.IsTaskLookupActiveSessionState`), so there is only one place left to update, and an existing drift-guard test compares it against the SQL filter automatically.
**Who hits this:** anyone changing what counts as an "active" task session for decision routing — most recently the author of #3218, who added the local copy this PR removes.
**Scope:** standalone chore, closes a review thread from #3218. No sibling PRs.
**Not here:** the two other `isActiveSessionState`-shaped checks in `orchestrator/task_operations.go` (3 states, no `Created`, lazy-resume semantics) and `task/statussummary/projector_derive.go` (string-typed, not `TaskSessionState`) — genuinely different state sets. Unifying either would be a behavior change and is out of scope here.

Removes a hand-maintained copy of the active-session-state set from the office dispatcher and delegates to the shared `taskmodels` predicate, so the dispatcher, the SQL active-session filter, and a dedicated drift-guard test all read from the same source instead of three independently-maintained lists.

## Validation

- `go test ./internal/office/engine_dispatcher/... ./internal/task/models/... ./internal/task/repository/sqlite/... -run 'ActiveSessionState|Dispatcher' -v` → all pass (dispatcher tests, `TestIsTaskLookupActiveSessionState` 8/8 states, `TestActiveSessionStateMatchesSQLFilter` 8/8 states).
- `make lint` (backend) → `0 issues.` Re-run after rebase → `0 issues.`
- `gofmt -l` on the changed file → clean.
- `cd apps/web && pnpm run i18n:ratchet` → `✓ i18n new-code ratchet — no UI source added or modified` (no web files touched).
- `make lint-format` does not exist as a target in this repo (checked the root `Makefile`; only `lint`, `fmt`, `vet` exist for the Go backend) — skipped.
- E2E not required: the only changed file is one backend Go file, no schema/raw SQL/event-bus subscriber touched.
- `make typecheck test lint`: typecheck passed; `test` failed only inside the unrelated `internal/worktree` package (`unsafe worktree path: not a directory`, `Filename too long`). Proven pre-existing: reproduced identically against `origin/main` (`c51ec0a21`) in an isolated `/tmp` scratch worktree with zero diff applied — same test names, same errors.
- Rebased onto `origin/main` (`e6f98d996` → `c51ec0a21`); re-verified `go build`, the targeted test set, and a full `make lint` (backend + web + harness + spec + architecture) after the rebase — all clean.

## Possible Improvements

Low risk: behavior-preserving delegation to a set-identical predicate, verified against the SQL filter and an existing 8/8-state drift-guard test. No new test added — coverage already exists.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->