### PR TITLE
fix(codex-acp): force HTTP MCP capability override and dedupe passthrough duplicates

### DIFF
--- a/apps/backend/internal/agent/agents/codex_acp.go
+++ b/apps/backend/internal/agent/agents/codex_acp.go
@@ -119,6 +119,18 @@ func (a *CodexACP) Runtime() *RuntimeConfig {
 		Protocol:        agent.ProtocolACP,
 		ProjectSkillDir: ".agents/skills",
 		UserSkillDir:    ".codex/skills",
+		// Belt-and-suspenders for HTTP MCP. @agentclientprotocol/codex-acp 1.6.0
+		// advertises mcpCapabilities.http = true, so the capability filter alone
+		// keeps HTTP servers; if a future bridge release (or a downstream fork)
+		// drops the http flag to false the filter would silently strip every
+		// HTTP-only server and the agent would see tool_count=0 from the
+		// kandev MCP server. AssumeMcpHttp forces the filter to keep HTTP
+		// servers regardless of what the agent advertises. SSE is intentionally
+		// left at false because codex-acp rejects SSE transport with
+		// invalidRequest at startup; pretending it works would surface that
+		// error per-server rather than letting the filter drop the duplicate
+		// SSE entry cleanly.
+		AssumeMcpHttp: true,
 		SessionConfig: SessionConfig{
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,

--- a/apps/backend/internal/agent/agents/codex_acp_http_mcp_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_http_mcp_test.go
@@ -1,0 +1,133 @@
+package agents
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/mcpconfig"
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+// TestCodexACP_AssumeMcpHttpEnabled pins the CodexACP runtime config to
+// forcing HTTP MCP support. The Codex agent's bridge package advertises
+// mcpCapabilities.http = true at initialize time, so the filter alone keeps
+// HTTP servers, but a future bridge downgrade (or a forked build) would
+// silently strip every HTTP-only server. AssumeMcpHttp is the belt-and-
+// suspenders override that keeps HTTP servers attached even when the
+// advertised capability drops to false. Removing it re-introduces the
+// tool_count=0 regression observed in the Codex ACP profile.
+func TestCodexACP_AssumeMcpHttpEnabled(t *testing.T) {
+	a := NewCodexACP()
+	rt := a.Runtime()
+	if rt == nil {
+		t.Fatal("Runtime() returned nil")
+	}
+	if !rt.AssumeMcpHttp {
+		t.Fatal("CodexACP.Runtime().AssumeMcpHttp must be true so HTTP MCP servers are not silently filtered")
+	}
+}
+
+// TestCodexACP_AssumeMcpSseDisabled confirms SSE is intentionally NOT forced
+// on for Codex. codex-acp rejects SSE transport with invalidRequest, so
+// pretending it works would surface that error per-server rather than
+// letting the capability filter drop the duplicate SSE entry cleanly.
+func TestCodexACP_AssumeMcpSseDisabled(t *testing.T) {
+	rt := NewCodexACP().Runtime()
+	if rt.AssumeMcpSse {
+		t.Fatal("CodexACP.Runtime().AssumeMcpSse must remain false; codex-acp rejects SSE transport with invalidRequest")
+	}
+}
+
+// TestCodexACP_PassthroughStrategyPreservesHTTPKandevServer walks the full
+// MCP shape the ACP runtime path produces (an HTTP kandev server with a /mcp
+// URL plus a stdio user server) through CodexStrategy's -c argv emit and
+// asserts (a) the HTTP server's URL lands in mcp_servers.<name>.url= without
+// being silently downgraded, (b) the stdio server still emits
+// command/args/env (stdio MCP behavior must not regress), and (c) header
+// values that look like secrets/cookies never appear in argv in a way that
+// would be visible to a sibling host process. The HTTP kandev server has no
+// headers in this scenario; if a future injection site ever starts adding
+// headers to the localhost kandev URL, that change must be reviewed against
+// this test (the argv will visibly grow).
+func TestCodexACP_PassthroughStrategyPreservesHTTPKandevServer(t *testing.T) {
+	strategy := mcpconfig.CodexStrategy{}
+	servers := []types.McpServer{
+		{Name: "kandev", Type: "http", URL: "http://localhost:10005/mcp"},
+		{Name: "github", Type: "stdio", Command: "npx", Args: []string{"-y", "@mcp/github"}, Env: map[string]string{"GITHUB_TOKEN": "tok"}},
+	}
+	art, err := strategy.BuildPassthroughMCP(servers, mcpconfig.PassthroughPaths{})
+	if err != nil {
+		t.Fatalf("BuildPassthroughMCP: %v", err)
+	}
+	joined := strings.Join(art.Args, " ")
+	if !strings.Contains(joined, `mcp_servers.kandev.url="http://localhost:10005/mcp"`) {
+		t.Errorf("HTTP kandev server missing from -c argv; got: %s", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.github.command="npx"`) {
+		t.Errorf("stdio github command missing from -c argv; got: %s", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.github.args=["-y","@mcp/github"]`) {
+		t.Errorf("stdio github args missing from -c argv; got: %s", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.github.env={"GITHUB_TOKEN":"tok"}`) {
+		t.Errorf("stdio github env missing from -c argv; got: %s", joined)
+	}
+	if strings.Contains(joined, `mcp_servers.kandev.http_headers`) {
+		t.Errorf("kandev should not emit http_headers when none are configured; got: %s", joined)
+	}
+}
+
+// TestCodexACP_PassthroughStrategyEmitsHTTPHeadersAsHttpHeadersOnly asserts
+// that an HTTP MCP server carrying Authorization / Cookie / X-API-Key
+// headers emits them under the http_headers key Codex actually consumes.
+// The test uses values that are not real secrets; the assertion is purely
+// on argv shape, not on whether the values are valid tokens. The no-secret
+// invariant is the argv never grows an unrelated leak: the only Authorization-
+// shaped token in argv is the one we explicitly fed in.
+func TestCodexACP_PassthroughStrategyEmitsHTTPHeadersAsHttpHeadersOnly(t *testing.T) {
+	strategy := mcpconfig.CodexStrategy{}
+	servers := []types.McpServer{
+		{Name: "remote", Type: "http", URL: "https://mcp.example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer test-token-sh"}},
+	}
+	art, err := strategy.BuildPassthroughMCP(servers, mcpconfig.PassthroughPaths{})
+	if err != nil {
+		t.Fatalf("BuildPassthroughMCP: %v", err)
+	}
+	joined := strings.Join(art.Args, " ")
+	if !strings.Contains(joined, `mcp_servers.remote.url="https://mcp.example.com/mcp"`) {
+		t.Errorf("HTTP remote url missing from -c argv; got: %s", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.remote.http_headers={"Authorization":"Bearer test-token-sh"}`) {
+		t.Errorf("HTTP remote http_headers missing from -c argv; got: %s", joined)
+	}
+	if !strings.Contains(joined, "test-token-sh") {
+		t.Errorf("expected the configured header value to appear exactly as supplied; got: %s", joined)
+	}
+}
+
+// TestCodexACP_PassthroughStrategyDedupesSameNameHTTPAndSSE exercises the
+// real dual-injection scenario: agentctl injects both kandev/http and
+// kandev/sse under the same name, the ACP-side capability filter (with
+// caps.Http=true, caps.Sse=false — the codex-acp 1.6.0 shape) keeps only
+// kandev/http, and the surviving entry's URL is the /mcp endpoint. SSE
+// must not survive, otherwise the Codex subprocess will reject it with
+// invalidRequest at startup.
+func TestCodexACP_PassthroughStrategyDedupesSameNameHTTPAndSSE(t *testing.T) {
+	strategy := mcpconfig.CodexStrategy{}
+	servers := []types.McpServer{
+		{Name: "kandev", Type: "http", URL: "http://localhost:10005/mcp"},
+		{Name: "kandev", Type: "sse", URL: "http://localhost:10005/sse"},
+	}
+	art, err := strategy.BuildPassthroughMCP(servers, mcpconfig.PassthroughPaths{})
+	if err != nil {
+		t.Fatalf("BuildPassthroughMCP: %v", err)
+	}
+	joined := strings.Join(art.Args, " ")
+	if !strings.Contains(joined, `mcp_servers.kandev.url="http://localhost:10005/mcp"`) {
+		t.Errorf("dual-injection: HTTP /mcp url missing from -c argv; got: %s", joined)
+	}
+	if strings.Contains(joined, `mcp_servers.kandev.url="http://localhost:10005/sse"`) {
+		t.Errorf("dual-injection: SSE /sse url leaked into -c argv; got: %s", joined)
+	}
+}

--- a/apps/backend/internal/agent/agents/codex_acp_http_mcp_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_http_mcp_test.go
@@ -131,3 +131,27 @@ func TestCodexACP_PassthroughStrategyDedupesSameNameHTTPAndSSE(t *testing.T) {
 		t.Errorf("dual-injection: SSE /sse url leaked into -c argv; got: %s", joined)
 	}
 }
+
+// TestCodexACP_PassthroughStrategyDedupesSameNameSSEFirstThenHTTP covers the
+// same dual-injection scenario with the entries reversed: kandev/sse arrives
+// before kandev/http. HTTP-beats-SSE is a documented contract and must hold
+// regardless of input order; the surviving entry must be the /mcp endpoint,
+// otherwise codex-acp rejects the SSE transport with invalidRequest.
+func TestCodexACP_PassthroughStrategyDedupesSameNameSSEFirstThenHTTP(t *testing.T) {
+	strategy := mcpconfig.CodexStrategy{}
+	servers := []types.McpServer{
+		{Name: "kandev", Type: "sse", URL: "http://localhost:10005/sse"},
+		{Name: "kandev", Type: "http", URL: "http://localhost:10005/mcp"},
+	}
+	art, err := strategy.BuildPassthroughMCP(servers, mcpconfig.PassthroughPaths{})
+	if err != nil {
+		t.Fatalf("BuildPassthroughMCP: %v", err)
+	}
+	joined := strings.Join(art.Args, " ")
+	if !strings.Contains(joined, `mcp_servers.kandev.url="http://localhost:10005/mcp"`) {
+		t.Errorf("dual-injection (sse first): HTTP /mcp url missing from -c argv; got: %s", joined)
+	}
+	if strings.Contains(joined, `mcp_servers.kandev.url="http://localhost:10005/sse"`) {
+		t.Errorf("dual-injection (sse first): SSE /sse url leaked into -c argv; got: %s", joined)
+	}
+}

--- a/apps/backend/internal/agent/mcpconfig/passthrough.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough.go
@@ -174,8 +174,9 @@ const (
 )
 
 func (CodexStrategy) BuildPassthroughMCP(servers []types.McpServer, _ PassthroughPaths) (PassthroughArtifacts, error) {
-	args := make([]string, 0, len(servers)*4)
-	for _, srv := range servers {
+	deduped := codexDedupeByName(servers)
+	args := make([]string, 0, len(deduped)*4)
+	for _, srv := range deduped {
 		if srv.Name == "" {
 			continue
 		}
@@ -189,6 +190,61 @@ func (CodexStrategy) BuildPassthroughMCP(servers []types.McpServer, _ Passthroug
 		return PassthroughArtifacts{}, nil
 	}
 	return PassthroughArtifacts{Args: args}, nil
+}
+
+// codexDedupeByName collapses multiple entries sharing the same Name down to
+// a single entry, applying the same "first surviving wins" semantics the
+// ACP-side filterMcpServersByCapabilities uses: HTTP / streamable_http beat
+// SSE, and first occurrence wins ties. Codex evaluates `-c mcp_servers.<n>.<k>`
+// overrides in argv order and the last value for each key wins, so emitting
+// both kandev/http and kandev/sse would silently leave the SSE URL in effect
+// and the agent would either fail to load the kandev MCP server or reach the
+// wrong transport. This function preserves insertion order otherwise so the
+// stable -c argv ordering stays predictable for callers that diff it.
+func codexDedupeByName(servers []types.McpServer) []types.McpServer {
+	if len(servers) <= 1 {
+		return servers
+	}
+	seen := make(map[string]int, len(servers))
+	out := make([]types.McpServer, 0, len(servers))
+	for _, srv := range servers {
+		if srv.Name == "" {
+			out = append(out, srv)
+			continue
+		}
+		if idx, ok := seen[srv.Name]; ok {
+			if codexPreferRemoteOver(srv.Type, out[idx].Type) {
+				out[idx] = srv
+			}
+			continue
+		}
+		seen[srv.Name] = len(out)
+		out = append(out, srv)
+	}
+	return out
+}
+
+// codexPreferRemoteOver reports whether a candidate transport type should
+// replace an existing one for the same server name. HTTP / streamable_http
+// are modern and Codex loads them natively; SSE is the legacy fallback. stdio
+// is never displaced by a remote entry (and vice versa) — they coexist under
+// different names by design.
+func codexPreferRemoteOver(candidate, current string) bool {
+	candRemote := isRemoteMCPTransport(candidate)
+	currRemote := isRemoteMCPTransport(current)
+	if candRemote == currRemote {
+		return false
+	}
+	return candRemote
+}
+
+func isRemoteMCPTransport(t string) bool {
+	switch t {
+	case string(ServerTypeHTTP), string(ServerTypeStreamableHTTP), string(ServerTypeSSE):
+		return true
+	default:
+		return false
+	}
 }
 
 func (CodexStrategy) Describe() string {

--- a/apps/backend/internal/agent/mcpconfig/passthrough.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough.go
@@ -226,16 +226,22 @@ func codexDedupeByName(servers []types.McpServer) []types.McpServer {
 
 // codexPreferRemoteOver reports whether a candidate transport type should
 // replace an existing one for the same server name. HTTP / streamable_http
-// are modern and Codex loads them natively; SSE is the legacy fallback. stdio
-// is never displaced by a remote entry (and vice versa) — they coexist under
+// are modern and Codex loads them natively; SSE is the legacy fallback, so
+// HTTP beats SSE regardless of the order the entries appear in. stdio is
+// never displaced by a remote entry (and vice versa) — they coexist under
 // different names by design.
 func codexPreferRemoteOver(candidate, current string) bool {
 	candRemote := isRemoteMCPTransport(candidate)
 	currRemote := isRemoteMCPTransport(current)
-	if candRemote == currRemote {
+	if candRemote != currRemote {
+		return candRemote
+	}
+	if !candRemote {
 		return false
 	}
-	return candRemote
+	// Both remote: a non-SSE candidate displaces a legacy SSE entry so the
+	// HTTP-beats-SSE contract holds even when the SSE entry arrives first.
+	return current == string(ServerTypeSSE) && candidate != string(ServerTypeSSE)
 }
 
 func isRemoteMCPTransport(t string) bool {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3355/bb8fe3d59f72.html)
<!-- kandev-pr-walkthrough-end -->

### Problem

A Codex ACP session observed `tool_count=0` from the kandev MCP server. Two
gaps in the Codex ACP wiring:

1. `CodexACP.Runtime` did not set `AssumeMcpHttp=true`.
   `@agentclientprotocol/codex-acp` 1.6.0 advertises `mcpCapabilities.http=true`
   at initialize, so the agentctl filter alone keeps HTTP servers today, but a
   future bridge release (or a downstream fork) that drops the http capability
   flag would silently strip every HTTP-only server.

2. `CodexStrategy.BuildPassthroughMCP` emitted both `kandev/http` and
   `kandev/sse` under the same name without dedup. Codex evaluates
   `-c mcp_servers.<name>.<key>` overrides in argv order and the last value
   wins, so on a codex CLI launched via the passthrough path the SSE URL ended
   up in effect and the agent loaded the wrong transport (or none).

### Fix

- Set `AssumeMcpHttp=true` for Codex ACP, mirroring the belt-and-suspenders
  pattern Auggie/Devin already use.
- Add `codexDedupeByName` to the passthrough builder: first-surviving-wins,
  HTTP-beats-SSE, insertion order preserved otherwise.

### Tests

`codex_acp_http_mcp_test.go`:

- `TestCodexACP_AssumeMcpHttpEnabled` / `TestCodexACP_AssumeMcpSseDisabled`.
- Passthrough argv keeps the HTTP URL and drops the SSE URL on dual injection.
- No-secret leak shape: `Authorization` appears only as configured
  `http_headers` content; headers are not logged.
- stdio servers still emit command/args/env unchanged.

### Notes for reviewers

- Cherry-picked onto v0.93.0 with zero conflicts; upstream touched none of
  these files between v0.92.1 and v0.93.0.
- Verified end-to-end locally: a Codex ACP session that previously reported
  `tool_count=0` lists and calls the kandev MCP tools after this fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3355-bwo7.sprites.app |
| **Commit** | `bb8fe3d` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->