### PR TITLE
fix(web): stop chat from saying no utility agent is configured after you save one

### DIFF
--- a/apps/backend/internal/backendapp/boot_state_routes.go
+++ b/apps/backend/internal/backendapp/boot_state_routes.go
@@ -655,6 +655,7 @@ func mapUserSettingsState(response userdto.UserSettingsResponse, workspaceID str
 		"sidebarTaskPrefs":                  mapSidebarTaskPrefs(settings.SidebarTaskPrefs),
 		"taskCreateLastUsed":                mapTaskCreateLastUsed(settings.TaskCreateLastUsed),
 		"defaultUtilityAgentId":             nullString(settings.DefaultUtilityAgentID),
+		"defaultUtilityAgentProfileId":      nullString(settings.DefaultUtilityAgentProfileID),
 		"keyboardShortcuts":                 mapStringAny(settings.KeyboardShortcuts),
 		"terminalLinkBehavior":              terminalLinkBehavior(settings.TerminalLinkBehavior),
 		"terminalFontFamily":                nullString(settings.TerminalFontFamily),

--- a/apps/backend/internal/backendapp/boot_state_user_settings_test.go
+++ b/apps/backend/internal/backendapp/boot_state_user_settings_test.go
@@ -185,6 +185,19 @@ func TestMapUserSettingsStateNormalizesLastSeenDisplay(t *testing.T) {
 	}
 }
 
+// TestMapUserSettingsStateIncludesDefaultUtilityAgentProfileID verifies boot state carries the
+// default utility agent profile id, the field the Settings UI actually writes.
+func TestMapUserSettingsStateIncludesDefaultUtilityAgentProfileID(t *testing.T) {
+	state := mapUserSettingsState(userdto.UserSettingsResponse{
+		Settings: userdto.UserSettingsDTO{DefaultUtilityAgentProfileID: "profile-1"},
+	}, "workspace-1")
+
+	got, ok := state["defaultUtilityAgentProfileId"].(string)
+	if !ok || got != "profile-1" {
+		t.Fatalf("defaultUtilityAgentProfileId = %#v, want profile-1", state["defaultUtilityAgentProfileId"])
+	}
+}
+
 // TestMapUserSettingsStateIncludesSystemMetricsDisplayPreference verifies boot state carries the system metrics display preference.
 func TestMapUserSettingsStateIncludesSystemMetricsDisplayPreference(t *testing.T) {
 	state := mapUserSettingsState(userdto.UserSettingsResponse{

--- a/apps/web/components/settings/utility-agents-section-save.test.tsx
+++ b/apps/web/components/settings/utility-agents-section-save.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { StateProvider, useAppStore } from "@/components/state-provider";
+import { StateProvider, useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { defaultState } from "@/lib/state/default-state";
 import { SettingsSaveProvider } from "./settings-save-provider";
 import type { UtilityAgent } from "@/lib/api/domains/utility-api";
@@ -66,12 +66,31 @@ function ReadDefaultUtilityAgentProfileId() {
   return <div data-testid="stored-profile-id">{value ?? ""}</div>;
 }
 
+function SetNewerDefaultUtilityAgentProfile() {
+  const storeApi = useAppStoreApi();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        storeApi.getState().setUserSettings({
+          ...storeApi.getState().userSettings,
+          defaultUtilityAgentProfileId: "profile-2",
+          revision: 2,
+        })
+      }
+    >
+      Apply newer profile update
+    </button>
+  );
+}
+
 function renderSection() {
   return render(
     <StateProvider initialState={{ userSettings: { ...defaultState.userSettings } }}>
       <SettingsSaveProvider>
         <UtilityAgentsSection />
       </SettingsSaveProvider>
+      <SetNewerDefaultUtilityAgentProfile />
       <ReadDefaultUtilityAgentProfileId />
     </StateProvider>,
   );
@@ -105,6 +124,33 @@ describe("UtilityAgentsSection save", () => {
     );
     await waitFor(() =>
       expect(screen.getByTestId("stored-profile-id").textContent).toBe("profile-1"),
+    );
+  });
+
+  it("does not overwrite a newer store update when the save response arrives late", async () => {
+    let resolveUpdate: (value: unknown) => void = () => undefined;
+    updateUserSettings.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Pick default profile" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(updateUserSettings).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply newer profile update" }));
+    resolveUpdate({
+      settings: {
+        revision: 1,
+        default_utility_agent_profile_id: "profile-1",
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("stored-profile-id").textContent).toBe("profile-2"),
     );
   });
 });

