### PR TITLE
fix(ssh): read the stdin environment to EOF for bash on macOS

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -332,7 +332,7 @@ func (r *SSHExecutor) preflightGitHubCredentialBroker(
 			return nil, err
 		}
 		input := strings.NewReader(envScript)
-		wrapped := WrapLoginShell(shell, "set -a; . /dev/stdin; set +a\n"+command)
+		wrapped := WrapLoginShell(shell, "set -a; "+sshStdinEnvImport+"; set +a\n"+command)
 		stdout, stderr, err := runSSHCommandStdin(ctx, client, wrapped, input)
 		return []byte(stdout + stderr), err
 	})

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials.go
@@ -116,14 +116,14 @@ func (r *SSHExecutor) runOneAuthSetupScript(
 			zap.Error(err))
 		return
 	}
-	// `. /dev/stdin` sources the env lines fed via session.Stdin; `set -a`
+	// `sshStdinEnvImport` evaluates the env lines fed via session.Stdin; `set -a`
 	// makes those assignments automatically exported so the user's setup
 	// script sees them in env without a per-key `export`. The script body
 	// itself runs in the same shell after stdin EOF, which means scripts
 	// that need their own stdin are unsupported here — none of the
 	// env-type SetupScripts in the catalog (gh_cli_env etc.) consume
 	// stdin, so this is fine in practice.
