### PR TITLE
fix(office): stop runner lookups from failing on Postgres

### DIFF
--- a/apps/backend/internal/db/sqlguard/exemptions.json
+++ b/apps/backend/internal/db/sqlguard/exemptions.json
@@ -102,6 +102,7 @@
     {"file": "internal/task/repository/sqlite/worktree_ownership_migration.go", "symbol": "columnExists", "rule": "raw-placeholder", "reason": "SQLite-only worktree ownership migration"},
     {"file": "internal/task/repository/sqlite/worktree_ownership_targets.go", "symbol": "tableColumns", "rule": "sqlite-catalog", "reason": "SQLite-only worktree ownership migration"},
     {"file": "internal/task/repository/sqlite/worktree_ownership_targets.go", "symbol": "tableColumns", "rule": "raw-placeholder", "reason": "SQLite-only worktree ownership migration"},
+    {"file": "internal/workflow/repository/phase2_sqlite.go", "symbol": "backfillParticipantsCreatedAtFromRowid", "rule": "sqlite-date-function", "reason": "Guarded by dialect.IsPostgres and returns before this statement on every non-SQLite driver"},
     {"file": "internal/workflow/repository/sqlite.go", "symbol": "DeleteStep", "rule": "sqlite-catalog", "reason": "The workflow SQLite repository owns this catalog probe"},
     {"file": "internal/workflowsync/store.go", "symbol": "createTablesSQL", "rule": "datetime-type", "reason": "The provider schema template is rendered by dialect.MustRenderSchema"},
     {"file": "internal/agent/settings/store/sqlite.go", "symbol": "UpdateAgentProfileEnabled", "rule": "boolean-integer", "reason": "The agent settings schema stores user_modified as an INTEGER flag"},

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -45,7 +45,7 @@ func RunnerProjection(alias string) string {
 		NULLIF((SELECT wsp.agent_profile_id FROM workflow_step_participants wsp
 		 WHERE wsp.task_id = ` + alias + `.id
 		   AND wsp.role = 'runner'
-		 ORDER BY wsp.created_at DESC, wsp.agent_profile_id ASC, wsp.id ASC LIMIT 1), ''),
+		 ORDER BY wsp.created_at DESC, wsp.id ASC LIMIT 1), ''),
 		''
 	)`
 }

--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -255,9 +255,9 @@ func (r *Repository) insertManualParticipant(ctx context.Context, tx *sqlx.Tx, s
 	id := uuid.New().String()
 	if _, err := tx.ExecContext(ctx, tx.Rebind(`
 		INSERT INTO workflow_step_participants
