### PR TITLE
fix(backend): stop retries from hammering a failed credential after a restart

### DIFF
--- a/apps/backend/internal/agent/runtime/dynamic/circuit.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
 )
 
@@ -66,19 +68,48 @@ func WithCircuitPersistence(persistence CircuitPersistence) CircuitRegistryOptio
 	return func(registry *CircuitRegistry) { registry.persist = persistence }
 }
 
+// WithCircuitLogger sets the logger used to report a failed durable write.
+// Defaults to a no-op logger.
+func WithCircuitLogger(log *zap.Logger) CircuitRegistryOption {
+	return func(registry *CircuitRegistry) {
+		if log != nil {
+			registry.logger = log
+		}
+	}
+}
+
 type CircuitRegistry struct {
 	mu       sync.Mutex
 	now      func() time.Time
 	circuits map[string]circuit
 	persist  CircuitPersistence
+	logger   *zap.Logger
+	pending  map[string]struct{}
 }
 
 func NewCircuitRegistry(options ...CircuitRegistryOption) *CircuitRegistry {
-	registry := &CircuitRegistry{now: time.Now, circuits: make(map[string]circuit)}
+	registry := &CircuitRegistry{
+		now:      time.Now,
+		circuits: make(map[string]circuit),
+		logger:   zap.NewNop(),
+		pending:  make(map[string]struct{}),
+	}
 	for _, option := range options {
 		option(registry)
 	}
 	return registry
+}
+
+// PendingPersists reports the keys whose durable state failed to persist and
+// has not yet been successfully flushed.
+func (r *CircuitRegistry) PendingPersists() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	keys := make([]string, 0, len(r.pending))
+	for key := range r.pending {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 // Restore loads durable circuit state before routing workers start.
@@ -107,8 +138,9 @@ func (r *CircuitRegistry) Open(key string, until time.Time, code routingerr.Code
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.flushPendingLocked()
 	r.circuits[key] = circuit{state: CircuitOpen, until: until, code: code}
-	r.persistSnapshotLocked(key)
+	_ = r.persistSnapshotLocked(key)
 }
 
 func (r *CircuitRegistry) IsOpen(key string, now time.Time) bool {
@@ -138,6 +170,7 @@ func (r *CircuitRegistry) AcquireProbe(key string, duration time.Duration) (Prob
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.flushPendingLocked()
 	now := r.now()
 	entry, ok := r.circuits[key]
 	if !ok || entry.state == CircuitClosed || now.Before(entry.until) || now.Before(entry.probeUntil) {
@@ -147,7 +180,7 @@ func (r *CircuitRegistry) AcquireProbe(key string, duration time.Duration) (Prob
 	entry.state = CircuitHalfOpen
 	entry.probeUntil = lease.ExpiresAt
 	r.circuits[key] = entry
-	r.persistSnapshotLocked(key)
+	_ = r.persistSnapshotLocked(key)
 	return lease, true
 }
 
@@ -157,6 +190,7 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.flushPendingLocked()
 	entry, ok := r.circuits[lease.Key]
 	if !ok || entry.state != CircuitHalfOpen || !entry.probeUntil.Equal(lease.ExpiresAt) {
 		return
@@ -171,22 +205,48 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 		entry.until = r.now().Add(backoff)
 	}
 	r.circuits[lease.Key] = entry
-	r.persistSnapshotLocked(lease.Key)
+	_ = r.persistSnapshotLocked(lease.Key)
 }
 
-func (r *CircuitRegistry) persistSnapshotLocked(key string) {
+// flushPendingLocked retries the durable write for every key whose previous
+// SaveCircuit failed, using each key's current in-memory snapshot. Called at
+// the start of every mutator so a transient persistence failure self-heals
+// on the next circuit event instead of leaving the durable row permanently
+// behind memory.
+func (r *CircuitRegistry) flushPendingLocked() {
+	for key := range r.pending {
+		_ = r.persistSnapshotLocked(key)
+	}
+}
+
+// persistSnapshotLocked writes key's current snapshot and returns the
+// persistence error, if any. A failure is logged at WARN and the key is
+// recorded in pending so a later mutation retries the write; a caller-visible
+// error here would either fail routing decisions that must still complete
+// (Open) or make every candidate unselectable while the store is down
+// (AcquireProbe), so callers do not act on the return value directly.
+func (r *CircuitRegistry) persistSnapshotLocked(key string) error {
 	if r.persist == nil {
-		return
+		return nil
 	}
 	entry, ok := r.circuits[key]
 	if !ok {
-		return
+		return nil
 	}
-	// Selection remains fail-closed in memory if persistence is temporarily
-	// unavailable. Startup Restore and health reconciliation surface durable
-	// read failures to their caller.
-	_ = r.persist.SaveCircuit(context.Background(), CircuitSnapshot{
+	err := r.persist.SaveCircuit(context.Background(), CircuitSnapshot{
 		Key: key, State: entry.state, Until: entry.until,
 		Code: entry.code, ProbeUntil: entry.probeUntil,
 	})
+	if err != nil {
+		r.pending[key] = struct{}{}
+		r.logger.Warn("failed to persist circuit snapshot",
+			zap.String("key", key),
+			zap.String("state", string(entry.state)),
+			zap.Time("until", entry.until),
+			zap.Error(err),
+		)
+		return err
+	}
+	delete(r.pending, key)
+	return nil
 }

--- a/apps/backend/internal/agent/runtime/dynamic/circuit.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit.go
@@ -197,12 +197,13 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 }
 
 // pendingFlushBudget bounds how many other pending keys a single mutation
-// retries. r.mu also gates IsOpen on the routing hot path, so a mutation
-// during a sustained persistence outage must cost O(1) extra writes, not
-// O(len(pending)): unbounded fan-out means N circuits opening during an
-// outage cost O(N^2) SaveCircuit calls and stall concurrent routing
-// decisions behind them.
-const pendingFlushBudget = 8
+// retries. r.mu also gates IsOpen on the routing hot path, and each retry is
+// a blocking SaveCircuit call, so a mutation during a sustained persistence
+// outage must hold the lock for at most one extra write, not one per pending
+// key: unbounded fan-out both grows total SaveCircuit calls quadratically
+// across mutations and holds the routing mutex for the sum of every pending
+// write's duration.
+const pendingFlushBudget = 1
 
 // flushPendingLocked retries the durable write for up to pendingFlushBudget
 // keys whose previous SaveCircuit failed, using each key's current in-memory

--- a/apps/backend/internal/agent/runtime/dynamic/circuit.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit.go
@@ -100,18 +100,6 @@ func NewCircuitRegistry(options ...CircuitRegistryOption) *CircuitRegistry {
 	return registry
 }
 
-// PendingPersists reports the keys whose durable state failed to persist and
-// has not yet been successfully flushed.
-func (r *CircuitRegistry) PendingPersists() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	keys := make([]string, 0, len(r.pending))
-	for key := range r.pending {
-		keys = append(keys, key)
-	}
-	return keys
-}
-
 // Restore loads durable circuit state before routing workers start.
 func (r *CircuitRegistry) Restore(ctx context.Context) error {
 	if r.persist == nil {
@@ -170,12 +158,12 @@ func (r *CircuitRegistry) AcquireProbe(key string, duration time.Duration) (Prob
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.flushPendingLocked()
 	now := r.now()
 	entry, ok := r.circuits[key]
 	if !ok || entry.state == CircuitClosed || now.Before(entry.until) || now.Before(entry.probeUntil) {
 		return ProbeLease{}, false
 	}
+	r.flushPendingLocked()
 	lease := ProbeLease{Key: key, ExpiresAt: now.Add(duration)}
 	entry.state = CircuitHalfOpen
 	entry.probeUntil = lease.ExpiresAt
@@ -190,11 +178,11 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.flushPendingLocked()
 	entry, ok := r.circuits[lease.Key]
 	if !ok || entry.state != CircuitHalfOpen || !entry.probeUntil.Equal(lease.ExpiresAt) {
 		return
 	}
+	r.flushPendingLocked()
 	entry.probeUntil = time.Time{}
 	if success {
 		entry.state = CircuitClosed
@@ -208,23 +196,37 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 	_ = r.persistSnapshotLocked(lease.Key)
 }
 
-// flushPendingLocked retries the durable write for every key whose previous
-// SaveCircuit failed, using each key's current in-memory snapshot. Called at
-// the start of every mutator so a transient persistence failure self-heals
-// on the next circuit event instead of leaving the durable row permanently
-// behind memory.
+// pendingFlushBudget bounds how many other pending keys a single mutation
+// retries. r.mu also gates IsOpen on the routing hot path, so a mutation
+// during a sustained persistence outage must cost O(1) extra writes, not
+// O(len(pending)): unbounded fan-out means N circuits opening during an
+// outage cost O(N^2) SaveCircuit calls and stall concurrent routing
+// decisions behind them.
+const pendingFlushBudget = 8
+
+// flushPendingLocked retries the durable write for up to pendingFlushBudget
+// keys whose previous SaveCircuit failed, using each key's current in-memory
+// snapshot. Called from every mutator so a transient persistence failure
+// self-heals across subsequent circuit events instead of leaving the durable
+// row permanently behind memory.
 func (r *CircuitRegistry) flushPendingLocked() {
+	flushed := 0
 	for key := range r.pending {
+		if flushed >= pendingFlushBudget {
+			return
+		}
 		_ = r.persistSnapshotLocked(key)
+		flushed++
 	}
 }
 
 // persistSnapshotLocked writes key's current snapshot and returns the
-// persistence error, if any. A failure is logged at WARN and the key is
-// recorded in pending so a later mutation retries the write; a caller-visible
-// error here would either fail routing decisions that must still complete
-// (Open) or make every candidate unselectable while the store is down
-// (AcquireProbe), so callers do not act on the return value directly.
+// persistence error, if any. A failure is logged at WARN once per failure
+// streak (not once per retry) and the key is recorded in pending so a later
+// mutation retries the write; a caller-visible error here would either fail
+// routing decisions that must still complete (Open) or make every candidate
+// unselectable while the store is down (AcquireProbe), so callers do not act
+// on the return value directly.
 func (r *CircuitRegistry) persistSnapshotLocked(key string) error {
 	if r.persist == nil {
 		return nil
@@ -238,13 +240,16 @@ func (r *CircuitRegistry) persistSnapshotLocked(key string) error {
 		Code: entry.code, ProbeUntil: entry.probeUntil,
 	})
 	if err != nil {
+		_, alreadyPending := r.pending[key]
 		r.pending[key] = struct{}{}
-		r.logger.Warn("failed to persist circuit snapshot",
-			zap.String("key", key),
-			zap.String("state", string(entry.state)),
-			zap.Time("until", entry.until),
-			zap.Error(err),
-		)
+		if !alreadyPending {
+			r.logger.Warn("failed to persist circuit snapshot",
+				zap.String("key", key),
+				zap.String("state", string(entry.state)),
+				zap.Time("until", entry.until),
+				zap.Error(err),
+			)
+		}
 		return err
 	}
 	delete(r.pending, key)

--- a/apps/backend/internal/agent/runtime/dynamic/circuit.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit.go
@@ -126,7 +126,7 @@ func (r *CircuitRegistry) Open(key string, until time.Time, code routingerr.Code
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.flushPendingLocked()
+	r.flushPendingLocked(key)
 	r.circuits[key] = circuit{state: CircuitOpen, until: until, code: code}
 	_ = r.persistSnapshotLocked(key)
 }
@@ -163,7 +163,7 @@ func (r *CircuitRegistry) AcquireProbe(key string, duration time.Duration) (Prob
 	if !ok || entry.state == CircuitClosed || now.Before(entry.until) || now.Before(entry.probeUntil) {
 		return ProbeLease{}, false
 	}
-	r.flushPendingLocked()
+	r.flushPendingLocked(key)
 	lease := ProbeLease{Key: key, ExpiresAt: now.Add(duration)}
 	entry.state = CircuitHalfOpen
 	entry.probeUntil = lease.ExpiresAt
@@ -182,7 +182,7 @@ func (r *CircuitRegistry) ReleaseProbe(lease ProbeLease, success bool, backoff t
 	if !ok || entry.state != CircuitHalfOpen || !entry.probeUntil.Equal(lease.ExpiresAt) {
 		return
 	}
-	r.flushPendingLocked()
+	r.flushPendingLocked(lease.Key)
 	entry.probeUntil = time.Time{}
 	if success {
 		entry.state = CircuitClosed
@@ -210,9 +210,12 @@ const pendingFlushBudget = 1
 // snapshot. Called from every mutator so a transient persistence failure
 // self-heals across subsequent circuit events instead of leaving the durable
 // row permanently behind memory.
-func (r *CircuitRegistry) flushPendingLocked() {
+func (r *CircuitRegistry) flushPendingLocked(skipKey string) {
 	flushed := 0
 	for key := range r.pending {
+		if key == skipKey {
+			continue
+		}
 		if flushed >= pendingFlushBudget {
 			return
 		}

--- a/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
@@ -78,6 +78,12 @@ func (s *stubCircuitPersistence) row(key string) (CircuitSnapshot, bool) {
 	return row, ok
 }
 
+func (s *stubCircuitPersistence) saveCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saves
+}
+
 func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
 	core, observed := observer.New(zapcore.WarnLevel)
 	return zap.New(core), observed
@@ -153,6 +159,23 @@ func TestPersistSnapshotFailureIsSurfacedOnReleaseProbe(t *testing.T) {
 	entries := observed.FilterMessageSnippet("persist circuit").All()
 	if len(entries) != 1 {
 		t.Fatalf("warn log entries = %d, want 1", len(entries))
+	}
+}
+
+func TestMutationDoesNotFlushItsOwnPendingKey(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	persist.setFailing(true)
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist))
+
+	registry.Open("credential:acme", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+	persist.setFailing(false)
+	registry.Open("credential:acme", time.Now().Add(2*time.Hour), routingerr.CodeProviderUnavailable)
+
+	if got := persist.saveCount(); got != 2 {
+		t.Fatalf("SaveCircuit calls = %d, want 2 (one failed write and one current mutation write)", got)
+	}
+	if pending := pendingKeys(registry); len(pending) != 0 {
+		t.Fatalf("pending keys = %v, want empty", pending)
 	}
 }
 
@@ -282,31 +305,30 @@ func TestFlushDuringOutageIsLinearNotQuadratic(t *testing.T) {
 	}
 }
 
-// slowFailingCircuitPersistence simulates a persistence backend whose writes
-// are both slow and always failing, to exercise the lock-hold bound during a
-// sustained outage. writeStarted signals each SaveCircuit entry so a test can
-// observe that r.mu is held without racing on wall-clock timing.
-type slowFailingCircuitPersistence struct {
-	delay        time.Duration
-	saves        atomic.Int64
-	writeStarted chan struct{}
+// gatedFailingCircuitPersistence blocks writes after setup and releases each
+// write through a channel, so the lock-hold bound is tested without sleeps.
+type gatedFailingCircuitPersistence struct {
+	blocking     atomic.Bool
+	writeStarted chan string
+	releaseWrite chan struct{}
 }
 
-func newSlowFailingCircuitPersistence(delay time.Duration) *slowFailingCircuitPersistence {
-	return &slowFailingCircuitPersistence{delay: delay, writeStarted: make(chan struct{}, 64)}
-}
-
-func (s *slowFailingCircuitPersistence) SaveCircuit(_ context.Context, _ CircuitSnapshot) error {
-	s.saves.Add(1)
-	select {
-	case s.writeStarted <- struct{}{}:
-	default:
+func newGatedFailingCircuitPersistence() *gatedFailingCircuitPersistence {
+	return &gatedFailingCircuitPersistence{
+		writeStarted: make(chan string),
+		releaseWrite: make(chan struct{}),
 	}
-	time.Sleep(s.delay)
+}
+
+func (s *gatedFailingCircuitPersistence) SaveCircuit(_ context.Context, snapshot CircuitSnapshot) error {
+	if s.blocking.Load() {
+		s.writeStarted <- snapshot.Key
+		<-s.releaseWrite
+	}
 	return errors.New("db is locked")
 }
 
-func (s *slowFailingCircuitPersistence) LoadCircuits(_ context.Context) ([]CircuitSnapshot, error) {
+func (s *gatedFailingCircuitPersistence) LoadCircuits(_ context.Context) ([]CircuitSnapshot, error) {
 	return nil, nil
 }
 
@@ -317,8 +339,7 @@ func (s *slowFailingCircuitPersistence) LoadCircuits(_ context.Context) ([]Circu
 // mutation holds the lock for at most its own write plus a single flush
 // attempt, regardless of how many keys are pending.
 func TestFlushDuringOutageDoesNotStallRoutingHotPath(t *testing.T) {
-	const delay = 50 * time.Millisecond
-	persist := newSlowFailingCircuitPersistence(delay)
+	persist := newGatedFailingCircuitPersistence()
 	registry := NewCircuitRegistry(WithCircuitPersistence(persist))
 
 	const n = 8
@@ -328,22 +349,39 @@ func TestFlushDuringOutageDoesNotStallRoutingHotPath(t *testing.T) {
 	if got := len(pendingKeys(registry)); got != n {
 		t.Fatalf("pending keys = %d, want %d", got, n)
 	}
-	for len(persist.writeStarted) > 0 {
-		<-persist.writeStarted
-	}
+	persist.blocking.Store(true)
 
-	go registry.Open("credential:new", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
-	<-persist.writeStarted // the mutation above now holds r.mu inside a blocking SaveCircuit call
+	mutationDone := make(chan struct{})
+	go func() {
+		defer close(mutationDone)
+		registry.Open("credential:new", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+	}()
+	<-persist.writeStarted
 
-	start := time.Now()
-	registry.IsOpen("credential:c0", time.Now())
-	blocked := time.Since(start)
+	isOpenDone := make(chan struct{})
+	go func() {
+		registry.IsOpen("credential:c0", time.Now())
+		close(isOpenDone)
+	}()
+	persist.releaseWrite <- struct{}{}
 
-	// Budget-1 fan-out holds the lock for at most two writes (one flush
-	// attempt, one own write): well under the n+1 writes an unbounded flush
-	// of n=8 pending keys would have held it for.
-	if max := 3 * delay; blocked > max {
-		t.Fatalf("IsOpen blocked for %v while a mutation flushed pending writes, want <= %v", blocked, max)
+	writes := 1
+	for {
+		select {
+		case <-persist.writeStarted:
+			writes++
+			persist.releaseWrite <- struct{}{}
+		case <-mutationDone:
+			if writes != 2 {
+				t.Fatalf("blocked mutation used %d writes, want 2", writes)
+			}
+			select {
+			case <-isOpenDone:
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("IsOpen did not complete after the bounded mutation finished")
+			}
+			return
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -270,8 +271,79 @@ func TestFlushDuringOutageIsLinearNotQuadratic(t *testing.T) {
 	if want := n * (pendingFlushBudget + 1); persist.saves > want {
 		t.Fatalf("SaveCircuit calls = %d, want <= %d (linear in N, bounded flush fan-out)", persist.saves, want)
 	}
+	// Lower bound: this must also prove flushing actually happens, not just
+	// that it stays bounded. n own writes alone (flush disabled) would leave
+	// saves == n; each mutation after the first also retries a pending key.
+	if persist.saves <= n {
+		t.Fatalf("SaveCircuit calls = %d, want > %d (flush must retry pending keys, not just perform each mutation's own write)", persist.saves, n)
+	}
 	if len(pendingKeys(registry)) != n {
 		t.Fatalf("pending keys = %d, want %d (persistence is still down)", len(pendingKeys(registry)), n)
+	}
+}
+
+// slowFailingCircuitPersistence simulates a persistence backend whose writes
+// are both slow and always failing, to exercise the lock-hold bound during a
+// sustained outage. writeStarted signals each SaveCircuit entry so a test can
+// observe that r.mu is held without racing on wall-clock timing.
+type slowFailingCircuitPersistence struct {
+	delay        time.Duration
+	saves        atomic.Int64
+	writeStarted chan struct{}
+}
+
+func newSlowFailingCircuitPersistence(delay time.Duration) *slowFailingCircuitPersistence {
+	return &slowFailingCircuitPersistence{delay: delay, writeStarted: make(chan struct{}, 64)}
+}
+
+func (s *slowFailingCircuitPersistence) SaveCircuit(_ context.Context, _ CircuitSnapshot) error {
+	s.saves.Add(1)
+	select {
+	case s.writeStarted <- struct{}{}:
+	default:
+	}
+	time.Sleep(s.delay)
+	return errors.New("db is locked")
+}
+
+func (s *slowFailingCircuitPersistence) LoadCircuits(_ context.Context) ([]CircuitSnapshot, error) {
+	return nil, nil
+}
+
+// TestFlushDuringOutageDoesNotStallRoutingHotPath pins Review Round 2's
+// blocker: a mutation's pending-key flush must not hold r.mu long enough to
+// stall a concurrent IsOpen call (the routing hot path) for the sum of every
+// pending write's duration. With pendingFlushBudget bounded to 1, one
+// mutation holds the lock for at most its own write plus a single flush
+// attempt, regardless of how many keys are pending.
+func TestFlushDuringOutageDoesNotStallRoutingHotPath(t *testing.T) {
+	const delay = 50 * time.Millisecond
+	persist := newSlowFailingCircuitPersistence(delay)
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist))
+
+	const n = 8
+	for i := 0; i < n; i++ {
+		registry.Open(fmt.Sprintf("credential:c%d", i), time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+	}
+	if got := len(pendingKeys(registry)); got != n {
+		t.Fatalf("pending keys = %d, want %d", got, n)
+	}
+	for len(persist.writeStarted) > 0 {
+		<-persist.writeStarted
+	}
+
+	go registry.Open("credential:new", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+	<-persist.writeStarted // the mutation above now holds r.mu inside a blocking SaveCircuit call
+
+	start := time.Now()
+	registry.IsOpen("credential:c0", time.Now())
+	blocked := time.Since(start)
+
+	// Budget-1 fan-out holds the lock for at most two writes (one flush
+	// attempt, one own write): well under the n+1 writes an unbounded flush
+	// of n=8 pending keys would have held it for.
+	if max := 3 * delay; blocked > max {
+		t.Fatalf("IsOpen blocked for %v while a mutation flushed pending writes, want <= %v", blocked, max)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,18 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
 )
+
+// pendingKeys reads r.pending directly; the test lives in package dynamic so
+// it needs no exported accessor for a field production code never consumes.
+func pendingKeys(r *CircuitRegistry) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	keys := make([]string, 0, len(r.pending))
+	for key := range r.pending {
+		keys = append(keys, key)
+	}
+	return keys
+}
 
 // stubCircuitPersistence is an in-memory CircuitPersistence whose SaveCircuit
 // can be made to fail on demand, to exercise the persistence-failure paths.
@@ -77,9 +90,9 @@ func TestPersistSnapshotFailureIsSurfacedOnOpen(t *testing.T) {
 
 	registry.Open("credential:acme", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
 
-	pending := registry.PendingPersists()
+	pending := pendingKeys(registry)
 	if len(pending) != 1 || pending[0] != "credential:acme" {
-		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+		t.Fatalf("pending keys = %v, want [credential:acme]", pending)
 	}
 	entries := observed.FilterMessageSnippet("persist circuit").All()
 	if len(entries) != 1 {
@@ -104,9 +117,9 @@ func TestPersistSnapshotFailureIsSurfacedOnAcquireProbe(t *testing.T) {
 		t.Fatalf("AcquireProbe: expected success, lease=%#v", lease)
 	}
 
-	pending := registry.PendingPersists()
+	pending := pendingKeys(registry)
 	if len(pending) != 1 || pending[0] != "credential:acme" {
-		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+		t.Fatalf("pending keys = %v, want [credential:acme]", pending)
 	}
 	entries := observed.FilterMessageSnippet("persist circuit").All()
 	if len(entries) != 1 {
@@ -132,9 +145,9 @@ func TestPersistSnapshotFailureIsSurfacedOnReleaseProbe(t *testing.T) {
 	persist.setFailing(true)
 	registry.ReleaseProbe(lease, true, time.Minute)
 
-	pending := registry.PendingPersists()
+	pending := pendingKeys(registry)
 	if len(pending) != 1 || pending[0] != "credential:acme" {
-		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+		t.Fatalf("pending keys = %v, want [credential:acme]", pending)
 	}
 	entries := observed.FilterMessageSnippet("persist circuit").All()
 	if len(entries) != 1 {
@@ -173,8 +186,8 @@ func TestFailedPersistDoesNotSurviveRestart(t *testing.T) {
 	persist.setFailing(false)
 	registry.Open("credential:other", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
 
-	if len(registry.PendingPersists()) != 0 {
-		t.Fatalf("PendingPersists should be empty after a successful flush, got %v", registry.PendingPersists())
+	if len(pendingKeys(registry)) != 0 {
+		t.Fatalf("pending keys should be empty after a successful flush, got %v", pendingKeys(registry))
 	}
 	if _, ok := persist.row("credential:acme"); !ok {
 		t.Fatalf("durable row for credential:acme should have been backfilled")
@@ -191,7 +204,10 @@ func TestFailedPersistDoesNotSurviveRestart(t *testing.T) {
 
 // TestFlushWritesCurrentSnapshotNotStale ensures the pending-flush re-reads
 // the circuit's current in-memory state rather than replaying the stale
-// snapshot captured at the time of the original failed write.
+// snapshot captured at the time of the original failed write. It observes the
+// flush write in isolation by triggering it through a mutation of a
+// DIFFERENT key, so credential:acme's own write never runs in that call and
+// the persisted row can only have come from the flush.
 func TestFlushWritesCurrentSnapshotNotStale(t *testing.T) {
 	persist := newStubCircuitPersistence()
 	persist.setFailing(true)
@@ -200,6 +216,9 @@ func TestFlushWritesCurrentSnapshotNotStale(t *testing.T) {
 		WithCircuitClock(func() time.Time { return time.Unix(1000, 0) }),
 	)
 
+	// credential:acme fails to persist while opening, then advances to
+	// half-open via AcquireProbe -- still while persistence is failing, so
+	// the durable store never observes either state directly.
 	registry.Open("credential:acme", time.Unix(900, 0), routingerr.CodeProviderUnavailable)
 	lease, ok := registry.AcquireProbe("credential:acme", time.Minute)
 	if !ok {
@@ -207,17 +226,52 @@ func TestFlushWritesCurrentSnapshotNotStale(t *testing.T) {
 	}
 
 	persist.setFailing(false)
-	registry.ReleaseProbe(lease, true, time.Minute)
+	registry.Open("credential:other", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
 
-	if len(registry.PendingPersists()) != 0 {
-		t.Fatalf("PendingPersists should be empty, got %v", registry.PendingPersists())
-	}
 	row, ok := persist.row("credential:acme")
 	if !ok {
-		t.Fatalf("durable row for credential:acme should exist")
+		t.Fatalf("durable row for credential:acme should have been backfilled by the flush")
 	}
-	if row.State != CircuitClosed {
-		t.Fatalf("durable row state = %v, want %v (current snapshot, not stale open)", row.State, CircuitClosed)
+	if row.State != CircuitHalfOpen {
+		t.Fatalf("durable row state = %v, want %v (current snapshot, not the stale open snapshot from the original failure)", row.State, CircuitHalfOpen)
+	}
+	if !row.ProbeUntil.Equal(lease.ExpiresAt) {
+		t.Fatalf("durable row probeUntil = %v, want %v (current snapshot, not stale)", row.ProbeUntil, lease.ExpiresAt)
+	}
+	if pending := pendingKeys(registry); len(pending) != 0 {
+		t.Fatalf("pending keys should be empty after the flush, got %v", pending)
+	}
+
+	// The original mutation path still ends up durable too, via its own write.
+	registry.ReleaseProbe(lease, true, time.Minute)
+	row, ok = persist.row("credential:acme")
+	if !ok || row.State != CircuitClosed {
+		t.Fatalf("durable row after ReleaseProbe = %+v, ok=%v, want closed", row, ok)
+	}
+}
+
+// TestFlushDuringOutageIsLinearNotQuadratic pins the Finding-2 fix: opening N
+// circuits during a sustained persistence outage must cost O(N) SaveCircuit
+// calls (bounded fan-out per mutation), not O(N^2) from retrying every
+// pending key on every mutation.
+func TestFlushDuringOutageIsLinearNotQuadratic(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	persist.setFailing(true)
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist))
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		registry.Open(fmt.Sprintf("credential:c%d", i), time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+	}
+
+	// Quadratic behavior (retry every pending key on every mutation) would
+	// cost n + n(n-1)/2 = 1,275 calls for n=50. Bounded fan-out costs at most
+	// n own writes plus pendingFlushBudget flush attempts per mutation.
+	if want := n * (pendingFlushBudget + 1); persist.saves > want {
+		t.Fatalf("SaveCircuit calls = %d, want <= %d (linear in N, bounded flush fan-out)", persist.saves, want)
+	}
+	if len(pendingKeys(registry)) != n {
+		t.Fatalf("pending keys = %d, want %d (persistence is still down)", len(pendingKeys(registry)), n)
 	}
 }
 
@@ -228,8 +282,8 @@ func TestCleanPathLeavesNoPendingAndLogsNothing(t *testing.T) {
 
 	registry.Open("credential:acme", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
 
-	if pending := registry.PendingPersists(); len(pending) != 0 {
-		t.Fatalf("PendingPersists = %v, want empty", pending)
+	if pending := pendingKeys(registry); len(pending) != 0 {
+		t.Fatalf("pending keys = %v, want empty", pending)
 	}
 	if observed.Len() != 0 {
 		t.Fatalf("expected no log entries on the clean path, got %d", observed.Len())

--- a/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
+++ b/apps/backend/internal/agent/runtime/dynamic/circuit_test.go
@@ -1,0 +1,237 @@
+package dynamic
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
+)
+
+// stubCircuitPersistence is an in-memory CircuitPersistence whose SaveCircuit
+// can be made to fail on demand, to exercise the persistence-failure paths.
+type stubCircuitPersistence struct {
+	mu      sync.Mutex
+	rows    map[string]CircuitSnapshot
+	failing bool
+	saves   int
+}
+
+func newStubCircuitPersistence() *stubCircuitPersistence {
+	return &stubCircuitPersistence{rows: make(map[string]CircuitSnapshot)}
+}
+
+func (s *stubCircuitPersistence) SaveCircuit(_ context.Context, snapshot CircuitSnapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saves++
+	if s.failing {
+		return errors.New("db is locked")
+	}
+	s.rows[snapshot.Key] = snapshot
+	return nil
+}
+
+func (s *stubCircuitPersistence) LoadCircuits(_ context.Context) ([]CircuitSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshots := make([]CircuitSnapshot, 0, len(s.rows))
+	for _, row := range s.rows {
+		if row.State == CircuitClosed {
+			continue
+		}
+		snapshots = append(snapshots, row)
+	}
+	return snapshots, nil
+}
+
+func (s *stubCircuitPersistence) setFailing(failing bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failing = failing
+}
+
+func (s *stubCircuitPersistence) row(key string) (CircuitSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	row, ok := s.rows[key]
+	return row, ok
+}
+
+func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, observed := observer.New(zapcore.WarnLevel)
+	return zap.New(core), observed
+}
+
+func TestPersistSnapshotFailureIsSurfacedOnOpen(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	persist.setFailing(true)
+	log, observed := newObservedLogger()
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist), WithCircuitLogger(log))
+
+	registry.Open("credential:acme", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+
+	pending := registry.PendingPersists()
+	if len(pending) != 1 || pending[0] != "credential:acme" {
+		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+	}
+	entries := observed.FilterMessageSnippet("persist circuit").All()
+	if len(entries) != 1 {
+		t.Fatalf("warn log entries = %d, want 1", len(entries))
+	}
+}
+
+func TestPersistSnapshotFailureIsSurfacedOnAcquireProbe(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	log, observed := newObservedLogger()
+	registry := NewCircuitRegistry(
+		WithCircuitPersistence(persist),
+		WithCircuitLogger(log),
+		WithCircuitClock(func() time.Time { return time.Unix(1000, 0) }),
+	)
+	registry.Open("credential:acme", time.Unix(900, 0), routingerr.CodeProviderUnavailable)
+	observed.TakeAll()
+
+	persist.setFailing(true)
+	lease, ok := registry.AcquireProbe("credential:acme", time.Minute)
+	if !ok {
+		t.Fatalf("AcquireProbe: expected success, lease=%#v", lease)
+	}
+
+	pending := registry.PendingPersists()
+	if len(pending) != 1 || pending[0] != "credential:acme" {
+		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+	}
+	entries := observed.FilterMessageSnippet("persist circuit").All()
+	if len(entries) != 1 {
+		t.Fatalf("warn log entries = %d, want 1", len(entries))
+	}
+}
+
+func TestPersistSnapshotFailureIsSurfacedOnReleaseProbe(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	log, observed := newObservedLogger()
+	registry := NewCircuitRegistry(
+		WithCircuitPersistence(persist),
+		WithCircuitLogger(log),
+		WithCircuitClock(func() time.Time { return time.Unix(1000, 0) }),
+	)
+	registry.Open("credential:acme", time.Unix(900, 0), routingerr.CodeProviderUnavailable)
+	lease, ok := registry.AcquireProbe("credential:acme", time.Minute)
+	if !ok {
+		t.Fatalf("AcquireProbe: expected success")
+	}
+	observed.TakeAll()
+
+	persist.setFailing(true)
+	registry.ReleaseProbe(lease, true, time.Minute)
+
+	pending := registry.PendingPersists()
+	if len(pending) != 1 || pending[0] != "credential:acme" {
+		t.Fatalf("PendingPersists = %v, want [credential:acme]", pending)
+	}
+	entries := observed.FilterMessageSnippet("persist circuit").All()
+	if len(entries) != 1 {
+		t.Fatalf("warn log entries = %d, want 1", len(entries))
+	}
+}
+
+// TestFailedPersistDoesNotSurviveRestart is the regression test: an Open
+// whose SaveCircuit fails must not leave the durable row permanently absent.
+// A later mutation that succeeds should flush the pending write so a fresh
+// registry's Restore sees the binding as open, not closed.
+func TestFailedPersistDoesNotSurviveRestart(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	persist.setFailing(true)
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist))
+
+	until := time.Now().Add(time.Hour)
+	registry.Open("credential:acme", until, routingerr.CodeProviderUnavailable)
+
+	if _, ok := persist.row("credential:acme"); ok {
+		t.Fatalf("durable row should be absent while persistence is failing")
+	}
+
+	// Restart now: a fresh registry restores from the (still-empty) store and
+	// reads the binding as closed. This is the bug before the fix.
+	restored := NewCircuitRegistry(WithCircuitPersistence(persist))
+	if err := restored.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.IsOpen("credential:acme", time.Now()) {
+		t.Fatalf("restored registry should not see the lost write yet")
+	}
+
+	// The store recovers; a further mutation on the original registry should
+	// flush the pending write.
+	persist.setFailing(false)
+	registry.Open("credential:other", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+
+	if len(registry.PendingPersists()) != 0 {
+		t.Fatalf("PendingPersists should be empty after a successful flush, got %v", registry.PendingPersists())
+	}
+	if _, ok := persist.row("credential:acme"); !ok {
+		t.Fatalf("durable row for credential:acme should have been backfilled")
+	}
+
+	restoredAfterRecovery := NewCircuitRegistry(WithCircuitPersistence(persist))
+	if err := restoredAfterRecovery.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if !restoredAfterRecovery.IsOpen("credential:acme", time.Now()) {
+		t.Fatalf("restored registry should see credential:acme as open after recovery")
+	}
+}
+
+// TestFlushWritesCurrentSnapshotNotStale ensures the pending-flush re-reads
+// the circuit's current in-memory state rather than replaying the stale
+// snapshot captured at the time of the original failed write.
+func TestFlushWritesCurrentSnapshotNotStale(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	persist.setFailing(true)
+	registry := NewCircuitRegistry(
+		WithCircuitPersistence(persist),
+		WithCircuitClock(func() time.Time { return time.Unix(1000, 0) }),
+	)
+
+	registry.Open("credential:acme", time.Unix(900, 0), routingerr.CodeProviderUnavailable)
+	lease, ok := registry.AcquireProbe("credential:acme", time.Minute)
+	if !ok {
+		t.Fatalf("AcquireProbe: expected success")
+	}
+
+	persist.setFailing(false)
+	registry.ReleaseProbe(lease, true, time.Minute)
+
+	if len(registry.PendingPersists()) != 0 {
+		t.Fatalf("PendingPersists should be empty, got %v", registry.PendingPersists())
+	}
+	row, ok := persist.row("credential:acme")
+	if !ok {
+		t.Fatalf("durable row for credential:acme should exist")
+	}
+	if row.State != CircuitClosed {
+		t.Fatalf("durable row state = %v, want %v (current snapshot, not stale open)", row.State, CircuitClosed)
+	}
+}
+
+func TestCleanPathLeavesNoPendingAndLogsNothing(t *testing.T) {
+	persist := newStubCircuitPersistence()
+	log, observed := newObservedLogger()
+	registry := NewCircuitRegistry(WithCircuitPersistence(persist), WithCircuitLogger(log))
+
+	registry.Open("credential:acme", time.Now().Add(time.Hour), routingerr.CodeProviderUnavailable)
+
+	if pending := registry.PendingPersists(); len(pending) != 0 {
+		t.Fatalf("PendingPersists = %v, want empty", pending)
+	}
+	if observed.Len() != 0 {
+		t.Fatalf("expected no log entries on the clean path, got %d", observed.Len())
+	}
+}

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -96,6 +96,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 	}))
 	dynamicCircuits := dynamicruntime.NewCircuitRegistry(
 		dynamicruntime.WithCircuitPersistence(repos.Task),
+		dynamicruntime.WithCircuitLogger(log.Zap()),
 	)
 	if err := dynamicCircuits.Restore(context.Background()); err != nil {
 		return nil, nil, fmt.Errorf("restore dynamic routing health: %w", err)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3357/9ac445dbe316.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** When the dynamic agent's circuit breaker fails to write an update (SQLite locked, disk full, etc.), the failure is silently discarded. If the backend restarts before another circuit mutation happens, the durable row still shows the circuit closed, so the agent immediately retries the same credential it had just opened a circuit against — exactly the retry storm the circuit exists to prevent.

**After this:** A failed circuit-breaker write is now logged at WARN and queued for retry. The next circuit mutation (open, probe-acquire, probe-release) re-persists it from the current in-memory snapshot, so durable state catches up with memory instead of staying stuck behind a one-time write failure.

**Who hits this:** Anyone running Dynamic Agent whose SQLite write briefly fails while a circuit is open or being probed. Without this fix, a restart during that window resurrects the failing credential and the instance retry-herds it.

**Scope:** standalone, single-file circuit-breaker fix; no mutator signature, engine, or persistence-layer changes.

**Not here:** The retry queue is memory-only, so a restart that lands after the store recovers but before the next circuit mutation can still lose that one write. This is an accepted limitation of a mutation-driven retry queue (a durable pending-queue / background flusher would be separate feature work) — the card asked only for WARN-level visibility as the minimum bar.

`persistSnapshotLocked` (`apps/backend/internal/agent/runtime/dynamic/circuit.go`) discarded `SaveCircuit` errors with `_ =` on every mutation path (`Open`, `AcquireProbe`, `ReleaseProbe`). It now returns the error, logs a WARN once per failure streak, and tracks the key in a `pending` set. `flushPendingLocked()` re-persists one pending key (bounded, so it can't stall the routing hot path that takes the same lock) at the top of each of those three call sites. `apps/backend/internal/backendapp/services.go` wires the registry's logger in production; the persistence-less registry in `engine.go` keeps the no-op default.

## Validation

- `go test -tags fts5 -count=1 ./internal/agent/runtime/dynamic/...` — PASS
- `go test -tags fts5 -race -count=1 ./internal/agent/runtime/dynamic/...` — PASS, no races
- `make typecheck test lint` — typecheck and lint clean. `internal/worktree`, `internal/task/service`, and `internal/task/handlers` show pre-existing failures reproduced identically (same error strings) against a scratch worktree at the merge-base commit — a macOS `/tmp` vs `/private/tmp` symlink-resolution issue unrelated to this diff.
- `make lint-format` — clean
- `cd apps/web && pnpm run i18n:ratchet` — no UI files touched, passes trivially
- `golangci-lint run ./internal/agent/runtime/dynamic/... ./internal/backendapp/...` — 0 issues
- `gofmt -l` on the three changed files — clean

## Possible Improvements

Low risk. The pending-retry queue is memory-only (see **Not here**), so a narrow restart window can still lose one write; a durable queue is a reasonable follow-up but out of scope for this fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->