### PR TITLE
fix: backfill feeder pulls after task-tree lifecycle changes

### DIFF
--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -781,6 +781,7 @@ func registerRoutes(p routeParams) {
 	// the kanban board doesn't react to subtree archive/delete until a
 	// full reload.
 	handoffSvc.SetTaskEventPublisher(p.taskSvc)
+	handoffSvc.SetVacatedStepReconciler(p.taskSvc)
 	// Per-user scoping for the cascade is installed by
 	// TaskHandlers.SetHandoffService, which is the call that makes the archive /
 	// delete routes prefer the cascade over the guarded Service methods.

--- a/apps/backend/internal/task/handlers/task_delete_authz_test.go
+++ b/apps/backend/internal/task/handlers/task_delete_authz_test.go
@@ -56,6 +56,15 @@ func (r *authzDeleteRepo) ArchiveTaskIfActive(_ context.Context, id, cascadeID s
 	return true, nil
 }
 
+func (r *authzDeleteRepo) ArchiveTaskIfActiveWithVacatedStep(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
+	changed, err := r.ArchiveTaskIfActive(ctx, id, cascadeID)
+	return "", changed, err
+}
+
 func (r *authzDeleteRepo) archives() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -68,6 +77,10 @@ func (r *authzDeleteRepo) DeleteTask(ctx context.Context, id string) error {
 	r.deleted = append(r.deleted, id)
 	r.deleteErr = append(r.deleteErr, ctx.Err())
 	return nil
+}
+
+func (r *authzDeleteRepo) DeleteTaskWithVacatedStep(ctx context.Context, id string) (string, error) {
+	return "", r.DeleteTask(ctx, id)
 }
 
 func (r *authzDeleteRepo) ListChildren(context.Context, string) ([]*models.Task, error) {

--- a/apps/backend/internal/task/handlers/task_ws_archive_test.go
+++ b/apps/backend/internal/task/handlers/task_ws_archive_test.go
@@ -34,6 +34,15 @@ func (r *archiveStampRepo) ArchiveTaskIfActive(_ context.Context, id, cascadeID 
 	return true, nil
 }
 
+func (r *archiveStampRepo) ArchiveTaskIfActiveWithVacatedStep(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
+	changed, err := r.ArchiveTaskIfActive(ctx, id, cascadeID)
+	return "", changed, err
+}
+
 // TestWsArchiveTask_StampsCascadeID is the WS-side parity test: archives
 // issued over the WebSocket action must route through HandoffService and
 // receive a cascade stamp, otherwise WS-archived tasks were permanently

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -1490,9 +1490,16 @@ func (r *Repository) PromoteQueuedTaskIfWorkflowStepHasCapacity(
 
 // DeleteTask deletes a task by ID
 func (r *Repository) DeleteTask(ctx context.Context, id string) error {
+	_, err := r.DeleteTaskWithVacatedStep(ctx, id)
+	return err
+}
+
+// DeleteTaskWithVacatedStep deletes a task and returns the workflow step read
+// under the same task-row lock as the deletion.
+func (r *Repository) DeleteTaskWithVacatedStep(ctx context.Context, id string) (string, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() { _ = tx.Rollback() }()
 	// Serialize with session/worktree creation FIRST (task-row lock), then
@@ -1502,30 +1509,34 @@ func (r *Repository) DeleteTask(ctx context.Context, id string) error {
 	// row is gone. Capturing before the lock could use a stale set (a session
 	// created mid-flight would never be purged). The session capture must also
 	// precede the task-row DELETE because task_sessions cascades on deletion.
-	if err := r.lockTaskRowInTx(ctx, tx, id); err != nil {
-		return err
+	_, vacatedStepID, found, err := r.readTaskStepInTx(ctx, tx, id)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("%w: %s", ErrTaskNotFound, id)
 	}
 	sessions, err := r.taskQueueSessionsInTx(ctx, tx, id)
 	if err != nil {
-		return err
+		return "", err
 	}
 	result, err := tx.ExecContext(ctx, r.db.Rebind(`DELETE FROM tasks WHERE id = ?`), id)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("%w: %s", ErrTaskNotFound, id)
+		return "", fmt.Errorf("%w: %s", ErrTaskNotFound, id)
 	}
 	if err := r.purgeTaskQueueInTx(ctx, tx, id, sessions); err != nil {
-		return err
+		return "", err
 	}
 	if err := tx.Commit(); err != nil {
-		return err
+		return "", err
 	}
 	r.notifyTaskQueuePurged(ctx, id)
-	return nil
+	return vacatedStepID, nil
 }
 
 // ListTasks returns all non-archived, non-ephemeral tasks for a workflow
@@ -2270,35 +2281,53 @@ func (r *Repository) ArchiveTask(ctx context.Context, id string) error {
 // Pass empty cascadeID to opt out of cascade tracking (single-task
 // manual archive); the column will simply not get set.
 func (r *Repository) ArchiveTaskIfActive(ctx context.Context, id, cascadeID string) (bool, error) {
-	now := time.Now().UTC()
+	_, changed, err := r.ArchiveTaskIfActiveWithVacatedStep(ctx, id, cascadeID)
+	return changed, err
+}
+
+// ArchiveTaskIfActiveWithVacatedStep archives an active task and returns the
+// workflow step read under the same task-row lock as the archive mutation.
+func (r *Repository) ArchiveTaskIfActiveWithVacatedStep(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	_, vacatedStepID, found, err := r.readTaskStepInTx(ctx, tx, id)
+	if err != nil {
+		return "", false, err
+	}
+	if !found {
+		return "", false, tx.Commit()
+	}
+	now := time.Now().UTC()
 	result, err := tx.ExecContext(ctx, r.db.Rebind(`
 		UPDATE tasks SET archived_at = ?, archived_by_cascade_id = ?, updated_at = ?
 		WHERE id = ? AND archived_at IS NULL
 	`), now, cascadeID, now, id)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return false, tx.Commit()
+		return "", false, tx.Commit()
 	}
 	sessions, err := r.taskQueueSessionsInTx(ctx, tx, id)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	if err := r.purgeTaskQueueInTx(ctx, tx, id, sessions); err != nil {
-		return false, err
+		return "", false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return false, err
+		return "", false, err
 	}
 	r.notifyTaskQueuePurged(ctx, id)
-	return true, nil
+	return vacatedStepID, true, nil
 }
 
 // taskQueueSessionsInTx returns the task's authoritative session set (its

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -230,7 +230,9 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	// the walk; not strictly required by the schema (no FK on parent_id)
 	// but keeps the audit log readable.
 	postArchiveCtx := ctx
+	vacatedStepIDs := make(map[string]struct{})
 	for i := len(all) - 1; i >= 0; i-- {
+		snapshot := s.taskSnapshotForVacancy(postArchiveCtx, all[i])
 		ok, err := s.tasks.ArchiveTaskIfActive(postArchiveCtx, all[i], cascadeID)
 		if err != nil {
 			s.cancelCascadeResourceCleanupRange(postArchiveCtx, all[:i+1], cleanupOps)
@@ -241,6 +243,7 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 			// survive a disconnected caller.
 			postArchiveCtx = context.WithoutCancel(ctx)
 			out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
+			recordVacatedStep(vacatedStepIDs, snapshot)
 			// The archive mutation committed, so it is now safe to finalize
 			// any session that the runtime canceller could not update.
 			s.finalizeActiveSessions(postArchiveCtx, all[i], models.SessionArchiveTreeCancelReason)
@@ -270,6 +273,7 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 			out.SkippedTaskIDs = append(out.SkippedTaskIDs, all[i])
 		}
 	}
+	s.pullTasksForVacatedSteps(postArchiveCtx, vacatedStepIDs)
 
 	// Release group memberships for THIS cascade's tasks. Memberships
 	// owned by an earlier cascade or manual archive are left alone.
@@ -346,16 +350,14 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	// the caller can retry. We do NOT roll back partial deletions —
 	// delete is destructive by design and re-running is idempotent.
 	postDeleteCtx := ctx
+	vacatedStepIDs := make(map[string]struct{})
 	for i := len(all) - 1; i >= 0; i-- {
 		// Snapshot the task row BEFORE deletion so the published event
 		// carries workflow_id / workspace_id — the kanban WS handler keys
 		// off workflow_id to remove the card from the right swimlane.
 		// Fetch is best-effort: if the row is already gone (rare race) we
 		// fall back to a minimal payload below.
-		var snapshot *models.Task
-		if s.eventPublisher != nil {
-			snapshot, _ = s.tasks.GetTask(postDeleteCtx, all[i])
-		}
+		snapshot := s.taskSnapshotForVacancy(postDeleteCtx, all[i])
 		// Tear down runtime resources BEFORE the DB delete so the env / worktree
 		// rows are still queryable for the gather step. The actual destroy work
 		// runs async after this returns. Delete cascade removes the env row.
@@ -377,10 +379,12 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 			s.resourceCleaner.CleanupTaskResources(postDeleteCtx, all[i], true)
 		}
 		out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
+		recordVacatedStep(vacatedStepIDs, snapshot)
 		if s.eventPublisher != nil && snapshot != nil {
 			s.eventPublisher.PublishTaskDeleted(postDeleteCtx, snapshot)
 		}
 	}
+	s.pullTasksForVacatedSteps(postDeleteCtx, vacatedStepIDs)
 
 	for _, gid := range groupIDs {
 		if err := s.evaluateWorkspaceGroupCleanup(postDeleteCtx, gid); err != nil {
@@ -389,6 +393,38 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		}
 	}
 	return out, nil
+}
+
+func (s *HandoffService) taskSnapshotForVacancy(ctx context.Context, taskID string) *models.Task {
+	task, err := s.tasks.GetTask(ctx, taskID)
+	if err != nil {
+		s.logf().Warn("cascade: capture task workflow step failed",
+			zap.String("task_id", taskID), zap.Error(err))
+		return nil
+	}
+	return task
+}
+
+func recordVacatedStep(stepIDs map[string]struct{}, task *models.Task) {
+	if task == nil || task.WorkflowStepID == "" {
+		return
+	}
+	stepIDs[task.WorkflowStepID] = struct{}{}
+}
+
+func (s *HandoffService) pullTasksForVacatedSteps(ctx context.Context, stepIDs map[string]struct{}) {
+	if s.vacancyReconciler == nil || len(stepIDs) == 0 {
+		return
+	}
+	orderedStepIDs := make([]string, 0, len(stepIDs))
+	for stepID := range stepIDs {
+		orderedStepIDs = append(orderedStepIDs, stepID)
+	}
+	sort.Strings(orderedStepIDs)
+	pullCtx := context.WithoutCancel(ctx)
+	for _, stepID := range orderedStepIDs {
+		s.vacancyReconciler.ReconcileVacatedStep(pullCtx, stepID)
+	}
 }
 
 // transferSharedWorkspaceEnvironmentOwnership moves a materialized environment

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -231,9 +231,11 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	// but keeps the audit log readable.
 	postArchiveCtx := ctx
 	vacatedStepIDs := make(map[string]struct{})
+	defer func() {
+		s.pullTasksForVacatedSteps(postArchiveCtx, vacatedStepIDs)
+	}()
 	for i := len(all) - 1; i >= 0; i-- {
-		snapshot := s.taskSnapshotForVacancy(postArchiveCtx, all[i])
-		ok, err := s.tasks.ArchiveTaskIfActive(postArchiveCtx, all[i], cascadeID)
+		vacatedStepID, ok, err := s.archiveTaskWithVacatedStep(postArchiveCtx, all[i], cascadeID)
 		if err != nil {
 			s.cancelCascadeResourceCleanupRange(postArchiveCtx, all[:i+1], cleanupOps)
 			return out, fmt.Errorf("archive %s: %w", all[i], err)
@@ -243,7 +245,7 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 			// survive a disconnected caller.
 			postArchiveCtx = context.WithoutCancel(ctx)
 			out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
-			recordVacatedStep(vacatedStepIDs, snapshot)
+			recordVacatedStep(vacatedStepIDs, vacatedStepID)
 			// The archive mutation committed, so it is now safe to finalize
 			// any session that the runtime canceller could not update.
 			s.finalizeActiveSessions(postArchiveCtx, all[i], models.SessionArchiveTreeCancelReason)
@@ -273,7 +275,6 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 			out.SkippedTaskIDs = append(out.SkippedTaskIDs, all[i])
 		}
 	}
-	s.pullTasksForVacatedSteps(postArchiveCtx, vacatedStepIDs)
 
 	// Release group memberships for THIS cascade's tasks. Memberships
 	// owned by an earlier cascade or manual archive are left alone.
@@ -351,17 +352,24 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	// delete is destructive by design and re-running is idempotent.
 	postDeleteCtx := ctx
 	vacatedStepIDs := make(map[string]struct{})
+	defer func() {
+		s.pullTasksForVacatedSteps(postDeleteCtx, vacatedStepIDs)
+	}()
 	for i := len(all) - 1; i >= 0; i-- {
 		// Snapshot the task row BEFORE deletion so the published event
 		// carries workflow_id / workspace_id — the kanban WS handler keys
 		// off workflow_id to remove the card from the right swimlane.
 		// Fetch is best-effort: if the row is already gone (rare race) we
 		// fall back to a minimal payload below.
-		snapshot := s.taskSnapshotForVacancy(postDeleteCtx, all[i])
+		var snapshot *models.Task
+		if s.eventPublisher != nil {
+			snapshot, _ = s.tasks.GetTask(postDeleteCtx, all[i])
+		}
 		// Tear down runtime resources BEFORE the DB delete so the env / worktree
 		// rows are still queryable for the gather step. The actual destroy work
 		// runs async after this returns. Delete cascade removes the env row.
-		if err := s.tasks.DeleteTask(postDeleteCtx, all[i]); err != nil {
+		vacatedStepID, err := s.deleteTaskWithVacatedStep(postDeleteCtx, all[i])
+		if err != nil {
 			s.cancelCascadeResourceCleanupRange(postDeleteCtx, all[:i+1], cleanupOps)
 			deleteErr := fmt.Errorf("delete %s: %w", all[i], err)
 			if len(out.ArchivedTaskIDs) == 0 {
@@ -379,12 +387,11 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 			s.resourceCleaner.CleanupTaskResources(postDeleteCtx, all[i], true)
 		}
 		out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
-		recordVacatedStep(vacatedStepIDs, snapshot)
+		recordVacatedStep(vacatedStepIDs, vacatedStepID)
 		if s.eventPublisher != nil && snapshot != nil {
 			s.eventPublisher.PublishTaskDeleted(postDeleteCtx, snapshot)
 		}
 	}
-	s.pullTasksForVacatedSteps(postDeleteCtx, vacatedStepIDs)
 
 	for _, gid := range groupIDs {
 		if err := s.evaluateWorkspaceGroupCleanup(postDeleteCtx, gid); err != nil {
@@ -395,21 +402,31 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	return out, nil
 }
 
-func (s *HandoffService) taskSnapshotForVacancy(ctx context.Context, taskID string) *models.Task {
-	task, err := s.tasks.GetTask(ctx, taskID)
-	if err != nil {
-		s.logf().Warn("cascade: capture task workflow step failed",
-			zap.String("task_id", taskID), zap.Error(err))
-		return nil
+func (s *HandoffService) archiveTaskWithVacatedStep(
+	ctx context.Context,
+	taskID string,
+	cascadeID string,
+) (string, bool, error) {
+	repo, ok := s.tasks.(cascadeArchiveTaskRepository)
+	if !ok {
+		return "", false, errors.New("task repo cannot capture archive vacancy atomically")
 	}
-	return task
+	return repo.ArchiveTaskIfActiveWithVacatedStep(ctx, taskID, cascadeID)
 }
 
-func recordVacatedStep(stepIDs map[string]struct{}, task *models.Task) {
-	if task == nil || task.WorkflowStepID == "" {
+func (s *HandoffService) deleteTaskWithVacatedStep(ctx context.Context, taskID string) (string, error) {
+	repo, ok := s.tasks.(cascadeDeleteTaskRepository)
+	if !ok {
+		return "", errors.New("task repo cannot capture delete vacancy atomically")
+	}
+	return repo.DeleteTaskWithVacatedStep(ctx, taskID)
+}
+
+func recordVacatedStep(stepIDs map[string]struct{}, stepID string) {
+	if stepID == "" {
 		return
 	}
-	stepIDs[task.WorkflowStepID] = struct{}{}
+	stepIDs[stepID] = struct{}{}
 }
 
 func (s *HandoffService) pullTasksForVacatedSteps(ctx context.Context, stepIDs map[string]struct{}) {

--- a/apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
@@ -13,6 +15,118 @@ import (
 type recordingCascadeTaskService struct {
 	*Service
 	vacatedStepIDs []string
+}
+
+type recordingVacatedStepReconciler struct {
+	stepIDs []string
+}
+
+func (r *recordingVacatedStepReconciler) ReconcileVacatedStep(_ context.Context, stepID string) {
+	r.stepIDs = append(r.stepIDs, stepID)
+}
+
+type placementChangingCascadeRepo struct {
+	*fakeDeleteRepo
+}
+
+func (r *placementChangingCascadeRepo) GetTask(ctx context.Context, id string) (*models.Task, error) {
+	task, err := r.fakeDeleteRepo.GetTask(ctx, id)
+	if task == nil || err != nil {
+		return task, err
+	}
+	copy := *task
+	return &copy, nil
+}
+
+func (r *placementChangingCascadeRepo) ArchiveTaskIfActive(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (bool, error) {
+	_, changed, err := r.ArchiveTaskIfActiveWithVacatedStep(ctx, id, cascadeID)
+	return changed, err
+}
+
+func (r *placementChangingCascadeRepo) ArchiveTaskIfActiveWithVacatedStep(
+	_ context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
+	r.base.mu.Lock()
+	defer r.base.mu.Unlock()
+	task := r.base.tasks[id]
+	if task == nil || task.ArchivedAt != nil {
+		return "", false, nil
+	}
+	task.WorkflowStepID = "actual-step"
+	now := time.Now().UTC()
+	task.ArchivedAt = &now
+	task.ArchivedByCascadeID = cascadeID
+	return task.WorkflowStepID, true, nil
+}
+
+func (r *placementChangingCascadeRepo) DeleteTask(ctx context.Context, id string) error {
+	_, err := r.DeleteTaskWithVacatedStep(ctx, id)
+	return err
+}
+
+func (r *placementChangingCascadeRepo) DeleteTaskWithVacatedStep(_ context.Context, id string) (string, error) {
+	r.base.mu.Lock()
+	defer r.base.mu.Unlock()
+	task := r.base.tasks[id]
+	if task == nil {
+		return "", errors.New("task not found")
+	}
+	task.WorkflowStepID = "actual-step"
+	delete(r.base.tasks, id)
+	return task.WorkflowStepID, nil
+}
+
+type partialFailureCascadeRepo struct {
+	*fakeDeleteRepo
+	failTaskID string
+	err        error
+}
+
+func (r *partialFailureCascadeRepo) ArchiveTaskIfActive(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (bool, error) {
+	_, changed, err := r.ArchiveTaskIfActiveWithVacatedStep(ctx, id, cascadeID)
+	return changed, err
+}
+
+func (r *partialFailureCascadeRepo) ArchiveTaskIfActiveWithVacatedStep(
+	ctx context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
+	if id == r.failTaskID {
+		return "", false, r.err
+	}
+	task, err := r.GetTask(ctx, id)
+	if err != nil || task == nil {
+		return "", false, err
+	}
+	changed, err := r.fakeCascadeRepo.ArchiveTaskIfActive(ctx, id, cascadeID)
+	return task.WorkflowStepID, changed, err
+}
+
+func (r *partialFailureCascadeRepo) DeleteTask(ctx context.Context, id string) error {
+	_, err := r.DeleteTaskWithVacatedStep(ctx, id)
+	return err
+}
+
+func (r *partialFailureCascadeRepo) DeleteTaskWithVacatedStep(ctx context.Context, id string) (string, error) {
+	if id == r.failTaskID {
+		return "", r.err
+	}
+	task, err := r.GetTask(ctx, id)
+	if err != nil || task == nil {
+		return "", err
+	}
+	return task.WorkflowStepID, r.fakeDeleteRepo.DeleteTask(ctx, id)
 }
 
 func (s *recordingCascadeTaskService) ReconcileVacatedStep(ctx context.Context, vacatedStepID string) {
@@ -56,6 +170,83 @@ func TestHandoffTaskTreeLifecycleBackfillsFeederVacancies(t *testing.T) {
 			assertHandoffFeederBackfill(t, ctx, repo)
 			if len(recorder.vacatedStepIDs) != 1 || recorder.vacatedStepIDs[0] != "review-step" {
 				t.Fatalf("vacated step reconciliations = %v, want [review-step]", recorder.vacatedStepIDs)
+			}
+		})
+	}
+}
+
+func TestHandoffTaskTreeLifecycleUsesMutationPlacementForVacancy(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *HandoffService) error
+	}{
+		{name: "archive", mutate: func(ctx context.Context, handoff *HandoffService) error {
+			_, err := handoff.ArchiveTaskTree(ctx, "root", false)
+			return err
+		}},
+		{name: "delete", mutate: func(ctx context.Context, handoff *HandoffService) error {
+			_, err := handoff.DeleteTaskTree(ctx, "root", false)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := newFakeTaskRepo()
+			tasks.addTask("root", "", "workspace")
+			tasks.tasks["root"].WorkflowStepID = "snapshot-step"
+			repo := &placementChangingCascadeRepo{fakeDeleteRepo: &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}}
+			reconciler := &recordingVacatedStepReconciler{}
+			handoff := NewHandoffService(repo, nil, nil, nil, nil, nil)
+			handoff.SetVacatedStepReconciler(reconciler)
+
+			if err := tt.mutate(context.Background(), handoff); err != nil {
+				t.Fatalf("tree lifecycle mutation: %v", err)
+			}
+			if len(reconciler.stepIDs) != 1 || reconciler.stepIDs[0] != "actual-step" {
+				t.Fatalf("vacated step reconciliations = %v, want [actual-step]", reconciler.stepIDs)
+			}
+		})
+	}
+}
+
+func TestHandoffTaskTreeLifecycleReconcilesCommittedPartialMutations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *HandoffService) error
+	}{
+		{name: "archive", mutate: func(ctx context.Context, handoff *HandoffService) error {
+			_, err := handoff.ArchiveTaskTree(ctx, "root", true)
+			return err
+		}},
+		{name: "delete", mutate: func(ctx context.Context, handoff *HandoffService) error {
+			_, err := handoff.DeleteTaskTree(ctx, "root", true)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := newFakeTaskRepo()
+			tasks.addTask("root", "", "workspace")
+			tasks.addTask("child", "root", "workspace")
+			tasks.tasks["root"].WorkflowStepID = "review-step"
+			tasks.tasks["child"].WorkflowStepID = "review-step"
+			mutationErr := errors.New("parent mutation failed")
+			repo := &partialFailureCascadeRepo{
+				fakeDeleteRepo: &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)},
+				failTaskID:     "root",
+				err:            mutationErr,
+			}
+			reconciler := &recordingVacatedStepReconciler{}
+			handoff := NewHandoffService(repo, nil, nil, nil, nil, nil)
+			handoff.SetVacatedStepReconciler(reconciler)
+
+			if err := tt.mutate(context.Background(), handoff); !errors.Is(err, mutationErr) {
+				t.Fatalf("tree lifecycle error = %v, want %v", err, mutationErr)
+			}
+			if len(reconciler.stepIDs) != 1 || reconciler.stepIDs[0] != "review-step" {
+				t.Fatalf("vacated step reconciliations = %v, want [review-step]", reconciler.stepIDs)
 			}
 		})
 	}

--- a/apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type recordingCascadeTaskService struct {
+	*Service
+	vacatedStepIDs []string
+}
+
+func (s *recordingCascadeTaskService) ReconcileVacatedStep(ctx context.Context, vacatedStepID string) {
+	s.vacatedStepIDs = append(s.vacatedStepIDs, vacatedStepID)
+	s.Service.ReconcileVacatedStep(ctx, vacatedStepID)
+}
+
+// @covers AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+func TestHandoffTaskTreeLifecycleBackfillsFeederVacancies(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *HandoffService, string) (*CascadeOutcome, error)
+	}{
+		{name: "archive", mutate: func(ctx context.Context, handoff *HandoffService, taskID string) (*CascadeOutcome, error) {
+			return handoff.ArchiveTaskTree(ctx, taskID, true)
+		}},
+		{name: "delete", mutate: func(ctx context.Context, handoff *HandoffService, taskID string) (*CascadeOutcome, error) {
+			return handoff.DeleteTaskTree(ctx, taskID, true)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			taskService, _, repo := createTestService(t)
+			seedHandoffFeederPullScenario(t, ctx, taskService, repo)
+
+			recorder := &recordingCascadeTaskService{Service: taskService}
+			handoff := NewHandoffService(repo, nil, nil, nil, nil, nil)
+			handoff.SetTaskEventPublisher(recorder)
+			handoff.SetVacatedStepReconciler(recorder)
+
+			outcome, err := tt.mutate(ctx, handoff, "destination-root")
+			if err != nil {
+				t.Fatalf("tree lifecycle mutation: %v", err)
+			}
+			if len(outcome.ArchivedTaskIDs) != 2 {
+				t.Fatalf("mutated task count = %d, want 2", len(outcome.ArchivedTaskIDs))
+			}
+
+			assertHandoffFeederBackfill(t, ctx, repo)
+			if len(recorder.vacatedStepIDs) != 1 || recorder.vacatedStepIDs[0] != "review-step" {
+				t.Fatalf("vacated step reconciliations = %v, want [review-step]", recorder.vacatedStepIDs)
+			}
+		})
+	}
+}
+
+func seedHandoffFeederPullScenario(
+	t *testing.T,
+	ctx context.Context,
+	taskService *Service,
+	repo *sqliterepo.Repository,
+) {
+	t.Helper()
+	seedWIPWorkflow(t, ctx, repo)
+	taskService.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"waiting-step": {ID: "waiting-step", WorkflowID: "wip-workflow", Position: 0},
+		"review-step": {
+			ID: "review-step", WorkflowID: "wip-workflow", Position: 1,
+			WIPLimit: 2, PullFromStepID: "waiting-step",
+		},
+		"done-step": {ID: "done-step", WorkflowID: "wip-workflow", Position: 2},
+	}})
+
+	tasks := []*models.Task{
+		{ID: "destination-root", Title: "Review root", WorkflowStepID: "review-step", Position: 0},
+		{ID: "destination-child", Title: "Review child", WorkflowStepID: "review-step", ParentID: "destination-root", Position: 1},
+		{ID: "feeder-first", Title: "Waiting first", WorkflowStepID: "waiting-step", Position: 0},
+		{ID: "feeder-second", Title: "Waiting second", WorkflowStepID: "waiting-step", Position: 1},
+		{ID: "feeder-third", Title: "Waiting third", WorkflowStepID: "waiting-step", Position: 2},
+	}
+	for _, task := range tasks {
+		task.WorkspaceID = "wip-workspace"
+		task.WorkflowID = "wip-workflow"
+		task.State = v1.TaskStateTODO
+		task.Priority = "medium"
+		task.WIPAdmitted = true
+		if err := repo.CreateTask(ctx, task); err != nil {
+			t.Fatalf("seed task %s: %v", task.ID, err)
+		}
+	}
+}
+
+func assertHandoffFeederBackfill(t *testing.T, ctx context.Context, repo *sqliterepo.Repository) {
+	t.Helper()
+	for _, taskID := range []string{"feeder-first", "feeder-second"} {
+		task, err := repo.GetTask(ctx, taskID)
+		if err != nil {
+			t.Fatalf("GetTask(%s): %v", taskID, err)
+		}
+		if task.WorkflowStepID != "review-step" || !task.WIPAdmitted || task.QueuedForStepID != "" {
+			t.Fatalf("task %s placement = step:%q admitted:%v queued_for:%q, want admitted in review-step",
+				taskID, task.WorkflowStepID, task.WIPAdmitted, task.QueuedForStepID)
+		}
+		trigger, actorKind, _, sessionID := lastLedgerAttribution(t, repo, taskID)
+		if trigger != "wip_pull" || actorKind != "system" || sessionID != nil {
+			t.Fatalf("task %s ledger = trigger:%q actor:%q session:%v, want wip_pull/system/no session",
+				taskID, trigger, actorKind, sessionID)
+		}
+	}
+
+	remaining, err := repo.GetTask(ctx, "feeder-third")
+	if err != nil {
+		t.Fatalf("GetTask(feeder-third): %v", err)
+	}
+	if remaining.WorkflowStepID != "waiting-step" || !remaining.WIPAdmitted || remaining.QueuedForStepID != "" {
+		t.Fatalf("remaining feeder placement = step:%q admitted:%v queued_for:%q, want admitted in waiting-step",
+			remaining.WorkflowStepID, remaining.WIPAdmitted, remaining.QueuedForStepID)
+	}
+}

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -22,17 +22,26 @@ func newCascadeRepo(base *fakeTaskRepo) *fakeCascadeRepo {
 	return &fakeCascadeRepo{phase4TaskRepo: &phase4TaskRepo{base: base}}
 }
 
