### PR TITLE
fix(web): keep model selector visible after model switches

### DIFF
--- a/apps/web/components/task/model-selector.test.ts
+++ b/apps/web/components/task/model-selector.test.ts
@@ -435,15 +435,43 @@ describe("cross-agent persisted config reconciliation", () => {
     expect(hasCompleteDynamicConfig(session, catalogEntry(advertised, true), noAgents)).toBe(true);
   });
 
-  it("keeps a profile-snapshot key required even when the agent has not advertised it", () => {
+  it("keeps an unadvertised profile-snapshot key required while the catalog is unsettled", () => {
     const session = makeSession({
       metadata: { runtime_config: { config_options: { model: providerModelId } } },
       agent_profile_snapshot: { config_options: { verbosity: "terse" } },
     });
 
     expect(
-      hasCompleteDynamicConfig(session, catalogEntry([modelConfigOption], true), noAgents),
+      hasCompleteDynamicConfig(session, catalogEntry([modelConfigOption], false), noAgents),
     ).toBe(false);
+  });
+
+  it("hydrates when a settled model catalog omits profile options from a prior model", () => {
+    const session = makeSession({
+      metadata: {
+        runtime_config: {
+          config_options: {
+            effort: "high",
+            fast: "false",
+            mode: "agent",
+            model: providerModelId,
+            optimize_for: "balanced",
+          },
+        },
+        runtime_config_overrides: {
+          model: providerModelId,
+          config_options: { model: providerModelId },
+        },
+      },
+      agent_profile_snapshot: { config_options: { fast: "false" } },
+    });
+    const advertised = [
+      selectOption("mode", "agent"),
+      modelConfigOption,
+      selectOption("optimize_for", "balanced"),
+    ];
+
+    expect(hasCompleteDynamicConfig(session, catalogEntry(advertised, true), noAgents)).toBe(true);
   });
 
   it("still requires persisted-only unadvertised keys while the catalog is unsettled", () => {

--- a/apps/web/components/task/model-selector.test.ts
+++ b/apps/web/components/task/model-selector.test.ts
@@ -474,6 +474,21 @@ describe("cross-agent persisted config reconciliation", () => {
     expect(hasCompleteDynamicConfig(session, catalogEntry(advertised, true), noAgents)).toBe(true);
   });
 
+  it("hydrates when a settled model catalog omits a profile-only option", () => {
+    const session = makeSession({
+      metadata: { runtime_config: { config_options: { model: providerModelId } } },
+      agent_profile_snapshot: { config_options: { fast: "false" } },
+    });
+
+    expect(
+      hasCompleteDynamicConfig(
+        session,
+        catalogEntry([modelConfigOption, selectOption("mode", "agent")], true),
+        noAgents,
+      ),
+    ).toBe(true);
+  });
+
   it("still requires persisted-only unadvertised keys while the catalog is unsettled", () => {
     const session = makeSession({
       metadata: { runtime_config: { config_options: { model: providerModelId, effort: "x" } } },

--- a/apps/web/components/task/model-selector.tsx
+++ b/apps/web/components/task/model-selector.tsx
@@ -141,19 +141,16 @@ export function hasCompleteDynamicConfig(
   const hasFlatModelList = !!sessionModelsData.models.length;
   const catalogSettled = sessionModelsData.configOptionsSettled === true;
   const hasLegacyAgentConfig = catalogSettled && isLegacyAgentConfig(session, agents);
-  // Keys written only by a prior agent type into persisted runtime metadata are
-  // not required for the selector to render: once the current agent's catalog
-  // has settled without advertising them, they are stale cross-agent leftovers
-  // that the backend replay also drops.
-  const profileRequired = session ? profileRequiredConfigKeys(session, agents) : new Set<string>();
-  const isPersistedOnlyStaleKey = (key: string): boolean =>
-    key !== AGENT_CONFIG_KEY && catalogSettled && !available.has(key) && !profileRequired.has(key);
+  // A settled catalog is authoritative for which non-agent config keys apply
+  // to the selected model.
+  const isUnadvertisedSettledKey = (key: string): boolean =>
+    key !== AGENT_CONFIG_KEY && catalogSettled && !available.has(key);
   return required.every(
     (key) =>
       available.has(key) ||
       (key === AGENT_CONFIG_KEY && hasLegacyAgentConfig) ||
       (key === MODEL_CONFIG_KEY && hasFlatModelList) ||
-      isPersistedOnlyStaleKey(key),
+      isUnadvertisedSettledKey(key),
   );
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3349/6b807cea4ac6.html)
<!-- kandev-pr-walkthrough-end -->

Switching models within the same agent could hide the model selector when the newly selected model did not advertise a profile-declared option. The hydration gate now treats a settled model catalog as authoritative for non-agent options, keeping the selector available while preserving strict startup behavior.

## Validation

- `pnpm --filter @kandev/web test -- model-selector session-models` (49 tests passed)
- `pnpm run typecheck`
- `pnpm --filter @kandev/web lint`
- `CAPTURE_PR_ASSETS=true pnpm e2e:run --host --project chromium tests/chat/chat-input-font-size.spec.ts`
- `CAPTURE_PR_ASSETS=true pnpm e2e:run --host --project mobile-chrome tests/chat/mobile-chat-input-font-size.spec.ts`

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

<!-- kandev-screenshots-start -->
![Desktop composer at 1440px](https://raw.githubusercontent.com/kdlbs/kandev/b8c908219d9c5643a5f588cff412757271b74d88/chat-input-font-size--composer-1440px.png)

![Desktop composer at 900px](https://raw.githubusercontent.com/kdlbs/kandev/b8c908219d9c5643a5f588cff412757271b74d88/chat-input-font-size--composer-900px.png)

![Mobile composer on Pixel 5](https://raw.githubusercontent.com/kdlbs/kandev/b8c908219d9c5643a5f588cff412757271b74d88/mobile-chat-input-font-size--mobile-composer.png)
<!-- kandev-screenshots-end -->