--- a/apps/web/components/settings/utility-agents-section-save.test.tsx
+++ b/apps/web/components/settings/utility-agents-section-save.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StateProvider, useAppStore } from "@/components/state-provider";
+import { defaultState } from "@/lib/state/default-state";
+import { SettingsSaveProvider } from "./settings-save-provider";
+import type { UtilityAgent } from "@/lib/api/domains/utility-api";
+
+const listUtilityAgents = vi.fn();
+const updateUtilityAgent = vi.fn();
+const deleteUtilityAgent = vi.fn();
+const fetchUserSettings = vi.fn();
+const updateUserSettings = vi.fn();
+
+vi.mock("@/lib/api/domains/utility-api", () => ({
+  listUtilityAgents: (...args: unknown[]) => listUtilityAgents(...args),
+  updateUtilityAgent: (...args: unknown[]) => updateUtilityAgent(...args),
+  deleteUtilityAgent: (...args: unknown[]) => deleteUtilityAgent(...args),
+}));
+
+vi.mock("@/lib/api/domains/settings-api", () => ({
+  fetchUserSettings: (...args: unknown[]) => fetchUserSettings(...args),
+  updateUserSettings: (...args: unknown[]) => updateUserSettings(...args),
+}));
+
+vi.mock("@/components/settings/config-chat-agent-section", () => ({
+  ConfigChatAgentSection: () => null,
+}));
+
+vi.mock("@/components/settings/utility-agent-dialog", () => ({
+  UtilityAgentDialog: () => null,
+}));
+
+vi.mock("@/components/settings/utility-sections", async () => {
+  const actual = await vi.importActual<typeof import("./utility-sections")>("./utility-sections");
+  return {
+    ...actual,
+    DefaultModelSection: ({ onProfileChange }: { onProfileChange: (value: string) => void }) => (
+      <button type="button" onClick={() => onProfileChange("profile-1")}>
+        Pick default profile
+      </button>
+    ),
+    PerActionOverridesSection: () => null,
+    CustomAgentsSection: () => null,
+  };
+});
+
+import { UtilityAgentsSection } from "./utility-agents-section";
+
+function agent(id: string): UtilityAgent {
+  return {
+    id,
+    name: id,
+    description: "",
+    builtin: true,
+    enabled: true,
+    agent_id: "agent-1",
+    model: "",
+    prompt: "",
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function ReadDefaultUtilityAgentProfileId() {
+  const value = useAppStore((state) => state.userSettings.defaultUtilityAgentProfileId);
+  return <div data-testid="stored-profile-id">{value ?? ""}</div>;
+}
+
+function renderSection() {
+  return render(
+    <StateProvider initialState={{ userSettings: { ...defaultState.userSettings } }}>
+      <SettingsSaveProvider>
+        <UtilityAgentsSection />
+      </SettingsSaveProvider>
+      <ReadDefaultUtilityAgentProfileId />
+    </StateProvider>,
+  );
+}
+
+beforeEach(() => {
+  listUtilityAgents.mockReset().mockResolvedValue({ agents: [agent("commit")] });
+  fetchUserSettings.mockReset().mockResolvedValue({ settings: {} });
+  updateUserSettings.mockReset().mockResolvedValue({ settings: {} });
+  updateUtilityAgent.mockReset().mockResolvedValue({});
+  deleteUtilityAgent.mockReset().mockResolvedValue({});
+});
+
+afterEach(cleanup);
+
+describe("UtilityAgentsSection save", () => {
+  it("pushes the saved default utility agent profile id into the store", async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Pick default profile" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(updateUserSettings).toHaveBeenCalledWith({
+        default_utility_agent_profile_id: "profile-1",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("stored-profile-id").textContent).toBe("profile-1"),
+    );
+  });
+});

