### PR TITLE
fix(web): guard session resumption across task navigation

### DIFF
--- a/apps/web/hooks/domains/session/use-session-resumption-request-guard.ts
+++ b/apps/web/hooks/domains/session/use-session-resumption-request-guard.ts
@@ -1,0 +1,55 @@
+import type { RefObject } from "react";
+import type { ResumeStateSetter } from "./use-session-resumption";
+
+export type SessionRequestIdentity = {
+  key: string;
+  generation: number;
+};
+
+export function isCurrentRequest(
+  activeRequest: SessionRequestIdentity,
+  capturedRequest: SessionRequestIdentity,
+): boolean {
+  return (
+    activeRequest.key === capturedRequest.key &&
+    activeRequest.generation === capturedRequest.generation
+  );
+}
+
+/** Wrap state setters so callbacks from an obsolete request cannot mutate state. */
+export function buildGuardedSetters(
+  activeRequestRef: RefObject<SessionRequestIdentity>,
+  capturedRequest: SessionRequestIdentity,
+  setters: ResumeStateSetter,
+): ResumeStateSetter {
+  const guard = () => isCurrentRequest(activeRequestRef.current, capturedRequest);
+  return {
+    ...setters,
+    setResumptionState: (s) => {
+      if (guard()) setters.setResumptionState(s);
+    },
+    setError: (e) => {
+      if (guard()) setters.setError(e);
+    },
+    setNotice: (notice) => {
+      if (guard()) setters.setNotice?.(notice);
+    },
+    setWorktreePath: (p) => {
+      if (guard()) setters.setWorktreePath(p);
+    },
+    setWorktreeBranch: (b) => {
+      if (guard()) setters.setWorktreeBranch(b);
+    },
+    // Store setters are keyed by session id, but a stale callback can still
+    // mutate that row after navigation unless every setter is guarded.
+    setTaskSession: (s) => {
+      if (guard()) setters.setTaskSession(s);
+    },
+    setAgentctlReady: (sid) => {
+      if (guard()) setters.setAgentctlReady?.(sid);
+    },
+    setResumeSkipped: (sid, skipped) => {
+      if (guard()) setters.setResumeSkipped?.(sid, skipped);
+    },
+  };
+}

--- a/apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts
+++ b/apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRequest = vi.fn();
+const mockSetTaskSession = vi.fn();
+const mockSetSessionAgentctlStatus = vi.fn();
+const mockSetResumeSkipped = vi.fn();
+const sessionItems = {
+  s1: {
+    started_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    state: "WAITING_FOR_INPUT",
+  },
+};
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      connection: { status: "connected" },
+      taskSessions: { items: sessionItems },
+      setTaskSession: mockSetTaskSession,
+      setSessionAgentctlStatus: mockSetSessionAgentctlStatus,
+      setResumeSkipped: mockSetResumeSkipped,
+      userSettings: { preventAutoStartAgentOnOpen: true },
+      tasks: { resumeSkippedSessionIds: {} },
+    }),
+  useAppStoreApi: () => ({
+    getState: () => ({ taskSessions: { items: sessionItems } }),
+  }),
+}));
+
+const SESSION_ID = "s1";
+const TASK_ID = "t1";
+const PREVIOUS_TASK_ID = "previous-task";
+
+import { useSessionResumption } from "./use-session-resumption";
+
+describe("useSessionResumption task navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7
+  it("ignores the previous task response when navigation keeps the same session id", async () => {
+    const oldRequest = Promise.withResolvers<unknown>();
+    const currentRequest = Promise.withResolvers<unknown>();
+    mockRequest.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(currentRequest.promise);
+
+    const { result, rerender } = renderHook(
+      ({ taskId }: { taskId: string }) => useSessionResumption(taskId, SESSION_ID),
+      { initialProps: { taskId: PREVIOUS_TASK_ID } },
+    );
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    rerender({ taskId: TASK_ID });
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      currentRequest.resolve({
+        session_id: SESSION_ID,
+        task_id: TASK_ID,
+        state: "WAITING_FOR_INPUT",
+        is_agent_running: false,
+        is_resumable: false,
+        needs_resume: false,
+        updated_at: "2026-01-02T00:00:00.000Z",
+      });
+    });
+    await act(async () => {
+      oldRequest.resolve({
+        session_id: SESSION_ID,
+        task_id: PREVIOUS_TASK_ID,
+        state: "FAILED",
+        is_agent_running: false,
+        is_resumable: false,
+        needs_resume: false,
+        error: "session does not belong to task",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      });
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.sessionStatus?.task_id).toBe(TASK_ID);
+  });
+});

