### PR TITLE
fix(office): stop the reject leg from waking the reviewer, not the assignee

### DIFF
--- a/apps/backend/internal/office/dashboard/agent_decisions_test.go
+++ b/apps/backend/internal/office/dashboard/agent_decisions_test.go
@@ -3,6 +3,7 @@ package dashboard_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/office/dashboard"
@@ -138,6 +139,9 @@ func TestRecordAgentDecision_RejectedQueuesAssigneeRunWithReason(t *testing.T) {
 	}
 	if got.DecisionComment != "tests fail on the happy path" {
 		t.Errorf("comment lost: %q", got.DecisionComment)
+	}
+	if got.IdempotencyKey == "" || !strings.HasPrefix(got.IdempotencyKey, "decision:") {
+		t.Errorf("idempotency key = %q, want a decision-scoped key", got.IdempotencyKey)
 	}
 }
 

--- a/apps/backend/internal/office/dashboard/agent_decisions_test.go
+++ b/apps/backend/internal/office/dashboard/agent_decisions_test.go
@@ -106,6 +106,41 @@ func TestRecordAgentDecision_SessionIDForwardedWhenFlagOn(t *testing.T) {
 	}
 }
 
+// TestRecordAgentDecision_RejectedQueuesAssigneeRunWithReason is the
+// agent-path counterpart to TestRequestTaskChanges_QueuesAssigneeRun (plan
+// unit 7): an agent's "rejected" verdict must queue exactly one run for the
+// task's assignee, carrying the reason as DecisionComment, the same way
+// changes_requested already does for the human path — the quorum engine
+// treats the two verdicts as synonyms (isRejectionVerdict).
+func TestRecordAgentDecision_RejectedQueuesAssigneeRunWithReason(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTaskWithAssignee(t, deps.db, "rej1", "ws-d", "REJ1", "in_review", 2, "asg-rej")
+	mustAddParticipant(t, deps, "rej1", "agent-rev", models.ParticipantRoleReviewer)
+
+	q := &stubApprovalQueuer{}
+	deps.svc.SetApprovalReactivityQueuer(q)
+
+	_, err := deps.svc.RecordAgentDecision(context.Background(), dashboard.RecordAgentDecisionInput{
+		TaskID:         "rej1",
+		AgentProfileID: "agent-rev",
+		Decision:       engine.DecisionRejected,
+		Reason:         "tests fail on the happy path",
+	})
+	if err != nil {
+		t.Fatalf("RecordAgentDecision: %v", err)
+	}
+	if len(q.runs) != 1 {
+		t.Fatalf("runs = %d, want 1: %#v", len(q.runs), q.runs)
+	}
+	got := q.runs[0]
+	if got.AgentID != "asg-rej" {
+		t.Errorf("run targeted %q, want assignee asg-rej", got.AgentID)
+	}
+	if got.DecisionComment != "tests fail on the happy path" {
+		t.Errorf("comment lost: %q", got.DecisionComment)
+	}
+}
+
 // insertTestTaskNoStep inserts a task row with no workflow_step_id bound
 // (the schema default is ” — see tasks.workflow_step_id NOT NULL DEFAULT
 // ”), exercising the AC-7/AC-55(1) precondition RecordAgentDecision must

--- a/apps/backend/internal/office/dashboard/decisions.go
+++ b/apps/backend/internal/office/dashboard/decisions.go
@@ -465,6 +465,7 @@ func (s *DashboardService) buildDecisionRuns(
 			ActorID:         d.DeciderID,
 			ActorType:       d.DeciderType,
 			DecisionComment: d.Comment,
+			IdempotencyKey:  decisionRunIdempotencyKey(d),
 		}}
 	case models.DecisionApproved:
 		if !s.allApproversApproved(ctx, d.TaskID) {
@@ -474,15 +475,26 @@ func (s *DashboardService) buildDecisionRuns(
 			return nil
 		}
 		return []ApprovalRun{{
-			AgentID:     exec.AssigneeAgentProfileID,
-			Reason:      runTaskReadyToClose,
-			TaskID:      d.TaskID,
-			WorkspaceID: exec.WorkspaceID,
-			ActorID:     d.DeciderID,
-			ActorType:   d.DeciderType,
+			AgentID:        exec.AssigneeAgentProfileID,
+			Reason:         runTaskReadyToClose,
+			TaskID:         d.TaskID,
+			WorkspaceID:    exec.WorkspaceID,
+			ActorID:        d.DeciderID,
+			ActorType:      d.DeciderType,
+			IdempotencyKey: decisionRunIdempotencyKey(d),
 		}}
 	}
 	return nil
+}
+
+// decisionRunIdempotencyKey scopes an approval-flow wake to the durable
+// decision that produced it. A task may enter review more than once, so the
+// scheduler's default (reason, task, agent) key would suppress later rounds.
+func decisionRunIdempotencyKey(d *DecisionRecord) string {
+	if d == nil || d.ID == "" {
+		return ""
+	}
+	return "decision:" + d.ID
 }
 
 // isReviewState returns true when a stored task state represents the

--- a/apps/backend/internal/office/dashboard/decisions.go
+++ b/apps/backend/internal/office/dashboard/decisions.go
@@ -422,10 +422,10 @@ func (s *DashboardService) logDecisionActivity(ctx context.Context, d *DecisionR
 }
 
 // runReactivityForDecision queues the appropriate run after a