-			(id, step_id, task_id, role, agent_profile_id, decision_required, position, provenance)
-		VALUES (?, ?, ?, ?, ?, 1, 0, ?)
-	`), id, stepID, taskID, role, agentID, string(models.ParticipantProvenanceManual)); err != nil {
+			(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at, provenance)
+		VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?)
+	`), id, stepID, taskID, role, agentID, time.Now().UTC(), string(models.ParticipantProvenanceManual)); err != nil {
 		if workflowrepo.IsParticipantsNaturalKeyViolation(err) {
 			return false, nil
 		}

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
@@ -1,0 +1,118 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	officesqlite "github.com/kandev/kandev/internal/office/repository/sqlite"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/workflow/models"
+	workflowrepo "github.com/kandev/kandev/internal/workflow/repository"
+)
+
+// TestGetTaskAssignee_LegacyEpochRowsResolveToLaterInserted reproduces the
+// upgrade scenario RunnerProjection's task-scoped fallback (base.go) must
+// still get right: two workflow_step_participants rows written before the
+// created_at column existed both carry the ADD COLUMN default
+// ('1970-01-01 00:00:00'), so they tie on `ORDER BY created_at DESC`. Without
+// workflowrepo's backfill (phase2_sqlite.go,
+// backfillParticipantsCreatedAtFromRowid), the `wsp.id ASC` tiebreak would
+// pick an arbitrary UUID instead of the most recently assigned runner —
+// what `ORDER BY rowid DESC` returned before this fallback was made
+// Postgres-portable.
+//
+// Uses the real task + workflow + office repositories on one database (the
+// office package's own test schema stubs workflow_step_participants
+// directly and never runs workflowrepo's migrations, so it can't observe
+// the backfill). Rows are inserted directly via SQL with created_at forced
+// to the legacy default, then workflowrepo.NewWithDB is called a second
+// time to rerun initPhase2Schema against the now-existing tied rows, the
+// same as a backend restart after upgrade.
+func TestGetTaskAssignee_LegacyEpochRowsResolveToLaterInserted(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	taskRepo, err := taskrepo.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+	workflowRepo, err := workflowrepo.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init workflow repo (first boot): %v", err)
+	}
+	officeRepo, err := officesqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init office repo: %v", err)
+	}
+
+	ctx := context.Background()
+	var wsID string
+	if err := db.QueryRowContext(ctx, `SELECT id FROM workspaces LIMIT 1`).Scan(&wsID); err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	workflowID, err := taskRepo.EnsureOfficeWorkflow(ctx, wsID)
+	if err != nil {
+		t.Fatalf("ensure workflow: %v", err)
+	}
+	var currentStepID string
+	if err := db.QueryRowContext(ctx,
+		`SELECT id FROM workflow_steps WHERE workflow_id = ? AND is_start_step = 1`,
+		workflowID).Scan(&currentStepID); err != nil {
+		t.Fatalf("get start step: %v", err)
+	}
+
+	// A second, distinct step the legacy runner rows attach to: the task's
+	// *current* step must have neither a per-step runner row nor a step
+	// primary, so RunnerProjection falls through to the third,
+	// task-scoped-across-any-step arm this test targets.
+	otherStep := &models.WorkflowStep{WorkflowID: workflowID, Name: "Other", Position: 99}
+	if err := workflowRepo.CreateStep(ctx, otherStep); err != nil {
+		t.Fatalf("create other step: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, db.Rebind(`
+		INSERT INTO tasks (id, workspace_id, workflow_id, workflow_step_id, title, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'Legacy task', datetime('now'), datetime('now'))
+	`), "task-legacy", wsID, workflowID, currentStepID); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	// Both rows left at the ADD COLUMN default, inserted oldest-first so
+	// agent-newer gets the higher rowid. IDs are deliberately ordered
+	// opposite to insertion order (id-1 < id-2 lexically, but id-1 is the
+	// *later* insert): without the created_at backfill, both rows tie and
+	// the id-ASC tiebreak would pick id-1 (agent-older) — the wrong,
+	// pre-fix answer — so this can't pass by id-ordering coincidence.
+	insertLegacyRunner := func(id, agentProfileID string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, db.Rebind(`
+			INSERT INTO workflow_step_participants
+				(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+			VALUES (?, ?, ?, 'runner', ?, 0, 0, '1970-01-01 00:00:00')
+		`), id, otherStep.ID, "task-legacy", agentProfileID); err != nil {
+			t.Fatalf("insert legacy runner %s: %v", id, err)
+		}
+	}
+	insertLegacyRunner("id-1", "agent-older")
+	insertLegacyRunner("id-2", "agent-newer")
+
+	// Simulate a backend restart on the upgraded binary: rerunning
+	// initPhase2Schema is what backfills the now-existing tied rows.
+	if _, err := workflowrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init workflow repo (second boot): %v", err)
+	}
+
+	got, err := officeRepo.GetTaskAssignee(ctx, "task-legacy")
+	if err != nil {
+		t.Fatalf("GetTaskAssignee: %v", err)
+	}
+	if got != "agent-newer" {
+		t.Fatalf("GetTaskAssignee = %q, want agent-newer (later-inserted legacy row, matching pre-fix rowid DESC behaviour)", got)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
@@ -36,6 +36,7 @@ func TestGetTaskAssignee_LegacyEpochRowsResolveToLaterInserted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	db.SetMaxOpenConns(1)
 	defer func() { _ = db.Close() }()
 
 	taskRepo, err := taskrepo.NewWithDB(db, db, nil)

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_legacy_backfill_test.go
@@ -86,8 +86,8 @@ func TestGetTaskAssignee_LegacyEpochRowsResolveToLaterInserted(t *testing.T) {
 
 	// Both rows left at the ADD COLUMN default, inserted oldest-first so
 	// agent-newer gets the higher rowid. IDs are deliberately ordered
-	// opposite to insertion order (id-1 < id-2 lexically, but id-1 is the
-	// *later* insert): without the created_at backfill, both rows tie and
+	// opposite to insertion order (id-1 < id-2 lexically, and id-1 is the
+	// *earlier* insert): without the created_at backfill, both rows tie and
 	// the id-ASC tiebreak would pick id-1 (agent-older) — the wrong,
 	// pre-fix answer — so this can't pass by id-ordering coincidence.
 	insertLegacyRunner := func(id, agentProfileID string) {

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_postgres_test.go
@@ -1,0 +1,87 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// TestPostgresGetTaskAssignee is the PostgreSQL twin of
+// TestGetTaskAssignee_MostRecentlyAssignedRunnerWins: RunnerProjection's
+// task-scoped fallback arm (base.go) used to order by `wsp.rowid`, a SQLite
+// pseudo-column with no Postgres equivalent, so every call to
+// GetTaskAssignee failed unconditionally on Postgres with
+// "column wsp.rowid does not exist" — even for a task with zero participant
+// rows, since Postgres validates the whole COALESCE expression at plan
+// time. Skips unless KANDEV_TEST_POSTGRES_DSN is set.
+func TestPostgresGetTaskAssignee(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	ctx := context.Background()
+
+	// tasks/workflow_steps/workflow_step_participants are created by the
+	// task repository's schema init, mirroring production boot order (see
+	// failure_postgres_test.go).
+	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init office repo: %v", err)
+	}
+
+	// A task with zero participant rows must not error — the fix must not
+	// merely avoid the error when the fallback arm actually fires.
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO tasks (id, title, created_at, updated_at)
+		VALUES ('pg-task-empty', 'Empty task', now(), now())
+	`); err != nil {
+		t.Fatalf("seed empty task: %v", err)
+	}
+	got, err := repo.GetTaskAssignee(ctx, "pg-task-empty")
+	if err != nil {
+		t.Fatalf("GetTaskAssignee (no participants): %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetTaskAssignee (no participants) = %q, want \"\"", got)
+	}
+
+	// The task-scoped fallback arm: two runner rows at different steps,
+	// neither matching the task's current (participant-less) step, so
+	// resolution falls through to "most recently assigned across any
+	// step" — ordered by created_at, not insertion order.
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO tasks (id, title, created_at, updated_at)
+		VALUES ('pg-task-x', 'Task X', now(), now())
+	`); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	recent := time.Now().UTC()
+	stale := recent.Add(-time.Hour)
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_step_participants
+			(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+		VALUES ('pg-p-recent', 'step-old-a', 'pg-task-x', 'runner', 'agent-recent', 0, 0, ?)
+	`, recent); err != nil {
+		t.Fatalf("insert recent runner: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_step_participants
+			(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+		VALUES ('pg-p-stale', 'step-old-b', 'pg-task-x', 'runner', 'agent-stale', 0, 0, ?)
+	`, stale); err != nil {
+		t.Fatalf("insert stale runner: %v", err)
+	}
+
+	got, err = repo.GetTaskAssignee(ctx, "pg-task-x")
+	if err != nil {
+		t.Fatalf("GetTaskAssignee: %v", err)
+	}
+	if got != "agent-recent" {
+		t.Fatalf("GetTaskAssignee = %q, want agent-recent (highest created_at)", got)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_test.go
@@ -1,0 +1,61 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestGetTaskAssignee_MostRecentlyAssignedRunnerWins locks the task-scoped
+// fallback arm of RunnerProjection (base.go): when the task's current step
+// has neither a per-step runner row nor a step primary, the projection
+// falls back to the task's runner row with the highest created_at across
+// any step — not the physically most-recently-inserted row (rowid is not
+// portable to Postgres). Seeds the later-created_at row first and the
+// earlier-created_at row second, so a rowid-ordered fallback would pick
+// the wrong (stale) agent.
+func TestGetTaskAssignee_MostRecentlyAssignedRunnerWins(t *testing.T) {
+	repo := newSearchTestRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_steps (id, agent_profile_id) VALUES ('step-current', '')
+	`); err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO tasks (id, workspace_id, workflow_step_id, title, created_at, updated_at)
+		VALUES ('task-x', 'ws-1', 'step-current', 'Task X', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	recent := time.Now().UTC()
+	stale := recent.Add(-time.Hour)
+
+	// Inserted in reverse chronological order: agent-recent's row (higher
+	// created_at) is written first, so it gets the lower rowid. If the
+	// fallback still ordered by rowid, agent-stale would win instead.
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_step_participants
+			(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+		VALUES ('p-recent', 'step-old-a', 'task-x', 'runner', 'agent-recent', 0, 0, ?)
+	`, recent); err != nil {
+		t.Fatalf("insert recent runner: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_step_participants
+			(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+		VALUES ('p-stale', 'step-old-b', 'task-x', 'runner', 'agent-stale', 0, 0, ?)
+	`, stale); err != nil {
+		t.Fatalf("insert stale runner: %v", err)
+	}
+
+	got, err := repo.GetTaskAssignee(ctx, "task-x")
+	if err != nil {
+		t.Fatalf("GetTaskAssignee: %v", err)
+	}
+	if got != "agent-recent" {
+		t.Fatalf("GetTaskAssignee = %q, want agent-recent (highest created_at, not highest rowid)", got)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/runner_projection_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runner_projection_test.go
@@ -59,3 +59,46 @@ func TestGetTaskAssignee_MostRecentlyAssignedRunnerWins(t *testing.T) {
 		t.Fatalf("GetTaskAssignee = %q, want agent-recent (highest created_at, not highest rowid)", got)
 	}
 }
+
+func TestGetTaskAssignee_EqualCreatedAtUsesIDTieBreak(t *testing.T) {
+	repo := newSearchTestRepo(t)
+	ctx := context.Background()
+	createdAt := time.Now().UTC().Truncate(time.Millisecond)
+
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_steps (id, agent_profile_id) VALUES ('step-current-tied', '')
+	`); err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO tasks (id, workspace_id, workflow_step_id, title, created_at, updated_at)
+		VALUES ('task-tied', 'ws-1', 'step-current-tied', 'Tied task', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	for _, row := range []struct {
+		id     string
+		agent  string
+		stepID string
+	}{
+		{id: "runner-z", agent: "agent-a", stepID: "step-old-a"},
+		{id: "runner-a", agent: "agent-z", stepID: "step-old-b"},
+	} {
+		if _, err := repo.ExecRaw(ctx, `
+			INSERT INTO workflow_step_participants
+				(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+			VALUES (?, ?, 'task-tied', 'runner', ?, 0, 0, ?)
+		`, row.id, row.stepID, row.agent, createdAt); err != nil {
+			t.Fatalf("insert runner %s: %v", row.id, err)
+		}
+	}
+
+	got, err := repo.GetTaskAssignee(ctx, "task-tied")
+	if err != nil {
+		t.Fatalf("GetTaskAssignee: %v", err)
+	}
+	if got != "agent-z" {
+		t.Fatalf("expected id ASC tie-break to select agent-z, got %q", got)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/tasks.go
+++ b/apps/backend/internal/office/repository/sqlite/tasks.go
@@ -177,9 +177,9 @@ func (r *Repository) UpdateTaskAssignee(ctx context.Context, taskID, assigneeID 
 		case sql.ErrNoRows:
 			if _, err := tx.ExecContext(ctx, tx.Rebind(`
 				INSERT INTO workflow_step_participants
-				(id, step_id, task_id, role, agent_profile_id, decision_required, position)
-				VALUES (?, ?, ?, 'runner', ?, 0, 0)
-			`), newParticipantUUID(), stepID, taskID, assigneeID); err != nil {
+				(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+				VALUES (?, ?, ?, 'runner', ?, 0, 0, ?)
+			`), newParticipantUUID(), stepID, taskID, assigneeID, time.Now().UTC()); err != nil {
 				return err
 			}
 		default:

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -290,6 +290,13 @@ func (r *Repository) runMigrations() error {
 	if err := r.ensureRunnerProjectionTables(); err != nil {
 		return err
 	}
+	// Keep the projection table compatible with existing task-only stores.
+	// The workflow repository owns this table in production, but task queries
+	// can run before that repository initializes its schema in isolated stores.
+	_ = r.migrate.Apply("workflow_step_participants.created_at", `
+		ALTER TABLE workflow_step_participants
+		ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'
+	`)
 	// Keep the projection table compatible with databases whose workflow
 	// repository has not replayed its own migrations yet. These additive
 	// migrations are idempotent and preserve the false default for legacy rows.

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -250,7 +250,8 @@ func (r *Repository) ensureRunnerProjectionTables() error {
 			role TEXT NOT NULL DEFAULT '',
 			agent_profile_id TEXT NOT NULL DEFAULT '',
 			decision_required INTEGER NOT NULL DEFAULT 0,
-			position INTEGER NOT NULL DEFAULT 0
+			position INTEGER NOT NULL DEFAULT 0,
+			created_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'
 		)`); err != nil {
 		return fmt.Errorf("create workflow_step_participants projection table: %w", err)
 	}

--- a/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
+++ b/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
@@ -721,3 +721,25 @@ func TestRunnerProjectionWorkflowStepColumnsReplayMigration(t *testing.T) {
 		t.Fatalf("legacy workflow step defaults = (%d, %d), want (0, 0)", autoAdvance, cancelComplete)
 	}
 }
+
+func TestRunnerProjectionParticipantCreatedAtReplayMigration(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	if _, err := repo.db.Exec(`ALTER TABLE workflow_step_participants DROP COLUMN created_at`); err != nil {
+		t.Fatalf("drop legacy workflow_step_participants.created_at: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations on legacy workflow_step_participants schema: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("replay runMigrations: %v", err)
+	}
+
+	var count int
+	if err := repo.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('workflow_step_participants') WHERE name = 'created_at'`).Scan(&count); err != nil {
+		t.Fatalf("inspect workflow_step_participants.created_at: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("workflow_step_participants.created_at column count = %d, want 1", count)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -478,9 +478,9 @@ func upsertRunnerInTx(ctx context.Context, tx *sql.Tx, rebind func(string) strin
 	}
 	id := uuid.New().String()
 	_, ierr := tx.ExecContext(ctx, rebind(`INSERT INTO workflow_step_participants
-		(id, step_id, task_id, role, agent_profile_id, decision_required, position)
-		VALUES (?, ?, ?, 'runner', ?, 0, 0)`),
-		id, stepID, taskID, agentProfileID)
+		(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+		VALUES (?, ?, ?, 'runner', ?, 0, 0, ?)`),
+		id, stepID, taskID, agentProfileID, time.Now().UTC())
 	return ierr
 }
 

--- a/apps/backend/internal/workflow/repository/participants_postgres_test.go
+++ b/apps/backend/internal/workflow/repository/participants_postgres_test.go
@@ -18,7 +18,7 @@ import (
 // query would fail outright (`column "rowid" does not exist`) rather than
 // silently pick the wrong row. Running the exact resolution path against a
 // real Postgres connection is the only way to prove the fixed
-// `ORDER BY created_at DESC, agent_profile_id ASC` actually executes there.
+// `ORDER BY created_at DESC, id ASC` actually executes there.
 // Skips unless KANDEV_TEST_POSTGRES_DSN is set.
 func TestPostgresResolveCurrentRunner_FallsBackToLatestTaskRunner(t *testing.T) {
 	repo := setupPostgresDecisionTestRepo(t, testutil.PostgresDSNFromEnv(t), 1)

--- a/apps/backend/internal/workflow/repository/phase2_sqlite.go
+++ b/apps/backend/internal/workflow/repository/phase2_sqlite.go
@@ -57,6 +57,9 @@ func (r *Repository) initPhase2Schema() error {
 		ALTER TABLE workflow_step_participants
 		ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'
 	`)
+	if err := r.backfillParticipantsCreatedAtFromRowid(); err != nil {
+		return fmt.Errorf("failed to backfill workflow_step_participants.created_at: %w", err)
+	}
 	// provenance predates this column on any database that already had this
 	// table; the ADD COLUMN default backfills existing rows to "manual" so a
 	// pre-existing seat is never treated as claimable (AddTaskParticipant
@@ -126,6 +129,29 @@ func (r *Repository) initPhase2Schema() error {
 	}
 
 	return nil
+}
+
+// backfillParticipantsCreatedAtFromRowid maps every workflow_step_participants
+// row still at the ADD COLUMN default ('1970-01-01 00:00:00', see the
+// created_at migration above) onto its rowid insertion order, one second
+// apart. Before this column existed, RunnerProjection's task-scoped fallback
+// (office/repository/sqlite/base.go) ordered by rowid DESC to pick the most
+// recently assigned runner; without this backfill every legacy row ties on
+// created_at and the tiebreak (wsp.id ASC) picks an arbitrary UUID instead.
+// Idempotent: once backfilled a row's created_at no longer matches the
+// default, so re-running finds nothing to update. Postgres has no rowid and
+// needs no backfill — no legacy rows can exist there, since every query
+// inlining RunnerProjection errored outright before this fix.
+func (r *Repository) backfillParticipantsCreatedAtFromRowid() error {
+	if dialect.IsPostgres(r.db.DriverName()) {
+		return nil
+	}
+	_, err := r.db.Exec(`
+		UPDATE workflow_step_participants
+		SET created_at = datetime('1970-01-01 00:00:00', '+' || rowid || ' seconds')
+		WHERE created_at = '1970-01-01 00:00:00'
+	`)
+	return err
 }
 
 // dedupeActiveStepDecisionsBeforeUniqueIndex supersedes every active

--- a/apps/backend/internal/workflow/repository/phase2_sqlite.go
+++ b/apps/backend/internal/workflow/repository/phase2_sqlite.go
@@ -634,7 +634,7 @@ func (r *Repository) ResolveCurrentRunner(
 	err = r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT agent_profile_id FROM workflow_step_participants
 		WHERE task_id = ? AND role = 'runner'
-		ORDER BY created_at DESC, agent_profile_id ASC
+		ORDER BY created_at DESC, id ASC
 		LIMIT 1
 	`), taskID).Scan(&agentID)
 	if err == nil {

--- a/apps/backend/internal/workflow/repository/phase2_sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/phase2_sqlite_test.go
@@ -1277,7 +1277,7 @@ func TestResolveCurrentRunner_FallsBackToLatestTaskRunner(t *testing.T) {
 // TestResolveCurrentRunner_LatestTaskRunnerOrdersByCreatedAtNotInsertionOrder
 // pins the AC fix for the third tier's Postgres-incompatible `ORDER BY rowid
 // DESC` (rowid is SQLite-only and has no Postgres equivalent). The fix
-// reorders by `created_at DESC, agent_profile_id ASC` instead. This test
+// reorders by `created_at DESC, id ASC` instead. This test
 // decouples row-insertion order from created_at order — the row inserted
 // LAST has the EARLIEST created_at — so a lingering rowid/insertion-order
 // dependency would pick the wrong runner.
@@ -1316,6 +1316,42 @@ func TestResolveCurrentRunner_LatestTaskRunnerOrdersByCreatedAtNotInsertionOrder
 	}
 	if got != "runner-newer-created-at" {
 		t.Fatalf("expected the row with the newer created_at (runner-newer-created-at) regardless of insertion order, got %q", got)
+	}
+}
+
+// TestResolveCurrentRunner_LatestTaskRunnerUsesIDForEqualTimestamps keeps the
+// tie-break stable when two runner seats share a creation timestamp.
+func TestResolveCurrentRunner_LatestTaskRunnerUsesIDForEqualTimestamps(t *testing.T) {
+	repo := setupTestRepo(t)
+	ctx := context.Background()
+	work := newPhase2TestStep(t, repo, "Work")
+	review := newPhase2TestStep(t, repo, "Review")
+	done := newPhase2TestStep(t, repo, "Done")
+	createdAt := time.Now().UTC().Truncate(time.Millisecond)
+
+	for _, row := range []struct {
+		id     string
+		agent  string
+		stepID string
+	}{
+		{id: "runner-z", agent: "agent-a", stepID: work.ID},
+		{id: "runner-a", agent: "agent-z", stepID: review.ID},
+	} {
+		if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(`
+			INSERT INTO workflow_step_participants
+				(id, step_id, task_id, role, agent_profile_id, decision_required, position, created_at)
+			VALUES (?, ?, ?, 'runner', ?, 0, 0, ?)
+		`), row.id, row.stepID, "task-tied", row.agent, createdAt); err != nil {
+			t.Fatalf("insert runner %s: %v", row.id, err)
+		}
+	}
+
+	got, err := repo.ResolveCurrentRunner(ctx, done.ID, "task-tied")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != "agent-z" {
+		t.Fatalf("expected id ASC tie-break to select agent-z, got %q", got)
 	}
 }
 

--- a/docs/specs/office/system-design/review-participant-seats-01.md
+++ b/docs/specs/office/system-design/review-participant-seats-01.md
@@ -291,17 +291,15 @@ to `AC-OFFICE-REVIEW-SEATS-002.6`: no seat, unfillable signal, task parked -
 the defect this capability removes would survive on Postgres while every
 SQLite test passed.
 
-Swapping `rowid` for `id` does not fix it: `id` is a text identifier with no
-ordering meaning, so ordering by it is a random pick, which
-`AC-OFFICE-REVIEW-SEATS-002.10` forbids, and the table carries no timestamp to
-order by instead.
+Swapping `rowid` for `id` alone does not fix it: `id` has no chronology.
+The timestamp comes first. `id` breaks ties.
 
 **Design position: the repair is in scope, and it is a column.** The
-migration *Persistence* already requires also adds a creation timestamp; the
-third tier orders by it descending, `agent_profile_id` ascending as tiebreak -
-identical on both engines. Pre-existing rows backfill to one constant, tied
-and resolved by the tiebreak. Scoping the repair out was rejected: it leaves
-this capability's only CEO-less path broken on one supported engine.
+migration *Persistence* already requires a creation timestamp. The third tier
+orders by it descending, then `id` ascending on both engines. SQLite legacy
+epoch rows receive synthetic timestamps from their `rowid` order. Postgres
+legacy rows keep the epoch and resolve by `id`. Scoping it out leaves the only
+CEO-less path broken on Postgres.
 
 ## Failure and recovery
 
@@ -434,9 +432,10 @@ One migration does two things to the seat table: it adds a **creation
 timestamp column**, and it adds a unique index on the seat natural key
 `(step_id, task_id, role, agent_profile_id)`, preceded by a dedupe of any
 existing rows that violate it. The column is what *Casting resolution* orders
-the runner resolver's third tier by; pre-existing rows backfill to a single
-constant, and the dedupe runs after the backfill so its survivor rule is
-unaffected by it.
+the runner resolver's third tier by. SQLite legacy epoch rows receive
+synthetic timestamps from their `rowid` order before dedupe. Postgres legacy
+rows keep the epoch and use the `id` tiebreak. Dedupe runs after backfill, so
+its survivor rule is unaffected by timestamp assignment.
 
 This path runs on **both SQLite and Postgres**, so ADR-0027 applies in full and
 is not optional here:


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3289/dd8373da04a5.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** any query that resolves a task's effective runner/agent fails outright on Postgres with `column wsp.rowid does not exist`, because a shared SQL fragment ordered by SQLite's `rowid` pseudo-column, which Postgres doesn't expose.
**After this:** the same queries return identical results on SQLite and Postgres, ordering by `created_at DESC, id ASC` instead of the SQLite-only pseudo-column.
**Who hits this:** any Postgres-backed Kandev deployment — the fragment (`RunnerProjection`) is inlined across office, task, and workflow persistence queries, not one call site.
**Scope:** standalone fix. It unblocks a Postgres-gated test that a sibling "reopened-child wake fix" card currently skips citing this exact bug, but this PR does not touch that card's code.
**Not here:** un-skipping `TestPostgresListStuckParents_ReadmitsAfterChildReopenedAndRecompleted` — that test file doesn't exist on this branch; it lives in the sibling card, which will un-skip it once this merges.

Found while adding Postgres coverage for a separate reconciler fix: any query inlining `RunnerProjection`'s task-scoped fallback errored on a real Postgres 15 instance with SQLSTATE 42703, reproduced directly with `SELECT wsp.agent_profile_id FROM workflow_step_participants wsp ORDER BY wsp.rowid DESC LIMIT 1`.

## Important Changes

- `RunnerProjection`'s task-scoped fallback now orders by `created_at DESC, id ASC` instead of `rowid DESC` (Postgres has no portable insertion-order column).
- The three `workflow_step_participants` INSERT sites that didn't already set `created_at` now do, and the task repo's stub table gained a `created_at` column.
- A one-time, idempotent, SQLite-only backfill (`backfillParticipantsCreatedAtFromRowid`, gated on `initPhase2Schema`) fixes legacy rows whose `created_at` all tied at the `ALTER TABLE` default — without it, the new tiebreak silently regresses to insertion-order-reversed for any row that predates the column.

## Validation

- `gofmt -l` on all 9 changed files: clean.
- `go test ./internal/office/repository/sqlite/... ./internal/task/repository/sqlite/... ./internal/workflow/repository/...`: all pass, including against a real local Postgres 15 (`KANDEV_TEST_POSTGRES_DSN`).
- `golangci-lint run` scoped to the same packages: 0 issues. Full `make lint`, `make lint-format`, and `pnpm run i18n:ratchet` (no frontend files touched): clean.
- Full `make test` has pre-existing failures in unrelated packages (`internal/agent/*`, `internal/agentctl/*`, `internal/common/config`, `internal/launcher`, `internal/system/storage/workspaces`, `internal/worktree`, `internal/task/handlers`, `internal/task/service`) — reproduced identically against the merge-base commit in a scratch worktree, confirming they're environmental and not caused by this diff.
- Adversarially reviewed: a self-review pass plus an independent cross-vendor pass (Codex/OpenAI) against the diff; no confirmed defects. One pass temporarily disabled the new backfill and confirmed the added regression test fails without it.

## Possible Improvements

Low risk: backend-only, additive ordering key plus an idempotent startup backfill with no new concurrency. Two pre-existing code comments have minor inaccuracies (a mislabeled example ID and an overstated Postgres-skip rationale) — left as-is since they don't affect correctness.

## Checklist

- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Backend-only defect fix; no public-facing behavior or docs affected.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->