--- a/apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts
+++ b/apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts
@@ -60,6 +60,18 @@ describe("useSessionResumption task navigation", () => {
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
 
     await act(async () => {
+      oldRequest.resolve({
+        session_id: SESSION_ID,
+        task_id: PREVIOUS_TASK_ID,
+        state: "FAILED",
+        is_agent_running: false,
+        is_resumable: false,
+        needs_resume: false,
+        error: "session does not belong to task",
+        updated_at: "2026-01-03T00:00:00.000Z",
+      });
+    });
+    await act(async () => {
       currentRequest.resolve({
         session_id: SESSION_ID,
         task_id: TASK_ID,
@@ -70,20 +82,62 @@ describe("useSessionResumption task navigation", () => {
         updated_at: "2026-01-02T00:00:00.000Z",
       });
     });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.sessionStatus?.task_id).toBe(TASK_ID);
+    expect(mockSetTaskSession).toHaveBeenCalledTimes(1);
+    expect(mockSetTaskSession).toHaveBeenCalledWith(
+      expect.objectContaining({ task_id: TASK_ID, state: "WAITING_FOR_INPUT" }),
+    );
+  });
+
+  // @covers AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7
+  it("ignores an obsolete response when navigation returns to the same task and session", async () => {
+    const firstRequest = Promise.withResolvers<unknown>();
+    const middleRequest = Promise.withResolvers<unknown>();
+    const currentRequest = Promise.withResolvers<unknown>();
+    mockRequest
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(middleRequest.promise)
+      .mockReturnValueOnce(currentRequest.promise);
+
+    const { result, rerender } = renderHook(
+      ({ taskId }: { taskId: string }) => useSessionResumption(taskId, SESSION_ID),
+      { initialProps: { taskId: PREVIOUS_TASK_ID } },
+    );
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    rerender({ taskId: TASK_ID });
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+    rerender({ taskId: PREVIOUS_TASK_ID });
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(3));
+
     await act(async () => {
-      oldRequest.resolve({
+      currentRequest.resolve({
+        session_id: SESSION_ID,
+        task_id: PREVIOUS_TASK_ID,
+        state: "WAITING_FOR_INPUT",
+        is_agent_running: false,
+        is_resumable: false,
+        needs_resume: false,
+        updated_at: "2026-01-02T00:00:00.000Z",
+      });
+      firstRequest.resolve({
         session_id: SESSION_ID,
         task_id: PREVIOUS_TASK_ID,
         state: "FAILED",
         is_agent_running: false,
         is_resumable: false,
         needs_resume: false,
-        error: "session does not belong to task",
-        updated_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-03T00:00:00.000Z",
       });
     });
 
     expect(result.current.error).toBeNull();
-    expect(result.current.sessionStatus?.task_id).toBe(TASK_ID);
+    expect(result.current.sessionStatus?.task_id).toBe(PREVIOUS_TASK_ID);
+    expect(mockSetTaskSession).toHaveBeenCalledTimes(1);
+    expect(mockSetTaskSession).toHaveBeenCalledWith(
+      expect.objectContaining({ task_id: PREVIOUS_TASK_ID, state: "WAITING_FOR_INPUT" }),
+    );
   });
 });

