### PR TITLE
fix(web): compact TUI MCP strategy selector

### DIFF
--- a/apps/web/components/settings/mcp-strategy-select.tsx
+++ b/apps/web/components/settings/mcp-strategy-select.tsx
@@ -91,19 +91,28 @@ export function MCPStrategySelect({
         onValueChange={(next) => onChange(fromStrategyValue(next))}
         disabled={disabled}
       >
-        <SelectTrigger id={id} className="cursor-pointer" data-testid="mcp-strategy-select">
+        <SelectTrigger
+          id={id}
+          className="w-full min-w-0 cursor-pointer [@media(pointer:coarse)]:min-h-11"
+          data-testid="mcp-strategy-select"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value={MCP_STRATEGY_NONE} className="cursor-pointer">
+          <SelectItem
+            value={MCP_STRATEGY_NONE}
+            className="cursor-pointer [@media(pointer:coarse)]:min-h-11"
+          >
             {t("agents:mcpStrategyNone")}
           </SelectItem>
           {strategies.map((option) => (
-            <SelectItem key={option.key} value={option.key} className="cursor-pointer">
-              {t("agents:mcpStrategyOption", {
-                name: option.key,
-                mechanism: option.description,
-              })}
+            <SelectItem
+              key={option.key}
+              value={option.key}
+              description={option.description}
+              className="cursor-pointer [@media(pointer:coarse)]:min-h-11"
+            >
+              {option.key}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts
+++ b/apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("Custom TUI MCP strategy selector", () => {
+  test("keeps strategy descriptions out of the selected value and dialog width", async ({
+    testPage,
+  }) => {
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.2
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.3
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.4
+    await testPage.goto("/settings/agents");
+    await testPage.getByTestId("new-agent-button").click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Add TUI Agent" });
+    await expect(dialog).toBeVisible();
+
+    const trigger = dialog.getByTestId("mcp-strategy-select");
+    const dialogBox = await dialog.boundingBox();
+    await trigger.click();
+
+    const option = testPage.getByRole("option").filter({ hasText: /^opencode/i });
+    await expect(option).toBeVisible();
+    const descriptionId = await option.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    await expect(testPage.locator(`[id="${descriptionId}"]`)).toContainText("OPENCODE_CONFIG");
+
+    const listbox = testPage.getByRole("listbox");
+    const [listboxBox, viewport] = await Promise.all([
+      listbox.boundingBox(),
+      testPage.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })),
+    ]);
+    expect(dialogBox).not.toBeNull();
+    expect(listboxBox).not.toBeNull();
+    expect(dialogBox!.x).toBeGreaterThanOrEqual(0);
+    expect(dialogBox!.x + dialogBox!.width).toBeLessThanOrEqual(viewport.width);
+    expect(listboxBox!.x).toBeGreaterThanOrEqual(0);
+    expect(listboxBox!.x + listboxBox!.width).toBeLessThanOrEqual(viewport.width);
+
+    await option.click();
+    await expect(trigger).toHaveText("opencode");
+    await expect(
+      dialog.evaluate((element) => element.scrollWidth <= element.clientWidth),
+    ).resolves.toBe(true);
+    await expect(
+      testPage.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts
+++ b/apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts
@@ -18,13 +18,13 @@ test.describe("Custom TUI MCP strategy selector", () => {
     const dialogBox = await dialog.boundingBox();
     await trigger.click();
 
-    const option = testPage.getByRole("option").filter({ hasText: /^opencode/i });
+    const listbox = testPage.getByRole("listbox");
+    const option = listbox.getByRole("option").filter({ hasText: /^opencode/i });
     await expect(option).toBeVisible();
     const descriptionId = await option.getAttribute("aria-describedby");
     expect(descriptionId).toBeTruthy();
     await expect(testPage.locator(`[id="${descriptionId}"]`)).toContainText("OPENCODE_CONFIG");
 
-    const listbox = testPage.getByRole("listbox");
     const [listboxBox, viewport] = await Promise.all([
       listbox.boundingBox(),
       testPage.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })),

--- a/apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
@@ -20,14 +20,14 @@ test.describe("Custom TUI MCP strategy selector on mobile", () => {
     const dialogBox = await dialog.boundingBox();
 
     await trigger.tap();
-    const option = testPage.getByRole("option").filter({ hasText: /^opencode/i });
+    const listbox = testPage.getByRole("listbox");
+    const option = listbox.getByRole("option").filter({ hasText: /^opencode/i });
     await expect(option).toBeVisible();
 
     const descriptionId = await option.getAttribute("aria-describedby");
     expect(descriptionId).toBeTruthy();
     await expect(testPage.locator(`[id="${descriptionId}"]`)).toContainText("OPENCODE_CONFIG");
 
-    const listbox = testPage.getByRole("listbox");
     await expect
       .poll(async () => (await option.boundingBox())?.height ?? 0)
       .toBeGreaterThanOrEqual(44);

--- a/apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("Custom TUI MCP strategy selector on mobile", () => {
+  test("keeps the selector contained and touch targets usable", async ({ testPage }) => {
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.2
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.3
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.4
+    // @covers AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.5
+    await testPage.goto("/settings/agents");
+    await testPage.getByTestId("new-agent-button").tap();
+
+    const dialog = testPage.getByRole("dialog", { name: "Add TUI Agent" });
+    await expect(dialog).toBeVisible();
+
+    const trigger = dialog.getByTestId("mcp-strategy-select");
+    await expect
+      .poll(async () => (await trigger.boundingBox())?.height ?? 0)
+      .toBeGreaterThanOrEqual(44);
+    const dialogBox = await dialog.boundingBox();
+
+    await trigger.tap();
+    const option = testPage.getByRole("option").filter({ hasText: /^opencode/i });
+    await expect(option).toBeVisible();
+
+    const descriptionId = await option.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    await expect(testPage.locator(`[id="${descriptionId}"]`)).toContainText("OPENCODE_CONFIG");
+
+    const listbox = testPage.getByRole("listbox");
+    await expect
+      .poll(async () => (await option.boundingBox())?.height ?? 0)
+      .toBeGreaterThanOrEqual(44);
+    const [listboxBox, viewport] = await Promise.all([
+      listbox.boundingBox(),
+      testPage.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })),
+    ]);
+    expect(dialogBox).not.toBeNull();
+    expect(listboxBox).not.toBeNull();
+    expect(dialogBox!.x).toBeGreaterThanOrEqual(0);
+    expect(dialogBox!.x + dialogBox!.width).toBeLessThanOrEqual(viewport.width);
+    expect(listboxBox!.x).toBeGreaterThanOrEqual(0);
+    expect(listboxBox!.x + listboxBox!.width).toBeLessThanOrEqual(viewport.width);
+
+    await option.tap();
+    await expect(trigger).toHaveText("opencode");
+    await expect(
+      testPage.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/docs/plans/custom-tui-mcp-selector-layout/plan.md
+++ b/docs/plans/custom-tui-mcp-selector-layout/plan.md
@@ -1,0 +1,101 @@
+---
+created: 2026-09-04
+status: done
+requirements:
+  - REQ-UI-DESCRIPTIVE-SELECT-OPTIONS-001
+system_design:
+  - ../../specs/ui/system-design/descriptive-select-options.md
+legacy_specs: []
+---
+
+# Implementation Plan: Compact Custom TUI MCP Selector
+
+## Overview
+
+Replace the custom TUI agent MCP selector's concatenated option labels with the
+shared name-plus-description anatomy already used by sidebar view selectors.
+One focused work order adds the regression coverage, applies the presentation
+fix, and proves dialog containment on desktop and mobile.
+
+## Scope
+
+### In scope
+
+- Render each backend-supplied MCP strategy name above its description in the
+  open selector.
+- Keep the selected trigger compact by showing only the strategy name.
+- Keep the selector and Add TUI Agent dialog contained on desktop and phone.
+- Preserve accessible descriptions, selected values, and submission behavior.
+
+### Out of scope
+
+- Backend strategy registration, ordering, descriptions, or API payloads.
+- Custom TUI agent persistence and runtime MCP injection.
+- Copy changes or broad changes to the shared Select primitive.
+
+## Technical approach
+
+- Update `MCPStrategySelect` to pass the backend mechanism through the shared
+  `SelectItem.description` property and keep `option.key` as `ItemText`.
+- Give the local trigger a full-width, zero-minimum layout and give its trigger
+  and option rows coarse-pointer-only 44-pixel minimum hit areas.
+- Keep the focused mapping tests for stable strategy identities and use
+  Playwright to inspect the rendered Radix option structure, accessibility
+  association, and compact selected value.
+- Add focused desktop and mobile settings E2E coverage for the real dialog and
+  strategy endpoint. Use geometry assertions for viewport containment rather
+  than fixed visual widths.
+
+## Tests
+
+- Existing value-mapping tests in
+  `apps/web/components/settings/mcp-strategy-select.test.tsx` continue to prove
+  that the sentinel and backend strategy keys are unchanged.
+
+## E2E tests
+
+- `AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1` through `.4`:
+  `apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts` opens
+  the Add TUI Agent dialog, verifies the two-row strategy entry and compact
+  selected trigger, and checks dialog/list containment.
+- `AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1` through `.5`:
+  `apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts`
+  proves the same selection through touch, checks 44-pixel hit areas, and
+  asserts no document horizontal overflow in the mobile-Chrome project.
+
+## Mobile design contract
+
+- Desktop outcome: compare MCP strategies in the Add TUI Agent dialog without
+  long descriptions widening the control or dialog.
+- Mobile entry point: Add TUI Agent on `/settings/agents`; it keeps the existing
+  centered dialog and selector because this is a short temporary choice.
+- Nearest shipped exemplar: the sidebar view `GroupPicker` and
+  `TypedSortPicker`, which use `SelectItem.description` for the same two-level
+  option hierarchy.
+- Hierarchy and primary action: strategy name first, mechanism second; choosing
+  a row completes the temporary selection and returns to the form.
+- Scroll and safe area: the Radix option list owns overflow; the document and
+  dialog do not scroll horizontally. Existing dialog dismissal and footer
+  behavior remain unchanged.
+- Shared logic: all values, API data, selection, and form submission stay
+  shared. Only responsive hit-area classes differ for coarse pointers.
+
+## Work orders
+
+- [x] [Task 01: Render compact MCP strategy options](task-01-render-compact-mcp-strategy-options.md)
+
+## Verification results
+
+Completed on 2026-09-04. The MCP strategy selector now uses the shared
+name-plus-description option anatomy, keeps only the short strategy key in the
+closed trigger, and provides coarse-pointer-only 44-pixel hit areas. Focused
+desktop and mobile Playwright regressions passed against a rebuilt production
+frontend, and rendered 1372 x 900 and 393 x 851 views were inspected without
+horizontal overflow.
+
+## Risks
+
+- Radix derives the closed value from `ItemText`; a regression test must guard
+  against accidentally placing the description back inside that node.
+- Portal geometry differs between desktop and phone, so both Playwright
+  projects must assert the rendered containment contract.

--- a/docs/plans/custom-tui-mcp-selector-layout/task-01-render-compact-mcp-strategy-options.md
+++ b/docs/plans/custom-tui-mcp-selector-layout/task-01-render-compact-mcp-strategy-options.md
@@ -50,13 +50,14 @@ widths.
 ## Verification
 
 ```bash
-cd apps && pnpm install --frozen-lockfile
-cd apps/web && pnpm test -- components/settings/mcp-strategy-select.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps/web && pnpm exec eslint components/settings/mcp-strategy-select.tsx components/settings/mcp-strategy-select.test.tsx e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
-cd apps/web && pnpm run i18n:check
-cd apps/web && pnpm e2e:run --project chromium tests/settings/custom-tui-mcp-strategy-selector.spec.ts
-cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+(cd apps && pnpm install --frozen-lockfile)
+cd apps/web
+pnpm test -- components/settings/mcp-strategy-select.test.tsx
+pnpm run typecheck
+pnpm exec eslint components/settings/mcp-strategy-select.tsx components/settings/mcp-strategy-select.test.tsx e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+pnpm run i18n:check
+pnpm e2e:run --project chromium tests/settings/custom-tui-mcp-strategy-selector.spec.ts
+pnpm e2e:run --project mobile-chrome tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
 ```
 
 The desktop and mobile browser regressions must fail for the expected

--- a/docs/plans/custom-tui-mcp-selector-layout/task-01-render-compact-mcp-strategy-options.md
+++ b/docs/plans/custom-tui-mcp-selector-layout/task-01-render-compact-mcp-strategy-options.md
@@ -1,0 +1,111 @@
+---
+id: "01-render-compact-mcp-strategy-options"
+title: "Render compact MCP strategy options"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-DESCRIPTIVE-SELECT-OPTIONS-001
+acceptance_criteria:
+  - AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1
+  - AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.2
+  - AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.3
+  - AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.4
+  - AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.5
+system_design:
+  - ../../specs/ui/system-design/descriptive-select-options.md
+---
+
+# Task 01: Render Compact MCP Strategy Options
+
+## Summary
+
+Render backend-supplied MCP strategies with a concise first-row name and a
+second-row mechanism description. Keep the selected trigger compact, preserve
+value semantics, and prove containment and touch behavior at desktop and phone
+widths.
+
+## In scope
+
+- Add a failing focused browser regression before changing the selector.
+- Reuse the shared `SelectItem.description` property in `MCPStrategySelect`.
+- Add local shrink/full-width and coarse-pointer hit-area classes.
+- Add focused desktop and mobile Playwright coverage for the real dialog.
+
+## Out of scope
+
+- Shared Select primitive changes.
+- Locale copy changes.
+- Backend, API, store, persistence, or runtime MCP changes.
+
+## Acceptance
+
+- Every backend strategy option exposes a first-row name and an associated
+  second-row description, while the closed trigger contains only the name.
+- The existing sentinel mapping and submitted strategy key remain unchanged.
+- Desktop and mobile browser checks prove dialog/list containment, no document
+  horizontal overflow, and coarse-pointer hit areas of at least 44 pixels.
+
+## Verification
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+cd apps/web && pnpm test -- components/settings/mcp-strategy-select.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm exec eslint components/settings/mcp-strategy-select.tsx components/settings/mcp-strategy-select.test.tsx e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+cd apps/web && pnpm run i18n:check
+cd apps/web && pnpm e2e:run --project chromium tests/settings/custom-tui-mcp-strategy-selector.spec.ts
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts
+```
+
+The desktop and mobile browser regressions must fail for the expected
+concatenated trigger, missing option structure, containment, or hit-area reason
+before the implementation change. The managed E2E runner rebuilds the
+production frontend before each final browser run.
+
+## Files likely touched
+
+- `apps/web/components/settings/mcp-strategy-select.tsx`
+- `apps/web/components/settings/mcp-strategy-select.test.tsx`
+- `apps/web/e2e/tests/settings/custom-tui-mcp-strategy-selector.spec.ts`
+- `apps/web/e2e/tests/settings/mobile-custom-tui-mcp-strategy-selector.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Description text placed inside `SelectPrimitive.ItemText` would recreate the
+  overflow by restoring it to the selected trigger.
+- A desktop-only assertion would miss coarse-pointer row sizing and mobile
+  portal containment.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/ui/requirements/descriptive-select-options.md`
+- `docs/specs/ui/system-design/descriptive-select-options.md`
+- `apps/web/components/task/sidebar-filter/group-picker.tsx`
+- `apps/packages/ui/src/select.tsx`
+
+## Results
+
+Completed on 2026-09-04.
+
+- RED: the desktop regression failed because the flattened option had no
+  `aria-describedby`; the mobile regression then failed because the trigger
+  rendered at 27.4 pixels instead of the required 44 pixels.
+- GREEN: the desktop Chromium and mobile-Chrome regressions each passed after
+  the two-row anatomy, containment sizing, and coarse-pointer hit areas were
+  applied.
+- `mcp-strategy-select.test.tsx`: 5 tests passed.
+- TypeScript, focused ESLint, Prettier, i18n, specification lints, and
+  `git diff --check` passed.
+- The open selector was inspected at 1372 x 900 and 393 x 851. Strategy names
+  and descriptions render on separate rows, and the dialog and menu remain
+  within the viewport.

--- a/docs/specs/ui/README.md
+++ b/docs/specs/ui/README.md
@@ -17,6 +17,7 @@ UI owns responsive behavior; other systems own behavior/state.
 - [Task Add-Panel PR Submenu](requirements/add-panel-pr-submenu.md)
 - [Agent Launch Prompt Composer](requirements/agent-launch-prompt-composer.md)
 - [Dialog containment](requirements/dialog-content-containment.md)
+- [Descriptive select options](requirements/descriptive-select-options.md)
 - [Surface text](requirements/surface-text-hierarchy.md)
 - [Message comments](requirements/agent-message-comments.md)
 - [Agent Todo List Panel](requirements/agent-todo-list-panel.md)
@@ -136,6 +137,7 @@ UI owns responsive behavior; other systems own behavior/state.
 ### Design
 - [Clarification submit feedback](system-design/clarification-submit-feedback.md)
 - [Dialog containment](system-design/dialog-content-containment.md)
+- [Descriptive select options](system-design/descriptive-select-options.md)
 - [Surface text](system-design/surface-text-hierarchy.md)
 - [Agent Todo List Panel](system-design/agent-todo-list-panel.md)
 - [App Status Bar](system-design/app-status-bar.md)

--- a/docs/specs/ui/requirements/descriptive-select-options.md
+++ b/docs/specs/ui/requirements/descriptive-select-options.md
@@ -1,0 +1,65 @@
+---
+status: active
+system: ui
+created: 2026-09-04
+owners:
+  - kandev
+---
+
+# Descriptive Select Options Requirements
+
+## Overview
+
+Some selectors need supporting text for each choice, but that text must not
+turn the selected value into a long, non-wrapping label. The UI system owns the
+reusable presentation contract that separates a concise option name from its
+description while preserving the selector's existing value and behavior.
+
+The first covered consumer is the Kandev MCP strategy selector used when a
+user creates or configures a custom TUI agent.
+
+## Terminology
+
+- **Option name:** The concise text that identifies a selectable value and is
+  shown in the closed trigger after selection.
+- **Option description:** Supporting text shown with an option while the list
+  is open.
+
+## Requirements
+
+### REQ-UI-DESCRIPTIVE-SELECT-OPTIONS-001: Compact descriptive selector entries
+
+**Intent:** Let users compare described choices without allowing explanatory
+text to distort the selector or its containing surface.
+
+**User story:** As a user choosing a Kandev MCP strategy for a custom TUI
+agent, I want each strategy name and mechanism to have separate visual roles,
+so that I can scan the choices without the dialog overflowing.
+
+#### Acceptance criteria
+
+- **AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.1:** When the custom TUI agent MCP
+  strategy selector is open, each backend-supplied strategy shall show its
+  strategy name on the first row and its mechanism description on the second
+  row.
+- **AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.2:** When a described strategy is
+  selected, the closed trigger shall show only its concise strategy name and
+  shall not copy the mechanism description into the trigger.
+- **AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.3:** At supported desktop and phone
+  widths, the selector, its open option list, and the containing dialog shall
+  remain within the viewport without document-level horizontal overflow.
+- **AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.4:** Option descriptions shall remain
+  programmatically associated with their option names, and strategy selection,
+  keyboard behavior, dismissal, and submitted values shall remain unchanged.
+- **AC-UI-DESCRIPTIVE-SELECT-OPTIONS-001.5:** On coarse-pointer viewports, the
+  selector trigger and option rows shall provide touch targets at least 44 CSS
+  pixels high while fine-pointer desktop controls retain their existing
+  density.
+
+## Out of scope
+
+- Changing the available MCP strategy keys, descriptions, ordering, or backend
+  API.
+- Changing custom TUI agent creation, persistence, or launch behavior.
+- Rewriting the concise existing Off option or other selector copy.
+- Changing every select control that does not present per-option descriptions.

--- a/docs/specs/ui/system-design/descriptive-select-options.md
+++ b/docs/specs/ui/system-design/descriptive-select-options.md
@@ -1,0 +1,100 @@
+---
+status: current
+system: ui
+requirements:
+  - REQ-UI-DESCRIPTIVE-SELECT-OPTIONS-001
+---
+
+# Descriptive Select Options System Design
+
+## Purpose and boundaries
+
+This design applies the shared two-row `SelectItem` presentation to the custom
+TUI agent MCP strategy selector. It changes only option anatomy, responsive
+geometry, and test coverage. The backend remains authoritative for strategy
+keys, descriptions, and ordering, and the existing form remains authoritative
+for the selected value and submission.
+
+The UI system owns this contract because separating option names from
+descriptions is reusable presentation behavior independent of MCP strategy
+state. The CLI and agent systems continue to own strategy resolution and
+runtime injection.
+
+## Requirement mapping
+
+| Requirement                             | Design sections                                                                                                   |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `REQ-UI-DESCRIPTIVE-SELECT-OPTIONS-001` | [Option anatomy](#option-anatomy), [Responsive behavior](#responsive-behavior), and [Verification](#verification) |
+
+## Current-state evidence
+
+`MCPStrategySelect` currently formats each backend option as one translated
+string containing both `option.key` and `option.description`. Radix Select uses
+the whole `SelectItem` text as the selected `SelectValue`, and the shared
+trigger is non-wrapping. The resulting intrinsic width expands the add-agent
+dialog grid and makes the other full-width form controls overflow with it.
+
+The sidebar view `GroupPicker` and `TypedSortPicker` already use the shared
+`SelectItem` `description` property. That primitive renders `ItemText` for the
+name and an `aria-describedby`-linked second row for supporting text while
+copying only `ItemText` into the closed trigger.
+
+## Option anatomy
+
+`apps/web/components/settings/mcp-strategy-select.tsx` passes
+`option.description` through `SelectItem.description` and renders
+`option.key` as the item child. The concise Off choice remains a single-row
+option because it is a local sentinel rather than a backend-supplied strategy.
+
+The selector trigger gains an explicit full-width, zero-minimum layout so it
+shrinks inside the form grid. Selection and wire-value mapping continue through
+`toStrategyValue` and `fromStrategyValue`; no strategy identifiers or API
+payloads change.
+
+## Responsive behavior
+
+- Desktop and mobile use the existing add-agent Dialog and Radix Select. No
+  new drawer or route is introduced because this is a short temporary choice
+  and the current selector remains viewport-contained.
+- The option list remains the only scroll owner when its content exceeds the
+  available height. The dialog and document do not gain horizontal scrolling.
+- Coarse-pointer trigger and option rows use a 44-pixel minimum hit area.
+  Fine-pointer desktop keeps the surrounding settings density.
+- Name, description, selected state, and value mapping are shared across
+  viewports; there is no mobile-specific state or business logic.
+
+The nearest shipped mobile exemplar is the sidebar view group selector, which
+uses the same shared two-row option primitive. The custom TUI agent selector
+reuses its name/description hierarchy and accessible association while keeping
+the existing settings-dialog entry point.
+
+## Failure and recovery
+
+Strategy-list fetch failure keeps the existing safe fallback: only the Off
+choice is available and custom TUI agent creation can continue without MCP
+injection. Missing or empty strategy descriptions do not invent copy; the
+shared item renders only the available name. No new asynchronous path is
+introduced.
+
+## Persistence and security
+
+None. Strategy persistence, validation, and runtime MCP configuration remain
+unchanged. Backend descriptions are displayed as React text and are not
+interpreted as markup.
+
+## Verification
+
+A focused desktop browser regression opens the selector with a representative
+long strategy description and proves that the open option has separate name
+and description nodes with an accessible association. After selection, it
+proves that the trigger contains the strategy name without the description.
+
+Focused Chromium and mobile-Chrome tests open the real Add TUI Agent dialog,
+inspect a backend-supplied strategy entry, select it, and assert the compact
+trigger. Geometry checks cover dialog and option-list viewport containment,
+absence of document horizontal overflow, and 44-pixel coarse-pointer hit areas.
+
+## Related decisions
+
+None. The fix reuses the existing shared Select API and establishes no new
+public API, persistence boundary, or ownership rule.


### PR DESCRIPTION
Long MCP strategy descriptions were being flattened into the selected value,
which widened the Add TUI Agent dialog. This changes each option to a compact
name/description pair while preserving strategy values and improving phone hit
targets.

## Important Changes

- Reuse the shared two-row `SelectItem` presentation for MCP strategy names and descriptions.
- Keep the closed selector to the concise strategy key and contain it within the form grid.
- Add coarse-pointer hit-area sizing plus desktop and mobile browser regressions.

## Validation

- `pnpm test -- components/settings/mcp-strategy-select.test.tsx` (5 passed)
- `pnpm run typecheck`
- Focused ESLint and Prettier checks
- `pnpm run i18n:check`
- `python3 scripts/lint-spec-files.py --all`
- Desktop Chromium and mobile Chrome Playwright regressions
- Manual rendered inspection at 1372x900 and 393x851

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


## Screenshots

<!-- kandev-screenshots-start -->
![Desktop custom TUI agent MCP strategy selector](https://raw.githubusercontent.com/kdlbs/kandev/eee4067e625701482eca3cc36c11352fd28e4903/strategy-selector-desktop.png)

![Mobile custom TUI agent MCP strategy selector](https://raw.githubusercontent.com/kdlbs/kandev/eee4067e625701482eca3cc36c11352fd28e4903/strategy-selector-mobile.png)
<!-- kandev-screenshots-end -->