-// decision lands. For changes_requested, the assignee is woken with
-// the comment passed through. For approved, when all approvers now
-// have current approved decisions AND the task is in_review, the
-// assignee is woken with task_ready_to_close.
+// decision lands. For changes_requested and rejected (synonyms), the
+// assignee is woken with the comment passed through. For approved,
+// when all approvers now have current approved decisions AND the task
+// is in_review, the assignee is woken with task_ready_to_close.
 //
 // Best-effort — failures are logged, never propagated.
 func (s *DashboardService) runReactivityForDecision(ctx context.Context, d *DecisionRecord) {
@@ -456,7 +456,7 @@ func (s *DashboardService) buildDecisionRuns(
 	ctx context.Context, d *DecisionRecord, exec *sqlite.TaskExecutionFields,
 ) []ApprovalRun {
 	switch d.Decision {
-	case models.DecisionChangesRequested:
+	case models.DecisionChangesRequested, models.DecisionRejected:
 		return []ApprovalRun{{
 			AgentID:         exec.AssigneeAgentProfileID,
 			Reason:          runTaskChangesRequested,

--- a/apps/backend/internal/office/dashboard/decisions_test.go
+++ b/apps/backend/internal/office/dashboard/decisions_test.go
@@ -165,6 +165,9 @@ func TestRequestTaskChanges_QueuesAssigneeRun(t *testing.T) {
 	if got.DecisionComment != "tighten the diff" {
 		t.Errorf("comment lost: %q", got.DecisionComment)
 	}
+	if got.IdempotencyKey == "" || !strings.HasPrefix(got.IdempotencyKey, "decision:") {
+		t.Errorf("idempotency key = %q, want a decision-scoped key", got.IdempotencyKey)
+	}
 }
 
 // TestApproveTask_QueuesReadyToCloseOnFinalApproval — when the last

--- a/apps/backend/internal/office/dashboard/service.go
+++ b/apps/backend/internal/office/dashboard/service.go
@@ -281,7 +281,11 @@ type ApprovalRun struct {
 	ActorID         string
 	ActorType       string
 	Role            string // reviewer|approver, when relevant
-	DecisionComment string // for changes_requested
+	DecisionComment string // for changes_requested/rejected
+	// IdempotencyKey identifies the decision event that caused this wake.
+	// Decision reactivity can recur for the same task, so the scheduler
+	// must not fall back to its once-per-task reason key.
+	IdempotencyKey string
 }
 
 // ApprovalReactivityQueuer queues approval-flow runs (review

--- a/apps/backend/internal/office/models/models.go
+++ b/apps/backend/internal/office/models/models.go
@@ -675,6 +675,11 @@ const (
 const (
 	DecisionApproved         = "approved"
 	DecisionChangesRequested = "changes_requested"
+	// DecisionRejected is the agent-path verdict literal
+	// (engine.DecisionRejected) for the same semantic as
+	// DecisionChangesRequested — the quorum engine already treats them as
+	// synonyms (isRejectionVerdict in internal/workflow/engine/quorum.go).
+	DecisionRejected = "rejected"
 
 	DeciderTypeUser  = "user"
 	DeciderTypeAgent = "agent"

--- a/apps/backend/internal/office/scheduler/approval_adapter.go
+++ b/apps/backend/internal/office/scheduler/approval_adapter.go
@@ -43,6 +43,7 @@ func (a *DashboardApprovalAdapter) QueueApprovalRuns(
 			ActorType:       w.ActorType,
 			Role:            w.Role,
 			DecisionComment: w.DecisionComment,
+			IdempotencyKey:  w.IdempotencyKey,
 		}
 		if err := a.scheduler.QueueRunCtx(ctx, w.AgentID, c); err != nil {
 			a.scheduler.logger.Warn("approval run failed: " + err.Error())

--- a/apps/backend/internal/office/scheduler/dashboard_adapter_test.go
+++ b/apps/backend/internal/office/scheduler/dashboard_adapter_test.go
@@ -1,7 +1,10 @@
 package scheduler
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/office/dashboard"
 )
@@ -22,5 +25,84 @@ func TestConvertChangeToMutation_PropagatesSkipAssigneeCommentWake(t *testing.T)
 	}
 	if !got.Comment.SkipAssigneeWake {
 		t.Fatal("SkipAssigneeWake = false, want true")
+	}
+}
+
+func TestDashboardApprovalAdapter_PropagatesDecisionWakeContext(t *testing.T) {
+	repo := newReactivityTestRepo(t)
+	ss := newChildrenCompletedTestScheduler(t, repo)
+	createChildrenCompletedAgent(t, repo, "assignee-1")
+	adapter := NewDashboardApprovalAdapter(ss)
+
+	err := adapter.QueueApprovalRuns(context.Background(), []dashboard.ApprovalRun{{
+		AgentID:         "assignee-1",
+		Reason:          RunReasonTaskChangesRequested,
+		TaskID:          "task-1",
+		WorkspaceID:     "ws-1",
+		ActorID:         "reviewer-1",
+		ActorType:       "agent",
+		DecisionComment: "The retry path still drops the error.",
+		IdempotencyKey:  "decision:decision-1",
+	}})
+	if err != nil {
+		t.Fatalf("QueueApprovalRuns: %v", err)
+	}
+
+	runs, err := repo.ListRuns(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(runs))
+	}
+	if runs[0].IdempotencyKey == nil || *runs[0].IdempotencyKey != "decision:decision-1" {
+		t.Fatalf("idempotency key = %v, want decision:decision-1", runs[0].IdempotencyKey)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(runs[0].Payload), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload["decision_comment"] != "The retry path still drops the error." {
+		t.Fatalf("decision_comment = %q, want rejection reason", payload["decision_comment"])
+	}
+}
+
+func TestDashboardApprovalAdapter_AllowsDistinctDecisionWakes(t *testing.T) {
+	repo := newReactivityTestRepo(t)
+	ss := newChildrenCompletedTestScheduler(t, repo)
+	createChildrenCompletedAgent(t, repo, "assignee-1")
+	adapter := NewDashboardApprovalAdapter(ss)
+	ctx := context.Background()
+
+	keys := []string{"decision:decision-1", "decision:decision-2"}
+	comments := []string{"round one", "round two"}
+	for i, key := range keys {
+		if err := adapter.QueueApprovalRuns(ctx, []dashboard.ApprovalRun{{
+			AgentID:         "assignee-1",
+			Reason:          RunReasonTaskChangesRequested,
+			TaskID:          "task-1",
+			WorkspaceID:     "ws-1",
+			DecisionComment: comments[i],
+			IdempotencyKey:  key,
+		}}); err != nil {
+			t.Fatalf("QueueApprovalRuns round %d: %v", i+1, err)
+		}
+		if i == 0 {
+			// A real second review round occurs after the first run has been
+			// delivered. Age the row past the coalescing window so this test
+			// isolates idempotency-key behavior.
+			ageRunsRequestedAt(t, ss, 10*time.Second)
+		}
+	}
+
+	runs, err := repo.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("runs = %d, want 2 for two decision rounds", len(runs))
+	}
+	if runs[0].IdempotencyKey == nil || runs[1].IdempotencyKey == nil || *runs[0].IdempotencyKey == *runs[1].IdempotencyKey {
+		t.Fatalf("decision wake keys = %v, %v, want distinct keys", runs[0].IdempotencyKey, runs[1].IdempotencyKey)
 	}
 }

--- a/apps/backend/internal/office/service/prompt_builder.go
+++ b/apps/backend/internal/office/service/prompt_builder.go
@@ -82,6 +82,8 @@ func BuildPrompt(pc *PromptContext) string {
 		prompt = buildLegacyStagePrompt(pc, stageTypeApproval)
 	case RunReasonTaskReviewRequested:
 		prompt = buildTaskAssignedPrompt(pc)
+	case RunReasonTaskChangesRequested:
+		prompt = buildReworkPrompt(pc)
 	case RunReasonTaskComment:
 		prompt = buildTaskCommentPrompt(pc)
 	case RunReasonTaskBlockersResolved:

--- a/apps/backend/internal/office/service/run.go
+++ b/apps/backend/internal/office/service/run.go
@@ -25,6 +25,7 @@ const (
 	RunReasonTaskChildrenCompleted = "task_children_completed"
 	RunReasonApprovalResolved      = "approval_resolved"
 	RunReasonTaskReviewRequested   = "task_review_requested"
+	RunReasonTaskChangesRequested  = "task_changes_requested"
 	RunReasonRoutineTrigger        = "routine_trigger"
 	// RunReasonHeartbeat aliases shared.RunReasonHeartbeat so this package's
 	// local constant and the shared idle-skip classifier cannot drift apart

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -937,6 +937,15 @@ func (si *SchedulerIntegration) buildPromptContext(
 		}
 	}
 
+	if reason == RunReasonTaskChangesRequested {
+		pc.ReviewFeedback = parsed["decision_comment"]
+		if pc.ReviewFeedback == "" {
+			// Keep compatibility with older queued runs that used the
+			// generic feedback field before decision_comment was added.
+			pc.ReviewFeedback = parsed["feedback"]
+		}
+	}
+
 	if reason == RunReasonTaskComment {
 		si.enrichCommentContext(ctx, pc, parsed["comment_id"])
 	}

--- a/apps/backend/internal/office/service/scheduler_integration_test.go
+++ b/apps/backend/internal/office/service/scheduler_integration_test.go
@@ -349,6 +349,33 @@ func TestSchedulerIntegration_BuildPromptContext_TaskComment(t *testing.T) {
 	}
 }
 
+func TestSchedulerIntegration_BuildPromptContext_TaskChangesRequestedIncludesDecisionComment(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	insertTaskForPrompt(t, svc, "task-rework", "ws-1", "Fix the rejected change", "Implement the requested fix", 3)
+	pc := service.BuildPromptContextForTest(
+		svc,
+		ctx,
+		service.RunReasonTaskChangesRequested,
+		`{"task_id":"task-rework","decision_comment":"The retry path still drops the error."}`,
+	)
+
+	if pc.ReviewFeedback != "The retry path still drops the error." {
+		t.Fatalf("ReviewFeedback = %q, want decision comment", pc.ReviewFeedback)
+	}
+	prompt := service.BuildPrompt(pc)
+	if !containsIgnoreCase(prompt, "The retry path still drops the error.") {
+		t.Fatalf("changes-requested prompt missing decision comment: %s", prompt)
+	}
+	if !containsIgnoreCase(prompt, "Address the feedback") {
+		t.Fatalf("changes-requested prompt missing rework instruction: %s", prompt)
+	}
+	if strings.HasPrefix(prompt, "You have been woken for reason:") {
+		t.Fatalf("changes-requested prompt fell through to generic wake text: %s", prompt)
+	}
+}
+
 func TestSchedulerIntegration_BuildPromptContext_ApprovalStageIncludesRecentComments(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -123,14 +123,14 @@ func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID strin
 		return false
 	}
 
-	appliedTransition := s.applyEngineTransition(
+	appliedTransition := s.applyEngineTransitionWithMode(
 		ctx,
 		parentID,
 		session,
 		result,
 		engine.TriggerOnChildrenCompleted,
 		parent.Description,
-		true,
+		transitionLifecycleWithOnEnter,
 	)
 	if !appliedTransition {
 		return false

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -4984,7 +4984,7 @@ func (s *Service) processOnTurnCompleteViaEngineWithCause(
 	if cause == turnCompletionCauseUserCancellation {
 		ctx = cancellationTransitionAttribution(ctx)
 	}
-	return s.applyEngineTransition(ctx, taskID, session, result, engine.TriggerOnTurnComplete, task.Description, true)
+	return s.applyEngineTransitionWithMode(ctx, taskID, session, result, engine.TriggerOnTurnComplete, task.Description, transitionLifecycleWithOnEnter)
 }
 
 // acquireTurnCompletionCriticalSection serializes on_turn_complete
@@ -5171,12 +5171,25 @@ func (s *Service) allowEngineSignalCompletion(
 	return true
 }
 
+// transitionLifecycleMode identifies the caller-owned part of a transition.
+// Guarded decisions use a session-independent mode because the session passed
+// by the engine is the decider's session, not the assignee's destination
+// session. Keeping this distinction explicit prevents the on_turn_start
+// lifecycle from being reused for quorum transitions by accident.
+type transitionLifecycleMode uint8
+
+const (
+	transitionLifecycleWithOnEnter transitionLifecycleMode = iota
+	transitionLifecycleOnTurnStart
+	transitionLifecycleGuardedDecision
+)
+
 // applyGuardedTransitionLifecycle is the service-owned lifecycle bridge for
 // quorum re-evaluation. The engine still selects the target and owns the CAS,
-// but credential checks, on_exit, history, signal cleanup, terminal handling,
-// and session/profile state stay in the orchestrator path.
+// but transition history and task-level terminal handling stay in the
+// orchestrator path. The decider session is not changed.
 //
-// on_enter is deliberately NOT triggered here (triggerOnEnter=false below):
+// Session-shaped on_enter work is deliberately NOT triggered here:
 // sessionID is the decider's session (reviewer/approver), not the task's
 // assignee, so dispatching on_enter would hand auto_start_agent's session
 // continuation that same decider session. Office's reactivity
@@ -5201,14 +5214,14 @@ func (s *Service) applyGuardedTransitionLifecycle(
 
 	casAttempted := false
 	casApplied := false
-	lifecycleApplied := s.applyEngineTransitionWithCommit(
+	lifecycleApplied := s.applyEngineTransitionWithCommitMode(
 		ctx,
 		taskID,
 		session,
 		engine.HandleResult{Transitioned: true, FromStepID: fromStepID, ToStepID: toStepID},
 		trigger,
 		task.Description,
-		false,
+		transitionLifecycleGuardedDecision,
 		func(commitCtx context.Context) (bool, error) {
 			casAttempted = true
 			transitionCtx := commitCtx
@@ -5226,7 +5239,7 @@ func (s *Service) applyGuardedTransitionLifecycle(
 			}
 			casApplied = true
 			// The raw CAS commit intentionally has no side effects. The shared
-			// lifecycle helper performs session state and on_enter work below.
+			// lifecycle helper performs the remaining task-level work below.
 			s.publishTaskUpdated(ctx, committedTask, oldWorkflowID)
 			s.workflowStore.pullNextTaskOnVacate(ctx, fromStepID, taskID)
 			return true, nil
@@ -5242,14 +5255,30 @@ func (s *Service) applyGuardedTransitionLifecycle(
 	return false, errors.New("guarded transition lifecycle did not apply")
 }
 
-// applyEngineTransition applies an engine-evaluated transition: on_exit, DB transition,
-// data patches, and optionally on_enter processing. Returns true if the transition was applied.
+// applyEngineTransition is the legacy wrapper for session-originated
+// transitions. Guarded decisions must use applyEngineTransitionWithMode so
+// they cannot be mistaken for an on_turn_start transition.
 func (s *Service) applyEngineTransition(
 	ctx context.Context, taskID string, session *models.TaskSession,
 	result engine.HandleResult, trigger engine.Trigger, taskDescription string,
 	triggerOnEnter bool,
 ) bool {
-	return s.applyEngineTransitionWithCommit(ctx, taskID, session, result, trigger, taskDescription, triggerOnEnter,
+	mode := transitionLifecycleOnTurnStart
+	if triggerOnEnter {
+		mode = transitionLifecycleWithOnEnter
+	}
+	return s.applyEngineTransitionWithMode(ctx, taskID, session, result, trigger, taskDescription, mode)
+}
+
+// applyEngineTransitionWithMode applies an engine-evaluated transition with
+// an explicit lifecycle mode: on_exit, DB transition, data patches, and
+// optional on_enter processing. Returns true if the transition was applied.
+func (s *Service) applyEngineTransitionWithMode(
+	ctx context.Context, taskID string, session *models.TaskSession,
+	result engine.HandleResult, trigger engine.Trigger, taskDescription string,
+	mode transitionLifecycleMode,
+) bool {
+	return s.applyEngineTransitionWithCommitMode(ctx, taskID, session, result, trigger, taskDescription, mode,
 		func(commitCtx context.Context) (bool, error) {
 			if err := s.workflowStore.ApplyTransition(commitCtx, taskID, session.ID, result.FromStepID, result.ToStepID, trigger); err != nil {
 				return false, err
@@ -5258,50 +5287,40 @@ func (s *Service) applyEngineTransition(
 		})
 }
 
-// applyEngineTransitionWithCommit applies the shared lifecycle around a
+// applyEngineTransitionWithCommitMode applies the shared lifecycle around a
 // transition commit. The default path commits through ApplyTransition. The
 // quorum decision path supplies a CAS commit so lifecycle hooks cannot be
 // bypassed by the engine's guarded-transition re-evaluation.
 //
-//nolint:cyclop,funlen // this coordinates independent transition lifecycle stages.
-func (s *Service) applyEngineTransitionWithCommit(
+//nolint:cyclop,gocognit,funlen // this coordinates independent transition lifecycle stages.
+func (s *Service) applyEngineTransitionWithCommitMode(
 	ctx context.Context, taskID string, session *models.TaskSession,
 	result engine.HandleResult, trigger engine.Trigger, taskDescription string,
-	triggerOnEnter bool, commit func(context.Context) (bool, error),
+	mode transitionLifecycleMode, commit func(context.Context) (bool, error),
 ) bool {
 	ctx = withWorkflowMetaCache(ctx)
+	sessionLifecycle := mode != transitionLifecycleGuardedDecision
 	// Validate the target step exists BEFORE persisting the transition.
 	// This prevents the task from being moved to an invalid step_id
 	// (e.g., a template-level alias like "review" that doesn't resolve to a real UUID).
-	var targetStep *wfmodels.WorkflowStep
-	if triggerOnEnter {
-		var err error
-		targetStep, err = s.workflowStepGetter.GetStep(ctx, result.ToStepID)
-		if err != nil {
-			s.logger.Warn("target step not found, skipping transition",
-				zap.String("step_id", result.ToStepID),
-				zap.Error(err))
-			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
-			return false
-		}
-	} else {
-		// Even without on_enter, load the target step — needed for profile switch check.
-		var err error
-		targetStep, err = s.workflowStepGetter.GetStep(ctx, result.ToStepID)
-		if err != nil {
-			s.logger.Warn("target step not found, skipping transition",
-				zap.String("step_id", result.ToStepID),
-				zap.Error(err))
-			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
-			return false
-		}
-	}
-	if err := s.preflightWorkflowStepCredentials(ctx, taskID, session, targetStep); err != nil {
-		s.logger.Warn("target profile credential preflight failed, skipping transition",
-			zap.String("task_id", taskID),
+	targetStep, err := s.workflowStepGetter.GetStep(ctx, result.ToStepID)
+	if err != nil {
+		s.logger.Warn("target step not found, skipping transition",
 			zap.String("step_id", result.ToStepID),
 			zap.Error(err))
+		if sessionLifecycle {
+			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		}
 		return false
+	}
+	if sessionLifecycle {
+		if err := s.preflightWorkflowStepCredentials(ctx, taskID, session, targetStep); err != nil {
+			s.logger.Warn("target profile credential preflight failed, skipping transition",
+				zap.String("task_id", taskID),
+				zap.String("step_id", result.ToStepID),
+				zap.Error(err))
+			return false
+		}
 	}
 
 	terminalTarget := s.workflowStepIsTerminal(ctx, targetStep.ID)
@@ -5311,19 +5330,17 @@ func (s *Service) applyEngineTransitionWithCommit(
 		s.logger.Warn("failed to load from-step for on_exit",
 			zap.String("step_id", result.FromStepID),
 			zap.Error(err))
-		s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
-		return false
+	} else if sessionLifecycle {
+		s.processOnExit(ctx, taskID, session, fromStep)
 	}
-	s.processOnExit(ctx, taskID, session, fromStep)
 
 	// A ResultHolder is only attached when this transition will actually
 	// trigger on_enter (triggerOnEnter) — an on_turn_start transition never
-	// reaches launchProcessOnEnter below, so allocating a step-entry it will
-	// never dispatch would be a needless write. See applyTransition's
-	// matching gate in workflow_store.go.
+	// reaches launchProcessOnEnter below, and a guarded decision is dispatched
+	// through the repository's session-independent step-entry path.
 	var stepEntry *stepentry.AllocationResult
 	applyCtx := ctx
-	if triggerOnEnter {
+	if mode == transitionLifecycleWithOnEnter {
 		stepEntry = &stepentry.AllocationResult{}
 		applyCtx = stepentry.WithResultHolder(applyCtx, stepEntry)
 	}
@@ -5333,7 +5350,9 @@ func (s *Service) applyEngineTransitionWithCommit(
 			zap.String("task_id", taskID),
 			zap.String("session_id", session.ID),
 			zap.Error(err))
-		s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		if sessionLifecycle {
+			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		}
 		return false
 	}
 	if !applied {
@@ -5341,11 +5360,10 @@ func (s *Service) applyEngineTransitionWithCommit(
 	}
 
 	// ADR 0015 — record the audit row before the pending signal (if any) is
-	// cleared. Only an on_turn_complete transition can have consumed a
-	// signal; on_turn_start and on_children_completed transitions record
-	// with no signal metadata.
+	// cleared. Only an on_turn_complete transition can have consumed a signal;
+	// guarded decision transitions do not mutate the decider's signal bag.
 	var consumedSignal *models.PendingStepCompletionSignal
-	if trigger == engine.TriggerOnTurnComplete {
+	if sessionLifecycle && trigger == engine.TriggerOnTurnComplete {
 		if signal, has := models.LoadPendingStepSignal(session.Metadata); has && signal.StepID == result.FromStepID {
 			consumedSignal = &signal
 		}
@@ -5361,12 +5379,13 @@ func (s *Service) applyEngineTransitionWithCommit(
 
 	// ADR 0015 — a successful on_turn_complete transition consumes any
 	// pending step-completion signal for the source step. The bag must be
-	// cleared so the next step's gating starts from a clean slate.
-	if trigger == engine.TriggerOnTurnComplete {
+	// cleared so the next step's gating starts from a clean slate. A guarded
+	// decision must leave the decider session untouched.
+	if sessionLifecycle && trigger == engine.TriggerOnTurnComplete {
 		s.clearPendingStepSignal(ctx, session)
 	}
 
-	if len(result.DataPatch) > 0 {
+	if len(result.DataPatch) > 0 && sessionLifecycle {
 		if err := s.workflowStore.PersistData(ctx, session.ID, result.DataPatch); err != nil {
 			s.logger.Warn("failed to persist workflow data patch",
 				zap.String("session_id", session.ID),
@@ -5378,7 +5397,9 @@ func (s *Service) applyEngineTransitionWithCommit(
 	if queuedErr == nil && queuedTask != nil && queuedTask.QueuedForStepID == result.ToStepID && !queuedTask.WIPAdmitted {
 		// The source transition is committed, but destination state and
 		// on_enter behavior wait for the queue promotion event.
-		s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		if sessionLifecycle {
+			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		}
 		return true
 	}
 
@@ -5386,16 +5407,14 @@ func (s *Service) applyEngineTransitionWithCommit(
 		s.markTaskCompletedForTerminalStep(ctx, taskID, targetStep.ID)
 	}
 
-	if !triggerOnEnter {
-		// on_turn_start transitions: user is about to send a message, no on_enter needed.
-		// Guarded-transition (quorum re-evaluation) callers also land here — see
-		// applyGuardedTransitionLifecycle's doc comment. For that path the "next
-		// prompt" actually goes to the assignee via office/dashboard's own
-		// reactivity, not through this session's continuation, so the profile
-		// switch below is a no-op whenever the target step carries no explicit
-		// agent_profile_id (the common office-workflow case). It still runs
-		// unconditionally for correctness, in case a future step configuration
-		// gives the target step its own profile.
+	if mode == transitionLifecycleGuardedDecision {
+		return true
+	}
+	if mode == transitionLifecycleOnTurnStart {
+		// on_turn_start transitions: user is about to send a message, no
+		// on_enter needed. We still need to switch the agent profile if the
+		// target step requires a different one — the next prompt should go
+		// to the correct agent.
 		effectiveSession, ok := s.maybySwitchSessionForProfile(ctx, taskID, session, targetStep, fromStep)
 		if !ok {
 			return false
@@ -5520,5 +5539,5 @@ func (s *Service) processOnTurnStartViaEngine(ctx context.Context, taskID string
 		zap.String("to_step_id", result.ToStepID))
 
 	// on_turn_start does NOT trigger on_enter (user's message is the next prompt).
-	return s.applyEngineTransition(ctx, taskID, session, result, engine.TriggerOnTurnStart, "", false)
+	return s.applyEngineTransitionWithMode(ctx, taskID, session, result, engine.TriggerOnTurnStart, "", transitionLifecycleOnTurnStart)
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -5174,7 +5174,16 @@ func (s *Service) allowEngineSignalCompletion(
 // applyGuardedTransitionLifecycle is the service-owned lifecycle bridge for
 // quorum re-evaluation. The engine still selects the target and owns the CAS,
 // but credential checks, on_exit, history, signal cleanup, terminal handling,
-// session/profile state, and on_enter stay in the orchestrator path.
+// and session/profile state stay in the orchestrator path.
+//
+// on_enter is deliberately NOT triggered here (triggerOnEnter=false below):
+// sessionID is the decider's session (reviewer/approver), not the task's
+// assignee, so dispatching on_enter would hand auto_start_agent's session
+// continuation that same decider session. Office's reactivity
+// (office/dashboard.runReactivityForDecision) is what wakes the assignee.
+// Engine-owned on_enter actions (clear_decisions, ensure_participant_seat,
+// queue_run_for_each_participant) are unaffected — they run unconditionally
+// via the CAS commit's dispatchStepEntry call below.
 func (s *Service) applyGuardedTransitionLifecycle(
 	ctx context.Context, taskID, sessionID, fromStepID, toStepID string, trigger engine.Trigger,
 ) (bool, error) {
@@ -5199,7 +5208,7 @@ func (s *Service) applyGuardedTransitionLifecycle(
 		engine.HandleResult{Transitioned: true, FromStepID: fromStepID, ToStepID: toStepID},
 		trigger,
 		task.Description,
-		true,
+		false,
 		func(commitCtx context.Context) (bool, error) {
 			casAttempted = true
 			transitionCtx := commitCtx
@@ -5379,8 +5388,10 @@ func (s *Service) applyEngineTransitionWithCommit(
 
 	if !triggerOnEnter {
 		// on_turn_start transitions: user is about to send a message, no on_enter needed.
-		// However, we still need to switch the agent profile if the target step requires
-		// a different one — the user's prompt should go to the correct agent.
+		// Guarded-transition (quorum re-evaluation) callers also land here — see
+		// applyGuardedTransitionLifecycle's doc comment. Either way we still need
+		// to switch the agent profile if the target step requires a different
+		// one — the next prompt should go to the correct agent.
 		effectiveSession, ok := s.maybySwitchSessionForProfile(ctx, taskID, session, targetStep, fromStep)
 		if !ok {
 			return false

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -5270,6 +5270,21 @@ func (s *Service) applyEngineTransition(
 	return s.applyEngineTransitionWithMode(ctx, taskID, session, result, trigger, taskDescription, mode)
 }
 
+// applyEngineTransitionWithCommit preserves the legacy helper contract for
+// session-originated transitions. Guarded decisions use the explicit mode
+// variant so they cannot be mistaken for on_turn_start.
+func (s *Service) applyEngineTransitionWithCommit(
+	ctx context.Context, taskID string, session *models.TaskSession,
+	result engine.HandleResult, trigger engine.Trigger, taskDescription string,
+	triggerOnEnter bool, commit func(context.Context) (bool, error),
+) bool {
+	mode := transitionLifecycleOnTurnStart
+	if triggerOnEnter {
+		mode = transitionLifecycleWithOnEnter
+	}
+	return s.applyEngineTransitionWithCommitMode(ctx, taskID, session, result, trigger, taskDescription, mode, commit)
+}
+
 // applyEngineTransitionWithMode applies an engine-evaluated transition with
 // an explicit lifecycle mode: on_exit, DB transition, data patches, and
 // optional on_enter processing. Returns true if the transition was applied.
@@ -5330,7 +5345,12 @@ func (s *Service) applyEngineTransitionWithCommitMode(
 		s.logger.Warn("failed to load from-step for on_exit",
 			zap.String("step_id", result.FromStepID),
 			zap.Error(err))
-	} else if sessionLifecycle {
+		if sessionLifecycle {
+			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		}
+		return false
+	}
+	if sessionLifecycle {
 		s.processOnExit(ctx, taskID, session, fromStep)
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -5389,9 +5389,13 @@ func (s *Service) applyEngineTransitionWithCommit(
 	if !triggerOnEnter {
 		// on_turn_start transitions: user is about to send a message, no on_enter needed.
 		// Guarded-transition (quorum re-evaluation) callers also land here — see
-		// applyGuardedTransitionLifecycle's doc comment. Either way we still need
-		// to switch the agent profile if the target step requires a different
-		// one — the next prompt should go to the correct agent.
+		// applyGuardedTransitionLifecycle's doc comment. For that path the "next
+		// prompt" actually goes to the assignee via office/dashboard's own
+		// reactivity, not through this session's continuation, so the profile
+		// switch below is a no-op whenever the target step carries no explicit
+		// agent_profile_id (the common office-workflow case). It still runs
+		// unconditionally for correctness, in case a future step configuration
+		// gives the target step its own profile.
 		effectiveSession, ok := s.maybySwitchSessionForProfile(ctx, taskID, session, targetStep, fromStep)
 		if !ok {
 			return false

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
@@ -66,18 +66,28 @@ func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSes
 	reviewerSession := &models.TaskSession{
 		ID: "reviewer-sess", TaskID: "t1", AgentProfileID: "reviewer-agent",
 		AgentExecutionID: "reviewer-exec",
-		State:            models.TaskSessionStateWaitingForInput, IsPrimary: true,
+		State:            models.TaskSessionStateRunning, IsPrimary: true,
 		StartedAt: now, UpdatedAt: now,
 	}
 	if err := repo.CreateTaskSession(ctx, reviewerSession); err != nil {
 		t.Fatalf("create reviewer session: %v", err)
 	}
 	seedExecutorRunning(t, repo, reviewerSession.ID, "t1", reviewerSession.AgentExecutionID)
+	targetSession := &models.TaskSession{
+		ID: "target-sess", TaskID: "t1", AgentProfileID: "target-agent",
+		AgentExecutionID: "target-exec",
+		State:            models.TaskSessionStateWaitingForInput, IsPrimary: false,
+		StartedAt: now, UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, targetSession); err != nil {
+		t.Fatalf("create target session: %v", err)
+	}
+	seedExecutorRunning(t, repo, targetSession.ID, "t1", targetSession.AgentExecutionID)
 
 	stepGetter := newMockStepGetter()
 	stepGetter.steps["review"] = &wfmodels.WorkflowStep{ID: "review", WorkflowID: "wf1", Position: 1}
 	stepGetter.steps["work"] = &wfmodels.WorkflowStep{
-		ID: "work", WorkflowID: "wf1", Position: 0,
+		ID: "work", WorkflowID: "wf1", Position: 0, AgentProfileID: "target-agent",
 		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}}},
 	}
 	taskRepo := newMockTaskRepo()
@@ -117,23 +127,28 @@ func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSes
 		t.Fatalf("workflow_step_id = %q, want work", storedTask.WorkflowStepID)
 	}
 
-	// If on_enter was dispatched (pre-fix behavior), processOnEnter runs in a
-	// detached goroutine and signals completion here; wait for it before
-	// checking capturedPromptCalls so the assertion isn't racing the
-	// goroutine. Post-fix, on_enter is never dispatched for this path, so the
-	// channel never fires and the short timeout is the expected case.
-	//
-	// onEnterDone fires as soon as onProcessOnEnterComplete runs, which is
-	// right at the end of processOnEnter — before any PromptTask call it
-	// triggered has necessarily completed. So promptCalls could still read 0
-	// on a pre-fix regression where the goroutine fired but PromptTask itself
-	// failed or hadn't landed yet by the time this select returns. That's
-	// fine for this red/green proof (a fired goroutine is itself the
-	// regression this test targets), but promptCalls > 0 is not the only
-	// signal a future change to this test should rely on.
 	select {
 	case <-onEnterDone:
+		t.Fatal("guarded transition dispatched session-shaped on_enter actions")
 	case <-time.After(300 * time.Millisecond):
+	}
+
+	storedReviewer, err := repo.GetTaskSession(ctx, reviewerSession.ID)
+	if err != nil {
+		t.Fatalf("get reviewer session: %v", err)
+	}
+	if storedReviewer.State != models.TaskSessionStateRunning || !storedReviewer.IsPrimary {
+		t.Fatalf("reviewer session changed during guarded transition: %#v", storedReviewer)
+	}
+	if storedReviewer.AgentProfileID != reviewerSession.AgentProfileID || storedReviewer.AgentExecutionID != reviewerSession.AgentExecutionID {
+		t.Fatalf("reviewer session identity changed during guarded transition: %#v", storedReviewer)
+	}
+	storedTarget, err := repo.GetTaskSession(ctx, targetSession.ID)
+	if err != nil {
+		t.Fatalf("get target session: %v", err)
+	}
+	if storedTarget.State != targetSession.State || storedTarget.IsPrimary != targetSession.IsPrimary {
+		t.Fatalf("target session changed during guarded transition: %#v", storedTarget)
 	}
 
 	agentMgr.mu.Lock()

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 // TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSession
-// is the two-session regression proof for the office reject leg (plan unit
-// 7). wait_for_quorum guards are exclusively an Office-workflow feature
+// is the regression proof, at the orchestrator layer, that the office reject
+// leg (plan unit 7) never continues the decider's session. wait_for_quorum
+// guards are exclusively an Office-workflow feature
 // (config/workflows/office-default.yml), and applyGuardedTransitionLifecycle
 // is reached only from the engine's guarded-transition re-evaluation
 // (quorum.go's applyFirstSatisfiedGuardedTransition -> ApplyTransitionIfAtStep),
@@ -30,8 +31,13 @@ import (
 // runReactivityForDecision) is the mechanism that correctly resolves and
 // wakes the assignee; this test proves the orchestrator's guarded-transition
 // bridge no longer also fires a second, wrongly-targeted prompt through
-// session continuation. With one session in play this failure mode is
-// unobservable — hence two distinct sessions (reviewer vs. assignee agent).
+// session continuation. It deliberately gives the task an assignee
+// (AssigneeAgentProfileID) distinct from the reviewer's own live session, so
+// a regression that continued the "wrong" session would be observable — it
+// does not create a second TaskSession row for the assignee, since
+// runReactivityForDecision (the assignee-wake path) lives outside
+// applyGuardedTransitionLifecycle and is covered separately by the two e2e
+// specs (workflow-quorum-transitions.spec.ts, approval-flow.spec.ts).
 func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSession(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -116,6 +122,15 @@ func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSes
 	// checking capturedPromptCalls so the assertion isn't racing the
 	// goroutine. Post-fix, on_enter is never dispatched for this path, so the
 	// channel never fires and the short timeout is the expected case.
+	//
+	// onEnterDone fires as soon as onProcessOnEnterComplete runs, which is
+	// right at the end of processOnEnter — before any PromptTask call it
+	// triggered has necessarily completed. So promptCalls could still read 0
+	// on a pre-fix regression where the goroutine fired but PromptTask itself
+	// failed or hadn't landed yet by the time this select returns. That's
+	// fine for this red/green proof (a fired goroutine is itself the
+	// regression this test targets), but promptCalls > 0 is not the only
+	// signal a future change to this test should rely on.
 	select {
 	case <-onEnterDone:
 	case <-time.After(300 * time.Millisecond):

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
@@ -1,0 +1,130 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/workflow/engine"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSession
+// is the two-session regression proof for the office reject leg (plan unit
+// 7). wait_for_quorum guards are exclusively an Office-workflow feature
+// (config/workflows/office-default.yml), and applyGuardedTransitionLifecycle
+// is reached only from the engine's guarded-transition re-evaluation
+// (quorum.go's applyFirstSatisfiedGuardedTransition -> ApplyTransitionIfAtStep),
+// with sessionID set to whichever session RecordParticipantDecision resolved
+// for the decider (the reviewer), not the task's assignee.
+//
+// Before the fix, applyGuardedTransitionLifecycle dispatched on_enter
+// (triggerOnEnter=true), and Work's on_enter (auto_start_agent, no
+// agent_profile_id of its own) fell through to processOnEnter's session
+// continuation, prompting the reviewer's session directly into Work — the
+// wrong agent. Office's own reactivity (office/dashboard.
+// runReactivityForDecision) is the mechanism that correctly resolves and
+// wakes the assignee; this test proves the orchestrator's guarded-transition
+// bridge no longer also fires a second, wrongly-targeted prompt through
+// session continuation. With one session in play this failure mode is
+// unobservable — hence two distinct sessions (reviewer vs. assignee agent).
+func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSession(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "review",
+		// ProjectID non-empty marks the task as Office-owned (IsFromOfficePredicate).
+		ProjectID: "proj-1", AssigneeAgentProfileID: "assignee-agent",
+		Title: "T", Description: "T", State: v1.TaskStateReview,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// The reviewer's own session — the identity RecordParticipantDecision
+	// resolves and passes through as sessionID (AC-16a / officeSessionIdentity).
+	// It is a distinct agent from the task's assignee and must never be the
+	// one auto-started into Work.
+	reviewerSession := &models.TaskSession{
+		ID: "reviewer-sess", TaskID: "t1", AgentProfileID: "reviewer-agent",
+		AgentExecutionID: "reviewer-exec",
+		State:            models.TaskSessionStateWaitingForInput, IsPrimary: true,
+		StartedAt: now, UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, reviewerSession); err != nil {
+		t.Fatalf("create reviewer session: %v", err)
+	}
+	seedExecutorRunning(t, repo, reviewerSession.ID, "t1", reviewerSession.AgentExecutionID)
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["review"] = &wfmodels.WorkflowStep{ID: "review", WorkflowID: "wf1", Position: 1}
+	stepGetter.steps["work"] = &wfmodels.WorkflowStep{
+		ID: "work", WorkflowID: "wf1", Position: 0,
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}}},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "T", State: v1.TaskStateReview}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo, isAgentRunning: true}
+	log := testLogger()
+	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+	svc := &Service{
+		logger: log, repo: repo, workflowStepGetter: stepGetter, taskRepo: taskRepo, agentManager: agentMgr,
+		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
+		workflowStore: newWorkflowStore(repo, stepGetter, agentMgr, noopPublisher, log),
+	}
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
+
+	applied, err := svc.applyGuardedTransitionLifecycle(
+		ctx, "t1", reviewerSession.ID, "review", "work", engine.TriggerOnTurnComplete,
+	)
+	if err != nil {
+		t.Fatalf("applyGuardedTransitionLifecycle: %v", err)
+	}
+	if !applied {
+		t.Fatal("applyGuardedTransitionLifecycle() = false, want true (task should move to work)")
+	}
+
+	storedTask, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if storedTask.WorkflowStepID != "work" {
+		t.Fatalf("workflow_step_id = %q, want work", storedTask.WorkflowStepID)
+	}
+
+	// If on_enter was dispatched (pre-fix behavior), processOnEnter runs in a
+	// detached goroutine and signals completion here; wait for it before
+	// checking capturedPromptCalls so the assertion isn't racing the
+	// goroutine. Post-fix, on_enter is never dispatched for this path, so the
+	// channel never fires and the short timeout is the expected case.
+	select {
+	case <-onEnterDone:
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	agentMgr.mu.Lock()
+	promptCalls := len(agentMgr.capturedPromptCalls)
+	agentMgr.mu.Unlock()
+	if promptCalls != 0 {
+		t.Fatalf("reviewer session was prompted into Work (%d calls) — the reject leg must wake the assignee via Office reactivity, not by continuing the decider's session", promptCalls)
+	}
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3294/e2547f8f860c.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** When a reviewer rejects a task back to Work in a `wait_for_quorum` workflow step, the *reviewer's own session* gets prompted to continue into Work — not the assignee who's supposed to pick the rejected task back up. On top of that, if the same task is rejected (or sent back with changes requested, or fully approved) a second time within 24 hours, the assignee's wake is silently dropped by the scheduler's dedup window, so nobody is notified at all.
**After this:** The reject leg always wakes the assignee's session (never the reviewer's), carrying the rejection reason with it. Each distinct decision now gets its own wake, so a second rejection, a second changes-requested round, or a task that clears final approval more than once all queue a fresh run instead of colliding with the first one's dedup key.
**Who hits this:** Any workflow using human-in-the-loop review with `wait_for_quorum` (the shipped `office-default.yml` is one), on every reject / changes-requested / approve decision — and especially on repeat decisions for the same task within a day.
**Scope:** standalone — single defect fix, not part of a larger slice.
**Not here:** making the assignee wake transactional with the transition itself. The wake is still queued via the pre-existing best-effort `QueueRunCtx` path; a silent-failure mode there is a known limitation, not something this PR changes.

A guarded quorum transition drove the deciding session's own on_enter continuation instead of the assignee's, and the scheduler's default idempotency key collapsed repeat decisions on the same task into a single dropped wake; this fixes both so the assignee is reliably woken on every distinct decision.

## Important Changes

- Guarded decisions now run through an explicit `transitionLifecycleMode` (`WithOnEnter` / `OnTurnStart` / `GuardedDecision`) instead of an overloaded `triggerOnEnter bool`. This was tightened during review: the original fix reused the `on_turn_start` code path for guarded decisions (both had `triggerOnEnter=false`), which left session-lifecycle side effects (profile switching, `setSessionWaitingForInput`) still running against the *reviewer's* session. The explicit mode makes guarded decisions skip all session-shaped work — only the CAS commit and its unconditional step-entry dispatch (`clear_decisions`, `ensure_participant_seat`, `queue_run_for_each_participant`) run. Office's own reactivity (`runReactivityForDecision`) is the sole wake source for the assignee.
- `buildDecisionRuns` now computes a per-decision `IdempotencyKey` (`"decision:" + d.ID`) for every reason it emits — `changes_requested`, `rejected`, and `task_ready_to_close` — so a second occurrence of any of them within the dedup window queues its own run instead of colliding with the first.
- `DecisionRejected` is wired as a synonym of `DecisionChangesRequested` in `buildDecisionRuns`; previously a straight rejection queued no run at all and silently dropped the rejection reason.

## Validation

- `go build ./...`: clean
- `go test ./internal/office/... ./internal/orchestrator/...`: all packages `ok`
- Targeted regression tests: `TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSession`, `TestDashboardApprovalAdapter_AllowsDistinctDecisionWakes`, `TestDashboardApprovalAdapter_PropagatesDecisionWakeContext`, `TestApplyEngineTransition_UnknownSourceKeepsCommitUnapplied` (a `main`-side regression test, kept green after rebasing this fix onto current `main`) — all pass
- `make lint`: `0 issues.` (backend golangci-lint, web eslint, harness, specs, architecture all clean)
- `make typecheck`: clean
- `make lint-format`: clean
- `pnpm run i18n:ratchet` (apps/web): clean — no UI files touched by this diff
- `make -C apps/backend test` (full suite): fails only in `internal/worktree` and `internal/task/service`, both `unsafe worktree path` / git-worktree-in-a-worktree sandbox artifacts reproducible against `origin/main` at the merge base and unrelated to this diff (which touches zero files in either package)
- Rebased onto current `main`; resolved a real conflict against `#3225`'s `fromStep`-aware `maybySwitchSessionForProfile` signature, and against the `TestApplyEngineTransition_UnknownSourceKeepsCommitUnapplied` regression test, which required restoring an early-return-on-load-failure this diff had briefly dropped while reconciling

## Possible Improvements

Low risk: the assignee wake remains best-effort (pre-existing `QueueRunCtx` contract, unchanged by this PR) — a queuer failure silently loses the wake. Making it transactional with the transition is a larger change, tracked separately.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.