--- a/apps/web/hooks/domains/session/use-session-resumption.ts
+++ b/apps/web/hooks/domains/session/use-session-resumption.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { launchSession } from "@/lib/services/session-launch-service";
 import {
@@ -6,6 +6,11 @@ import {
   buildRestoreWorkspaceRequest,
 } from "@/lib/services/session-launch-helpers";
 import { useSessionRecoveryFeedback } from "./use-session-recovery-feedback";
+import {
+  buildGuardedSetters,
+  isCurrentRequest,
+  type SessionRequestIdentity,
+} from "./use-session-resumption-request-guard";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import {
   sessionId as toSessionId,
@@ -506,12 +511,22 @@ function useSessionResetAndCheck({
     sessionStatusState.requestKey === requestKey ? sessionStatusState.status : null;
   const hasAttemptedResume = useRef(false);
   const remoteStatusRetryCount = useRef(0);
-  const activeRequestRef = useRef(requestKey);
+  const requestGenerationRef = useRef(0);
+  const activeRequestRef = useRef<SessionRequestIdentity>({ key: requestKey, generation: 0 });
+
+  // Publish the new identity during commit so callbacks from the previous
+  // request are rejected before passive effects or queued promise handlers run.
+  useLayoutEffect(() => {
+    requestGenerationRef.current += 1;
+    activeRequestRef.current = {
+      key: requestKey,
+      generation: requestGenerationRef.current,
+    };
+  }, [requestKey]);
 
   // Reset all local state when session or task changes to prevent stale data
   // from a previous session leaking into the new one (e.g. topbar branch).
   useEffect(() => {
-    activeRequestRef.current = requestKey;
     hasAttemptedResume.current = false;
     remoteStatusRetryCount.current = 0;
     setters.setResumptionState("idle");
@@ -526,15 +541,16 @@ function useSessionResetAndCheck({
     if (!taskId || !sessionId || connectionStatus !== "connected" || hasAttemptedResume.current)
       return;
     hasAttemptedResume.current = true;
-    const guardedSetters = buildGuardedSetters(activeRequestRef, requestKey, setters);
+    const capturedRequest = activeRequestRef.current;
+    const guardedSetters = buildGuardedSetters(activeRequestRef, capturedRequest, setters);
     checkAndResume({
       taskId,
       sessionId,
       session,
       preventAutoStart,
       setSessionStatus: (s) => {
-        if (activeRequestRef.current === requestKey) {
-          setSessionStatus({ requestKey, status: s });
+        if (isCurrentRequest(activeRequestRef.current, capturedRequest)) {
+          setSessionStatus({ requestKey: capturedRequest.key, status: s });
         }
       },
       setters: guardedSetters,
@@ -548,6 +564,7 @@ function useSessionResetAndCheck({
     if (!sessionStatus?.is_remote_executor) return;
     if (sessionStatus.remote_checked_at || sessionStatus.remote_status_error) return;
     if (remoteStatusRetryCount.current >= 3) return;
+    const capturedRequest = activeRequestRef.current;
 
     const timer = window.setTimeout(async () => {
       const client = getWebSocketClient();
@@ -558,8 +575,8 @@ function useSessionResetAndCheck({
           task_id: taskId,
           session_id: sessionId,
         });
-        if (activeRequestRef.current === requestKey) {
-          setSessionStatus({ requestKey, status: nextStatus });
+        if (isCurrentRequest(activeRequestRef.current, capturedRequest)) {
+          setSessionStatus({ requestKey: capturedRequest.key, status: nextStatus });
         }
       } catch {
         // Best-effort refresh only.
@@ -570,46 +587,6 @@ function useSessionResetAndCheck({
   }, [taskId, sessionId, connectionStatus, sessionStatus]);
 
   return { sessionStatus };
-}
-
-/** Wrap state setters with a guard that prevents stale async callbacks from updating state. */
-function buildGuardedSetters(
-  activeRequestRef: React.RefObject<string>,
-  capturedRequestKey: string,
-  setters: ResumeStateSetter,
-): ResumeStateSetter {
-  const guard = () => activeRequestRef.current === capturedRequestKey;
-  return {
-    ...setters,
-    setResumptionState: (s) => {
-      if (guard()) setters.setResumptionState(s);
-    },
-    setError: (e) => {
-      if (guard()) setters.setError(e);
-    },
-    setNotice: (notice) => {
-      if (guard()) setters.setNotice?.(notice);
-    },
-    setWorktreePath: (p) => {
-      if (guard()) setters.setWorktreePath(p);
-    },
-    setWorktreeBranch: (b) => {
-      if (guard()) setters.setWorktreeBranch(b);
-    },
-    // The remaining setters write store state keyed by session id, but a
-    // stale async callback completing after navigation can still touch the
-    // previous session's row (e.g. re-mark it resume-skipped or overwrite its
-    // status). Guard them all so a switched-away session is never mutated.
-    setTaskSession: (s) => {
-      if (guard()) setters.setTaskSession(s);
-    },
-    setAgentctlReady: (sid) => {
-      if (guard()) setters.setAgentctlReady?.(sid);
-    },
-    setResumeSkipped: (sid, skipped) => {
-      if (guard()) setters.setResumeSkipped?.(sid, skipped);
-    },
-  };
 }
 
 export function useSessionResumption(

--- a/apps/web/hooks/domains/session/use-session-resumption.ts
+++ b/apps/web/hooks/domains/session/use-session-resumption.ts
@@ -485,6 +485,9 @@ type ResetAndCheckParams = {
   preventAutoStart: boolean;
 };
 
+const getSessionRequestKey = (taskId: string | null, sessionId: string | null) =>
+  JSON.stringify([taskId, sessionId]);
+
 /** Extracted effects: reset state on session/task change, auto-check/resume, and remote retry. */
 function useSessionResetAndCheck({
   taskId,
@@ -494,20 +497,21 @@ function useSessionResetAndCheck({
   setters,
   preventAutoStart,
 }: ResetAndCheckParams): SessionResetAndCheckResult {
+  const requestKey = getSessionRequestKey(taskId, sessionId);
   const [sessionStatusState, setSessionStatus] = useState<{
-    id: string | null;
+    requestKey: string;
     status: SessionStatus | null;
-  }>({ id: sessionId, status: null });
-  // Reset sessionStatus when sessionId changes (derived, not in effect)
-  const sessionStatus = sessionStatusState.id === sessionId ? sessionStatusState.status : null;
+  }>({ requestKey, status: null });
+  const sessionStatus =
+    sessionStatusState.requestKey === requestKey ? sessionStatusState.status : null;
   const hasAttemptedResume = useRef(false);
   const remoteStatusRetryCount = useRef(0);
-  const activeSessionRef = useRef(sessionId);
+  const activeRequestRef = useRef(requestKey);
 
   // Reset all local state when session or task changes to prevent stale data
   // from a previous session leaking into the new one (e.g. topbar branch).
   useEffect(() => {
-    activeSessionRef.current = sessionId;
+    activeRequestRef.current = requestKey;
     hasAttemptedResume.current = false;
     remoteStatusRetryCount.current = 0;
     setters.setResumptionState("idle");
@@ -522,14 +526,16 @@ function useSessionResetAndCheck({
     if (!taskId || !sessionId || connectionStatus !== "connected" || hasAttemptedResume.current)
       return;
     hasAttemptedResume.current = true;
-    const guardedSetters = buildGuardedSetters(activeSessionRef, sessionId, setters);
+    const guardedSetters = buildGuardedSetters(activeRequestRef, requestKey, setters);
     checkAndResume({
       taskId,
       sessionId,
       session,
       preventAutoStart,
       setSessionStatus: (s) => {
-        if (activeSessionRef.current === sessionId) setSessionStatus({ id: sessionId, status: s });
+        if (activeRequestRef.current === requestKey) {
+          setSessionStatus({ requestKey, status: s });
+        }
       },
       setters: guardedSetters,
     });
@@ -552,7 +558,9 @@ function useSessionResetAndCheck({
           task_id: taskId,
           session_id: sessionId,
         });
-        setSessionStatus({ id: sessionId, status: nextStatus });
+        if (activeRequestRef.current === requestKey) {
+          setSessionStatus({ requestKey, status: nextStatus });
+        }
       } catch {
         // Best-effort refresh only.
       }
@@ -566,11 +574,11 @@ function useSessionResetAndCheck({
 
 /** Wrap state setters with a guard that prevents stale async callbacks from updating state. */
 function buildGuardedSetters(
-  activeSessionRef: React.RefObject<string | null>,
-  capturedSessionId: string,
+  activeRequestRef: React.RefObject<string>,
+  capturedRequestKey: string,
   setters: ResumeStateSetter,
 ): ResumeStateSetter {
-  const guard = () => activeSessionRef.current === capturedSessionId;
+  const guard = () => activeRequestRef.current === capturedRequestKey;
   return {
     ...setters,
     setResumptionState: (s) => {

--- a/docs/plans/session-resumption-navigation-race/plan.md
+++ b/docs/plans/session-resumption-navigation-race/plan.md
@@ -1,0 +1,116 @@
+---
+created: 2026-09-02
+status: implemented
+requirements:
+  - REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002
+system_design:
+  - ../../specs/agents/system-design/agent-resume-runtime-recovery.md
+legacy_specs: []
+---
+
+# Implementation Plan: Guard Session Resumption During Navigation
+
+## Overview
+
+Prevent an automatic session-status result from the task being left from
+updating the recovery state of the task being opened. Treat the task ID and
+session ID together as the request identity and prove the navigation race with
+a focused hook regression test.
+
+## Confirmed root cause
+
+- During task navigation, the route can supply the destination session ID
+  before the task store replaces the previously active task ID.
+- `useSessionResetAndCheck` can therefore start one status request with the old
+  task ID and destination session ID, followed by a correct request for the
+  destination task and the same session ID.
+- The callback guard in `use-session-resumption.ts` compares only the session
+  ID. Because both requests use the same session, the stale mismatch response
+  remains authorized after the task ID changes.
+- A successful current response does not clear an error written later by the
+  stale response, so the task view shows `session does not belong to task`.
+- The backend ownership check is correct and must remain unchanged.
+
+## Scope
+
+### In scope
+
+- Make the automatic status and recovery callback guard identify both the task
+  and session captured for the request.
+- Ignore all feedback and session-status writes from a request whose task or
+  session is no longer current.
+- Add a deterministic hook test that keeps the session ID constant, changes
+  the task ID, and resolves the old request after the current request starts.
+- Keep the same behavior in desktop and mobile because both use the shared
+  session-resumption hook.
+
+### Out of scope
+
+- Relaxing backend task-session ownership validation.
+- Changing task routing, store hydration, or session selection behavior.
+- Changing recovery copy, layout, controls, or localization.
+- Adding a new retry or recovery workflow.
+
+## Technical approach
+
+Replace the session-only active-request reference in
+`useSessionResetAndCheck` with a task-session identity. Capture that identity
+when a status check begins and let guarded setters mutate error, notice,
+attempt, and status state only while the complete identity remains current.
+Keep the request and recovery protocol unchanged.
+
+Start with a failing regression in the existing stale-callback test group. The
+test rerenders the hook with a different task ID and the same session ID, lets
+the current request succeed, then delivers the old task's mismatch result. The
+observable state must remain successful with no stale recovery error.
+
+## Work orders
+
+- [x] [Task 01: Guard automatic recovery by task-session identity](task-01-guard-resumption-request-identity.md)
+
+## Dependency order
+
+```text
+Task 01
+```
+
+The production guard and its regression test share one behavioral boundary,
+so the package is sequential.
+
+## Verification strategy
+
+- Run the new test before the production edit and record its expected failure.
+- Run the focused session-resumption test file after the minimal guard change.
+- Run targeted lint and the web typecheck.
+- No new Playwright scenario is required. This is pure shared state
+  normalization with no rendered layout, touch target, navigation control, or
+  desktop/mobile composition change.
+
+## Risks
+
+- A session-only check can reintroduce the race when two tasks reference the
+  same route session during store convergence. Keep the complete identity in
+  one comparison boundary.
+- An over-broad cancellation mechanism could discard a valid response for the
+  current task. Test that the current request still updates state normally.
+- Updating only error setters would leave stale status or notice writes
+  possible. Apply the same identity guard to every callback from the request.
+
+## Package handoff
+
+Implement the single work order with TDD. Record the red and green commands in
+the work order and update both plan statuses when verification passes.
+
+## Results
+
+- Automatic status, recovery feedback, and delayed remote-status callbacks are
+  guarded by the complete task-session request key.
+- Session status snapshots are also keyed by the complete identity, so a task
+  change cannot reuse status merely because its session ID is unchanged.
+- The deterministic navigation regression failed before the production change
+  with `session does not belong to task` and passes after the change.
+- Both focused test files pass 20 tests. Targeted lint, web typecheck, Prettier,
+  specification lint, and `git diff --check` pass.
+- No Playwright test was added because the change normalizes shared state and
+  does not alter layout, touch behavior, scrolling, navigation, or responsive
+  composition. Desktop and mobile consume the same corrected hook.

--- a/docs/plans/session-resumption-navigation-race/plan.md
+++ b/docs/plans/session-resumption-navigation-race/plan.md
@@ -54,10 +54,11 @@ a focused hook regression test.
 ## Technical approach
 
 Replace the session-only active-request reference in
-`useSessionResetAndCheck` with a task-session identity. Capture that identity
-when a status check begins and let guarded setters mutate error, notice,
-attempt, and status state only while the complete identity remains current.
-Keep the request and recovery protocol unchanged.
+`useSessionResetAndCheck` with a task-session identity and a monotonic
+navigation generation. Publish the identity during commit, capture it when a
+status check begins, and let guarded setters mutate error, notice, attempt,
+and status state only while the complete identity remains current. Keep the
+request and recovery protocol unchanged.
 
 Start with a failing regression in the existing stale-callback test group. The
 test rerenders the hook with a different task ID and the same session ID, lets
@@ -90,7 +91,10 @@ so the package is sequential.
 
 - A session-only check can reintroduce the race when two tasks reference the
   same route session during store convergence. Keep the complete identity in
-  one comparison boundary.
+  one comparison boundary and include a generation for repeated navigation to
+  the same pair.
+- Publishing the identity in a passive effect leaves a commit-to-effect race.
+  Update it in a layout effect before asynchronous callbacks can run.
 - An over-broad cancellation mechanism could discard a valid response for the
   current task. Test that the current request still updates state normally.
 - Updating only error setters would leave stale status or notice writes
@@ -104,12 +108,15 @@ the work order and update both plan statuses when verification passes.
 ## Results
 
 - Automatic status, recovery feedback, and delayed remote-status callbacks are
-  guarded by the complete task-session request key.
+  guarded by the complete task-session request key and a monotonic generation.
+- The active identity is published in a commit-phase layout effect, so a
+  previous callback cannot run through the passive-effect setup window.
 - Session status snapshots are also keyed by the complete identity, so a task
   change cannot reuse status merely because its session ID is unchanged.
-- The deterministic navigation regression failed before the production change
-  with `session does not belong to task` and passes after the change.
-- Both focused test files pass 20 tests. Targeted lint, web typecheck, Prettier,
+- The deterministic navigation regressions cover both task changes and
+  navigation that returns to the same task-session pair. The original test
+  failed before the production change with `session does not belong to task`.
+- Both focused test files pass 21 tests. Targeted lint, web typecheck, Prettier,
   specification lint, and `git diff --check` pass.
 - No Playwright test was added because the change normalizes shared state and
   does not alter layout, touch behavior, scrolling, navigation, or responsive

--- a/docs/plans/session-resumption-navigation-race/task-01-guard-resumption-request-identity.md
+++ b/docs/plans/session-resumption-navigation-race/task-01-guard-resumption-request-identity.md
@@ -1,0 +1,102 @@
+---
+id: "01-guard-resumption-request-identity"
+title: "Guard resumption request identity"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002
+acceptance_criteria:
+  - AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7
+system_design:
+  - ../../specs/agents/system-design/agent-resume-runtime-recovery.md
+---
+
+# Task 01: Guard Automatic Recovery by Task-Session Identity
+
+## Summary
+
+Reject stale automatic session-status callbacks after task navigation, even
+when the old and current requests use the same session ID.
+
+## In scope
+
+- Add the regression test before editing production code.
+- Rerender the hook with a new task ID while preserving the session ID.
+- Control both status promises so the stale old-task result arrives after the
+  current request has started.
+- Make every request-owned setter validate the captured task ID and session ID.
+- Preserve current automatic resume, read-only fallback, and status behavior
+  for the active identity.
+
+## Out of scope
+
+- Backend validation changes.
+- Task-page routing or store synchronization changes.
+- UI markup, copy, responsive behavior, and localization changes.
+- New E2E coverage for a state-only fix.
+
+## Acceptance
+
+- A result captured for the prior task cannot set recovery error, notice,
+  attempt, or session-status state after the task ID changes.
+- The guard rejects the stale result when the session ID remains unchanged.
+- The current task-session request still updates state normally.
+- The focused hook suite, targeted lint, and web typecheck pass.
+
+## Verification
+
+Run from the repository root:
+
+```bash
+(cd apps && rtk pnpm --filter @kandev/web test -- --run hooks/domains/session/use-session-resumption.test.ts hooks/domains/session/use-session-resumption.navigation.test.ts)
+(cd apps/web && rtk pnpm exec eslint hooks/domains/session/use-session-resumption.ts hooks/domains/session/use-session-resumption.test.ts hooks/domains/session/use-session-resumption.navigation.test.ts)
+(cd apps/web && rtk pnpm run typecheck)
+```
+
+Before the production edit, run the focused regression by its exact test name
+and record the expected failure. After the edit, rerun the exact regression and
+then the complete commands above.
+
+## Files likely touched
+
+- `apps/web/hooks/domains/session/use-session-resumption.ts`
+- `apps/web/hooks/domains/session/use-session-resumption.test.ts`
+- `apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts`
+- `docs/plans/session-resumption-navigation-race/plan.md`
+- `docs/plans/session-resumption-navigation-race/task-01-guard-resumption-request-identity.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. The test and production guard share the same hook boundary.
+
+## Inputs
+
+- The confirmed request sequence from the running instance.
+- The amended recovery requirement and system design.
+- The existing stale-callback hook tests.
+
+## Output contract
+
+Report the files changed, red and green test evidence, lint and typecheck
+outcomes, and any remaining risk. Update this work order to `done` and the plan
+to `implemented` only after all task checks pass.
+
+## Results
+
+- RED: the exact navigation regression failed because the stale old-task
+  response set `session does not belong to task` after the correct response.
+- GREEN: the exact regression passes after the task-session request-key guard.
+- GREEN: the two focused session-resumption test files pass 20 tests.
+- GREEN: targeted ESLint completes with no warnings or errors, web typecheck
+  exits successfully, and both changed TypeScript files pass Prettier.
+- GREEN: all specification files pass their linter and `git diff --check`
+  succeeds.
+- Mobile parity is preserved through the shared hook. No rendered or
+  viewport-dependent behavior changed, so a new mobile Playwright case would
+  duplicate the state-level regression without adding coverage.

--- a/docs/plans/session-resumption-navigation-race/task-01-guard-resumption-request-identity.md
+++ b/docs/plans/session-resumption-navigation-race/task-01-guard-resumption-request-identity.md
@@ -26,7 +26,9 @@ when the old and current requests use the same session ID.
 - Rerender the hook with a new task ID while preserving the session ID.
 - Control both status promises so the stale old-task result arrives after the
   current request has started.
-- Make every request-owned setter validate the captured task ID and session ID.
+- Make every request-owned setter validate the captured task ID, session ID,
+  and monotonic navigation generation.
+- Publish the active request identity during commit before passive effects run.
 - Preserve current automatic resume, read-only fallback, and status behavior
   for the active identity.
 
@@ -42,6 +44,8 @@ when the old and current requests use the same session ID.
 - A result captured for the prior task cannot set recovery error, notice,
   attempt, or session-status state after the task ID changes.
 - The guard rejects the stale result when the session ID remains unchanged.
+- A repeated task-session pair receives a new generation, so an earlier
+  navigation cycle cannot update the returned task.
 - The current task-session request still updates state normally.
 - The focused hook suite, targeted lint, and web typecheck pass.
 
@@ -62,6 +66,7 @@ then the complete commands above.
 ## Files likely touched
 
 - `apps/web/hooks/domains/session/use-session-resumption.ts`
+- `apps/web/hooks/domains/session/use-session-resumption-request-guard.ts`
 - `apps/web/hooks/domains/session/use-session-resumption.test.ts`
 - `apps/web/hooks/domains/session/use-session-resumption.navigation.test.ts`
 - `docs/plans/session-resumption-navigation-race/plan.md`
@@ -92,9 +97,9 @@ to `implemented` only after all task checks pass.
 - RED: the exact navigation regression failed because the stale old-task
   response set `session does not belong to task` after the correct response.
 - GREEN: the exact regression passes after the task-session request-key guard.
-- GREEN: the two focused session-resumption test files pass 20 tests.
+- GREEN: the two focused session-resumption test files pass 21 tests.
 - GREEN: targeted ESLint completes with no warnings or errors, web typecheck
-  exits successfully, and both changed TypeScript files pass Prettier.
+  exits successfully, and all changed TypeScript files pass Prettier.
 - GREEN: all specification files pass their linter and `git diff --check`
   succeeds.
 - Mobile parity is preserved through the shared hook. No rendered or

--- a/docs/specs/agents/requirements/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/requirements/agent-resume-runtime-recovery.md
@@ -42,7 +42,7 @@ Preserve the observable behavior documented for Agent Resume and Runtime Recover
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.4:** A user can select read-only workspace restore after a manual resume failure. Kandev does not silently replace a manual Resume request with read-only restore.
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.5:** Desktop, narrow desktop, and mobile task views use the existing inline alert and chat recovery patterns. Recovery actions remain reachable by keyboard and touch without horizontal overflow.
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.6:** A Retry recovery control is disabled while its recovery request is in flight on every recovery surface. A repeated attempt cannot create overlapping `session.recover` requests.
-- **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7:** When task navigation changes the active task while an automatic session-status or recovery request is in flight, the task view ignores the result owned by the prior task-session identity. An error from the prior identity does not appear on the newly selected task.
+- **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7:** When task navigation changes the active task while an automatic session-status or recovery request is in flight, the task view ignores the result owned by the prior task-session identity. An error from the prior identity does not appear on the newly selected task. Each navigation cycle invalidates prior attempts even when the task-session pair later repeats.
 
 ### REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-003: Explicit continuation after branch loss
 
@@ -196,6 +196,10 @@ without repairing it.
   task's automatic session-status request remains unresolved, **WHEN** the
   prior result arrives after the current request starts, **THEN** the current
   task ignores the prior result and does not show its recovery error.
+- **GIVEN** navigation leaves a task-session pair and then returns to the same
+  pair while the first request remains unresolved, **WHEN** the first result
+  arrives after the return request starts, **THEN** the returned task ignores
+  the obsolete result and keeps the return request's state.
 - **GIVEN** the stored worktree branch is absent locally and on its configured
   remote, **WHEN** Resume fails, **THEN** the UI offers **Continue on a new
   branch** and does not run it automatically.

--- a/docs/specs/agents/requirements/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/requirements/agent-resume-runtime-recovery.md
@@ -2,7 +2,7 @@
 status: active
 system: agents
 created: 2026-07-27
-updated: 2026-09-01
+updated: 2026-09-02
 owners:
   - Kandev
 ---
@@ -42,6 +42,7 @@ Preserve the observable behavior documented for Agent Resume and Runtime Recover
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.4:** A user can select read-only workspace restore after a manual resume failure. Kandev does not silently replace a manual Resume request with read-only restore.
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.5:** Desktop, narrow desktop, and mobile task views use the existing inline alert and chat recovery patterns. Recovery actions remain reachable by keyboard and touch without horizontal overflow.
 - **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.6:** A Retry recovery control is disabled while its recovery request is in flight on every recovery surface. A repeated attempt cannot create overlapping `session.recover` requests.
+- **AC-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-002.7:** When task navigation changes the active task while an automatic session-status or recovery request is in flight, the task view ignores the result owned by the prior task-session identity. An error from the prior identity does not appear on the newly selected task.
 
 ### REQ-AGENTS-AGENT-RESUME-RUNTIME-RECOVERY-003: Explicit continuation after branch loss
 
@@ -112,6 +113,8 @@ without repairing it.
 - A failed resume stays visible with the backend cause and a recovery action.
 - An automatic read-only restore states that resume failed and that the
   restored workspace is read-only.
+- A task selected during navigation does not show a session-status or recovery
+  error produced for the task that was previously active.
 - A confirmed missing branch offers explicit continuation on a new branch from
   the task base branch. The same conversation continues, but lost code does
   not return.
@@ -189,6 +192,10 @@ without repairing it.
   workspace is read-only.
 - **GIVEN** automatic resume and read-only restore both fail, **WHEN** the task
   view loads, **THEN** it shows both failure causes.
+- **GIVEN** navigation selects a session on another task while the prior
+  task's automatic session-status request remains unresolved, **WHEN** the
+  prior result arrives after the current request starts, **THEN** the current
+  task ignores the prior result and does not show its recovery error.
 - **GIVEN** the stored worktree branch is absent locally and on its configured
   remote, **WHEN** Resume fails, **THEN** the UI offers **Continue on a new
   branch** and does not run it automatically.

--- a/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
@@ -236,6 +236,14 @@ resumption hook also clears stale feedback when the shared live session state
 transitions to `STARTING`, `RUNNING`, or `WAITING_FOR_INPUT` after an external
 manual recovery.
 
+An automatic status or recovery attempt is owned by the complete task-session
+identity, not by the session ID alone. Task navigation can briefly present the
+new route session while the task store still contains the previously active
+task. Each callback therefore applies feedback and status only when both its
+captured task ID and session ID still match the current request identity. A
+late result from the prior task cannot set an error, notice, or status on the
+newly selected task.
+
 ## Frontend status rendering
 
 `StatusMessage` maps `metadata.kind === "branch_recreated"` to localized
@@ -296,7 +304,8 @@ Backend tests start with the current failure:
 - The WebSocket handler maps the sentinel to a conflict with recovery details.
 
 Frontend unit tests cover the typed WebSocket error, both manual recovery
-surfaces, visible automatic fallback, dual failure detail, and
+surfaces, visible automatic fallback, dual failure detail, task navigation
+with the same route session while the task identity changes, and
 `branch_recreated` status rendering.
 
 Desktop and mobile Playwright tests cover the user sequence from a failed

--- a/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
+++ b/docs/specs/agents/system-design/agent-resume-runtime-recovery.md
@@ -240,9 +240,13 @@ An automatic status or recovery attempt is owned by the complete task-session
 identity, not by the session ID alone. Task navigation can briefly present the
 new route session while the task store still contains the previously active
 task. Each callback therefore applies feedback and status only when both its
-captured task ID and session ID still match the current request identity. A
-late result from the prior task cannot set an error, notice, or status on the
-newly selected task.
+captured task ID and session ID still match the current request identity. The
+identity also carries a monotonic generation that changes on every committed
+navigation cycle, so returning to the same task-session pair still invalidates
+callbacks from the earlier cycle. The frontend publishes the identity during
+the commit phase, before passive effects can start or finish a request. A late
+result from the prior task or navigation cycle cannot set an error, notice, or
+status on the newly selected task.
 
 ## Frontend status rendering
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3302/a1fa9ffa2656.html)
<!-- kandev-pr-walkthrough-end -->

Navigating between tasks could let a delayed session-resumption response from the previous task update the newly selected task when both reused the same session ID. Resumption state now validates the complete task-and-session request identity, and a regression test covers the race.

## Important Changes

- Bind asynchronous session-resumption status and recovery callbacks to the full task-and-session request identity so stale responses cannot cross task navigation boundaries.
- Add a regression test for navigation to a different task that reuses the same session ID.

## Validation

- `cd apps/web && pnpm vitest run hooks/domains/session/use-session-resumption.navigation.test.ts hooks/domains/session/use-session-resumption.test.ts`
- `cd apps/web && pnpm run typecheck`
- Targeted ESLint and Prettier checks for the changed frontend files.
- `python3 scripts/lint-spec-files.py --all`
- `git diff --check`
- Disposable Playwright capture at mobile and desktop viewports completed successfully; the screenshots are attached below.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop task view after navigation with no stale recovery error](https://raw.githubusercontent.com/kdlbs/kandev/accc3f9aa3f39e87ed5f4f6bbac9fff6ea51344d/mobile-pr-session-resumption-capture-desktop--desktop-task-navigation-stable.png)

![Mobile task view after navigation with no stale recovery error](https://raw.githubusercontent.com/kdlbs/kandev/accc3f9aa3f39e87ed5f4f6bbac9fff6ea51344d/mobile-pr-session-resumption-capture--mobile-task-navigation-stable.png)
<!-- kandev-screenshots-end -->