--- a/apps/web/components/settings/utility-agents-section-save.test.tsx
+++ b/apps/web/components/settings/utility-agents-section-save.test.tsx
@@ -80,7 +80,11 @@ function renderSection() {
 beforeEach(() => {
   listUtilityAgents.mockReset().mockResolvedValue({ agents: [agent("commit")] });
   fetchUserSettings.mockReset().mockResolvedValue({ settings: {} });
-  updateUserSettings.mockReset().mockResolvedValue({ settings: {} });
+  updateUserSettings
+    .mockReset()
+    .mockImplementation((payload: Record<string, unknown>) =>
+      Promise.resolve({ settings: { revision: 1, ...payload } }),
+    );
   updateUtilityAgent.mockReset().mockResolvedValue({});
   deleteUtilityAgent.mockReset().mockResolvedValue({});
 });

--- a/apps/web/components/settings/utility-agents-section.tsx
+++ b/apps/web/components/settings/utility-agents-section.tsx
@@ -19,7 +19,7 @@ import {
   CustomAgentsSection,
   USE_DEFAULT,
 } from "@/components/settings/utility-sections";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useSettingsSaveContributor } from "./settings-save-provider";
 export { isUtilityAgentDirty } from "./utility-dirty";
 
@@ -95,6 +95,8 @@ function revision(agents: UtilityAgent[], profileId: string) {
 export function UtilityAgentsSection() {
   const { t } = useTranslation();
   const profiles = useAppStore((state) => state.agentProfiles.items);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const storeApi = useAppStoreApi();
   const [agents, setAgents] = useState<UtilityAgent[]>([]);
   const [savedAgents, setSavedAgents] = useState<UtilityAgent[]>([]);
   const [defaultProfileId, setDefaultProfileId] = useState("");
@@ -157,6 +159,10 @@ export function UtilityAgentsSection() {
       ]);
       setSavedAgents(agents);
       setSavedDefaultProfileId(defaultProfileId);
+      setUserSettings({
+        ...storeApi.getState().userSettings,
+        defaultUtilityAgentProfileId: defaultProfileId || null,
+      });
     },
     discard: () => {
       setAgents(savedAgents);

--- a/apps/web/components/settings/utility-agents-section.tsx
+++ b/apps/web/components/settings/utility-agents-section.tsx
@@ -9,6 +9,8 @@ import {
   type UtilityAgent,
 } from "@/lib/api/domains/utility-api";
 import { fetchUserSettings, updateUserSettings } from "@/lib/api/domains/settings-api";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { compareUserSettingsRevisions } from "@/lib/settings/user-settings-revision";
 import { SettingsPageHeader } from "@/components/settings/settings-typography";
 import { Separator } from "@kandev/ui/separator";
 import { UtilityAgentDialog } from "@/components/settings/utility-agent-dialog";
@@ -147,7 +149,8 @@ export function UtilityAgentsSection() {
             );
           })(),
       );
