### PR TITLE
fix(events): contain a panicking subscriber so it stops crashing event delivery

### DIFF
--- a/apps/backend/internal/events/bus/bus.go
+++ b/apps/backend/internal/events/bus/bus.go
@@ -79,6 +79,9 @@ type EventBus interface {
 	// several subjects sequentially is fine: the memory bus dispatches its
 	// handlers synchronously inside Publish, so each handler observes the
 	// subject it was published on.
+	// Implementations contain panics raised by EventHandler. For synchronous
+	// delivery, a recovered panic does not stop later subscribers or become a
+	// Publish error. NATS callbacks also contain panics on the client goroutine.
 	Publish(ctx context.Context, subject string, event *Event) error
 
 	// Subscribe creates a subscription to a subject pattern

--- a/apps/backend/internal/events/bus/memory.go
+++ b/apps/backend/internal/events/bus/memory.go
@@ -384,7 +384,7 @@ func (b *MemoryEventBus) publishToQueue(ctx context.Context, queueKey, subject s
 	}
 
 	// Deliver synchronously to preserve ordering.
-	if err := invokeHandler(ctx, b.logger, "queue", subject, queueKey, event, selected.handler); err != nil {
+	if err := invokeHandler(ctx, b.logger, "queue", subject, selected.subject, event, selected.handler); err != nil {
 		b.logger.Error("Queue event handler error",
 			zap.String("subject", subject),
 			zap.String("queue", queueKey),

--- a/apps/backend/internal/events/bus/memory.go
+++ b/apps/backend/internal/events/bus/memory.go
@@ -139,7 +139,7 @@ func (b *MemoryEventBus) Publish(ctx context.Context, subject string, event *Eve
 			}
 
 			// Regular subscription - deliver to all synchronously to preserve ordering
-			if err := sub.handler(ctx, event); err != nil {
+			if err := invokeHandler(ctx, b.logger, "regular", subject, pattern, event, sub.handler); err != nil {
 				b.logger.Error("Event handler error",
 					zap.String("subject", subject),
 					zap.Error(err))
@@ -384,7 +384,7 @@ func (b *MemoryEventBus) publishToQueue(ctx context.Context, queueKey, subject s
 	}
 
 	// Deliver synchronously to preserve ordering.
-	if err := selected.handler(ctx, event); err != nil {
+	if err := invokeHandler(ctx, b.logger, "queue", subject, queueKey, event, selected.handler); err != nil {
 		b.logger.Error("Queue event handler error",
 			zap.String("subject", subject),
 			zap.String("queue", queueKey),

--- a/apps/backend/internal/events/bus/memory_test.go
+++ b/apps/backend/internal/events/bus/memory_test.go
@@ -814,6 +814,10 @@ func TestMemoryEventBus_QueuePanicSubscriberDoesNotEscapePublish(t *testing.T) {
 	}
 	defer func() { _ = sub.Unsubscribe() }()
 
+	patternKey := metricLabel("pattern", "test.queue.panic", "mode", "queue")
+	queueKeyLabel := metricLabel("pattern", "workers:test.queue.panic", "mode", "queue")
+	before := snapshotPanicCounter(t, patternKey)
+
 	publishReturnedNormally := func() (ok bool) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -828,6 +832,14 @@ func TestMemoryEventBus_QueuePanicSubscriberDoesNotEscapePublish(t *testing.T) {
 
 	if !publishReturnedNormally {
 		t.Fatal("Publish panicked into its caller instead of being contained")
+	}
+
+	if after := snapshotPanicCounter(t, patternKey); after != before+1 {
+		t.Fatalf("subscriberPanicTotal[%q] = %d, want %d (before %d + 1)", patternKey, after, before+1, before)
+	}
+	if got := snapshotPanicCounter(t, queueKeyLabel); got != 0 {
+		t.Fatalf("subscriberPanicTotal incremented a queueKey-labelled key %q (value %d); "+
+			"the label must be the bare subscription pattern, never queue+\":\"+pattern", queueKeyLabel, got)
 	}
 }
 

--- a/apps/backend/internal/events/bus/memory_test.go
+++ b/apps/backend/internal/events/bus/memory_test.go
@@ -741,6 +741,96 @@ func TestMemoryEventBus_PublishStampsSubject(t *testing.T) {
 	}
 }
 
+// TestMemoryEventBus_PanicSubscriberDoesNotStopDelivery is the regression
+// test for the panic guard: before invokeHandler existed, a panicking
+// regular subscriber unwound out of Publish's dispatch loop, so subscribers
+// ordered after it never ran and Publish itself panicked into its caller.
+// A panicking subscriber is registered first (slice order is deterministic,
+// unlike map iteration) so a broken guard fails this test rather than
+// happening to still call the healthy one.
+func TestMemoryEventBus_PanicSubscriberDoesNotStopDelivery(t *testing.T) {
+	log := newTestLogger(t)
+	bus := NewMemoryEventBus(log)
+	defer bus.Close()
+
+	ctx := context.Background()
+	secondCalled := make(chan struct{}, 1)
+
+	subPanic, err := bus.Subscribe("test.panic", func(ctx context.Context, event *Event) error {
+		panic("subscriber blew up")
+	})
+	if err != nil {
+		t.Fatalf("Subscribe (panicking) failed: %v", err)
+	}
+	defer func() { _ = subPanic.Unsubscribe() }()
+
+	subHealthy, err := bus.Subscribe("test.panic", func(ctx context.Context, event *Event) error {
+		secondCalled <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Subscribe (healthy) failed: %v", err)
+	}
+	defer func() { _ = subHealthy.Unsubscribe() }()
+
+	publishReturnedNormally := func() (ok bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				ok = false
+			}
+		}()
+		if err := bus.Publish(ctx, "test.panic", NewEvent("test.type", "test-source", nil)); err != nil {
+			t.Fatalf("Publish returned an error: %v", err)
+		}
+		return true
+	}()
+
+	if !publishReturnedNormally {
+		t.Fatal("Publish panicked into its caller instead of being contained")
+	}
+
+	select {
+	case <-secondCalled:
+	default:
+		t.Fatal("healthy subscriber ordered after the panicking one was never called")
+	}
+}
+
+// TestMemoryEventBus_QueuePanicSubscriberDoesNotEscapePublish is the queue-path
+// counterpart: publishToQueue must contain a panicking queue handler the same
+// way the regular dispatch loop does, so Publish still returns normally.
+func TestMemoryEventBus_QueuePanicSubscriberDoesNotEscapePublish(t *testing.T) {
+	log := newTestLogger(t)
+	bus := NewMemoryEventBus(log)
+	defer bus.Close()
+
+	ctx := context.Background()
+
+	sub, err := bus.QueueSubscribe("test.queue.panic", "workers", func(ctx context.Context, event *Event) error {
+		panic("queue subscriber blew up")
+	})
+	if err != nil {
+		t.Fatalf("QueueSubscribe failed: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	publishReturnedNormally := func() (ok bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				ok = false
+			}
+		}()
+		if err := bus.Publish(ctx, "test.queue.panic", NewEvent("test.type", "test-source", nil)); err != nil {
+			t.Fatalf("Publish returned an error: %v", err)
+		}
+		return true
+	}()
+
+	if !publishReturnedNormally {
+		t.Fatal("Publish panicked into its caller instead of being contained")
+	}
+}
+
 func TestEvent_EffectiveSubject(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/apps/backend/internal/events/bus/nats.go
+++ b/apps/backend/internal/events/bus/nats.go
@@ -104,7 +104,7 @@ func (b *NATSEventBus) Publish(ctx context.Context, subject string, event *Event
 
 // Subscribe creates a subscription to a subject pattern
 func (b *NATSEventBus) Subscribe(subject string, handler EventHandler) (Subscription, error) {
-	sub, err := b.conn.Subscribe(subject, b.createMsgHandler(handler))
+	sub, err := b.conn.Subscribe(subject, b.createMsgHandler(subject, handler))
 	if err != nil {
 		return nil, fmt.Errorf("failed to subscribe to %s: %w", subject, err)
 	}
@@ -115,7 +115,7 @@ func (b *NATSEventBus) Subscribe(subject string, handler EventHandler) (Subscrip
 
 // QueueSubscribe creates a queue subscription for load balancing
 func (b *NATSEventBus) QueueSubscribe(subject, queue string, handler EventHandler) (Subscription, error) {
-	sub, err := b.conn.QueueSubscribe(subject, queue, b.createMsgHandler(handler))
+	sub, err := b.conn.QueueSubscribe(subject, queue, b.createMsgHandler(subject, handler))
 	if err != nil {
 		return nil, fmt.Errorf("failed to queue subscribe to %s: %w", subject, err)
 	}
@@ -127,8 +127,12 @@ func (b *NATSEventBus) QueueSubscribe(subject, queue string, handler EventHandle
 	return &natsSubscription{sub: sub}, nil
 }
 
-// createMsgHandler creates a NATS message handler from an EventHandler
-func (b *NATSEventBus) createMsgHandler(handler EventHandler) nats.MsgHandler {
+// createMsgHandler creates a NATS message handler from an EventHandler.
+// pattern is the subject (possibly wildcarded) the subscription was
+// registered with; it is logged alongside the delivering msg.Subject if the
+// handler panics, since msg.Subject alone doesn't identify which
+// subscription matched on a shared bus.
+func (b *NATSEventBus) createMsgHandler(pattern string, handler EventHandler) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		var event Event
 		if err := json.Unmarshal(msg.Data, &event); err != nil {
@@ -145,7 +149,11 @@ func (b *NATSEventBus) createMsgHandler(handler EventHandler) nats.MsgHandler {
 		event.Subject = msg.Subject
 
 		ctx := context.Background()
-		if err := handler(ctx, &event); err != nil {
+		// The NATS client invokes this handler on its own goroutine, so an
+		// unrecovered panic here would kill the process rather than merely
+		// truncate a delivery loop — invokeHandler contains it the same way
+		// as the in-memory bus.
+		if err := invokeHandler(ctx, b.logger, "nats", msg.Subject, pattern, &event, handler); err != nil {
 			b.logger.Error("Event handler failed",
 				zap.String("subject", msg.Subject),
 				zap.String("event_id", event.ID),

--- a/apps/backend/internal/events/bus/nats_test.go
+++ b/apps/backend/internal/events/bus/nats_test.go
@@ -33,7 +33,7 @@ func TestNATSCreateMsgHandler_MessageSubjectIsAuthoritative(t *testing.T) {
 
 	receivedCh := make(chan *Event, 1)
 	b := &NATSEventBus{logger: newTestLogger(t)}
-	handler := b.createMsgHandler(func(_ context.Context, e *Event) error {
+	handler := b.createMsgHandler("shell.output.*", func(_ context.Context, e *Event) error {
 		receivedCh <- e
 		return nil
 	})
@@ -74,7 +74,7 @@ func TestNATSCreateMsgHandler_StampsSubjectOnUnstampedEvent(t *testing.T) {
 
 	receivedCh := make(chan *Event, 1)
 	b := &NATSEventBus{logger: newTestLogger(t)}
-	handler := b.createMsgHandler(func(_ context.Context, e *Event) error {
+	handler := b.createMsgHandler("task.created", func(_ context.Context, e *Event) error {
 		receivedCh <- e
 		return nil
 	})
@@ -88,6 +88,37 @@ func TestNATSCreateMsgHandler_StampsSubjectOnUnstampedEvent(t *testing.T) {
 		}
 	default:
 		t.Fatal("handler did not invoke the EventHandler")
+	}
+}
+
+// TestNATSCreateMsgHandler_PanicDoesNotEscape is the regression test for the
+// panic guard on the NATS receive path. The NATS client invokes the returned
+// nats.MsgHandler on its own goroutine, so an unrecovered panic there would
+// kill the process rather than merely truncate a delivery loop — containment
+// matters even more here than on the in-memory bus.
+func TestNATSCreateMsgHandler_PanicDoesNotEscape(t *testing.T) {
+	data, err := json.Marshal(&Event{ID: "evt-3", Type: "task.created", Source: "test"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	b := &NATSEventBus{logger: newTestLogger(t)}
+	handler := b.createMsgHandler("task.created", func(_ context.Context, e *Event) error {
+		panic("handler blew up")
+	})
+
+	handlerReturnedNormally := func() (ok bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				ok = false
+			}
+		}()
+		handler(&nats.Msg{Subject: "task.created", Data: data})
+		return true
+	}()
+
+	if !handlerReturnedNormally {
+		t.Fatal("nats.MsgHandler panicked into the NATS client's goroutine instead of being contained")
 	}
 }
 

--- a/apps/backend/internal/events/bus/safe_handler.go
+++ b/apps/backend/internal/events/bus/safe_handler.go
@@ -1,0 +1,63 @@
+package bus
+
+import (
+	"context"
+	"expvar"
+	"runtime/debug"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// subscriberPanicTotal counts subscriber panics recovered during event
+// delivery, labelled by subject and delivery mode (regular, queue, nats).
+var subscriberPanicTotal = expvar.NewMap("events_subscriber_panic_total")
+
+// invokeHandler calls handler and recovers a panic so that one bad
+// subscriber cannot truncate delivery to the remaining subscribers on the
+// same Publish call, nor escape into the Publish caller. A handler-returned
+// error is passed through unchanged; a recovered panic is logged (with the
+// subject, subscription pattern, event identity, and a stack trace — the
+// stack is load-bearing because handler is frequently an anonymous closure
+// with no other identity) and counted, and invokeHandler returns nil for it
+// so callers don't double-log the same failure via their existing
+// error-handling path.
+func invokeHandler(ctx context.Context, log *logger.Logger, mode, subject, pattern string, event *Event, handler EventHandler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			subscriberPanicTotal.Add(metricLabel("subject", subject, "mode", mode), 1)
+			var eventID, eventType string
+			if event != nil {
+				eventID, eventType = event.ID, event.Type
+			}
+			log.Error("Event subscriber panicked",
+				zap.String("subject", subject),
+				zap.String("pattern", pattern),
+				zap.String("mode", mode),
+				zap.String("event_id", eventID),
+				zap.String("event_type", eventType),
+				zap.Any("recovered", r),
+				zap.String("stack", string(debug.Stack())),
+			)
+			err = nil
+		}
+	}()
+	return handler(ctx, event)
+}
+
+// metricLabel builds a "k1=v1;k2=v2;..." label string for an expvar map key,
+// matching the convention in internal/workflow/signalmetrics/metrics_vars.go
+// so a downstream Prometheus translation layer can split on the same
+// delimiters. Keys are intentionally NOT escaped — callers control the
+// inputs (subject strings, the fixed mode constants).
+func metricLabel(pairs ...string) string {
+	label := ""
+	for i := 0; i+1 < len(pairs); i += 2 {
+		if label != "" {
+			label += ";"
+		}
+		label += pairs[i] + "=" + pairs[i+1]
+	}
+	return label
+}

--- a/apps/backend/internal/events/bus/safe_handler.go
+++ b/apps/backend/internal/events/bus/safe_handler.go
@@ -11,7 +11,13 @@ import (
 )
 
 // subscriberPanicTotal counts subscriber panics recovered during event
-// delivery, labelled by subject and delivery mode (regular, queue, nats).
+// delivery, labelled by subscription pattern and delivery mode (regular,
+// queue, nats). The pattern is the string a subscriber registered with
+// (Subscribe/QueueSubscribe), so its cardinality is bounded by the number of
+// distinct subscription call sites in the codebase — unlike the concrete
+// delivery subject, which embeds per-session/per-run identifiers (see
+// events.BuildGitWSEventSubject and friends) and would otherwise grow this
+// never-evicted expvar.Map by one key per session for the process lifetime.
 var subscriberPanicTotal = expvar.NewMap("events_subscriber_panic_total")
 
 // invokeHandler calls handler and recovers a panic so that one bad
@@ -26,7 +32,7 @@ var subscriberPanicTotal = expvar.NewMap("events_subscriber_panic_total")
 func invokeHandler(ctx context.Context, log *logger.Logger, mode, subject, pattern string, event *Event, handler EventHandler) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			subscriberPanicTotal.Add(metricLabel("subject", subject, "mode", mode), 1)
+			subscriberPanicTotal.Add(metricLabel("pattern", pattern, "mode", mode), 1)
 			var eventID, eventType string
 			if event != nil {
 				eventID, eventType = event.ID, event.Type
@@ -49,8 +55,9 @@ func invokeHandler(ctx context.Context, log *logger.Logger, mode, subject, patte
 // metricLabel builds a "k1=v1;k2=v2;..." label string for an expvar map key,
 // matching the convention in internal/workflow/signalmetrics/metrics_vars.go
 // so a downstream Prometheus translation layer can split on the same
-// delimiters. Keys are intentionally NOT escaped — callers control the
-// inputs (subject strings, the fixed mode constants).
+// delimiters. Keys are intentionally NOT escaped — callers must only pass
+// bounded-cardinality values (subscription patterns, the fixed mode
+// constants), never a concrete per-session/per-run subject.
 func metricLabel(pairs ...string) string {
 	label := ""
 	for i := 0; i+1 < len(pairs); i += 2 {

--- a/apps/backend/internal/events/bus/safe_handler_test.go
+++ b/apps/backend/internal/events/bus/safe_handler_test.go
@@ -1,0 +1,58 @@
+package bus
+
+import (
+	"context"
+	"expvar"
+	"testing"
+)
+
+// snapshotPanicCounter returns the current value of subscriberPanicTotal for
+// key, or 0 if the key has never been incremented.
+func snapshotPanicCounter(t *testing.T, key string) int64 {
+	t.Helper()
+	v := subscriberPanicTotal.Get(key)
+	if v == nil {
+		return 0
+	}
+	iv, ok := v.(*expvar.Int)
+	if !ok {
+		t.Fatalf("subscriberPanicTotal[%q] is not an *expvar.Int: %T", key, v)
+	}
+	return iv.Value()
+}
+
+// TestInvokeHandler_PanicIncrementsPatternLabelledCounter pins the fix for
+// the unbounded-cardinality finding: subscriberPanicTotal must be keyed by
+// the bounded subscription pattern, never the concrete delivery subject
+// (which embeds per-session/per-run identifiers in production, e.g.
+// events.BuildGitWSEventSubject). A recovered panic increments exactly one
+// key, and it is the pattern-based one — a refactor that swaps the label
+// back to subject, or drops the Add entirely, fails this test.
+func TestInvokeHandler_PanicIncrementsPatternLabelledCounter(t *testing.T) {
+	log := newTestLogger(t)
+	const pattern = "test.safe_handler.pattern"
+	const subject = "test.safe_handler.pattern.session-abc123"
+	patternKey := metricLabel("pattern", pattern, "mode", "regular")
+	subjectKey := metricLabel("subject", subject, "mode", "regular")
+
+	before := snapshotPanicCounter(t, patternKey)
+
+	err := invokeHandler(context.Background(), log, "regular", subject, pattern,
+		NewEvent("test.type", "test-source", nil),
+		func(_ context.Context, _ *Event) error {
+			panic("handler blew up")
+		})
+	if err != nil {
+		t.Fatalf("invokeHandler returned non-nil for a recovered panic: %v", err)
+	}
+
+	after := snapshotPanicCounter(t, patternKey)
+	if after != before+1 {
+		t.Fatalf("subscriberPanicTotal[%q] = %d, want %d (before %d + 1)", patternKey, after, before+1, before)
+	}
+
+	if got := snapshotPanicCounter(t, subjectKey); got != 0 {
+		t.Fatalf("subscriberPanicTotal incremented a subject-labelled key %q (value %d); "+
+			"the label must be pattern-based only, never the concrete per-session subject", subjectKey, got)
+	}
+}

--- a/apps/backend/internal/events/bus/safe_handler_test.go
+++ b/apps/backend/internal/events/bus/safe_handler_test.go
@@ -2,9 +2,12 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"testing"
 )
+
+type invokeHandlerContextKey struct{}
 
 // snapshotPanicCounter returns the current value of subscriberPanicTotal for
 // key, or 0 if the key has never been incremented.
@@ -54,5 +57,47 @@ func TestInvokeHandler_PanicIncrementsPatternLabelledCounter(t *testing.T) {
 	if got := snapshotPanicCounter(t, subjectKey); got != 0 {
 		t.Fatalf("subscriberPanicTotal incremented a subject-labelled key %q (value %d); "+
 			"the label must be pattern-based only, never the concrete per-session subject", subjectKey, got)
+	}
+}
+
+// TestInvokeHandler_PassesThroughHandlerError is reviewer-requested contract
+// coverage. This behavior already exists on the current head: invokeHandler
+// must forward the context and event unchanged, call the handler once, return
+// its exact error, and leave the panic counter unchanged.
+func TestInvokeHandler_PassesThroughHandlerError(t *testing.T) {
+	log := newTestLogger(t)
+	const pattern = "test.safe_handler.error"
+	const subject = "test.safe_handler.error.session-abc123"
+	patternKey := metricLabel("pattern", pattern, "mode", "regular")
+	before := snapshotPanicCounter(t, patternKey)
+	sentinel := errors.New("sentinel handler error")
+	ctx := context.WithValue(context.Background(), invokeHandlerContextKey{}, "marker")
+	event := NewEvent("test.type", "test-source", nil)
+	var calls int
+	var gotCtx context.Context
+	var gotEvent *Event
+
+	err := invokeHandler(ctx, log, "regular", subject, pattern, event,
+		func(handlerCtx context.Context, handlerEvent *Event) error {
+			calls++
+			gotCtx = handlerCtx
+			gotEvent = handlerEvent
+			return sentinel
+		})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("invokeHandler error = %v, want sentinel %v", err, sentinel)
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+	if gotCtx != ctx {
+		t.Fatal("invokeHandler did not forward the original context")
+	}
+	if gotEvent != event {
+		t.Fatal("invokeHandler did not forward the original event")
+	}
+	if after := snapshotPanicCounter(t, patternKey); after != before {
+		t.Fatalf("subscriberPanicTotal[%q] = %d, want unchanged value %d", patternKey, after, before)
 	}
 }

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -294,11 +294,11 @@ func (s *Service) enqueueTaskPublication(ctx context.Context, taskID, eventType 
 
 // drainTaskPublications runs the FIFO drain loop for one task's publication
 // queue. queue.draining is ALWAYS released before this call ends — including
-// when a synchronous EventBus subscriber inside next.publish panics — via the
-// deferred recover below. Without this, a panic recovered higher up the stack
-// (MemoryEventBus.Publish itself has no recover) would leave queue.draining
-// stuck true forever, and enqueueTaskPublication would silently append every
-// later publication for that task without ever draining them again.
+// when next.publish itself panics (event-data construction, not the
+// EventBus subscribers it calls into, which recover their own panics) — via
+// the deferred recover below. Without this, queue.draining would stay true
+// forever, and enqueueTaskPublication would silently append every later
+// publication for that task without ever draining them again.
 func (s *Service) drainTaskPublications(taskID string, queue *taskPublicationQueue) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3295/389715a5a22e.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** A panicking event-bus subscriber unwinds straight out of `Publish`'s synchronous delivery loop. Every subscriber registered after the panicking one silently never receives that event, and the panic propagates into whatever code called `Publish` — an HTTP handler, a lifecycle path, or another event handler — turning one bad subscriber into an unrelated request failure.
**After this:** The panic is recovered, logged (`Event subscriber panicked` with subject, subscription pattern, delivery mode, event id/type, and a stack trace), and counted in an expvar counter keyed by the bounded subscription pattern. Delivery continues to the remaining subscribers and `Publish` returns normally.
**Who hits this:** Anyone publishing a task or workflow event through the in-memory or NATS event bus — a bug in one subscriber (a plugin deliverer, a metrics hook, etc.) can currently crash the publisher's own call path.
**Scope:** standalone fix, no siblings.
**Not here:** the synchronous-delivery/ordering model, retry or replay, queue round-robin selection and locking, `Publish`'s error contract, and the per-task FIFO drainer's existing recover/re-panic control flow in `service_events.go` (that guard already existed and is untouched except for one corrected comment).

Guard subscriber invocation on the in-memory and NATS event buses against panics, so a defect in one subscriber can no longer truncate delivery to the rest or crash the publisher's own call path.

## Important Changes

- New `internal/events/bus/safe_handler.go`: `invokeHandler` wraps every subscriber invocation with a deferred `recover()`, logs the panic with full identity, and increments `events_subscriber_panic_total` (expvar map) labelled `pattern=…;mode=…` — bounded by the registered subscription pattern, never the concrete subject. A recovered panic is containment, not a `Publish` error: `Publish`'s error already means "bus is closed," and routing a subscriber panic through it would make partial delivery success look like whole-operation failure.
- `memory.go` (regular dispatch and `publishToQueue`) and `nats.go` (`createMsgHandler`) now route every handler call through `invokeHandler`.
- `service_events.go`: comment-only correction — the per-task drainer's `recover()` guards `next.publish` itself, not the bus's subscriber dispatch.

## Validation

- `go test ./internal/events/bus/... -count=1` → ok; `-race -run 'Panic|CreateMsgHandler' -v` → 6/6 pass.
- Mutation check: swapping all three `invokeHandler` call sites back to the raw handler call makes the three new panic tests fail, confirming they're not vacuous (files restored afterward, `git status` clean).
- `go build ./...`, `gofmt -l` on all 7 changed files, `golangci-lint run ./internal/events/bus/... ./internal/task/service/...` → clean.
- `make lint` (backend + web eslint + harness/specs/architecture), `make typecheck`, `make lint-format`, `pnpm run i18n:ratchet` (in `apps/web`) → all clean. No UI copy touched.
- `make test-backend` / `test-web` / `test-cli` / `test-scripts`: all failures encountered are pre-existing and unrelated to this diff (worktree-environment path issues in `internal/task/service` and `internal/worktree`, a Docker-daemon-dependent `apps/web` git-fixture test, and a Windows-path script test) — each reproduced identically against the merge-base commit (`0064b9fb5`) in a scratch worktree before this change.
- Diff is backend-only (`apps/backend/internal/events/bus/**`, `apps/backend/internal/task/service/service_events.go`) — no `apps/web/` files touched, so `make test-e2e` was not run.

## Possible Improvements

Low risk: the only new shared state is a concurrency-safe `expvar.Map`, verified clean under `-race`. Round-robin queue delivery is unaffected since `nextIndex` advances before the handler runs.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->