-	wrapped := WrapLoginShell(shell, "set -a; . /dev/stdin; set +a\n"+method.SetupScript)
+	wrapped := WrapLoginShell(shell, "set -a; "+sshStdinEnvImport+"; set +a\n"+method.SetupScript)
 	out, stderr, err := runSSHCommandStdin(ctx, client, wrapped, strings.NewReader(envScript))
 	if err != nil {
 		r.logger.Warn("auth setup script failed",

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_remote_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_remote_test.go
@@ -175,7 +175,7 @@ func TestSSHExecutorRunAuthSetupScripts(t *testing.T) {
 			t.Fatalf("setup script runs = %d, want 1", len(calls))
 		}
 		script := unwrapLoginShell(t, "bash", calls[0].Command)
-		if !strings.HasPrefix(script, "set -a; . /dev/stdin; set +a\n") {
+		if !strings.HasPrefix(script, "set -a; eval \"$(cat)\"; set +a\n") {
 			t.Fatalf("setup script must source stdin under set -a:\n%s", script)
 		}
 		if !strings.Contains(script, `printf %s "$CREDENTIAL_AGENT_TOKEN"`) {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
@@ -167,7 +167,7 @@ func TestBuildSSHEnvInitScript(t *testing.T) {
 			t.Fatalf("buildSSHEnvInitScript: %v", err)
 		}
 		// Each line is a POSIX shell assignment; the line break separates
-		// entries so `. /dev/stdin` under `set -a` exports each one.
+		// entries so evaluating stdin under `set -a` exports each one.
 		if got != "FOO='bar baz'\n" {
 			t.Errorf("buildSSHEnvInitScript = %q, want \"FOO='bar baz'\\n\"", got)
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -571,7 +571,7 @@ func startRemoteAgentctlOnPort(
 	// exactly the same resolved credentials as clone/setup commands.
 	innerScript := fmt.Sprintf(
 		`set -ae
-. /dev/stdin
+`+sshStdinEnvImport+`
 set +a
 set -e
 mkdir -p %[1]s

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_remote_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_remote_test.go
@@ -849,7 +849,7 @@ func TestStartRemoteAgentctlOnPortBuildsLaunchScript(t *testing.T) {
 		">> '/remote/session'/agentctl.log 2>&1 < /dev/null &",
 		`echo "$AGENTCTL_PID" > '/remote/session'/agentctl.pid`,
 		"mkdir -p '/remote/session'",
-		". /dev/stdin",
+		`eval "$(cat)"`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("launch script missing %q:\n%s", want, script)

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_remote_contribution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_remote_contribution.go
@@ -46,7 +46,7 @@ func (r *SSHExecutor) materializeSSHRemoteContribution(
 
 	shell := sshShellForRemote(req.Metadata, platform)
 	inner := sshRemoteContributionScript(taskDir, targetURL, binding)
-	wrapped := WrapLoginShell(shell, "set -ae; . /dev/stdin; set +a\n"+inner)
+	wrapped := WrapLoginShell(shell, "set -ae; "+sshStdinEnvImport+"; set +a\n"+inner)
 	_, _, runErr := runSSHCommandStdin(ctx, client, wrapped, strings.NewReader(envScript))
 	if runErr != nil {
 		// Git may include a credentialed helper URL in stderr. Keep the error

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_scripts.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_scripts.go
@@ -174,8 +174,16 @@ func (r *SSHExecutor) runPrepareScript(ctx context.Context, client *ssh.Client, 
 	return nil
 }
 
+// sshStdinEnvImport imports the `KEY='value'` lines Kandev writes to the remote
+// command's stdin. It must read stdin to EOF: bash 3.2, the /bin/bash on macOS,
+// sources a FIFO by reading only the bytes buffered when it opens the file, so
+// `. /dev/stdin` raced sshd's stdin forwarding and usually imported nothing.
+// `eval "$(cat)"` waits for EOF in sh, bash, and zsh and keeps the values out of
+// process arguments and the filesystem.
+const sshStdinEnvImport = `eval "$(cat)"`
+
 func sshScriptWithEnvironment(script string) string {
-	return "set -ae\n. /dev/stdin\nset +a\nset -e\n" + script
+	return "set -ae\n" + sshStdinEnvImport + "\nset +a\nset -e\n" + script
 }
 
 func redactSSHScriptOutput(output string, env map[string]string) string {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_scripts_remote_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_scripts_remote_test.go
@@ -64,7 +64,7 @@ func TestNormalizeSSHRemotePath(t *testing.T) {
 
 func TestSSHScriptWithEnvironment(t *testing.T) {
 	got := sshScriptWithEnvironment("echo hi")
-	if got != "set -ae\n. /dev/stdin\nset +a\nset -e\necho hi" {
+	if got != "set -ae\neval \"$(cat)\"\nset +a\nset -e\necho hi" {
 		t.Fatalf("sshScriptWithEnvironment = %q", got)
 	}
 }
@@ -224,7 +224,7 @@ func TestSSHExecutorRunPrepareScript(t *testing.T) {
 			t.Fatalf("prepare runs = %d, want 1", len(calls))
 		}
 		script := unwrapLoginShell(t, "zsh", calls[0].Command)
-		if !strings.HasPrefix(script, "set -ae\n. /dev/stdin\nset +a\nset -e\n") {
+		if !strings.HasPrefix(script, "set -ae\neval \"$(cat)\"\nset +a\nset -e\n") {
 			t.Fatalf("prepare script preamble missing:\n%s", script)
 		}
 		if !strings.Contains(script, "echo prepared") {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
@@ -1,7 +1,9 @@
 package lifecycle
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
@@ -9,11 +11,26 @@ import (
 	"time"
 )
 
+// sshStdinEnvReadyMarker is printed by the child as the statement before the
+// prelude reads stdin, so the test can order its write against the import
+// rather than against a guessed startup duration.
+const sshStdinEnvReadyMarker = "kandev-stdin-env-ready"
+
+// sshStdinEnvReadyTimeout bounds the wait for that marker. It only has to
+// cover shell startup on a loaded machine; the test fails fast rather than
+// hanging when the shell never reaches the import.
+const sshStdinEnvReadyTimeout = 30 * time.Second
+
 // TestSSHStdinEnvImportReadsStdinToEOF feeds the environment only after the
-// shell has started, which is the ordering sshd produces on a real target.
-// bash 3.2 (the /bin/bash on macOS) sources /dev/stdin by reading just the
-// bytes already buffered when it opens the FIFO, so the previous
+// shell has reached the stdin import, which is the ordering sshd produces on a
+// real target. bash 3.2 (the /bin/bash on macOS) sources /dev/stdin by reading
+// just the bytes already buffered when it opens the FIFO, so the previous
 // `. /dev/stdin` prelude imported nothing there.
+//
+// The readiness marker is what makes this a regression test rather than a race:
+// a fixed sleep after Start proves only that time passed. If the write won that
+// race the environment sat in the pipe buffer, where even the old prelude found
+// it, and the test would have passed against the bug it exists to catch.
 func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
 	envScript, err := buildSSHEnvInitScript(map[string]string{"KANDEV_TEST_STDIN_ENV": "bar baz"})
 	if err != nil {
@@ -25,29 +42,80 @@ func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
 			continue
 		}
 		t.Run(shell, func(t *testing.T) {
-			cmd := exec.Command(path, "-c", sshScriptWithEnvironment(`printf '%s\n' "value=${KANDEV_TEST_STDIN_ENV:-unset}"`))
+			script := `printf '%s\n' ` + sshStdinEnvReadyMarker + " >&2\n" +
+				sshScriptWithEnvironment(`printf '%s\n' "value=${KANDEV_TEST_STDIN_ENV:-unset}"`)
+			cmd := exec.Command(path, "-c", script)
 			stdin, err := cmd.StdinPipe()
 			if err != nil {
 				t.Fatalf("stdin pipe: %v", err)
 			}
-			var output bytes.Buffer
-			cmd.Stdout = &output
-			cmd.Stderr = &output
+			stderrPipe, err := cmd.StderrPipe()
+			if err != nil {
+				t.Fatalf("stderr pipe: %v", err)
+			}
+			var stdout bytes.Buffer
+			cmd.Stdout = &stdout
 			if err := cmd.Start(); err != nil {
 				t.Fatalf("start %s: %v", shell, err)
 			}
-			time.Sleep(200 * time.Millisecond)
-			if _, err := io.WriteString(stdin, envScript); err != nil {
-				t.Fatalf("write env: %v", err)
+
+			// Reads stderr to EOF so the child never blocks on it, and reports
+			// the marker exactly once. Every read of stderrTail below happens
+			// after drained closes.
+			ready := make(chan error, 1)
+			drained := make(chan struct{})
+			var stderrTail strings.Builder
+			go func() {
+				defer close(drained)
+				reader := bufio.NewReader(stderrPipe)
+				signalled := false
+				for {
+					line, readErr := reader.ReadString('\n')
+					if !signalled && strings.Contains(line, sshStdinEnvReadyMarker) {
+						signalled = true
+						ready <- nil
+					} else {
+						stderrTail.WriteString(line)
+					}
+					if readErr != nil {
+						if !signalled {
+							ready <- fmt.Errorf("%s exited before the readiness marker: %w", shell, readErr)
+						}
+						return
+					}
+				}
+			}()
+
+			abort := func(format string, args ...interface{}) {
+				t.Helper()
+				_ = cmd.Process.Kill()
+				<-drained
+				_ = cmd.Wait()
+				t.Fatalf(format+"\nstderr:\n%s", append(args, stderrTail.String())...)
 			}
-			if err := stdin.Close(); err != nil {
-				t.Fatalf("close stdin: %v", err)
+			select {
+			case err := <-ready:
+				if err != nil {
+					abort("%v", err)
+				}
+			case <-time.After(sshStdinEnvReadyTimeout):
+				abort("%s did not reach the stdin import within %s", shell, sshStdinEnvReadyTimeout)
 			}
-			if err := cmd.Wait(); err != nil {
-				t.Fatalf("%s exited with %v:\n%s", shell, err, output.String())
+
+			// A prelude that does not read to EOF finishes and exits while the
+			// write is still in flight, so the pipe breaks. That is the defect
+			// under test, not a harness failure: record it and let the value
+			// assertion below report what the shell actually imported.
+			_, writeErr := io.WriteString(stdin, envScript)
+			closeErr := stdin.Close()
+			<-drained
+			waitErr := cmd.Wait()
+			if got := strings.TrimSpace(stdout.String()); got != "value=bar baz" {
+				t.Fatalf("%s imported %q, want %q\nwrite: %v\nclose: %v\nexit: %v\nstderr:\n%s",
+					shell, got, "value=bar baz", writeErr, closeErr, waitErr, stderrTail.String())
 			}
-			if got := strings.TrimSpace(output.String()); got != "value=bar baz" {
-				t.Fatalf("%s imported %q, want %q", shell, got, "value=bar baz")
+			if waitErr != nil {
+				t.Fatalf("%s exited with %v:\nstdout:\n%s\nstderr:\n%s", shell, waitErr, stdout.String(), stderrTail.String())
 			}
 		})
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +34,9 @@ const sshStdinEnvReadyTimeout = 30 * time.Second
 // race the environment sat in the pipe buffer, where even the old prelude found
 // it, and the test would have passed against the bug it exists to catch.
 func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
-	envScript, err := buildSSHEnvInitScript(map[string]string{"KANDEV_TEST_STDIN_ENV": "bar baz"})
+	marker := filepath.Join(t.TempDir(), "command-substitution-ran")
+	wantValue := "bar baz $(touch " + marker + ") `printf backtick` it's\nsecond"
+	envScript, err := buildSSHEnvInitScript(map[string]string{"KANDEV_TEST_STDIN_ENV": wantValue})
 	if err != nil {
 		t.Fatalf("buildSSHEnvInitScript() error = %v", err)
 	}
@@ -43,7 +47,7 @@ func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
 		}
 		t.Run(shell, func(t *testing.T) {
 			script := `printf '%s\n' ` + sshStdinEnvReadyMarker + " >&2\n" +
-				sshScriptWithEnvironment(`printf '%s\n' "value=${KANDEV_TEST_STDIN_ENV:-unset}"`)
+				sshScriptWithEnvironment(`printf '%s' "$KANDEV_TEST_STDIN_ENV"`)
 			cmd := exec.Command(path, "-c", script)
 			stdin, err := cmd.StdinPipe()
 			if err != nil {
@@ -110,12 +114,17 @@ func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
 			closeErr := stdin.Close()
 			<-drained
 			waitErr := cmd.Wait()
-			if got := strings.TrimSpace(stdout.String()); got != "value=bar baz" {
+			if got := stdout.String(); got != wantValue {
 				t.Fatalf("%s imported %q, want %q\nwrite: %v\nclose: %v\nexit: %v\nstderr:\n%s",
-					shell, got, "value=bar baz", writeErr, closeErr, waitErr, stderrTail.String())
+					shell, got, wantValue, writeErr, closeErr, waitErr, stderrTail.String())
 			}
 			if waitErr != nil {
 				t.Fatalf("%s exited with %v:\nstdout:\n%s\nstderr:\n%s", shell, waitErr, stdout.String(), stderrTail.String())
+			}
+			if _, statErr := os.Stat(marker); statErr == nil {
+				t.Fatalf("%s evaluated command substitution in the environment value", shell)
+			} else if !os.IsNotExist(statErr) {
+				t.Fatalf("stat command-substitution marker: %v", statErr)
 			}
 		})
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stdin_env_test.go
@@ -1,0 +1,54 @@
+package lifecycle
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSSHStdinEnvImportReadsStdinToEOF feeds the environment only after the
+// shell has started, which is the ordering sshd produces on a real target.
+// bash 3.2 (the /bin/bash on macOS) sources /dev/stdin by reading just the
+// bytes already buffered when it opens the FIFO, so the previous
+// `. /dev/stdin` prelude imported nothing there.
+func TestSSHStdinEnvImportReadsStdinToEOF(t *testing.T) {
+	envScript, err := buildSSHEnvInitScript(map[string]string{"KANDEV_TEST_STDIN_ENV": "bar baz"})
+	if err != nil {
+		t.Fatalf("buildSSHEnvInitScript() error = %v", err)
+	}
+	for _, shell := range []string{"sh", "bash", "zsh"} {
+		path, err := exec.LookPath(shell)
+		if err != nil {
+			continue
+		}
+		t.Run(shell, func(t *testing.T) {
+			cmd := exec.Command(path, "-c", sshScriptWithEnvironment(`printf '%s\n' "value=${KANDEV_TEST_STDIN_ENV:-unset}"`))
+			stdin, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatalf("stdin pipe: %v", err)
+			}
+			var output bytes.Buffer
+			cmd.Stdout = &output
+			cmd.Stderr = &output
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("start %s: %v", shell, err)
+			}
+			time.Sleep(200 * time.Millisecond)
+			if _, err := io.WriteString(stdin, envScript); err != nil {
+				t.Fatalf("write env: %v", err)
+			}
+			if err := stdin.Close(); err != nil {
+				t.Fatalf("close stdin: %v", err)
+			}
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("%s exited with %v:\n%s", shell, err, output.String())
+			}
+			if got := strings.TrimSpace(output.String()); got != "value=bar baz" {
+				t.Fatalf("%s imported %q, want %q", shell, got, "value=bar baz")
+			}
+		})
+	}
+}


### PR DESCRIPTION
On a macOS SSH target with the profile shell set to `bash`, every launch ended in `ssh: agentctl handshake returned 403` because the environment Kandev writes to the remote command's stdin never reached `agentctl`: bash 3.2, the `/bin/bash` on macOS, sources a FIFO by reading only the bytes already buffered when it opens the file, so `set -a; . /dev/stdin` raced sshd's stdin forwarding and usually imported nothing (the prepare, credential-setup, contribution, and broker-preflight wrappers used the same prelude and silently ran without their environment). Importing with `eval "$(cat)"` reads to EOF in sh, bash, and zsh and keeps the values out of process arguments and the filesystem, exactly as before.

## Validation

- New `TestSSHStdinEnvImportReadsStdinToEOF` starts sh, bash, and zsh, feeds the environment 200 ms after the shell starts, and asserts a child process sees it; it passes with this change on macOS. The old prelude fails the same delayed feed on macOS: `(sleep 0.2; printf "FOO='bar'\n") | /bin/bash -c 'set -a; . /dev/stdin; set +a; echo ${FOO:-unset}'` prints `unset`
- Updated the four tests that pinned the exact wrapper text
- `go test ./internal/agent/runtime/lifecycle/ -count=1` in `apps/backend`; the nine failures it reports on this macOS host (`TestDefaultPrepareScriptKubernetes*`, `TestWorktreePreparer_*`, `TestBuildAuthMethodsIdentityAgentOverridesEnvironment`) fail identically on unmodified `main` and are unrelated to this change
- `gofmt -l` clean; `golangci-lint` v2.9.0 on `./internal/agent/runtime/lifecycle/...` reports no issues
- Manually verified from a Kandev v0.93.0 host against a macOS 26 (arm64) SSH target: the new wrapper exports the stdin values to a child process under both `bash -lc` and `zsh -lc` over the SSH exec channel, where `. /dev/stdin` under bash imported nothing
- The repository's commit-msg and pre-commit hook checks (commitlint, harness lint, architecture lint, gofmt, golangci-lint) run by hand and pass

## Possible Improvements

Low risk: the shell text changes from sourcing a path to evaluating the same single-quoted `KEY='value'` lines. If a value ever contained a newline, `$(cat)` preserves it the same way sourcing did.

Closes #3381

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
