### PR TITLE
fix(task): stop superseded session worktrees claiming cutover slots

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_flat_precedence_test.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_flat_precedence_test.go
@@ -215,3 +215,49 @@ func TestCutover_DoesNotLogRolledBackFlatDemotion(t *testing.T) {
 		t.Fatalf("rolled-back flat demotion logs = %d, want none", len(entries))
 	}
 }
+
+// TestCutover_SupersededHistoricalSessionWorktreeKeepsCanonicalSlot covers the
+// shape reported in issue #2505: a terminal session keeps an active legacy
+// worktree row on the empty branch slot while the surviving flat environment
+// and its canonical repository row own the same repository on a named slot.
+// The session row is superseded, so it must stay out of the normalized graph
+// instead of opening a second slot the worktree inventory check then rejects.
+func TestCutover_SupersededHistoricalSessionWorktreeKeepsCanonicalSlot(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seed := legacySeed{
+		envID:     "env-superseded-slot",
+		taskID:    "task-superseded-slot",
+		repoID:    "repo-superseded-slot",
+		sessionID: "sess-superseded-slot",
+	}
+	seedLegacyTask(t, db, seed, now)
+	seedLegacyFlatEnv(t, db, seed, "wt-canonical-slot", "/tasks/canonical-slot", "feature/canonical", now)
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_environment_repos (
+			id, task_environment_id, repository_id, branch_slug,
+			worktree_id, worktree_path, worktree_branch, position,
+			error_message, created_at, updated_at
+		) VALUES (?, ?, ?, 'main', ?, ?, ?, 0, '', ?, ?)`),
+		"env-repo-superseded", seed.envID, seed.repoID,
+		"wt-canonical-slot", "/tasks/canonical-slot", "feature/canonical", now, now); err != nil {
+		t.Fatalf("seed canonical repository row: %v", err)
+	}
+	seedLegacySessionWorktree(t, db, seed.sessionID, "wt-superseded", seed.repoID, "",
+		"/tasks/superseded", "feature/superseded", "active", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	env, err := repo.GetTaskEnvironment(context.Background(), seed.envID)
+	if err != nil {
+		t.Fatalf("get task environment: %v", err)
+	}
+	if len(env.Repos) != 1 {
+		t.Fatalf("normalized repos = %+v, want only the canonical slot", env.Repos)
+	}
+	if env.Repos[0].WorktreeID != "wt-canonical-slot" || env.Repos[0].BranchSlug != "main" {
+		t.Fatalf("normalized repo = %+v, want wt-canonical-slot on slot main", env.Repos[0])
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_flat_precedence_test.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_flat_precedence_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kandev/kandev/internal/common/logger"
 	dbutil "github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/task/models"
 )
 
 func TestCutover_CanonicalRepoSupersedesDivergentFlatOwner(t *testing.T) {
@@ -246,7 +247,12 @@ func TestCutover_SupersededHistoricalSessionWorktreeKeepsCanonicalSlot(t *testin
 	seedLegacySessionWorktree(t, db, seed.sessionID, "wt-superseded", seed.repoID, "",
 		"/tasks/superseded", "feature/superseded", "active", now)
 
-	repo, err := NewWithDB(db, db, nil)
+	core, logs := observer.New(zapcore.WarnLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("create observer logger: %v", err)
+	}
+	repo, err := NewWithDB(db, db, log)
 	if err != nil {
 		t.Fatalf("cutover: %v", err)
 	}
@@ -259,5 +265,92 @@ func TestCutover_SupersededHistoricalSessionWorktreeKeepsCanonicalSlot(t *testin
 	}
 	if env.Repos[0].WorktreeID != "wt-canonical-slot" || env.Repos[0].BranchSlug != "main" {
 		t.Fatalf("normalized repo = %+v, want wt-canonical-slot on slot main", env.Repos[0])
+	}
+	entries := logs.FilterMessage("cutover: duplicate legacy worktrees demoted to history").All()
+	if len(entries) != 1 {
+		t.Fatalf("session demotion logs = %d, want one", len(entries))
+	}
+	logged := fmt.Sprint(entries[0].ContextMap()["worktrees"])
+	for _, want := range []string{"sess-superseded-slot", "wt-superseded", "/tasks/superseded", "feature/superseded", "wt-canonical-slot"} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("session demotion log %q must mention %q", logged, want)
+		}
+	}
+}
+
+func TestCutover_PreservesActiveSessionWhenFlatOwnerIsDeletedCanonical(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seed := legacySeed{
+		envID:     "env-deleted-canonical",
+		taskID:    "task-deleted-canonical",
+		repoID:    "repo-deleted-canonical",
+		sessionID: "sess-deleted-canonical",
+	}
+	seedLegacyTask(t, db, seed, now)
+	seedLegacyFlatEnv(t, db, seed, "wt-deleted-canonical", "/tasks/deleted-canonical", "feature/deleted", now)
+	addLegacyRepoLifecycleColumns(t, db)
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_environment_repos (
+			id, task_environment_id, repository_id, branch_slug,
+			worktree_id, worktree_path, worktree_branch, position,
+			error_message, status, created_at, updated_at, merged_at, deleted_at
+		) VALUES (?, ?, ?, 'main', ?, ?, ?, 0, '', 'deleted', ?, ?, NULL, ?)`),
+		"env-repo-deleted-canonical", seed.envID, seed.repoID,
+		"wt-deleted-canonical", "/tasks/deleted-canonical", "feature/deleted", now, now, now); err != nil {
+		t.Fatalf("seed deleted canonical repository row: %v", err)
+	}
+	seedLegacySessionWorktree(t, db, seed.sessionID, "wt-active-session", seed.repoID, "",
+		"/tasks/active-session", "feature/active", "active", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	env, err := repo.GetTaskEnvironment(context.Background(), seed.envID)
+	if err != nil {
+		t.Fatalf("get task environment: %v", err)
+	}
+	slots := make(map[string]*models.TaskEnvironmentRepo, len(env.Repos))
+	for _, envRepo := range env.Repos {
+		slots[envRepo.RepositoryID+"\x00"+envRepo.BranchSlug] = envRepo
+	}
+	deleted := slots[seed.repoID+"\x00main"]
+	active := slots[seed.repoID+"\x00"]
+	if deleted == nil || deleted.WorktreeID != "wt-deleted-canonical" || deleted.Status != "deleted" {
+		t.Fatalf("deleted canonical repository = %+v", deleted)
+	}
+	if active == nil || active.WorktreeID != "wt-active-session" || active.Status == "deleted" {
+		t.Fatalf("active session repository = %+v, normalized repos = %+v", active, env.Repos)
+	}
+}
+
+func TestCutover_PreservesDeletedSessionWorktreeHistory(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seed := legacySeed{
+		envID:     "env-deleted-session-history",
+		taskID:    "task-deleted-session-history",
+		sessionID: "sess-deleted-session-history",
+	}
+	seedLegacyTask(t, db, seed, now)
+	seedLegacyFlatEnv(t, db, legacySeed{envID: seed.envID, taskID: seed.taskID}, "", "", "", now)
+	seedLegacySessionWorktree(t, db, seed.sessionID, "wt-deleted-session-history", "repo-deleted-session-history", "",
+		"/tasks/deleted-session-history", "feature/deleted", "deleted", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	env, err := repo.GetTaskEnvironment(context.Background(), seed.envID)
+	if err != nil {
+		t.Fatalf("get task environment: %v", err)
+	}
+	if len(env.Repos) != 1 {
+		t.Fatalf("normalized repos = %+v, want deleted history", env.Repos)
+	}
+	deleted := env.Repos[0]
+	if deleted.WorktreeID != "wt-deleted-session-history" || deleted.Status != "deleted" || deleted.DeletedAt == nil {
+		t.Fatalf("deleted session worktree = %+v", deleted)
 	}
 }

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_normalize.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_normalize.go
@@ -564,11 +564,50 @@ func (c *worktreeCutover) mergeSessionWorktrees() {
 			continue // another physical worktree owns this repository slot
 		}
 		targets := c.targetsForTask(c.sessionOwnerTaskID(wt.sessionID))
-		if err := targets.mergeSessionWorktree(wt, c.isSupersededSessionWorktree(wt)); err != nil {
+		historical := c.isSupersededSessionWorktree(wt)
+		if historical && !isLegacyDeletedWorktree(wt) {
+			if winner := c.demotionWinnerForSessionWorktree(wt, targets); winner != "" {
+				c.demoteSessionWorktree(wt, winner)
+				continue
+			}
+		}
+		if err := targets.mergeSessionWorktree(wt, historical); err != nil {
 			c.conflicts = append(c.conflicts, fmt.Sprintf(
 				"session %s worktree %s: %v", wt.sessionID, wt.worktreeID, err))
 		}
 	}
+}
+
+// demotionWinnerForSessionWorktree returns the active target that explains why
+// a historical session row is not an ownership source.
+func (c *worktreeCutover) demotionWinnerForSessionWorktree(
+	wt legacySessionWorktree, targets *taskWorktreeTargets,
+) string {
+	if targets.targetForWorktree(wt.worktreeID) != nil {
+		return ""
+	}
+	if target, ok := targets.byKey[envRepoKey(wt.repositoryID, wt.branchSlug)]; ok &&
+		target.worktreeID != "" && target.status != worktreeRepoStatusDeleted && target.deletedAt == nil {
+		return target.worktreeID
+	}
+	session, ok := c.sessions[wt.sessionID]
+	if !ok || !isLegacyHistoricalSession(session.state) {
+		return ""
+	}
+	ownerTaskID := c.sessionOwnerTaskID(wt.sessionID)
+	envID, ok := c.taskEnvIDs[ownerTaskID]
+	if !ok {
+		return ""
+	}
+	env, ok := c.envs[envID]
+	if !ok || env.taskID != ownerTaskID || env.repositoryID != wt.repositoryID || env.worktreeID == "" {
+		return ""
+	}
+	replacement := targets.activeTargetForWorktree(env.worktreeID)
+	if replacement == nil || replacement.worktreeID == wt.worktreeID {
+		return ""
+	}
+	return replacement.worktreeID
 }
 
 func isLegacyDeletedWorktree(wt legacySessionWorktree) bool {
@@ -705,7 +744,7 @@ func (c *worktreeCutover) linkSessions() {
 // longer an ownership source. Rows demoted by the slot election, repository
 // rows, and the surviving flat environment take precedence for the same
 // physical identity regardless of session state. Historical rows with no
-// authoritative replacement remain eligible for backfill.
+// active authoritative replacement remain eligible for backfill.
 func (c *worktreeCutover) isSupersededSessionWorktree(wt legacySessionWorktree) bool {
 	cacheKey := sessionWorktreeKey(wt.sessionID, wt.worktreeID)
 	if c.demotedWorktrees[cacheKey] {
@@ -731,7 +770,8 @@ func (c *worktreeCutover) isSupersededSessionWorktree(wt legacySessionWorktree) 
 				if !ok || env.taskID != ownerTaskID || row.worktreeID == "" {
 					continue
 				}
-				if row.repositoryID == wt.repositoryID && row.branchSlug == wt.branchSlug {
+				if row.repositoryID == wt.repositoryID && row.branchSlug == wt.branchSlug &&
+					row.status != worktreeRepoStatusDeleted && row.deletedAt == nil {
 					superseded = true
 					break
 				}
@@ -757,7 +797,10 @@ func (c *worktreeCutover) flatEnvironmentSupersedesSessionWorktree(
 		return false
 	}
 	env, ok := c.envs[envID]
-	return ok && env.taskID == ownerTaskID && env.repositoryID == wt.repositoryID && env.worktreeID != ""
+	if !ok || env.taskID != ownerTaskID || env.repositoryID != wt.repositoryID || env.worktreeID == "" {
+		return false
+	}
+	return c.targetsForTask(ownerTaskID).activeTargetForWorktree(env.worktreeID) != nil
 }
 
 // sessionOwnerTaskID returns the task that owns the environment a session

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
@@ -122,6 +122,15 @@ func (t *taskWorktreeTargets) mergeSessionWorktree(wt legacySessionWorktree, his
 		}
 		return existing.verifyWorktree(wt.worktreeID, wt.worktreePath, wt.worktreeBranch)
 	}
+	// A superseded row is historical evidence, never an ownership source, so
+	// it must not open a repository slot of its own: the legacy worktree
+	// inventory already excludes it, and claiming an unowned slot would add a
+	// live worktree the inventory check then reports as extra. A deleted row
+	// is the exception, because its claim carries the deleted status and stays
+	// out of both inventories.
+	if historical && !isLegacyDeletedWorktree(wt) {
+		return nil
+	}
 	target := t.rowForKey(wt.repositoryID, wt.branchSlug)
 	if historical && target.worktreeID != "" {
 		return nil

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
@@ -64,6 +64,16 @@ func (t *taskWorktreeTargets) targetForWorktree(worktreeID string) *envRepoTarge
 	return nil
 }
 
+// activeTargetForWorktree returns a target that can still own a physical
+// worktree during cutover. Deleted targets remain history, not ownership.
+func (t *taskWorktreeTargets) activeTargetForWorktree(worktreeID string) *envRepoTarget {
+	target := t.targetForWorktree(worktreeID)
+	if target == nil || target.status == worktreeRepoStatusDeleted || target.deletedAt != nil {
+		return nil
+	}
+	return target
+}
+
 // mergeLegacyEnvRepo merges a pre-existing environment-repository row. These
 // rows are the canonical source and win field conflicts (except for the
 // physical-worktree identity, which must agree everywhere).


### PR DESCRIPTION
## Problem

Upgrading a legacy database fails at startup with the worktree ownership cutover:

```
failed to initialize schema: cutover: worktree inventory mismatch: missing 0, extra 4:
  missing:
  extra: 6bb244ea-… /Users/…/tasks/new-api-call-tool_xkc/internalai feature/1f6d97bd-…,
         b6893bc8-… /Users/…/tasks/tool-to-export-impor_yc5/internalai feature/aa485823-…,
         3ed5c83e-… /Users/…/tasks/exploration-of-user_tyg/greybox-cloud mathieu/c3ddb5b8-…,
         13de3632-… /Users/…/tasks/retire-orchestrator_pub/greybox-cloud mathieu/4f858323-…
```

The backend never starts, so the user is stranded on the previous binary. This reproduces on `main` against the reporter's real database.

## Root cause

Two halves of the cutover disagree about the same legacy row.

`isSupersededSessionWorktree` returns `true` through `flatEnvironmentSupersedesSessionWorktree` when all of these hold:

- the session is terminal (`COMPLETED`, `FAILED`, or `CANCELLED`),
- the row sits on the empty branch slot (`branch_slug = ''`),
- the surviving flat environment owns the same repository with a non-empty `worktree_id`.

`legacyWorktreeInventory` therefore drops that row from the pre-cutover inventory.

`mergeSessionWorktree` still claimed it. Its `historical` guard ran only after `rowForKey`, and only declined a slot another worktree already owned:

```go
target := t.rowForKey(wt.repositoryID, wt.branchSlug)
if historical && target.worktreeID != "" {
    return nil
}
```

The canonical repository row lives on a named slot (`branch_slug = 'main'`), so the empty slot was unclaimed. `rowForKey` created it, the superseded worktree was claimed with status `active`, and it entered the normalized inventory alone. `validateCutover` then reported it as extra.

## Data shape that triggers it

Per affected task:

| source | row |
| --- | --- |
| `task_environments` | `repository_id = R`, `worktree_id = W` |
| `task_environment_repos` | `(R, branch_slug='main', W)` |
| `task_session_worktrees` | `(Wx, R, branch_slug='', status='active')` on a terminal session, `Wx != W` |

## Fix

A superseded row is historical evidence, not an ownership source, so it no longer claims a repository slot. A deleted row keeps the previous behavior, because its claim carries the deleted status and stays out of both inventories.

The migration performs no filesystem operation, so every demoted worktree directory and branch stays on disk.

## Testing

- New regression test `TestCutover_SupersededHistoricalSessionWorktreeKeepsCanonicalSlot` reproduces the exact shape. Without the fix it fails with `worktree inventory mismatch: missing 0, extra 1`; with the fix the task keeps its single canonical slot.
- `go test -tags fts5 ./internal/task/repository/sqlite/` passes.
- `make lint` reports 0 issues.
- Verified end to end: the reporter's real database (304 MB, from issue #2505) migrates cleanly through `NewWithDB` on this branch, and fails on `main`.

Fixes #2505


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