-      await Promise.all([
+      const settingsAtSubmit = storeApi.getState().userSettings;
+      const [userSettingsResponse] = await Promise.all([
         updateUserSettings({ default_utility_agent_profile_id: defaultProfileId }),
         ...changed.map((agent) =>
           updateUtilityAgent(agent.id, {
@@ -159,10 +162,16 @@ export function UtilityAgentsSection() {
       ]);
       setSavedAgents(agents);
       setSavedDefaultProfileId(defaultProfileId);
-      setUserSettings({
-        ...storeApi.getState().userSettings,
-        defaultUtilityAgentProfileId: defaultProfileId || null,
-      });
+      const latestUserSettings = storeApi.getState().userSettings;
+      const responseOrder = compareUserSettingsRevisions(
+        userSettingsResponse.settings.revision,
+        latestUserSettings.revision,
+      );
+      const responseIsCurrent =
+        responseOrder === null ? latestUserSettings === settingsAtSubmit : responseOrder >= 0;
+      if (responseIsCurrent) {
+        setUserSettings(mapUserSettingsResponse(userSettingsResponse, latestUserSettings));
+      }
     },
     discard: () => {
       setAgents(savedAgents);

--- a/apps/web/e2e/tests/task/enhance-prompt.spec.ts
+++ b/apps/web/e2e/tests/task/enhance-prompt.spec.ts
@@ -227,14 +227,36 @@ test.describe("Enhance prompt button in task creation", () => {
     await expect(testPage.getByTestId("prompt-result-recovery")).toHaveCount(0);
   });
 
+  test("enhance button is enabled when only the utility agent profile id is configured", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // This is the state every current user is in after using Settings > Utility
+    // Agents: the legacy default_utility_agent_id field is never written by the
+    // UI, only default_utility_agent_profile_id.
+    await apiClient.saveUserSettings({
+      default_utility_agent_id: "",
+      default_utility_agent_profile_id: seedData.agentProfileId,
+    });
+
+    await openCreateTaskDialog(testPage, seedData.workspaceId);
+
+    const enhanceBtn = testPage.getByTestId("enhance-prompt-button");
+    await expect(enhanceBtn).toBeVisible();
+    await expect(enhanceBtn).toBeEnabled();
+  });
+
   test("enhance button is disabled when no utility agent is configured", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    // Clear any default utility agent
+    // Clear any default utility agent, both the current and legacy fields —
+    // an earlier test in this worker may have set either one.
     await apiClient.saveUserSettings({
       default_utility_agent_id: "",
+      default_utility_agent_profile_id: "",
     });
 
     const kanban = new KanbanPage(testPage);

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -94,6 +94,7 @@ function makeUnloadedSettings(): UserSettingsState {
     gitlabSavedPresets: undefined,
     azureDevOpsBrowsePreferences: undefined,
     defaultUtilityAgentId: null,
+    defaultUtilityAgentProfileId: null,
     keyboardShortcuts: {},
     terminalLinkBehavior: "new_tab",
     terminalFontFamily: null,

--- a/apps/web/hooks/use-is-utility-configured.test.ts
+++ b/apps/web/hooks/use-is-utility-configured.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UserSettingsState } from "@/lib/state/slices/settings/types";
+
+type MockState = { userSettings: UserSettingsState };
+
+let mockState: MockState;
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: MockState) => unknown) => selector(mockState),
+}));
+
+import { useIsUtilityConfigured } from "./use-is-utility-configured";
+
+function baseSettings(): UserSettingsState {
+  return {
+    defaultUtilityAgentId: null,
+    defaultUtilityAgentProfileId: null,
+  } as UserSettingsState;
+}
+
+describe("useIsUtilityConfigured", () => {
+  it("is configured when only the default utility agent profile id is set", () => {
+    mockState = {
+      userSettings: { ...baseSettings(), defaultUtilityAgentProfileId: "profile-1" },
+    };
+
+    expect(useIsUtilityConfigured()).toBe(true);
+  });
+
+  it("is configured when only the legacy default utility agent id is set", () => {
+    mockState = {
+      userSettings: { ...baseSettings(), defaultUtilityAgentId: "legacy-agent-1" },
+    };
+
+    expect(useIsUtilityConfigured()).toBe(true);
+  });
+
+  it("is not configured when neither field is set", () => {
+    mockState = { userSettings: baseSettings() };
+
+    expect(useIsUtilityConfigured()).toBe(false);
+  });
+});

--- a/apps/web/hooks/use-is-utility-configured.ts
+++ b/apps/web/hooks/use-is-utility-configured.ts
@@ -2,5 +2,7 @@ import { useAppStore } from "@/components/state-provider";
 
 /** Returns true when the user has configured a default utility agent. */
 export function useIsUtilityConfigured(): boolean {
-  return useAppStore((s) => !!s.userSettings.defaultUtilityAgentId);
+  return useAppStore(
+    (s) => !!s.userSettings.defaultUtilityAgentProfileId || !!s.userSettings.defaultUtilityAgentId,
+  );
 }

--- a/apps/web/lib/ssr/user-settings.test.ts
+++ b/apps/web/lib/ssr/user-settings.test.ts
@@ -228,6 +228,18 @@ describe("buildCoreFields", () => {
     const result = buildCoreFields(settings);
     expect(result.terminalFontFamily).toBeNull();
   });
+
+  it("maps default_utility_agent_profile_id to defaultUtilityAgentProfileId", () => {
+    const settings = {
+      workspace_id: toWorkspaceId(""),
+      repository_ids: [],
+      default_utility_agent_profile_id: "profile-1",
+      updated_at: UPDATED_AT,
+    } as unknown as Parameters<typeof buildCoreFields>[0];
+
+    const result = buildCoreFields(settings);
+    expect(result.defaultUtilityAgentProfileId).toBe("profile-1");
+  });
 });
 
 describe("buildCoreFields task-create last-used mapping", () => {

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -74,6 +74,7 @@ export function createDefaultUserSettings(): UserSettingsState {
     gitlabSavedPresets: undefined,
     azureDevOpsBrowsePreferences: undefined,
     defaultUtilityAgentId: null,
+    defaultUtilityAgentProfileId: null,
     keyboardShortcuts: {},
     terminalLinkBehavior: "new_tab",
     terminalFontFamily: null,
@@ -234,6 +235,10 @@ function buildIdentityFields(s: UserSettingsData, current: UserSettingsState) {
     defaultUtilityAgentId: mapNullableString(
       s.default_utility_agent_id,
       current.defaultUtilityAgentId,
+    ),
+    defaultUtilityAgentProfileId: mapNullableString(
+      s.default_utility_agent_profile_id,
+      current.defaultUtilityAgentProfileId,
     ),
   };
 }

--- a/apps/web/lib/state/slices/settings/types.ts
+++ b/apps/web/lib/state/slices/settings/types.ts
@@ -438,6 +438,7 @@ export type UserSettingsState = {
   gitlabSavedPresets: unknown;
   azureDevOpsBrowsePreferences: unknown;
   defaultUtilityAgentId: string | null;
+  defaultUtilityAgentProfileId: string | null;
   keyboardShortcuts: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminalLinkBehavior: "new_tab" | "browser_panel";
   terminalFontFamily: string | null;


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3306/8b0af60e0674.html)
<!-- kandev-pr-walkthrough-end -->

Saving a utility agent in Settings > Utility Agents wrote `default_utility_agent_profile_id`, but the frontend gate that unlocks AI-enhance everywhere only ever checked the legacy `default_utility_agent_id`, so every chat and task-creation surface kept telling users to configure an agent they had already configured.

**Today:** Settings > Utility Agents saves successfully, but the New Task dialog, chat input, subtask dialog, and VCS dialogs still show "Configure a utility agent in settings" and keep AI-enhance disabled.
**After this:** Saving a utility agent profile in Settings immediately unlocks AI-enhance on every surface, no reload required.
**Who hits this:** Any user who configures a utility agent through the current (non-legacy) profile-id field — effectively every user who sets one up today.
**Scope:** standalone bug fix.
**Not here:** the legacy `default_utility_agent_id` field/migration (still honored as a fallback), and per-action utility overrides — chat surfaces still gate on the single default.

## Validation

```
cd apps/web && pnpm e2e:run --no-build --project chromium -- e2e/tests/task/enhance-prompt.spec.ts
→ 6 passed

cd apps/backend && go test ./internal/backendapp/... ./internal/user/... -count=1
→ ok (all packages)

cd apps/web && pnpm exec vitest run hooks/use-is-utility-configured.test.ts lib/ssr/user-settings.test.ts \
  components/settings/utility-agents-section-save.test.tsx hooks/use-ensure-user-settings.test.ts \
  lib/state/slices/settings/settings-slice.test.ts
→ 5 files / 71 tests passed

make fmt / make typecheck / make lint / make lint-format / pnpm run i18n:ratchet → all clean
```

Full `go test ./...` and `pnpm exec vitest run` were also run; the only failures are pre-existing and reproduce identically at the merge base (`7f92d01f2`) in a scratch worktree — sandbox-specific issues (no local Docker daemon, worktree/filesystem quirks under this host's temp dir, no real subprocess supervisors) unrelated to this change. None touch the files this PR modifies.

## Screenshots

New Task dialog, AI-enhance button enabled after only the profile-id field is configured (the state every current user is in):

![Enhance button enabled](https://raw.githubusercontent.com/nova28/kandev/8fd7a5ab9ec9478bd2b267fdccca229e8f5c4174/screenshots/enhance-button-enabled.png)

## Possible Improvements

Low risk: an 11-file frontend/backend wiring fix behind an existing gate, with a fallback `||` to the legacy field so users whose backfill hasn't run yet are unaffected.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR. (N/A: standalone bug fix, not architectural)
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.