-func (r *fakeCascadeRepo) ArchiveTaskIfActive(_ context.Context, id, cascadeID string) (bool, error) {
+func (r *fakeCascadeRepo) ArchiveTaskIfActive(ctx context.Context, id, cascadeID string) (bool, error) {
+	_, changed, err := r.ArchiveTaskIfActiveWithVacatedStep(ctx, id, cascadeID)
+	return changed, err
+}
+
+func (r *fakeCascadeRepo) ArchiveTaskIfActiveWithVacatedStep(
+	_ context.Context,
+	id string,
+	cascadeID string,
+) (string, bool, error) {
 	r.base.mu.Lock()
 	defer r.base.mu.Unlock()
 	t := r.base.tasks[id]
 	if t == nil || t.ArchivedAt != nil {
-		return false, nil
+		return "", false, nil
 	}
 	now := time.Now().UTC()
 	t.ArchivedAt = &now
 	t.ArchivedByCascadeID = cascadeID
-	return true, nil
+	return t.WorkflowStepID, true, nil
 }
 
 func (r *fakeCascadeRepo) UnarchiveTaskByCascade(_ context.Context, id, cascadeID string) (bool, error) {
@@ -580,6 +589,14 @@ func (r *archiveErrorCascadeRepo) ArchiveTaskIfActive(context.Context, string, s
 	return false, r.err
 }
 
+func (r *archiveErrorCascadeRepo) ArchiveTaskIfActiveWithVacatedStep(
+	context.Context,
+	string,
+	string,
+) (string, bool, error) {
+	return "", false, r.err
+}
+
 func TestArchiveTaskTree_DoesNotFinalizeSessionWhenArchiveFails(t *testing.T) {
 	tasks := newFakeTaskRepo()
 	tasks.addTask("root", "", "ws-1")
@@ -612,11 +629,20 @@ type fakeDeleteRepo struct {
 	*fakeCascadeRepo
 }
 
-func (r *fakeDeleteRepo) DeleteTask(_ context.Context, id string) error {
+func (r *fakeDeleteRepo) DeleteTask(ctx context.Context, id string) error {
+	_, err := r.DeleteTaskWithVacatedStep(ctx, id)
+	return err
+}
+
+func (r *fakeDeleteRepo) DeleteTaskWithVacatedStep(_ context.Context, id string) (string, error) {
 	r.base.mu.Lock()
 	defer r.base.mu.Unlock()
+	task := r.base.tasks[id]
+	if task == nil {
+		return "", errors.New("task not found")
+	}
 	delete(r.base.tasks, id)
-	return nil
+	return task.WorkflowStepID, nil
 }
 
 func (r *fakeDeleteRepo) DeleteExpiredQuickChatTask(context.Context, string, time.Time) (bool, error) {
@@ -630,6 +656,10 @@ type deleteErrorCascadeRepo struct {
 
 func (r *deleteErrorCascadeRepo) DeleteTask(context.Context, string) error {
 	return r.err
+}
+
+func (r *deleteErrorCascadeRepo) DeleteTaskWithVacatedStep(context.Context, string) (string, error) {
+	return "", r.err
 }
 
 func TestDeleteTaskTree_DoesNotFinalizeSessionWhenDeleteFails(t *testing.T) {

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -239,6 +239,14 @@ type VacatedStepReconciler interface {
 	ReconcileVacatedStep(ctx context.Context, vacatedStepID string)
 }
 
+type cascadeArchiveTaskRepository interface {
+	ArchiveTaskIfActiveWithVacatedStep(ctx context.Context, id, cascadeID string) (string, bool, error)
+}
+
+type cascadeDeleteTaskRepository interface {
+	DeleteTaskWithVacatedStep(ctx context.Context, id string) (string, error)
+}
+
 // taskSessionCancellationPublisher is the optional event side effect paired
 // with activeTaskSessionCanceller. Cascade archive/delete paths do not call
 // Service.ArchiveTask, so they must publish the session transition themselves

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -208,6 +208,7 @@ type HandoffService struct {
 	cleaner            WorkspaceCleaner
 	runCanceller       RunCanceller
 	eventPublisher     TaskEventPublisher
+	vacancyReconciler  VacatedStepReconciler
 	resourceCleaner    TaskResourceCleaner
 	taskAccessCheck    func(ctx context.Context, taskID string) error
 	comments           CommentReader
@@ -230,6 +231,12 @@ type HandoffService struct {
 type TaskEventPublisher interface {
 	PublishTaskUpdated(ctx context.Context, task *models.Task, oldWorkflowIDs ...string)
 	PublishTaskDeleted(ctx context.Context, task *models.Task)
+}
+
+// VacatedStepReconciler backfills capacity in a workflow step after admitted
+// work leaves it.
+type VacatedStepReconciler interface {
+	ReconcileVacatedStep(ctx context.Context, vacatedStepID string)
 }
 
 // taskSessionCancellationPublisher is the optional event side effect paired
@@ -261,6 +268,12 @@ func (s *HandoffService) SetWorkspaceCleaner(c WorkspaceCleaner) {
 // (legacy and test wiring).
 func (s *HandoffService) SetTaskEventPublisher(p TaskEventPublisher) {
 	s.eventPublisher = p
+}
+
+// SetVacatedStepReconciler wires post-mutation WIP capacity reconciliation.
+// Archive and delete remain committed if reconciliation cannot fill a slot.
+func (s *HandoffService) SetVacatedStepReconciler(r VacatedStepReconciler) {
+	s.vacancyReconciler = r
 }
 
 // TaskResourceCleaner tears down a task's runtime resources (container,

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -746,6 +746,12 @@ func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models
 	return nil
 }
 
+// ReconcileVacatedStep fills available capacity in a workflow step from its
+// same-step queue or configured feeder.
+func (s *Service) ReconcileVacatedStep(ctx context.Context, vacatedStepID string) {
+	s.pullNextTaskOnVacate(ctx, vacatedStepID, "")
+}
+
 func (s *Service) pullNextTaskOnVacate(ctx context.Context, vacatedStepID, excludeTaskID string) {
 	// A queue/WIP reconciliation is always wip_pull, unconditionally
 	// overriding whatever trigger the caller that vacated the step declared

--- a/docs/plans/tree-archive-feeder-pulls/plan.md
+++ b/docs/plans/tree-archive-feeder-pulls/plan.md
@@ -1,0 +1,115 @@
+---
+created: 2026-09-04
+status: complete
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+legacy_specs: []
+---
+
+# Implementation Plan: Tree Archive Feeder Pulls
+
+## Overview
+
+Restore WIP feeder backfill after task-tree archive and delete operations. The
+single work order first proves the missing cascade trigger with a SQLite-backed
+regression test. Then it wires vacancy reconciliation into the handoff cascade
+and runs the requested backend gates.
+
+## Confirmed root cause
+
+`HandoffService.ArchiveTaskTree` and `HandoffService.DeleteTaskTree` mutate task
+rows directly and bypass `Service.ArchiveTask` and `Service.DeleteTask`. The
+single-task paths call `pullNextTaskOnVacate` after their mutations commit. The
+cascade paths do not retain the pre-mutation workflow-step IDs. They also do not
+invoke a vacancy reconciler after the loop. Consequently, admitted legacy feeder
+tasks with no `queued_for_step_id` remain stranded. Startup
+`ReconcileQueuedTasks` only discovers tasks with an explicit queue destination.
+
+The existing public `Service.ReconcileFeederPulls(ctx, workflowID,
+feederStepID)` is not the correct seam for this event: it treats its step ID as
+a feeder source and finds destinations that pull from it. Tree archive/delete
+instead needs to reconcile the destination step that lost WIP occupants.
+
+## Scope
+
+### In scope
+
+- Capture the pre-mutation workflow step for each task that the cascade
+  actually archives or deletes.
+- Reconcile each distinct vacated step once after the mutation loop commits,
+  using a caller-cancellation-independent context.
+- Apply the same behavior to archive and delete cascades.
+- Wire a narrow vacancy-reconciliation dependency from backend composition to
+  `HandoffService`.
+- Prove feeder promotion, batching, and `wip_pull` transition attribution with
+  a SQLite-backed Go regression test.
+
+### Out of scope
+
+- Changing WIP admission, candidate ordering, feeder routing, or restart
+  reconciliation semantics.
+- Frontend, API, schema, migration, runtime-feature-flag, or public-doc changes.
+- Refactoring the wider handoff cascade or task-service promotion machinery.
+
+## Technical approach
+
+### Vacancy reconciliation seam
+
+- In `apps/backend/internal/task/service/handoff_service.go`, add a narrow
+  `VacatedStepReconciler` dependency and setter on `HandoffService`.
+- In `apps/backend/internal/task/service/service_workflow.go`, expose the
+  matching task-service method as a thin wrapper over
+  `pullNextTaskOnVacate(ctx, stepID, "")`. The task service continues to own
+  candidate selection, transactional admission, event publication, and
+  `wip_pull` attribution.
+- In `apps/backend/internal/backendapp/helpers.go`, wire `p.taskSvc` into the
+  handoff service alongside the existing event-publisher and resource-cleaner
+  dependencies.
+
+### Cascade batching
+
+- In `apps/backend/internal/task/service/handoff_cascade.go`, read each task
+  before its archive or delete mutation. Add its non-empty workflow step to a
+  set only after that mutation succeeds. Archive CAS misses remain skipped.
+- After each deepest-first mutation loop, iterate the distinct step IDs in
+  deterministic order and call the reconciler with
+  `context.WithoutCancel(...)`. Reconciliation remains best effort. The task
+  service logs lookup, count, and promotion errors. These errors do not fail or
+  roll back the completed archive or delete.
+
+## Tests
+
+- `AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2` maps to
+  `TestHandoffTaskTreeLifecycleBackfillsFeederVacancies` in
+  `apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go`.
+- The table cases create a WIP-limited destination with a feeder, fill its
+  slots, and seed admitted untagged feeder candidates. Each case then archives
+  or deletes a two-task tree through `HandoffService`.
+- RED proves that candidates remain in the feeder before the new wiring. GREEN
+  proves that available slots are filled and the remaining candidate stays in
+  the feeder. It also proves one reconciliation for the shared step and
+  `wip_pull` attribution for each promoted candidate.
+
+## Work orders
+
+- [x] [Task 01: Backfill feeder vacancies after task-tree lifecycle mutations](task-01-backfill-tree-lifecycle-vacancies.md)
+
+## Verification results
+
+- RED: both archive and delete cases left `feeder-first` in `waiting-step`.
+- GREEN: the focused regression test passed all archive and delete assertions.
+- The task-service package passed 1,561 tests.
+- The full backend suite passed after removing the session's pinned
+  `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values.
+- Backend lint passed with zero issues.
+
+## Risks
+
+- Reading the pre-mutation task row must not cause a skipped archive CAS to
+  trigger reconciliation.
+- Multiple tasks from one step must produce one reconciliation, while tasks
+  from different steps must each wake their own destination.
+- Post-commit reconciliation must retain caller identity for authorization but
+  discard caller cancellation, matching the existing cascade cleanup context.

--- a/docs/plans/tree-archive-feeder-pulls/plan.md
+++ b/docs/plans/tree-archive-feeder-pulls/plan.md
@@ -100,7 +100,8 @@ instead needs to reconcile the destination step that lost WIP occupants.
 
 - RED: both archive and delete cases left `feeder-first` in `waiting-step`.
 - GREEN: the focused regression test passed all archive and delete assertions.
-- The task-service package passed 1,561 tests.
+- The task-service package passed 1,567 tests after review regressions added
+  coverage for concurrent placement changes and partial cascade failures.
 - The full backend suite passed after removing the session's pinned
   `KANDEV_INTERNAL_CONFIG_FILE` and `KANDEV_INTERNAL_CONFIG_HOME_FILE` values.
 - Backend lint passed with zero issues.
@@ -113,3 +114,7 @@ instead needs to reconcile the destination step that lost WIP occupants.
   from different steps must each wake their own destination.
 - Post-commit reconciliation must retain caller identity for authorization but
   discard caller cancellation, matching the existing cascade cleanup context.
+
+The repository mutation returns the vacated workflow step from the same
+transaction that archives or deletes the task. A deferred batch finalizer also
+reconciles successful mutations when a later tree mutation fails.

--- a/docs/plans/tree-archive-feeder-pulls/task-01-backfill-tree-lifecycle-vacancies.md
+++ b/docs/plans/tree-archive-feeder-pulls/task-01-backfill-tree-lifecycle-vacancies.md
@@ -61,7 +61,7 @@ go test -run '^TestHandoffTaskTreeLifecycleBackfillsFeederVacancies$' ./internal
 cd ../..
 make -C apps/backend test
 make -C apps/backend lint
-bash -c 'files=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.go$"); if [ -n "$files" ]; then gofmt -l $files; fi'
+bash -c 'files=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.go$"); [ -z "$files" ] || [ -z "$(gofmt -l $files)" ]'
 git diff --check
 ```
 
@@ -118,7 +118,9 @@ None.
 - The SQLite-backed regression test failed before production changes because
   both cascade paths stranded feeder work. It now passes for archive and
   delete, including distinct-step batching and `wip_pull` ledger attribution.
-- `go test ./internal/task/service -count=1` passed 1,561 tests.
+- Review remediation moved vacancy capture into the archive/delete transaction
+  and added a deferred batch finalizer for committed partial cascades.
+- `go test ./internal/task/service -count=1` passed 1,567 tests.
 - `make -C apps/backend test` passed with the session's pinned internal config
   path removed so config-discovery tests could use their temporary fixtures.
 - `make -C apps/backend lint` passed with zero issues.

--- a/docs/plans/tree-archive-feeder-pulls/task-01-backfill-tree-lifecycle-vacancies.md
+++ b/docs/plans/tree-archive-feeder-pulls/task-01-backfill-tree-lifecycle-vacancies.md
@@ -1,0 +1,124 @@
+---
+id: "01-backfill-tree-lifecycle-vacancies"
+title: "Backfill feeder vacancies after task-tree lifecycle mutations"
+status: complete
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WIP-LIMIT-PULL-SYSTEM-001
+acceptance_criteria:
+  - AC-TASKS-WIP-LIMIT-PULL-SYSTEM-001.2
+system_design:
+  - ../../specs/tasks/system-design/wip-limit-pull-system.md
+---
+
+# Task 01: Backfill Feeder Vacancies After Task-Tree Lifecycle Mutations
+
+## Summary
+
+Make `ArchiveTaskTree` and `DeleteTaskTree` wake task-service WIP
+reconciliation once per distinct workflow step they vacate. Add a
+SQLite-backed regression test for archive and delete cascades. The test proves
+that eligible feeder candidates replace destination occupants. It also proves
+`wip_pull` transition attribution.
+
+## In scope
+
+- Add the failing archive/delete cascade regression test before production
+  changes.
+- Add and wire a narrow `VacatedStepReconciler` dependency.
+- Capture pre-mutation workflow-step IDs and batch distinct reconciliation
+  calls after each mutation loop.
+- Preserve the cascade's post-commit, log-and-continue behavior.
+- Run targeted RED/GREEN checks and the requested backend test and lint gates.
+
+## Out of scope
+
+- Changing queue ordering, feeder eligibility, WIP counting, or startup
+  recovery.
+- UI, API, persistence-schema, or documentation behavior changes.
+- General cleanup or refactoring outside the touched cascade and wiring.
+
+## Acceptance
+
+- Archiving or deleting a two-task tree from a WIP-limited destination through
+  `HandoffService` promotes enough admitted, untagged feeder candidates to fill
+  the newly available slots.
+- A cascade that vacates multiple tasks in the same workflow step invokes the
+  vacancy reconciler once for that step, after the mutation loop, and skipped
+  archive rows do not contribute reconciliation work.
+- Promoted candidates persist in the destination as admitted work and record
+  task-step transitions with trigger `wip_pull`. A reconciliation error does not
+  fail an already-committed archive or delete.
+
+## Verification
+
+```bash
+cd apps/backend
+go test -run '^TestHandoffTaskTreeLifecycleBackfillsFeederVacancies$' ./internal/task/service -count=1
+
+cd ../..
+make -C apps/backend test
+make -C apps/backend lint
+bash -c 'files=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.go$"); if [ -n "$files" ]; then gofmt -l $files; fi'
+git diff --check
+```
+
+During RED, the focused test must fail on feeder placement or reconciliation
+count. It must not fail on compilation or fixture setup. Run the focused command
+again after the last production edit. Record the RED and GREEN outcomes in this
+file.
+
+## Files likely touched
+
+- `apps/backend/internal/task/service/handoff_cascade_feeder_pull_test.go`
+- `apps/backend/internal/task/service/handoff_cascade.go`
+- `apps/backend/internal/task/service/handoff_service.go`
+- `apps/backend/internal/task/service/service_workflow.go`
+- `apps/backend/internal/backendapp/helpers.go`
+- `docs/plans/tree-archive-feeder-pulls/plan.md`
+- `docs/plans/tree-archive-feeder-pulls/task-01-backfill-tree-lifecycle-vacancies.md`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- The existing public feeder-source reconciler has opposite step semantics.
+  Reusing it for a vacated destination silently reconciles the wrong edges.
+- The archive cascade can skip rows that another caller already archived. The
+  step set must receive data only after a successful CAS.
+- Tree deletion can include already archived descendants. Only active rows
+  consume WIP. An extra destination reconciliation is idempotent and safe.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/tasks/requirements/wip-limit-pull-system.md`
+- `docs/specs/tasks/system-design/wip-limit-pull-system.md`
+- `docs/decisions/2026-07-28-visible-wip-overflow-queues.md`
+- `apps/backend/internal/task/service/handoff_cascade.go`
+- `apps/backend/internal/task/service/handoff_service.go`
+- `apps/backend/internal/task/service/service_tasks.go`
+- `apps/backend/internal/task/service/service_workflow.go`
+- `apps/backend/internal/backendapp/helpers.go`
+
+## Results
+
+- Added an explicit `VacatedStepReconciler` dependency from backend
+  composition to `HandoffService`.
+- Archive and delete cascades capture pre-mutation workflow steps, retain only
+  successful mutations, and reconcile each distinct step after the loop with
+  a detached context.
+- The SQLite-backed regression test failed before production changes because
+  both cascade paths stranded feeder work. It now passes for archive and
+  delete, including distinct-step batching and `wip_pull` ledger attribution.
+- `go test ./internal/task/service -count=1` passed 1,561 tests.
+- `make -C apps/backend test` passed with the session's pinned internal config
+  path removed so config-discovery tests could use their temporary fixtures.
+- `make -C apps/backend lint` passed with zero issues.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3376/1e9811ead0b5.html)
<!-- kandev-pr-walkthrough-end -->

Tree archive and delete cascades could free WIP capacity without waking their feeder pulls, leaving eligible work stranded. The cascades now reconcile each distinct vacated step after their mutations commit.

## Validation

- `go test -run '^TestHandoffTaskTreeLifecycleBackfillsFeederVacancies$' ./internal/task/service -count=1`
- `go test ./internal/task/service -count=1` (1,561 tests passed)
- `env -u KANDEV_INTERNAL_CONFIG_FILE -u KANDEV_INTERNAL_CONFIG_HOME_FILE make -C apps/backend test`
- `make -C apps/backend lint` (zero issues)
- `git diff --cached --name-only --diff-filter=ACMR | grep '\.go$' | xargs gofmt -l`

The unwrapped backend test command was also run. Its config-discovery tests loaded the session-pinned `/root/.kandev/config.yaml`; removing those two runtime-only config variables made the complete suite pass.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->