### PR TITLE
fix(routing): classify OpenCode period usage limits so dynamic routing can advance

### DIFF
--- a/apps/backend/internal/agent/runtime/routingerr/classify_test.go
+++ b/apps/backend/internal/agent/runtime/routingerr/classify_test.go
@@ -194,6 +194,33 @@ func TestClassify_OpenCodeUsageLimitIsHighConfidenceQuota(t *testing.T) {
 	}
 }
 
+func TestClassify_OpenCodePeriodUsageLimitsAreHighConfidenceQuota(t *testing.T) {
+	resetInjection()
+	for _, stderr := range []string{
+		"AI_APICallError: Weekly usage limit reached. Resets in 3 days. To continue using this model now, enable usage from your available balance",
+		"AI_APICallError: Daily usage limit reached. Resets in 4hr 19min.",
+		"AI_APICallError: monthly usage limit reached.",
+	} {
+		e := Classify(Input{
+			Phase:      PhaseStreaming,
+			ProviderID: "opencode-acp",
+			Stderr:     stderr,
+		})
+		if e.Code != CodeQuotaLimited || e.Confidence != ConfHigh {
+			t.Fatalf("classification of %q = %+v, want high-confidence quota_limited", stderr, e)
+		}
+	}
+}
+
+func TestHasProviderRules(t *testing.T) {
+	if !HasProviderRules("opencode-acp") {
+		t.Fatal("opencode-acp should have provider rules")
+	}
+	if HasProviderRules("opencode-go") {
+		t.Fatal("model-provider ID opencode-go must not resolve to provider rules")
+	}
+}
+
 func TestClassify_InjectionShortCircuit(t *testing.T) {
 	resetInjection()
 	t.Setenv("KANDEV_PROVIDER_FAILURES", "claude-acp:quota_limited,codex-acp:auth_required")

--- a/apps/backend/internal/agent/runtime/routingerr/rules.go
+++ b/apps/backend/internal/agent/runtime/routingerr/rules.go
@@ -25,7 +25,7 @@ var providerRules = map[string][]rule{
 		mustRule("codex.stderr.model.v1", `(?i)model_not_found`, CodeModelUnavailable, ConfHigh),
 	},
 	"opencode-acp": {
-		mustRule("opencode.stderr.usage_limit.v1", `(?i)\b\d+[- ]hour(?:s)?\s+usage\s+limit\s+reached\b`, CodeQuotaLimited, ConfHigh),
+		mustRule("opencode.stderr.usage_limit.v1", `(?i)\b(?:\d+[- ]hour(?:s)?|daily|weekly|monthly)\s+usage\s+limit\s+reached\b`, CodeQuotaLimited, ConfHigh),
 		mustRule("opencode.stderr.quota.v1", `(?i)quota`, CodeQuotaLimited, ConfMedium),
 		mustRule("opencode.stderr.rate.v1", `(?i)rate.?limit`, CodeRateLimited, ConfHigh),
 		mustRule("opencode.stderr.auth.v1", `(?i)unauthorized|invalid token`, CodeAuthRequired, ConfHigh),
@@ -44,6 +44,15 @@ var providerRules = map[string][]rule{
 
 func mustRule(id, pat string, code Code, conf Confidence) rule {
 	return rule{id: id, pattern: regexp.MustCompile(pat), code: code, confidence: conf}
+}
+
+// HasProviderRules reports whether providerID is a rules catalogue key (an
+// agent ID such as "opencode-acp"). Diagnostics can carry a different
+// provider identity, e.g. OpenCode's model-provider ID "opencode-go", which
+// must not be used for rule lookup.
+func HasProviderRules(providerID string) bool {
+	_, ok := providerRules[providerID]
+	return ok
 }
 
 func matchProviderRules(providerID, text string) (*Error, bool) {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr.go
@@ -20,7 +20,7 @@ const (
 var (
 	openCodeIdentifierPattern = regexp.MustCompile(`\b(?:wrk|ses|run)_[A-Za-z0-9_-]+\b`)
 	openCodeURLPattern        = regexp.MustCompile(`https?://[^\s]+`)
-	openCodeResetPattern      = regexp.MustCompile(`(?i)\bresets?\s+in\s+(?:(\d+)\s*(?:hours?|hrs?|h))?\s*(?:(\d+)\s*(?:minutes?|mins?|m|min))?`)
+	openCodeResetPattern      = regexp.MustCompile(`(?i)\bresets?\s+in\s+(?:(\d+)\s*(?:days?|d)\b)?\s*(?:(\d+)\s*(?:hours?|hrs?|h)\b)?\s*(?:(\d+)\s*(?:minutes?|mins?|m|min)\b)?`)
 )
 
 type openCodeStderrDiagnostic struct {
@@ -267,14 +267,15 @@ func safeOpenCodeField(value string) string {
 
 func openCodeResetAt(message string, occurredAt time.Time) *time.Time {
 	matches := openCodeResetPattern.FindStringSubmatch(message)
-	if len(matches) != 3 || (matches[1] == "" && matches[2] == "") {
+	if len(matches) != 4 || (matches[1] == "" && matches[2] == "" && matches[3] == "") {
 		return nil
 	}
-	hours, _ := strconv.Atoi(matches[1])
-	minutes, _ := strconv.Atoi(matches[2])
-	if hours == 0 && minutes == 0 {
+	days, _ := strconv.Atoi(matches[1])
+	hours, _ := strconv.Atoi(matches[2])
+	minutes, _ := strconv.Atoi(matches[3])
+	if days == 0 && hours == 0 && minutes == 0 {
 		return nil
 	}
-	resetAt := occurredAt.Add(time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute)
+	resetAt := occurredAt.Add(time.Duration(days)*24*time.Hour + time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute)
 	return &resetAt
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr_test.go
@@ -151,6 +151,18 @@ func TestParseOpenCodeStderrLineWeeklyLimitResetInDays(t *testing.T) {
 	if diagnostic.ProviderError.ResetAt == nil || !diagnostic.ProviderError.ResetAt.Equal(wantReset) {
 		t.Fatalf("reset at = %v, want %s", diagnostic.ProviderError.ResetAt, wantReset)
 	}
+
+	t.Run("mixed units", func(t *testing.T) {
+		line := `timestamp=2026-09-03T07:19:45.000Z level=ERROR run=4120ce87 message="stream error" providerID=opencode-go modelID=deepseek-v4-flash session.id=ses_f99491a97ffeeWlCMErV9o00vr small=false agent=build mode=primary error.error="AI_APICallError: Weekly usage limit reached. Resets in 3 days 4 hours 19 min."`
+		diagnostic, ok := parseOpenCodeStderrLine(line)
+		if !ok {
+			t.Fatal("parseOpenCodeStderrLine() rejected a mixed-unit weekly usage-limit stream error")
+		}
+		wantReset := wantOccurred.Add(3*24*time.Hour + 4*time.Hour + 19*time.Minute)
+		if diagnostic.ProviderError.ResetAt == nil || !diagnostic.ProviderError.ResetAt.Equal(wantReset) {
+			t.Fatalf("reset at = %v, want %s", diagnostic.ProviderError.ResetAt, wantReset)
+		}
+	})
 }
 
 func TestParseOpenCodeStderrLineAcceptsForegroundStreamError(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/opencode_stderr_test.go
@@ -139,6 +139,20 @@ func TestProviderErrorFromACPRequestErrorReadsOnlyStructuredActionURL(t *testing
 	})
 }
 
+func TestParseOpenCodeStderrLineWeeklyLimitResetInDays(t *testing.T) {
+	line := `timestamp=2026-09-03T07:19:45.000Z level=ERROR run=4120ce87 message="stream error" providerID=opencode-go modelID=deepseek-v4-flash session.id=ses_f99491a97ffeeWlCMErV9o00vr small=false agent=build mode=primary error.error="AI_APICallError: Weekly usage limit reached. Resets in 3 days. To continue using this model now, enable usage from your available balance: https://opencode.ai/workspace/wrk_01KQM7K5CYT715264YKKFB17ZY/go"`
+
+	diagnostic, ok := parseOpenCodeStderrLine(line)
+	if !ok {
+		t.Fatal("parseOpenCodeStderrLine() rejected a weekly usage-limit stream error")
+	}
+	wantOccurred := time.Date(2026, 9, 3, 7, 19, 45, 0, time.UTC)
+	wantReset := wantOccurred.Add(3 * 24 * time.Hour)
+	if diagnostic.ProviderError.ResetAt == nil || !diagnostic.ProviderError.ResetAt.Equal(wantReset) {
+		t.Fatalf("reset at = %v, want %s", diagnostic.ProviderError.ResetAt, wantReset)
+	}
+}
+
 func TestParseOpenCodeStderrLineAcceptsForegroundStreamError(t *testing.T) {
 	line := `timestamp=2026-08-02T15:15:44.504Z level=ERROR run=a93db686 message="stream error" providerID=opencode-go modelID=kimi-k3 session.id=ses_03d1ac324ffeA2eAGeBfuq80dq small=false agent=build mode=primary error.error="AI_APICallError: 5-hour usage limit reached. Resets in 4hr 19min. To continue using this model now, enable usage from your available balance: https://opencode.ai/workspace/wrk_01KQM7K5CYT715264YKKFB17ZY/go"`
 

--- a/apps/backend/internal/orchestrator/event_handlers_transient.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient.go
@@ -399,7 +399,8 @@ func classifyKanbanFailure(data watcher.AgentEventData) *routingerr.Error {
 		// model-provider ID instead ("opencode-go"), which has no rules; keeping
 		// the agent ID there lets the OpenCode usage-limit rule classify the
 		// failure so dynamic routing can advance to the next candidate.
-		if id := providerError.ProviderID; id != "" && routingerr.HasProviderRules(id) {
+		if id := providerError.ProviderID; id != "" &&
+			!routingerr.HasProviderRules(providerID) && routingerr.HasProviderRules(id) {
 			providerID = id
 		}
 		if providerError.Message != "" {

--- a/apps/backend/internal/orchestrator/event_handlers_transient.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient.go
@@ -395,8 +395,12 @@ func classifyKanbanFailure(data watcher.AgentEventData) *routingerr.Error {
 	message := data.ErrorMessage
 	var resetHint *time.Time
 	if providerError := data.ProviderError; providerError != nil {
-		if providerError.ProviderID != "" {
-			providerID = providerError.ProviderID
+		// Provider rules are keyed by agent ID. OpenCode diagnostics carry the
+		// model-provider ID instead ("opencode-go"), which has no rules; keeping
+		// the agent ID there lets the OpenCode usage-limit rule classify the
+		// failure so dynamic routing can advance to the next candidate.
+		if id := providerError.ProviderID; id != "" && routingerr.HasProviderRules(id) {
+			providerID = id
 		}
 		if providerError.Message != "" {
 			message = providerError.Message

--- a/apps/backend/internal/orchestrator/event_handlers_transient_opencode_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient_opencode_test.go
@@ -30,3 +30,24 @@ func TestClassifyKanbanFailure_OpenCodeModelProviderIDKeepsAgentRules(t *testing
 		t.Fatalf("quota_limited must allow dynamic fallback: %+v", classified)
 	}
 }
+
+func TestClassifyKanbanFailure_OpenCodeModelProviderCollisionKeepsAgentRules(t *testing.T) {
+	classified := classifyKanbanFailure(watcher.AgentEventData{
+		AgentID:      "opencode-acp",
+		ErrorMessage: "AI_APICallError: Weekly usage limit reached. Resets in 3 days.",
+		ProviderError: &streams.ProviderError{
+			Source:     streams.ProviderErrorSourceOpenCodeStderr,
+			ProviderID: "claude-acp",
+			Message:    "AI_APICallError: Weekly usage limit reached. Resets in 3 days.",
+		},
+	})
+	if classified == nil {
+		t.Fatal("classification = nil, want high-confidence quota_limited")
+	}
+	if classified.Code != routingerr.CodeQuotaLimited || classified.Confidence != routingerr.ConfHigh {
+		t.Fatalf("classification = %+v, want high-confidence quota_limited", classified)
+	}
+	if !classified.FallbackAllowed {
+		t.Fatalf("quota_limited must allow dynamic fallback: %+v", classified)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_transient_opencode_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient_opencode_test.go
@@ -1,0 +1,32 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+)
+
+// OpenCode stderr diagnostics carry the model-provider ID ("opencode-go"),
+// not the agent ID the provider rules are keyed by. The Kanban classifier
+// must keep the agent ID so a usage-limit error is still quota_limited and
+// dynamic routing can advance past the exhausted candidate.
+func TestClassifyKanbanFailure_OpenCodeModelProviderIDKeepsAgentRules(t *testing.T) {
+	classified := classifyKanbanFailure(watcher.AgentEventData{
+		AgentID:      "opencode-acp",
+		ErrorMessage: "AI_APICallError: Weekly usage limit reached. Resets in 3 days.",
+		ProviderError: &streams.ProviderError{
+			Source:     streams.ProviderErrorSourceOpenCodeStderr,
+			ProviderID: "opencode-go",
+			ModelID:    "deepseek-v4-flash",
+			Message:    "AI_APICallError: Weekly usage limit reached. Resets in 3 days.",
+		},
+	})
+	if classified.Code != routingerr.CodeQuotaLimited || classified.Confidence != routingerr.ConfHigh {
+		t.Fatalf("classification = %+v, want high-confidence quota_limited", classified)
+	}
+	if !classified.FallbackAllowed {
+		t.Fatalf("quota_limited must allow dynamic fallback: %+v", classified)
+	}
+}


### PR DESCRIPTION
## Summary

Dynamic routing never advanced past an OpenCode candidate that hit its **weekly** usage limit. Three causes, fixed together:

1. **Rules keyed by agent ID, looked up by model-provider ID.** OpenCode stderr diagnostics set `ProviderError.ProviderID` to the model provider (`opencode-go`), while `providerRules` is keyed by the agent ID (`opencode-acp`). `classifyKanbanFailure` replaced the agent ID with the diagnostic's provider ID, so no OpenCode rule ever applied on the dynamic-route path: the failure became a low-confidence `agent_runtime_error`, `FallbackAllowed` was false, the policy never ran, and the session parked in `WAITING_FOR_INPUT`. (The recovery card path uses `data.AgentID` and correctly showed `provider_quota_limited`, which made the bug confusing to diagnose.) Fix: keep the agent ID unless the diagnostic's provider ID is itself a rules key (`routingerr.HasProviderRules`). Cursor/Codex diagnostics use agent IDs, so they are unaffected.
2. **Quota rule only matched hourly limits.** `opencode.stderr.usage_limit.v1` matched `N-hour usage limit reached`; OpenCode also emits `Weekly usage limit reached` / `Daily …` / `Monthly …`. Extended the rule.
3. **Reset hint ignored days.** `Resets in 3 days` produced no `ResetAt`. The parser now accepts days in addition to hours/minutes.

## Reproduction

OpenCode Go subscription at its weekly cap. Dynamic profile: DeepSeek V4 Flash (OpenCode) → Claude Sonnet, hard policy retry 3× then `skip`. Launch a task: the DeepSeek attempt fails with
`AI_APICallError: Weekly usage limit reached. Resets in 3 days.` and the session stops in `WAITING_FOR_INPUT`; no `policy_skip` attempt is recorded. With this change the failure classifies as `quota_limited` and the conductor advances to the next candidate.

## Validation

- `go test ./internal/agent/runtime/routingerr ./internal/agentctl/server/adapter/transport/acp ./internal/orchestrator -count=1`
- New tests: `TestClassify_OpenCodePeriodUsageLimitsAreHighConfidenceQuota`, `TestHasProviderRules`, `TestClassifyKanbanFailure_OpenCodeModelProviderIDKeepsAgentRules`, `TestParseOpenCodeStderrLineWeeklyLimitResetInDays`
- `gofmt` / `go vet` clean on touched packages

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected (verified the classification and the `policy_skip` advance on a production board running v0.92.3-nightly with an equivalent patch).
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] UI files are not touched; no e2e changes.
- [x] No public docs change needed: behaviour now matches the documented dynamic-routing contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->