### PR TITLE
fix(task): stop clarification answers from timing out on large message tables

### DIFF
--- a/apps/backend/internal/task/repository/repository_indexes_test.go
+++ b/apps/backend/internal/task/repository/repository_indexes_test.go
@@ -32,6 +32,7 @@ func TestSQLiteRepository_CreatesPerformanceIndexes(t *testing.T) {
 		"idx_tasks_workspace_archived",
 		"idx_messages_metadata_tool_call_id",
 		"idx_messages_metadata_pending_id",
+		"idx_messages_metadata_pending_id_lookup",
 		"idx_messages_prompt_user_order",
 	}
 	for _, idx := range required {

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -164,6 +164,17 @@ func (r *Repository) ensureMessageMetadataIndexes() error {
 	if _, err := r.db.Exec(pendingIndex); err != nil {
 		return err
 	}
+	// idx_messages_metadata_pending_id leads with task_session_id, so it
+	// cannot be used by the clarification claim query, which filters on
+	// pending_id alone across all sessions. This bare-expression index makes
+	// that lookup seekable.
+	pendingIndexLookup := fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS idx_messages_metadata_pending_id_lookup ON task_session_messages((%s))`,
+		dialect.JSONExtract(driver, "metadata", "pending_id"),
+	)
+	if _, err := r.db.Exec(pendingIndexLookup); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_claim_index_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_claim_index_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/kandev/kandev/internal/db/dialect"
 )
 
 // TestClaimActiveClarificationBundleUsesPendingIDIndex is the regression
@@ -32,39 +30,7 @@ func TestClaimActiveClarificationBundleUsesPendingIDIndex(t *testing.T) {
 	}
 
 	drv := repo.db.DriverName()
-	pendingIDExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "pending_id")
-	statusExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "status")
-	bundlePendingIDExpr := dialect.JSONExtract(drv, "bundle.metadata", "pending_id")
-	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
-	claimQuery := fmt.Sprintf(`
-		EXPLAIN QUERY PLAN
-		UPDATE task_session_messages
-		SET metadata = %s, updated_at = ?
-		WHERE %s = ?
-		  AND type = 'clarification_request'
-		  AND COALESCE(%s, '') IN ('', 'pending')
-		  AND %s
-		  AND turn_id = (
-			SELECT turn_row.id
-			FROM task_session_turns turn_row
-			WHERE turn_row.task_session_id = task_session_messages.task_session_id
-			  AND %s
-			ORDER BY %s
-			LIMIT 1
-		  )
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM task_session_messages bundle
-			WHERE %s = ?
-			  AND (
-				bundle.type != 'clarification_request'
-				OR bundle.task_session_id != task_session_messages.task_session_id
-				OR bundle.turn_id != task_session_messages.turn_id
-			  )
-		  )
-	`, dialect.JSONSet(drv, "metadata", "status", clarificationStatusResponding), pendingIDExpr, statusExpr,
-		nonTerminalSessionPredicate("task_session_messages"),
-		predicate, orderBy, bundlePendingIDExpr)
+	claimQuery := "EXPLAIN QUERY PLAN\n" + clarificationClaimQuery(drv)
 
 	rows, err := repo.db.Query(repo.db.Rebind(claimQuery), now, "pending-claim-plan", "pending-claim-plan")
 	if err != nil {

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_claim_index_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_claim_index_test.go
@@ -1,0 +1,101 @@
+package sqlite
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/db/dialect"
+)
+
+// TestClaimActiveClarificationBundleUsesPendingIDIndex is the regression
+// witness for the claim query scanning task_session_messages instead of
+// seeking. idx_messages_metadata_pending_id leads with task_session_id, which
+// the claim predicate never constrains, so it cannot be used here. The
+// message table is seeded past the row count where SQLite's planner would
+// otherwise favor a scan, so the assertion reflects the query shape rather
+// than an artifact of an empty table.
+func TestClaimActiveClarificationBundleUsesPendingIDIndex(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	seedForMsgTest(t, repo, "task-claim-plan", "session-claim-plan", "turn-claim-plan")
+	now := time.Now().UTC()
+	for i := 0; i < 1000; i++ {
+		id := fmt.Sprintf("msg-claim-plan-%d", i)
+		if _, err := repo.db.Exec(repo.db.Rebind(`
+			INSERT INTO task_session_messages
+				(id, task_session_id, task_id, turn_id, author_type, author_id, content, requests_input, type, metadata, created_at, updated_at)
+			VALUES (?, ?, ?, ?, 'agent', '', 'hello', 0, 'message', '{}', ?, ?)
+		`), id, "session-claim-plan", "task-claim-plan", "turn-claim-plan", now, now); err != nil {
+			t.Fatalf("seed row %d: %v", i, err)
+		}
+	}
+
+	drv := repo.db.DriverName()
+	pendingIDExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "pending_id")
+	statusExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "status")
+	bundlePendingIDExpr := dialect.JSONExtract(drv, "bundle.metadata", "pending_id")
+	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
+	claimQuery := fmt.Sprintf(`
+		EXPLAIN QUERY PLAN
+		UPDATE task_session_messages
+		SET metadata = %s, updated_at = ?
+		WHERE %s = ?
+		  AND type = 'clarification_request'
+		  AND COALESCE(%s, '') IN ('', 'pending')
+		  AND %s
+		  AND turn_id = (
+			SELECT turn_row.id
+			FROM task_session_turns turn_row
+			WHERE turn_row.task_session_id = task_session_messages.task_session_id
+			  AND %s
+			ORDER BY %s
+			LIMIT 1
+		  )
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM task_session_messages bundle
+			WHERE %s = ?
+			  AND (
+				bundle.type != 'clarification_request'
+				OR bundle.task_session_id != task_session_messages.task_session_id
+				OR bundle.turn_id != task_session_messages.turn_id
+			  )
+		  )
+	`, dialect.JSONSet(drv, "metadata", "status", clarificationStatusResponding), pendingIDExpr, statusExpr,
+		nonTerminalSessionPredicate("task_session_messages"),
+		predicate, orderBy, bundlePendingIDExpr)
+
+	rows, err := repo.db.Query(repo.db.Rebind(claimQuery), now, "pending-claim-plan", "pending-claim-plan")
+	if err != nil {
+		t.Fatalf("explain claim query: %v", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Errorf("close plan rows: %v", closeErr)
+		}
+	}()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate plan rows: %v", err)
+	}
+
+	planText := strings.Join(plan, "\n")
+	for _, forbidden := range []string{"SCAN task_session_messages", "SCAN bundle"} {
+		if strings.Contains(planText, forbidden) {
+			t.Fatalf("claim query plan still scans instead of seeking:\n%s", planText)
+		}
+	}
+	if !strings.Contains(planText, "idx_messages_metadata_pending_id_lookup") {
+		t.Fatalf("claim query plan does not use idx_messages_metadata_pending_id_lookup:\n%s", planText)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
@@ -472,9 +472,6 @@ func (r *Repository) claimActiveClarificationBundle(
 	tx *sqlx.Tx,
 	drv, pendingID string,
 ) (int64, error) {
-	pendingIDExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "pending_id")
-	statusExpr := dialect.JSONExtract(drv, "task_session_messages.metadata", "status")
-	bundlePendingIDExpr := dialect.JSONExtract(drv, "bundle.metadata", "pending_id")
 	// A pending ID spanning message types, sessions, or turns is malformed. The
 	// NOT EXISTS guard intentionally makes the whole bundle ineligible to claim.
 	// Detached rows are intentionally eligible: agent_disconnected means the
@@ -483,8 +480,28 @@ func (r *Repository) claimActiveClarificationBundle(
 	// it is replaced with the requested terminal status before this transaction
 	// commits or is rolled back with the transaction.
 	claimAt := r.nowUTC()
-	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
-	claimQuery := fmt.Sprintf(`
+	claimQuery := clarificationClaimQuery(drv)
+	// pendingID is bound once for the outer bundle and once for the malformed-
+	// bundle NOT EXISTS guard.
+	result, err := tx.ExecContext(ctx, r.db.Rebind(claimQuery), claimAt, pendingID, pendingID)
+	if err != nil {
+		return 0, fmt.Errorf("claim active clarification bundle: %w", err)
+	}
+	claimedRows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count claimed clarification rows: %w", err)
+	}
+	return claimedRows, nil
+}
+
+// clarificationClaimQuery builds the shared claim statement for execution and
+// the query-plan regression test. Both paths must use the same predicates.
+func clarificationClaimQuery(driverName string) string {
+	pendingIDExpr := dialect.JSONExtract(driverName, "task_session_messages.metadata", "pending_id")
+	statusExpr := dialect.JSONExtract(driverName, "task_session_messages.metadata", "status")
+	bundlePendingIDExpr := dialect.JSONExtract(driverName, "bundle.metadata", "pending_id")
+	predicate, orderBy := currentTurnAuthority(driverName, "turn_row")
+	return fmt.Sprintf(`
 		UPDATE task_session_messages
 		SET metadata = %s, updated_at = ?
 		WHERE %s = ?
@@ -509,20 +526,9 @@ func (r *Repository) claimActiveClarificationBundle(
 				OR bundle.turn_id != task_session_messages.turn_id
 			  )
 		  )
-	`, dialect.JSONSet(drv, "metadata", "status", clarificationStatusResponding), pendingIDExpr, statusExpr,
+	`, dialect.JSONSet(driverName, "metadata", "status", clarificationStatusResponding), pendingIDExpr, statusExpr,
 		nonTerminalSessionPredicate("task_session_messages"),
 		predicate, orderBy, bundlePendingIDExpr)
-	// pendingID is bound once for the outer bundle and once for the malformed-
-	// bundle NOT EXISTS guard.
-	result, err := tx.ExecContext(ctx, r.db.Rebind(claimQuery), claimAt, pendingID, pendingID)
-	if err != nil {
-		return 0, fmt.Errorf("claim active clarification bundle: %w", err)
-	}
-	claimedRows, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("count claimed clarification rows: %w", err)
-	}
-	return claimedRows, nil
 }
 
 func (r *Repository) loadClaimedClarificationBundle(

--- a/apps/backend/internal/task/repository/sqlite/message_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_postgres_test.go
@@ -40,7 +40,7 @@ func TestPostgresPermissionClaimIgnoresEmptyMetadataRows(t *testing.T) {
 	// Simulate a legacy database from before the metadata expression indexes.
 	// Current indexes correctly reject malformed metadata before claim lookup,
 	// but the claim still needs to tolerate historical empty rows.
-	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id", "idx_messages_metadata_pending_id_lookup"} {
 		if _, err := repo.db.Exec("DROP INDEX " + index); err != nil {
 			t.Fatalf("drop metadata index %s: %v", index, err)
 		}

--- a/apps/backend/internal/task/repository/sqlite/message_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_test.go
@@ -148,7 +148,7 @@ func TestPermissionResolutionClaimIgnoresInvalidSQLiteMetadataRows(t *testing.T)
 			}
 			// Simulate a legacy database that predates the JSON expression indexes;
 			// current indexes reject malformed metadata before the claim path runs.
-			for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+			for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id", "idx_messages_metadata_pending_id_lookup"} {
 				if _, err := repo.db.Exec("DROP INDEX " + index); err != nil {
 					t.Fatalf("drop %s: %v", index, err)
 				}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
@@ -172,7 +172,7 @@ func newSubagentMigrationTestRepo(t *testing.T) (*Repository, *sqlx.DB) {
 // invalid JSON outright, which real corrupt rows predate.
 func dropMessageMetadataIndex(t *testing.T, db *sqlx.DB) {
 	t.Helper()
-	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id", "idx_messages_metadata_pending_id_lookup"} {
 		if _, err := db.Exec(`DROP INDEX IF EXISTS ` + index); err != nil {
 			t.Fatalf("drop %s: %v", index, err)
 		}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
@@ -217,12 +217,12 @@ func TestPostgresSubagentContextBackfillJSONHelpers(t *testing.T) {
 	seedPostgresForMsgTest(t, db, "task-pg-malformed", "session-pg-malformed", "turn-pg-malformed")
 	ts := time.Date(2026, 8, 5, 14, 0, 0, 0, time.UTC)
 
-	// idx_messages_metadata_tool_call_id / idx_messages_metadata_pending_id
-	// are expression indexes over metadata::jsonb; Postgres evaluates them on
-	// every insert, so a literal empty-string metadata row (simulating
-	// historical corruption that predates the index) can only be seeded with
-	// the index dropped first — matching subagent_context_migration_test.go's
-	// SQLite technique.
+	// idx_messages_metadata_tool_call_id / idx_messages_metadata_pending_id /
+	// idx_messages_metadata_pending_id_lookup are expression indexes over
+	// metadata::jsonb; Postgres evaluates them on every insert, so a literal
+	// empty-string metadata row (simulating historical corruption that
+	// predates the index) can only be seeded with the index dropped first —
+	// matching subagent_context_migration_test.go's SQLite technique.
 	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id", "idx_messages_metadata_pending_id_lookup"} {
 		if _, err := db.Exec(`DROP INDEX IF EXISTS ` + index); err != nil {
 			t.Fatalf("drop %s: %v", index, err)

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
@@ -223,7 +223,7 @@ func TestPostgresSubagentContextBackfillJSONHelpers(t *testing.T) {
 	// historical corruption that predates the index) can only be seeded with
 	// the index dropped first — matching subagent_context_migration_test.go's
 	// SQLite technique.
-	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id", "idx_messages_metadata_pending_id_lookup"} {
 		if _, err := db.Exec(`DROP INDEX IF EXISTS ` + index); err != nil {
 			t.Fatalf("drop %s: %v", index, err)
 		}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3322/31070de94b71.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** Answering an agent's clarification question fails with "Could not send your response," every single time, with no way to retry into success, once a task's message table grows large enough.
**After this:** The same answer submits succeeds well inside the 5s claim budget, even on a database with hundreds of thousands of messages.
**Who hits this:** Any user answering a clarification on a task whose session has enough message history to make the table scan slow. Reproduced live on a 3.6 GB / 364k-row database; the cost scales with total message-table size, not this task's own history.
**Scope:** standalone — the smallest fix that removes the actual bottleneck.
**Not here:** raising/scaling the 5s claim timeout, retry/backoff around the claim, and a dedicated "took too long, still claimable" UI state for `context deadline exceeded` (today it falls into the generic error toast) — found while diagnosing, deliberately left as follow-ups.

Answering an agent's clarification question fails permanently with "Could not send your response," because the query that claims the pending answer has no index it can actually use and falls back to scanning the entire messages table, which blows past its 5-second timeout on any database of meaningful size. Adding the missing expression index turns that scan into a sub-10ms index seek, so the claim — and the user's answer — succeeds.

## Validation

Live-instance measurements before/after, on the real 3.6 GB / 364k-row database (from diagnosis):
- Claim query plan: `SCAN task_session_messages` → `SEARCH ... USING INDEX idx_messages_metadata_pending_id_lookup`
- Claim query time: 1.889s → 0.009s
- Real clarification submit: 8-15s failure → 0.138s success

Automated:
```
go build ./...
go vet ./internal/task/repository/...
golangci-lint run ./internal/task/repository/...
go test ./internal/task/repository/...              # ok, both subpackages
gofmt -l <changed .go files>                         # empty
```

New regression test `TestClaimActiveClarificationBundleUsesPendingIDIndex` seeds 1000 messages, reconstructs the claim SQL, and asserts via `EXPLAIN QUERY PLAN` that it no longer scans `task_session_messages` or `bundle`. Confirmed it fails identically at this branch's merge-base with the fix reverted, and passes with the fix applied.

`make typecheck test lint`, `make lint-format`, and `pnpm run i18n:ratchet` all pass. The full backend `go test ./...` has a number of pre-existing failures in unrelated packages (`internal/worktree`, `internal/task/service`, `internal/launcher`, etc.) traced to this sandbox's filesystem/permission environment — reproduced identically against `origin/main` with this change reverted, so unrelated to this diff.

No `apps/web/` files changed, so no e2e run or screenshots.

## Possible Improvements

Low risk: this is an additive `CREATE INDEX IF NOT EXISTS`, applied idempotently at boot alongside four existing indexes on the same table built the same way. First boot after this ships pays a one-time index-build cost proportional to table size (a few seconds range for very large tables) before the index is available.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->