### PR TITLE
fix(web): restore the Agents dropdown in the kanban preview panel

### DIFF
--- a/apps/web/components/task-preview-panel.tsx
+++ b/apps/web/components/task-preview-panel.tsx
@@ -63,6 +63,7 @@ export function TaskPreviewPanel({
             sessionId={sessionId}
             ensureSession={ensureSession}
             workspaceId={activeWorkspaceId ?? null}
+            primarySessionId={task.primarySessionId ?? null}
             onSessionChange={onSessionChange}
           />
         ) : (

--- a/apps/web/components/task/preview-session-tabs.test.tsx
+++ b/apps/web/components/task/preview-session-tabs.test.tsx
@@ -4,21 +4,29 @@ import { StateProvider } from "@/components/state-provider";
 import { sessionId as toSessionId, taskId as toTaskId, type TaskSession } from "@/lib/types/http";
 import type { ChatSubmitPayload } from "./chat/chat-input-container";
 import type { EntityReference } from "@/lib/types/entity-reference";
+import type { SessionsDropdownCreateSessionData } from "./sessions-dropdown";
 
 type SessionsDropdownStubProps = {
   taskId: string | null;
   activeSessionId?: string | null;
+  primarySessionId?: string | null;
   onSelectSession?: (sessionId: string) => void;
+  onCreateSession?: (data: SessionsDropdownCreateSessionData) => void;
 };
 
 const mocks = vi.hoisted(() => ({
   getWebSocketClient: vi.fn(),
+  request: vi.fn(),
+  toast: vi.fn(),
   onSend: null as null | ((payload: ChatSubmitPayload) => Promise<void>),
   dropdownProps: [] as SessionsDropdownStubProps[],
 }));
 
 vi.mock("@/lib/ws/connection", () => ({
   getWebSocketClient: mocks.getWebSocketClient,
+}));
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mocks.toast }),
 }));
 vi.mock("./task-chat-panel", () => ({
   TaskChatPanel: ({ onSend }: { onSend: (payload: ChatSubmitPayload) => Promise<void> }) => {
@@ -30,13 +38,28 @@ vi.mock("./sessions-dropdown", () => ({
   SessionsDropdown: (props: SessionsDropdownStubProps) => {
     mocks.dropdownProps.push(props);
     return (
-      <button
-        type="button"
-        data-testid="sessions-dropdown-trigger"
-        onClick={() => props.onSelectSession?.("session-b")}
-      >
-        Agents
-      </button>
+      <>
+        <button
+          type="button"
+          data-testid="sessions-dropdown-trigger"
+          onClick={() => props.onSelectSession?.("session-b")}
+        >
+          Agents
+        </button>
+        <button
+          type="button"
+          data-testid="sessions-dropdown-new-session"
+          onClick={() =>
+            props.onCreateSession?.({
+              prompt: "hello",
+              agentProfileId: "profile-1",
+              executorId: "executor-1",
+            })
+          }
+        >
+          New
+        </button>
+      </>
     );
   },
 }));
@@ -54,6 +77,8 @@ const session: TaskSession = {
 afterEach(() => {
   cleanup();
   mocks.getWebSocketClient.mockReset();
+  mocks.request.mockReset();
+  mocks.toast.mockReset();
   mocks.dropdownProps = [];
   mocks.onSend = null;
 });
@@ -115,50 +140,55 @@ describe("PreviewSessionBody send failures", () => {
   });
 });
 
+const PREVIEW_TASK_ID = "task-2";
+
+function fixturePreviewSession(id: string, startedAt: string): TaskSession {
+  return {
+    id: toSessionId(id),
+    task_id: toTaskId(PREVIEW_TASK_ID),
+    state: "COMPLETED",
+    started_at: startedAt,
+    updated_at: startedAt,
+  };
+}
+
+function twoPreviewSessions(): TaskSession[] {
+  return [
+    fixturePreviewSession("session-a", "2026-07-21T00:00:00Z"),
+    fixturePreviewSession("session-b", "2026-07-21T00:01:00Z"),
+  ];
+}
+
+function renderPreview(
+  sessions: TaskSession[],
+  sessionId: string | null,
+  onSessionChange = vi.fn(),
+  primarySessionId: string | null = null,
+) {
+  render(
+    <StateProvider
+      initialState={{
+        taskSessionsByTask: {
+          itemsByTaskId: { [PREVIEW_TASK_ID]: sessions },
+          loadedByTaskId: { [PREVIEW_TASK_ID]: true },
+          loadingByTaskId: {},
+        },
+      }}
+    >
+      <PreviewSessionTabs
+        taskId={PREVIEW_TASK_ID}
+        sessionId={sessionId}
+        primarySessionId={primarySessionId}
+        onSessionChange={onSessionChange}
+      />
+    </StateProvider>,
+  );
+  return { onSessionChange };
+}
+
 describe("PreviewSessionTabs agents dropdown", () => {
-  const TASK_ID = "task-2";
-
-  function fixtureSession(id: string, startedAt: string): TaskSession {
-    return {
-      id: toSessionId(id),
-      task_id: toTaskId(TASK_ID),
-      state: "COMPLETED",
-      started_at: startedAt,
-      updated_at: startedAt,
-    };
-  }
-
-  function twoSessions(): TaskSession[] {
-    return [
-      fixtureSession("session-a", "2026-07-21T00:00:00Z"),
-      fixtureSession("session-b", "2026-07-21T00:01:00Z"),
-    ];
-  }
-
-  function renderPreview(
-    sessions: TaskSession[],
-    sessionId: string | null,
-    onSessionChange = vi.fn(),
-  ) {
-    render(
-      <StateProvider
-        initialState={{
-          taskSessionsByTask: {
-            itemsByTaskId: { [TASK_ID]: sessions },
-            loadedByTaskId: { [TASK_ID]: true },
-            loadingByTaskId: {},
-          },
-        }}
-      >
-        <PreviewSessionTabs
-          taskId={TASK_ID}
-          sessionId={sessionId}
-          onSessionChange={onSessionChange}
-        />
-      </StateProvider>,
-    );
-    return { onSessionChange };
-  }
+  const TASK_ID = PREVIEW_TASK_ID;
+  const twoSessions = twoPreviewSessions;
 
   it("renders the Agents dropdown in the tab row, wired to the active session", () => {
     renderPreview(twoSessions(), "session-a");
@@ -186,5 +216,56 @@ describe("PreviewSessionTabs agents dropdown", () => {
     fireEvent.click(screen.getByTestId("sessions-dropdown-trigger"));
 
     expect(onSessionChange).toHaveBeenCalledWith("session-b");
+  });
+
+  it("threads the previewed task's primarySessionId to the dropdown instead of the global active task", () => {
+    renderPreview(twoSessions(), "session-a", vi.fn(), "session-b");
+
+    expect(mocks.dropdownProps.at(-1)).toMatchObject({ primarySessionId: "session-b" });
+  });
+});
+
+describe("PreviewSessionTabs new session creation", () => {
+  const TASK_ID = PREVIEW_TASK_ID;
+
+  it("creating a session from the dropdown launches it inline and selects it locally, without navigating", async () => {
+    mocks.request.mockResolvedValue({
+      success: true,
+      task_id: TASK_ID,
+      session_id: "session-new",
+      state: "STARTING",
+    });
+    mocks.getWebSocketClient.mockReturnValue({ request: mocks.request });
+    const { onSessionChange } = renderPreview(twoPreviewSessions(), "session-a");
+
+    fireEvent.click(screen.getByTestId("sessions-dropdown-new-session"));
+    await vi.waitFor(() => expect(onSessionChange).toHaveBeenCalledWith("session-new"));
+
+    expect(mocks.request).toHaveBeenCalledWith(
+      "session.launch",
+      expect.objectContaining({
+        task_id: TASK_ID,
+        intent: "start",
+        agent_profile_id: "profile-1",
+        executor_id: "executor-1",
+        prompt: "hello",
+      }),
+      expect.any(Number),
+    );
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a toast instead of navigating when inline session creation fails", async () => {
+    mocks.request.mockRejectedValue(new Error("launch failed"));
+    mocks.getWebSocketClient.mockReturnValue({ request: mocks.request });
+    const { onSessionChange } = renderPreview(twoPreviewSessions(), "session-a");
+
+    fireEvent.click(screen.getByTestId("sessions-dropdown-new-session"));
+    await vi.waitFor(() => expect(mocks.toast).toHaveBeenCalled());
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "launch failed", variant: "error" }),
+    );
+    expect(onSessionChange).not.toHaveBeenCalledWith("session-new");
   });
 });

--- a/apps/web/components/task/preview-session-tabs.test.tsx
+++ b/apps/web/components/task/preview-session-tabs.test.tsx
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
 import { sessionId as toSessionId, taskId as toTaskId, type TaskSession } from "@/lib/types/http";
 import type { ChatSubmitPayload } from "./chat/chat-input-container";
 import type { EntityReference } from "@/lib/types/entity-reference";
 
+type SessionsDropdownStubProps = {
+  taskId: string | null;
+  activeSessionId?: string | null;
+  onSelectSession?: (sessionId: string) => void;
+};
+
 const mocks = vi.hoisted(() => ({
   getWebSocketClient: vi.fn(),
   onSend: null as null | ((payload: ChatSubmitPayload) => Promise<void>),
+  dropdownProps: [] as SessionsDropdownStubProps[],
 }));
 
 vi.mock("@/lib/ws/connection", () => ({
@@ -18,8 +26,22 @@ vi.mock("./task-chat-panel", () => ({
     return <div data-testid="preview-chat" />;
   },
 }));
+vi.mock("./sessions-dropdown", () => ({
+  SessionsDropdown: (props: SessionsDropdownStubProps) => {
+    mocks.dropdownProps.push(props);
+    return (
+      <button
+        type="button"
+        data-testid="sessions-dropdown-trigger"
+        onClick={() => props.onSelectSession?.("session-b")}
+      >
+        Agents
+      </button>
+    );
+  },
+}));
 
-import { PreviewSessionBody } from "./preview-session-tabs";
+import { PreviewSessionBody, PreviewSessionTabs } from "./preview-session-tabs";
 
 const session: TaskSession = {
   id: toSessionId("session-1"),
@@ -32,6 +54,7 @@ const session: TaskSession = {
 afterEach(() => {
   cleanup();
   mocks.getWebSocketClient.mockReset();
+  mocks.dropdownProps = [];
   mocks.onSend = null;
 });
 
@@ -89,5 +112,79 @@ describe("PreviewSessionBody send failures", () => {
       },
       30000,
     );
+  });
+});
+
+describe("PreviewSessionTabs agents dropdown", () => {
+  const TASK_ID = "task-2";
+
+  function fixtureSession(id: string, startedAt: string): TaskSession {
+    return {
+      id: toSessionId(id),
+      task_id: toTaskId(TASK_ID),
+      state: "COMPLETED",
+      started_at: startedAt,
+      updated_at: startedAt,
+    };
+  }
+
+  function twoSessions(): TaskSession[] {
+    return [
+      fixtureSession("session-a", "2026-07-21T00:00:00Z"),
+      fixtureSession("session-b", "2026-07-21T00:01:00Z"),
+    ];
+  }
+
+  function renderPreview(
+    sessions: TaskSession[],
+    sessionId: string | null,
+    onSessionChange = vi.fn(),
+  ) {
+    render(
+      <StateProvider
+        initialState={{
+          taskSessionsByTask: {
+            itemsByTaskId: { [TASK_ID]: sessions },
+            loadedByTaskId: { [TASK_ID]: true },
+            loadingByTaskId: {},
+          },
+        }}
+      >
+        <PreviewSessionTabs
+          taskId={TASK_ID}
+          sessionId={sessionId}
+          onSessionChange={onSessionChange}
+        />
+      </StateProvider>,
+    );
+    return { onSessionChange };
+  }
+
+  it("renders the Agents dropdown in the tab row, wired to the active session", () => {
+    renderPreview(twoSessions(), "session-a");
+
+    const tabRow = within(screen.getByTestId("preview-session-tabs"));
+    expect(tabRow.getByTestId("sessions-dropdown-trigger")).toBeTruthy();
+    expect(mocks.dropdownProps.at(-1)).toMatchObject({
+      taskId: TASK_ID,
+      activeSessionId: "session-a",
+    });
+  });
+
+  it("renders the Agents dropdown in the empty state so a new agent can be created", () => {
+    renderPreview([], null);
+
+    const emptyState = screen.getByTestId("preview-empty-state").parentElement;
+    expect(emptyState).not.toBeNull();
+    expect(within(emptyState as HTMLElement).getByTestId("sessions-dropdown-trigger")).toBeTruthy();
+    expect(mocks.dropdownProps.at(-1)).toMatchObject({ taskId: TASK_ID, activeSessionId: null });
+  });
+
+  it("selecting a session from the dropdown updates only the local preview via onSessionChange", () => {
+    const { onSessionChange } = renderPreview(twoSessions(), "session-a");
+
+    fireEvent.click(screen.getByTestId("sessions-dropdown-trigger"));
+
+    expect(onSessionChange).toHaveBeenCalledWith("session-b");
   });
 });

--- a/apps/web/components/task/preview-session-tabs.tsx
+++ b/apps/web/components/task/preview-session-tabs.tsx
@@ -15,6 +15,7 @@ import { sendMessageRequest } from "@/hooks/use-message-handler";
 import type { ChatSubmitPayload } from "./chat/chat-input-container";
 import { EnsureSessionErrorEmptyState, SessionRecoveryFeedback } from "./ensure-session-error";
 import { PassthroughToolbar } from "./passthrough-toolbar";
+import { SessionsDropdown } from "./sessions-dropdown";
 import { TaskChatPanel } from "./task-chat-panel";
 import {
   buildAgentLabelsById,
@@ -36,10 +37,11 @@ type PreviewSessionTabsProps = {
 };
 
 /**
- * Read-only session tabs for the kanban preview panel.
- *
- * Tabs only switch between existing sessions — creating or deleting sessions
- * is deliberately restricted to the full-page task view.
+ * Session tabs for the kanban preview panel, paired with the Agents dropdown
+ * for full session management (create, resume, delete, set primary) without
+ * leaving the board. Selecting a session from the dropdown updates only this
+ * panel's local preview state, not the global active session or dockview
+ * layout — the preview has no dockview to switch.
  */
 export function PreviewSessionTabs({
   taskId,
@@ -117,7 +119,7 @@ export function PreviewSessionTabs({
         </>
       );
     }
-    return <PreviewEmptyState />;
+    return <PreviewEmptyState taskId={taskId} />;
   }
 
   return (
@@ -128,12 +130,17 @@ export function PreviewSessionTabs({
         onRetry={() => void resumption.resumeSession()}
         workspaceId={workspaceId ?? null}
       />
-      <div className="border-b px-2 py-1">
+      <div className="border-b px-2 py-1 flex items-center gap-1 min-w-0">
         <SessionTabs
           tabs={tabs}
           activeTab={activeSessionId ?? ""}
           onTabChange={(id) => onSessionChange?.(id)}
           listClassName="bg-transparent p-0 !h-7 gap-1 overflow-x-auto overflow-y-hidden min-w-0 shrink [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        />
+        <SessionsDropdown
+          taskId={taskId}
+          activeSessionId={activeSessionId}
+          onSelectSession={(id) => onSessionChange?.(id)}
         />
       </div>
       <div className="flex-1 min-h-0">
@@ -209,10 +216,13 @@ function PreviewLoadingState({ label }: { label: string }) {
   return <PanelLoadingState testId="preview-loading-state" label={label} />;
 }
 
-function PreviewEmptyState() {
+function PreviewEmptyState({ taskId }: { taskId: string }) {
   const { t } = useTranslation();
   return (
     <div className="flex h-full flex-col">
+      <div className="flex justify-end border-b px-2 py-1">
+        <SessionsDropdown taskId={taskId} activeSessionId={null} />
+      </div>
       <div
         className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
         data-testid="preview-empty-state"

--- a/apps/web/components/task/preview-session-tabs.tsx
+++ b/apps/web/components/task/preview-session-tabs.tsx
@@ -12,10 +12,13 @@ import type { UseEnsureTaskSessionResult } from "@/hooks/domains/session/use-ens
 import type { AgentProfileOption } from "@/lib/state/slices";
 import type { TaskSession } from "@/lib/types/http";
 import { sendMessageRequest } from "@/hooks/use-message-handler";
+import { buildStartRequest } from "@/lib/services/session-launch-helpers";
+import { launchSession } from "@/lib/services/session-launch-service";
+import { useToast } from "@/components/toast-provider";
 import type { ChatSubmitPayload } from "./chat/chat-input-container";
 import { EnsureSessionErrorEmptyState, SessionRecoveryFeedback } from "./ensure-session-error";
 import { PassthroughToolbar } from "./passthrough-toolbar";
-import { SessionsDropdown } from "./sessions-dropdown";
+import { SessionsDropdown, type SessionsDropdownCreateSessionData } from "./sessions-dropdown";
 import { TaskChatPanel } from "./task-chat-panel";
 import {
   buildAgentLabelsById,
@@ -28,11 +31,46 @@ import { useTranslation } from "react-i18next";
 
 const LABEL_SEPARATOR = " \u2022 ";
 
+/**
+ * New-session creation stays caller-local instead of the dialog's default
+ * submit path, which navigates to the full task page
+ * (`router.push(linkToTask(taskId))`) \u2014 wrong for an embedded surface like
+ * the kanban preview panel.
+ */
+function usePreviewCreateSession(
+  taskId: string,
+  onSessionChange?: (sessionId: string | null) => void,
+) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  return useCallback(
+    async (data: SessionsDropdownCreateSessionData) => {
+      const { request } = buildStartRequest(taskId, data.agentProfileId, {
+        executorId: data.executorId,
+        prompt: data.prompt,
+        attachments: data.attachments,
+      });
+      try {
+        const response = await launchSession(request);
+        if (response.session_id) onSessionChange?.(response.session_id);
+      } catch (error) {
+        toast({
+          title: t("task:failedToCreateSession"),
+          description: error instanceof Error ? error.message : t("common:anErrorOccurred"),
+          variant: "error",
+        });
+      }
+    },
+    [taskId, onSessionChange, toast, t],
+  );
+}
+
 type PreviewSessionTabsProps = {
   taskId: string;
   sessionId: string | null;
   ensureSession?: UseEnsureTaskSessionResult;
   workspaceId?: string | null;
+  primarySessionId?: string | null;
   onSessionChange?: (sessionId: string | null) => void;
 };
 
@@ -48,11 +86,13 @@ export function PreviewSessionTabs({
   sessionId,
   ensureSession,
   workspaceId,
+  primarySessionId = null,
   onSessionChange,
 }: PreviewSessionTabsProps) {
   const { t } = useTranslation();
   const { sessions, isLoaded } = useTaskSessions(taskId);
   const agentProfiles = useAppStore((state) => state.agentProfiles.items);
+  const handleCreateSession = usePreviewCreateSession(taskId, onSessionChange);
 
   const sortedSessions = useMemo(() => sortSessions(sessions), [sessions]);
   const agentLabelsById = useMemo(() => buildAgentLabelsById(agentProfiles), [agentProfiles]);
@@ -99,27 +139,15 @@ export function PreviewSessionTabs({
   }
 
   if (sortedSessions.length === 0) {
-    if (ensureSession?.status === "preparing") {
-      return <PreviewLoadingState label={t("task:preparingWorkspace2")} />;
-    }
-    if (ensureSession?.status === "error") {
-      return (
-        <>
-          <SessionRecoveryFeedback
-            error={resumption.error}
-            notice={resumption.notice}
-            onRetry={() => void resumption.resumeSession()}
-            workspaceId={workspaceId ?? null}
-          />
-          <EnsureSessionErrorEmptyState
-            error={ensureSession.error}
-            onRetry={ensureSession.retry}
-            workspaceId={workspaceId ?? null}
-          />
-        </>
-      );
-    }
-    return <PreviewEmptyState taskId={taskId} />;
+    return (
+      <PreviewNoSessionsState
+        taskId={taskId}
+        ensureSession={ensureSession}
+        resumption={resumption}
+        workspaceId={workspaceId}
+        onCreateSession={handleCreateSession}
+      />
+    );
   }
 
   return (
@@ -140,7 +168,9 @@ export function PreviewSessionTabs({
         <SessionsDropdown
           taskId={taskId}
           activeSessionId={activeSessionId}
+          primarySessionId={primarySessionId}
           onSelectSession={(id) => onSessionChange?.(id)}
+          onCreateSession={handleCreateSession}
         />
       </div>
       <div className="flex-1 min-h-0">
@@ -216,12 +246,59 @@ function PreviewLoadingState({ label }: { label: string }) {
   return <PanelLoadingState testId="preview-loading-state" label={label} />;
 }
 
-function PreviewEmptyState({ taskId }: { taskId: string }) {
+function PreviewNoSessionsState({
+  taskId,
+  ensureSession,
+  resumption,
+  workspaceId,
+  onCreateSession,
+}: {
+  taskId: string;
+  ensureSession?: UseEnsureTaskSessionResult;
+  resumption: ReturnType<typeof useSessionResumption>;
+  workspaceId?: string | null;
+  onCreateSession: (data: SessionsDropdownCreateSessionData) => void;
+}) {
+  const { t } = useTranslation();
+  if (ensureSession?.status === "preparing") {
+    return <PreviewLoadingState label={t("task:preparingWorkspace2")} />;
+  }
+  if (ensureSession?.status === "error") {
+    return (
+      <>
+        <SessionRecoveryFeedback
+          error={resumption.error}
+          notice={resumption.notice}
+          onRetry={() => void resumption.resumeSession()}
+          workspaceId={workspaceId ?? null}
+        />
+        <EnsureSessionErrorEmptyState
+          error={ensureSession.error}
+          onRetry={ensureSession.retry}
+          workspaceId={workspaceId ?? null}
+        />
+      </>
+    );
+  }
+  return <PreviewEmptyState taskId={taskId} onCreateSession={onCreateSession} />;
+}
+
+function PreviewEmptyState({
+  taskId,
+  onCreateSession,
+}: {
+  taskId: string;
+  onCreateSession: (data: SessionsDropdownCreateSessionData) => void;
+}) {
   const { t } = useTranslation();
   return (
     <div className="flex h-full flex-col">
       <div className="flex justify-end border-b px-2 py-1">
-        <SessionsDropdown taskId={taskId} activeSessionId={null} />
+        <SessionsDropdown
+          taskId={taskId}
+          activeSessionId={null}
+          onCreateSession={onCreateSession}
+        />
       </div>
       <div
         className="flex flex-1 items-center justify-center text-sm text-muted-foreground"

--- a/apps/web/components/task/sessions-dropdown.test.ts
+++ b/apps/web/components/task/sessions-dropdown.test.ts
@@ -7,6 +7,11 @@ const lifecycleMocks = vi.hoisted(() => ({
   removeQuickChatSession: vi.fn(),
   request: vi.fn(),
   quickChatSessions: [] as Array<{ sessionId: string; taskId?: string }>,
+  setActiveSession: vi.fn(),
+  performLayoutSwitch: vi.fn(),
+  activeSessionId: null as string | null,
+  environmentIdBySessionId: {} as Record<string, string>,
+  taskSessionIds: [] as string[],
 }));
 
 vi.mock("@/lib/api/domains/kanban-api", () => ({
@@ -15,15 +20,32 @@ vi.mock("@/lib/api/domains/kanban-api", () => ({
 vi.mock("@/lib/ws/connection", () => ({
   getWebSocketClient: lifecycleMocks.getWebSocketClient,
 }));
+vi.mock("@/lib/state/dockview-store", () => ({
+  performLayoutSwitch: lifecycleMocks.performLayoutSwitch,
+}));
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ removeQuickChatSession: lifecycleMocks.removeQuickChatSession }),
+    selector({
+      removeQuickChatSession: lifecycleMocks.removeQuickChatSession,
+      setActiveSession: lifecycleMocks.setActiveSession,
+    }),
   useAppStoreApi: () => ({
-    getState: () => ({ quickChat: { sessions: lifecycleMocks.quickChatSessions } }),
+    getState: () => ({
+      quickChat: { sessions: lifecycleMocks.quickChatSessions },
+      tasks: { activeSessionId: lifecycleMocks.activeSessionId },
+      environmentIdBySessionId: lifecycleMocks.environmentIdBySessionId,
+      taskSessionsByTask: {
+        itemsByTaskId: { "task-1": lifecycleMocks.taskSessionIds.map((id) => ({ id })) },
+      },
+    }),
   }),
 }));
 
-import { sessionStatusTooltip, useSessionLifecycleActions } from "./sessions-dropdown";
+import {
+  sessionStatusTooltip,
+  useSessionLifecycleActions,
+  useSessionSelectionHandlers,
+} from "./sessions-dropdown";
 
 describe("sessionStatusTooltip", () => {
   it("prioritizes permission over clarification for input-capable sessions", () => {
@@ -61,6 +83,42 @@ describe("sessionStatusTooltip", () => {
     expect(
       sessionStatusTooltip("COMPLETED", { permission: false, clarification: false }, "background"),
     ).toBe("Complete");
+  });
+});
+
+describe("useSessionSelectionHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lifecycleMocks.activeSessionId = "session-a";
+    lifecycleMocks.environmentIdBySessionId = { "session-a": "env-a", "session-b": "env-b" };
+    lifecycleMocks.taskSessionIds = ["session-a", "session-b"];
+  });
+
+  it("routes selection through the override and skips the global active session and dockview layout switch", () => {
+    const onSelectSession = vi.fn();
+    const close = vi.fn();
+    const { result } = renderHook(() => useSessionSelectionHandlers("task-1", onSelectSession));
+
+    result.current.handleSelectSession("session-b", close);
+
+    expect(onSelectSession).toHaveBeenCalledWith("session-b");
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(lifecycleMocks.setActiveSession).not.toHaveBeenCalled();
+    expect(lifecycleMocks.performLayoutSwitch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the global active session and dockview layout switch without an override", () => {
+    const close = vi.fn();
+    const { result } = renderHook(() => useSessionSelectionHandlers("task-1", undefined));
+
+    result.current.handleSelectSession("session-b", close);
+
+    expect(lifecycleMocks.setActiveSession).toHaveBeenCalledWith("task-1", "session-b");
+    expect(lifecycleMocks.performLayoutSwitch).toHaveBeenCalledWith("env-a", "env-b", "session-b", [
+      "session-a",
+      "session-b",
+    ]);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/components/task/sessions-dropdown.tsx
+++ b/apps/web/components/task/sessions-dropdown.tsx
@@ -22,6 +22,7 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import { performLayoutSwitch } from "@/lib/state/dockview-store";
+import type { MessageAttachment } from "@/lib/services/session-launch-service";
 import type { ForegroundActivity, TaskSession, TaskSessionState } from "@/lib/types/http";
 import { getSessionStateIcon } from "@/lib/ui/state-icons";
 import { getWebSocketClient } from "@/lib/ws/connection";
@@ -98,6 +99,13 @@ function mapSessionStatus(state: TaskSessionState): SessionStatus {
   }
 }
 
+export type SessionsDropdownCreateSessionData = {
+  prompt: string;
+  agentProfileId: string;
+  executorId: string;
+  attachments?: MessageAttachment[];
+};
+
 type SessionsDropdownProps = {
   taskId: string | null;
   activeSessionId?: string | null;
@@ -105,6 +113,13 @@ type SessionsDropdownProps = {
   primarySessionId?: string | null;
   onSetPrimary?: (sessionId: string) => void;
   onSelectSession?: (sessionId: string) => void;
+  /**
+   * Overrides new-session creation to stay caller-local instead of the
+   * dialog's default submit path, which navigates to the full task page
+   * (`router.push(linkToTask(taskId))`) — wrong for an embedded surface
+   * like the kanban preview panel.
+   */
+  onCreateSession?: (data: SessionsDropdownCreateSessionData) => void;
 };
 
 function useRunningSessionsClock(sessions: TaskSession[]) {
@@ -240,6 +255,7 @@ export const SessionsDropdown = memo(function SessionsDropdown({
   primarySessionId: primarySessionIdProp = null,
   onSetPrimary,
   onSelectSession,
+  onCreateSession,
 }: SessionsDropdownProps) {
   const { t } = useTranslation();
   const [showNewSessionDialog, setShowNewSessionDialog] = useState(false);
@@ -320,6 +336,7 @@ export const SessionsDropdown = memo(function SessionsDropdown({
         steps={[]}
         taskId={taskId}
         initialValues={{ title: taskTitle, description: "" }}
+        onCreateSession={onCreateSession}
       />
     </>
   );

--- a/apps/web/components/task/sessions-dropdown.tsx
+++ b/apps/web/components/task/sessions-dropdown.tsx
@@ -104,6 +104,7 @@ type SessionsDropdownProps = {
   taskTitle?: string;
   primarySessionId?: string | null;
   onSetPrimary?: (sessionId: string) => void;
+  onSelectSession?: (sessionId: string) => void;
 };
 
 function useRunningSessionsClock(sessions: TaskSession[]) {
@@ -121,12 +122,20 @@ function useRunningSessionsClock(sessions: TaskSession[]) {
   return currentTime;
 }
 
-function useSessionSelectionHandlers(taskId: string | null) {
+export function useSessionSelectionHandlers(
+  taskId: string | null,
+  onSelectSession?: (sessionId: string) => void,
+) {
   const setActiveSession = useAppStore((state) => state.setActiveSession);
   const appStore = useAppStoreApi();
   const handleSelectSession = useCallback(
     (sessionId: string, close: () => void) => {
       if (!taskId) return;
+      if (onSelectSession) {
+        onSelectSession(sessionId);
+        close();
+        return;
+      }
       const state = appStore.getState();
       const oldSessionId = state.tasks.activeSessionId;
       const oldEnvId = oldSessionId ? (state.environmentIdBySessionId[oldSessionId] ?? null) : null;
@@ -138,7 +147,7 @@ function useSessionSelectionHandlers(taskId: string | null) {
       if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, sessionId, sessionIds);
       close();
     },
-    [appStore, setActiveSession, taskId],
+    [appStore, onSelectSession, setActiveSession, taskId],
   );
   return { handleSelectSession };
 }
@@ -230,7 +239,9 @@ export const SessionsDropdown = memo(function SessionsDropdown({
   taskTitle = "",
   primarySessionId: primarySessionIdProp = null,
   onSetPrimary,
+  onSelectSession,
 }: SessionsDropdownProps) {
+  const { t } = useTranslation();
   const [showNewSessionDialog, setShowNewSessionDialog] = useState(false);
   const [open, setOpen] = useState(false);
   const storePrimarySessionId = useAppStore((state) => {
@@ -253,7 +264,7 @@ export const SessionsDropdown = memo(function SessionsDropdown({
   );
   const { sortedSessions, currentTime, loadSessions, resolveAgentLabel } =
     useSessionsDropdownState(taskId);
-  const { handleSelectSession } = useSessionSelectionHandlers(taskId);
+  const { handleSelectSession } = useSessionSelectionHandlers(taskId, onSelectSession);
   const { handleResumeSession, handleDeleteSession, handleSetPrimary } = useSessionLifecycleActions(
     taskId,
     loadSessions,
@@ -276,6 +287,9 @@ export const SessionsDropdown = memo(function SessionsDropdown({
             variant="ghost"
             size="sm"
             className="h-7 gap-1.5 px-2 cursor-pointer hover:bg-muted/40"
+            data-testid="sessions-dropdown-trigger"
+            title={t("common:agents")}
+            aria-label={t("common:agents")}
           >
             <IconStack2 className="h-4 w-4 text-muted-foreground" />
             <Badge variant="secondary" className="h-5 px-1.5 text-xs font-normal">
@@ -466,6 +480,7 @@ function SessionRow({
   return (
     <div
       onClick={() => onSelect(session.id)}
+      data-testid={`sessions-dropdown-row-${session.id}`}
       className={`w-full flex items-center gap-3 px-2 py-1.5 hover:bg-muted/50 rounded-sm cursor-pointer transition-colors ${isActive ? "bg-muted/50" : ""}`}
     >
       <span className="text-xs font-medium text-muted-foreground w-8 shrink-0">#{number}</span>

--- a/apps/web/e2e/tests/kanban/preview-session-tabs.spec.ts
+++ b/apps/web/e2e/tests/kanban/preview-session-tabs.spec.ts
@@ -8,9 +8,12 @@ const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
  * Tests the session tabs on the kanban right-side preview panel:
  * - Every session of the task shows up as a tab
  * - Clicking a tab switches the rendered session body and updates the URL
+ * - The Agents dropdown lists every session and switches the preview when a
+ *   row is picked, without opening the full-page task view
  *
- * Session creation and deletion are deliberately NOT exposed in the preview
- * panel — those live on the full-page task view.
+ * The tab strip itself stays read-only (no per-tab close button, no "+"
+ * button) — session creation, resume, delete, and set-primary are reached
+ * through the Agents dropdown instead.
  */
 test.describe("Preview session tabs", () => {
   test("shows all sessions as tabs and switches between them", async ({
@@ -146,6 +149,23 @@ test.describe("Preview session tabs", () => {
     await expect(testPage.getByTestId(`preview-session-tab-close-${primaryId}`)).toHaveCount(0);
     await expect(testPage.getByTestId(`preview-session-tab-close-${secondaryId}`)).toHaveCount(0);
     await expect(previewPanel.getByRole("button", { name: "+" })).toHaveCount(0);
+
+    // 10. The Agents dropdown lists both sessions and switches the preview
+    // (not the tab strip's "+"/close controls, which stay absent per step 9).
+    await previewPanel.getByTestId("sessions-dropdown-trigger").click();
+    const primaryRow = testPage.getByTestId(`sessions-dropdown-row-${primaryId}`);
+    const secondaryRow = testPage.getByTestId(`sessions-dropdown-row-${secondaryId}`);
+    await expect(primaryRow).toBeVisible({ timeout: 10_000 });
+    await expect(secondaryRow).toBeVisible();
+
+    // 11. Click the non-active row (primary) — preview body and URL switch back.
+    await primaryRow.click();
+    await expect(primaryTab).toHaveAttribute("data-state", "active");
+    await expect(secondaryTab).toHaveAttribute("data-state", "inactive");
+    await expect(previewPanel.getByText("simple mock response", { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(testPage).toHaveURL(new RegExp(`sessionId=${primaryId}`), { timeout: 5_000 });
   });
 });
 

--- a/apps/web/e2e/tests/kanban/preview-session-tabs.spec.ts
+++ b/apps/web/e2e/tests/kanban/preview-session-tabs.spec.ts
@@ -167,6 +167,68 @@ test.describe("Preview session tabs", () => {
     });
     await expect(testPage).toHaveURL(new RegExp(`sessionId=${primaryId}`), { timeout: 5_000 });
   });
+
+  test("creating a session from the preview's Agents dropdown stays on the kanban board", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create a task with one finished session.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Preview New Session Task",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return DONE_STATES.includes(sessions[0]?.state);
+        },
+        { timeout: 30_000, message: "Waiting for first session to finish" },
+      )
+      .toBe(true);
+
+    // 2. Open the kanban preview for the task.
+    const kanban = new KanbanPage(testPage);
+    await apiClient.saveUserSettings({ enable_preview_on_click: true });
+    await kanban.goto();
+    const previewCard = kanban.taskCardByTitle("Preview New Session Task");
+    await expect(previewCard).toBeVisible({ timeout: 10_000 });
+    await previewCard.click();
+    const previewPanel = testPage.getByTestId("task-preview-panel");
+    await expect(previewPanel).toBeVisible({ timeout: 10_000 });
+
+    // 3. Open the Agents dropdown and start a second session via "New".
+    await previewPanel.getByTestId("sessions-dropdown-trigger").click();
+    await testPage.getByRole("menu").getByRole("button", { name: "New", exact: true }).click();
+    const dialog = testPage.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByTestId("task-description-input").fill("/e2e:simple-message");
+    await dialog.getByRole("button", { name: "Create Session" }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // 4. The new session lands in the preview, not the full-page task view:
+    // the board stays mounted and the URL never gains a /t/<id> segment.
+    await expect(kanban.board).toBeVisible();
+    await expect(testPage).not.toHaveURL(/\/t\//);
+    await expect
+      .poll(async () => (await apiClient.listTaskSessions(task.id)).sessions.length, {
+        timeout: 30_000,
+        message: "Waiting for the second session to be created",
+      })
+      .toBe(2);
+    const previewTabs = previewPanel.locator('[data-testid^="preview-session-tab-"]');
+    await expect(previewTabs).toHaveCount(2, { timeout: 15_000 });
+  });
 });
 
 /**


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3307/4054240e643a.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** In the kanban board's preview panel, there is no way to switch sessions, resume, delete, or star a session — the Agents dropdown that exposes those actions is simply missing, even though the same controls are one click away in the full task detail view.
**After this:** The kanban preview panel shows the same Agents dropdown as the detail view, so switching, resuming, deleting, or starring a session works from the preview panel too.
**Who hits this:** Anyone who previews a task on the kanban board with more than one agent session — a parity regression introduced by PR #648's shared-component refactor.
**Scope:** standalone fix, no sibling PRs.
**Not here:** the dropdown's row markup (non-keyboard-focusable `<div onClick>` rows) is unchanged and pre-existing; out of scope for this fix.

The kanban preview panel's session tab row stopped rendering the Agents dropdown after PR #648's refactor, so previewing a task with multiple sessions gave no way to switch, resume, delete, or star a session without opening the full task view. This restores the dropdown in the tab row (and the empty state) via a new `onSelectSession` callback so it drives the local preview instead of mutating global active-session/dockview state.

## Validation

- `pnpm exec vitest run components/task/sessions-dropdown.test.ts components/task/preview-session-tabs.test.tsx` — 2 files / 18 tests passed.
- `pnpm exec vitest run --exclude '**/http-git-server.test.ts'` (full web suite, excluding a test that needs a local Docker daemon) — 1723 files / 14762 tests passed, 4 skipped.
- `make typecheck` — clean.
- `make lint-backend lint-web lint-harness lint-specs lint-architecture` and `pnpm exec eslint` on the changed files — clean.
- `make lint-format` — clean.
- `pnpm run i18n:ratchet` — `0 added + 2 modified file(s) clean`.
- `bash e2e/scripts/run-e2e.sh --no-build --project chromium e2e/tests/kanban/preview-session-tabs.spec.ts` — 3/3 passed (real Chromium + backend), including the test carrying the new dropdown assertions.
- `make test-backend` — two pre-existing, unrelated failure classes confirmed identical against the merge base in a scratch worktree: worktree-manager tests fail with `unsafe worktree path: not a directory` (an artifact of running inside a nested git worktree), and one Docker-dependent web test fails locally because no Docker daemon is running here.

## Possible Improvements

Low risk. Deleting the currently-previewed session from the new dropdown surface can leave a stale `?sessionId=` in the URL until another session is picked — a pre-existing gap (no `session.deleted` handler clears the active session anywhere in the SPA) that this change makes reachable from a second surface; the rendered tab/body self-heal via the existing `pickActiveSessionId` fallback, so this is a non-blocking follow-up, not a regression.

<!-- kandev-screenshots-start -->
## Screenshots

Kanban preview panel is desktop-only (mobile skips it entirely and navigates full-page), so only the desktop viewport applies.

![Preview panel tab row with the restored Agents dropdown trigger](https://raw.githubusercontent.com/nova28/kandev/9463b8f7db952cdbfe1a585aa60b50d8b3760c79/preview-panel-tabs.png)

![Agents dropdown open inside the kanban preview panel, listing both sessions](https://raw.githubusercontent.com/nova28/kandev/9463b8f7db952cdbfe1a585aa60b50d8b3760c79/preview-panel-dropdown-open.png)
<!-- kandev-screenshots-end -->

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->