### PR TITLE
fix(office): stop office tasks reaching Done while stuck on an earlier workflow step

### DIFF
--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -1464,6 +1464,9 @@ func wireOfficeSvcsDependencies(
 	// reach the WebSocket broadcaster, so workflow moves have durable timeline
 	// data when the frontend refetches the task detail.
 	services.Task.SetTaskStateActivityLogger(services.OfficeSvcs.Dashboard)
+	// Route an Office task's terminal-step completion through Office's own
+	// status pipeline (approval gate included) instead of a raw state write.
+	orchestratorSvc.SetOfficeTaskStatusUpdater(services.OfficeSvcs.Dashboard)
 	// Wire the office service as the retry canceller for task reassignment.
 	services.OfficeSvcs.Dashboard.SetRetryCanceller(services.Office)
 	// Wire the office service as the task canceller for status→cancelled hard-cancels.

--- a/apps/backend/internal/office/dashboard/approval_gate_step_test.go
+++ b/apps/backend/internal/office/dashboard/approval_gate_step_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/office/dashboard"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+	"github.com/kandev/kandev/internal/office/shared"
 )
 
 // insertTestTaskAtNonTerminalStep creates a two-step workflow (stepID at
@@ -88,5 +91,50 @@ func TestUpdateTaskStatus_AgentDoneAtReview_NoApproverSeats_RedirectsToReview(t 
 	}
 	if state := readTaskState(t, deps, "rv1"); state != "REVIEW" {
 		t.Errorf("state = %q, want REVIEW (task must never read COMPLETED while on the Review step)", state)
+	}
+}
+
+// erroringTerminalStepRepo wraps a real *sqlite.Repository, replacing
+// IsTaskWorkflowStepTerminal with one that always fails, to test the
+// gate's behavior on a transient lookup error.
+type erroringTerminalStepRepo struct {
+	*sqlite.Repository
+	err error
+}
+
+func (r *erroringTerminalStepRepo) IsTaskWorkflowStepTerminal(context.Context, string) (bool, error) {
+	return false, r.err
+}
+
+// TestUpdateTaskStatus_TerminalStepLookupError_AbortsWithoutPersistingRedirect
+// is the MAJOR-2 regression test (review round 2): a transient
+// IsTaskWorkflowStepTerminal error must not be folded into "not terminal"
+// and persisted as a REVIEW redirect, since nothing then re-evaluates the
+// gate and the task is stranded reporting in_review forever with no
+// approver to clear it. A lookup error must abort the whole status update
+// (a plain, non-ApprovalsPendingError error) and leave the prior state
+// intact — still refusing the "done" write, but without a bogus redirect.
+func TestUpdateTaskStatus_TerminalStepLookupError_AbortsWithoutPersistingRedirect(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTask(t, deps.db, "lookup-err", "ws-g", "LE", "in_progress", 1)
+
+	wrapped := &erroringTerminalStepRepo{Repository: deps.repo, err: errors.New("database is locked")}
+	log := logger.Default()
+	svc := dashboard.NewDashboardService(wrapped, log, shared.NewActivityLogger(deps.repo, log), deps.agents, &stubCostChecker{})
+
+	err := svc.UpdateTaskStatus(context.Background(), dashboard.TaskStatusUpdateRequest{
+		TaskID:    "lookup-err",
+		NewStatus: "done",
+	})
+
+	var pending *dashboard.ApprovalsPendingError
+	if errors.As(err, &pending) {
+		t.Fatalf("err = %v, want a plain error: a lookup failure is not a confirmed redirect", err)
+	}
+	if err == nil {
+		t.Fatal("err = nil, want an error: a lookup failure must not silently let the task complete")
+	}
+	if state := readTaskState(t, deps, "lookup-err"); state != "in_progress" {
+		t.Errorf("state = %q, want unchanged in_progress (no redirect and no completion persisted)", state)
 	}
 }

--- a/apps/backend/internal/office/dashboard/approval_gate_step_test.go
+++ b/apps/backend/internal/office/dashboard/approval_gate_step_test.go
@@ -94,6 +94,43 @@ func TestUpdateTaskStatus_AgentDoneAtReview_NoApproverSeats_RedirectsToReview(t 
 	}
 }
 
+// insertChannelShapedTask inserts a task exactly as
+// office/repository/sqlite/channels.go CreateChannelTask does: no
+// workflow_id, no workflow_step_id. Channel tasks (the long-lived
+// Telegram/Slack/email assistant tasks) are the production shape that
+// exercises the "no workflow step at all" branch of the approval gate.
+func insertChannelShapedTask(t *testing.T, db sqlxExecutor, id, wsID, title string) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO tasks (id, workspace_id, title, state, created_at, updated_at)
+		VALUES (?, ?, ?, 'IN_PROGRESS', datetime('now'), datetime('now'))
+	`, id, wsID, title); err != nil {
+		t.Fatalf("insert channel-shaped task: %v", err)
+	}
+}
+
+// TestUpdateTaskStatus_ChannelTaskNoWorkflowStep_ReachesDone is the
+// regression test for Build round 5, Finding 1: a task with no
+// workflow_step_id at all (the channel-task shape) must still be able to
+// reach done. IsTaskWorkflowStepTerminal reporting "not terminal" for a
+// step that does not exist is not the same fact as a task sitting on a
+// genuine non-terminal step, and the gate must not conflate the two.
+func TestUpdateTaskStatus_ChannelTaskNoWorkflowStep_ReachesDone(t *testing.T) {
+	deps := newTestDeps(t)
+	insertChannelShapedTask(t, deps.db, "chan1", "ws-g", "Channel task")
+
+	err := deps.svc.UpdateTaskStatus(context.Background(), dashboard.TaskStatusUpdateRequest{
+		TaskID:    "chan1",
+		NewStatus: "done",
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil: a task with no workflow step must fall through to the approver check", err)
+	}
+	if state := readTaskState(t, deps, "chan1"); state != "COMPLETED" {
+		t.Errorf("state = %q, want COMPLETED", state)
+	}
+}
+
 // erroringTerminalStepRepo wraps a real *sqlite.Repository, replacing
 // IsTaskWorkflowStepTerminal with one that always fails, to test the
 // gate's behavior on a transient lookup error.
@@ -102,8 +139,8 @@ type erroringTerminalStepRepo struct {
 	err error
 }
 
-func (r *erroringTerminalStepRepo) IsTaskWorkflowStepTerminal(context.Context, string) (bool, error) {
-	return false, r.err
+func (r *erroringTerminalStepRepo) IsTaskWorkflowStepTerminal(context.Context, string) (bool, bool, error) {
+	return false, false, r.err
 }
 
 // TestUpdateTaskStatus_TerminalStepLookupError_AbortsWithoutPersistingRedirect

--- a/apps/backend/internal/office/dashboard/approval_gate_step_test.go
+++ b/apps/backend/internal/office/dashboard/approval_gate_step_test.go
@@ -1,0 +1,92 @@
+package dashboard_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/dashboard"
+)
+
+// insertTestTaskAtNonTerminalStep creates a two-step workflow (stepID at
+// position 0, named stepName; a later step at position 1) and a task
+// pointing at stepID, so IsTaskWorkflowStepTerminal reports false for it
+// regardless of the step's own name.
+func insertTestTaskAtNonTerminalStep(t *testing.T, db sqlxExecutor, id, wsID, title, state, stepName string) {
+	t.Helper()
+	workflowID := "wf-nonterm-" + id
+	stepID := "step-" + id
+	if _, err := db.Exec(`
+		INSERT INTO workflows (id, workspace_id, name, created_at, updated_at)
+		VALUES (?, ?, 'Test Workflow', datetime('now'), datetime('now'))
+	`, workflowID, wsID); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO workflow_steps (id, workflow_id, name, position, created_at, updated_at)
+		VALUES (?, ?, ?, 0, datetime('now'), datetime('now'))
+	`, stepID, workflowID, stepName); err != nil {
+		t.Fatalf("seed step: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO workflow_steps (id, workflow_id, name, position, created_at, updated_at)
+		VALUES (?, ?, 'Next', 1, datetime('now'), datetime('now'))
+	`, stepID+"-next", workflowID); err != nil {
+		t.Fatalf("seed next step: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO tasks (id, workspace_id, title, state, priority, identifier, workflow_step_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'medium', ?, ?, datetime('now'), datetime('now'))
+	`, id, wsID, title, state, id, stepID); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+}
+
+// TestUpdateTaskStatus_AgentDoneAtWork_RedirectsToReview is test-matrix
+// case (1): an agent-authored "done" write from a non-terminal ("Work")
+// step is redirected to in_review regardless of approvers — the task
+// never had any.
+func TestUpdateTaskStatus_AgentDoneAtWork_RedirectsToReview(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTaskAtNonTerminalStep(t, deps.db, "wk1", "ws-g", "WK", "in_progress", "Work")
+
+	err := deps.svc.UpdateTaskStatus(context.Background(), dashboard.TaskStatusUpdateRequest{
+		TaskID:    "wk1",
+		NewStatus: "done",
+	})
+	var pending *dashboard.ApprovalsPendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("err = %v, want *ApprovalsPendingError", err)
+	}
+	if len(pending.Pending) != 0 {
+		t.Errorf("pending = %v, want none: the redirect is on step position, not approvers", pending.Pending)
+	}
+	if state := readTaskState(t, deps, "wk1"); state != "REVIEW" {
+		t.Errorf("state = %q, want REVIEW", state)
+	}
+}
+
+// TestUpdateTaskStatus_AgentDoneAtReview_NoApproverSeats_RedirectsToReview
+// is test-matrix case (2) and the regression test for the live bug: five
+// Office tasks were observed reading COMPLETED while sitting on the
+// Review step. The old gate only checked for pending approvers, and a
+// task at Review has never entered the Approval step that creates
+// approver seats — so pendingApprovers always returned empty and the
+// gate never fired for exactly this case. This must fail against a gate
+// that only checks approvers, and pass once it also checks step position.
+func TestUpdateTaskStatus_AgentDoneAtReview_NoApproverSeats_RedirectsToReview(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTaskAtNonTerminalStep(t, deps.db, "rv1", "ws-g", "RV", "in_review", "Review")
+
+	err := deps.svc.UpdateTaskStatus(context.Background(), dashboard.TaskStatusUpdateRequest{
+		TaskID:    "rv1",
+		NewStatus: "done",
+	})
+	var pending *dashboard.ApprovalsPendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("err = %v, want *ApprovalsPendingError", err)
+	}
+	if state := readTaskState(t, deps, "rv1"); state != "REVIEW" {
+		t.Errorf("state = %q, want REVIEW (task must never read COMPLETED while on the Review step)", state)
+	}
+}

--- a/apps/backend/internal/office/dashboard/approval_gate_step_test.go
+++ b/apps/backend/internal/office/dashboard/approval_gate_step_test.go
@@ -64,6 +64,9 @@ func TestUpdateTaskStatus_AgentDoneAtWork_RedirectsToReview(t *testing.T) {
 	if len(pending.Pending) != 0 {
 		t.Errorf("pending = %v, want none: the redirect is on step position, not approvers", pending.Pending)
 	}
+	if got := pending.ReasonCode(); got != dashboard.ApprovalGateReasonWorkflowStep {
+		t.Errorf("reason = %q, want %q", got, dashboard.ApprovalGateReasonWorkflowStep)
+	}
 	if state := readTaskState(t, deps, "wk1"); state != "REVIEW" {
 		t.Errorf("state = %q, want REVIEW", state)
 	}

--- a/apps/backend/internal/office/dashboard/decisions.go
+++ b/apps/backend/internal/office/dashboard/decisions.go
@@ -38,12 +38,14 @@ const (
 const userParticipantSentinel = "user"
 
 // ApprovalsPendingError is returned by UpdateTaskStatus when a task is
-// being transitioned to "done" but one or more approvers have no
-// current approved decision recorded. The handler maps it to HTTP 409
-// and surfaces the redirected status in the response body.
+// being transitioned to "done" but either it is not yet on a terminal
+// workflow step, or it is and one or more approvers have no current
+// approved decision recorded. The handler maps it to HTTP 409 and
+// surfaces the redirected status in the response body.
 type ApprovalsPendingError struct {
 	// Pending is the list of approver agent IDs without a current
-	// approved decision.
+	// approved decision. Empty when the gate fired on the step-position
+	// check instead.
 	Pending []string
 }
 
@@ -61,8 +63,12 @@ func (e *InvalidTaskStatusError) Error() string {
 // through the Office runtime boundary.
 func (e *InvalidTaskStatusError) IsTaskStatusValidationError() {}
 
-// Error implements the error interface.
+// Error implements the error interface. An empty Pending means the gate
+// fired on the step-position check rather than on outstanding approvals.
 func (e *ApprovalsPendingError) Error() string {
+	if len(e.Pending) == 0 {
+		return "task is not on a terminal workflow step; redirected to in_review"
+	}
 	return fmt.Sprintf(
 		"approvals pending from %d approver(s): %s",
 		len(e.Pending), strings.Join(e.Pending, ","),

--- a/apps/backend/internal/office/dashboard/decisions.go
+++ b/apps/backend/internal/office/dashboard/decisions.go
@@ -29,6 +29,8 @@ const (
 	approvalCallerErrEmpty           = "caller type and id are required"
 	approvalCommentRequiredOnRequest = "comment is required for request_changes"
 	decisionStoreNotWiredErr         = "decision store not wired"
+	ApprovalGateReasonWorkflowStep   = "workflow_step"
+	ApprovalGateReasonApprovals      = "approvals"
 )
 
 // userParticipantSentinel is the participant_id used for decisions
@@ -47,6 +49,20 @@ type ApprovalsPendingError struct {
 	// approved decision. Empty when the gate fired on the step-position
 	// check instead.
 	Pending []string
+	// Reason identifies the gate that caused the redirect. It is stable API
+	// data for clients that need to distinguish workflow position from votes.
+	Reason string
+}
+
+// WorkflowStepChangedError reports that the task moved to another workflow
+// step after the completion gate read it. The caller can retry against the
+// new step without risking a stale completion write.
+type WorkflowStepChangedError struct {
+	TaskID string
+}
+
+func (e *WorkflowStepChangedError) Error() string {
+	return fmt.Sprintf("task %s workflow step changed during status update", e.TaskID)
 }
 
 // InvalidTaskStatusError identifies a caller-provided status value that the
@@ -73,6 +89,17 @@ func (e *ApprovalsPendingError) Error() string {
 		"approvals pending from %d approver(s): %s",
 		len(e.Pending), strings.Join(e.Pending, ","),
 	)
+}
+
+// ReasonCode returns the stable gate reason used in HTTP responses.
+func (e *ApprovalsPendingError) ReasonCode() string {
+	if e.Reason == "" {
+		if len(e.Pending) == 0 {
+			return ApprovalGateReasonWorkflowStep
+		}
+		return ApprovalGateReasonApprovals
+	}
+	return e.Reason
 }
 
 // PendingApproverIDs exposes the pending identities to runtime transports

--- a/apps/backend/internal/office/dashboard/decisions_test.go
+++ b/apps/backend/internal/office/dashboard/decisions_test.go
@@ -426,6 +426,34 @@ func TestUpdateTaskEndpoint_409OnApprovalGate(t *testing.T) {
 	if body["status"] != "in_review" {
 		t.Errorf("response status = %v, want in_review", body["status"])
 	}
+	if body["reason"] != dashboard.ApprovalGateReasonApprovals {
+		t.Errorf("response reason = %v, want %s", body["reason"], dashboard.ApprovalGateReasonApprovals)
+	}
+}
+
+func TestUpdateTaskEndpoint_409OnWorkflowStepGate(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTaskAtNonTerminalStep(t, deps.db, "ep-step-gate", "ws-step-gate", "Step gate", "in_progress", "Review")
+
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/office/tasks/ep-step-gate",
+		strings.NewReader(`{"status":"done"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	deps.router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["reason"] != dashboard.ApprovalGateReasonWorkflowStep {
+		t.Errorf("response reason = %v, want %s", body["reason"], dashboard.ApprovalGateReasonWorkflowStep)
+	}
+	if body["status"] != "in_review" {
+		t.Errorf("response status = %v, want in_review", body["status"])
+	}
 }
 
 // TestUpdateTaskEndpoint_409PendingApproversIncludesNames verifies that the

--- a/apps/backend/internal/office/dashboard/handler.go
+++ b/apps/backend/internal/office/dashboard/handler.go
@@ -689,16 +689,24 @@ func (h *Handler) applyTaskMutations(c *gin.Context, taskID, actorAgentID string
 }
 
 // respondStatusUpdateError translates UpdateTaskStatus errors into HTTP
-// responses. ApprovalsPendingError → 409 with a body listing pending
-// approvers (resolved to {agent_profile_id, name}) and the redirected
-// status. Everything else → 400.
+// responses. Gate errors return 409 with a stable reason, pending approvers,
+// and the redirected status. Everything else returns 400.
 func (h *Handler) respondStatusUpdateError(c *gin.Context, err error) {
 	var pending *ApprovalsPendingError
 	if errors.As(err, &pending) {
 		c.JSON(http.StatusConflict, gin.H{
 			"error":             err.Error(),
+			"reason":            pending.ReasonCode(),
 			"pending_approvers": h.svc.resolvePendingApprovers(c.Request.Context(), pending.Pending),
 			"status":            statusInReviewLowercase,
+		})
+		return
+	}
+	var stepChanged *WorkflowStepChangedError
+	if errors.As(err, &stepChanged) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  err.Error(),
+			"reason": "workflow_step_changed",
 		})
 		return
 	}

--- a/apps/backend/internal/office/dashboard/handler_test.go
+++ b/apps/backend/internal/office/dashboard/handler_test.go
@@ -282,13 +282,38 @@ func insertTestTask(t *testing.T, db *sqlx.DB, id, wsID, title, state string, pr
 	t.Helper()
 	// Give every test task a deterministic workflow_step_id so the office
 	// participant lookup (which now resolves through the task's step) has
-	// a stable target.
+	// a stable target, and back it with a last-position "Done" workflow
+	// step so the approval gate's step-position check (which the approver
+	// tests here don't otherwise exercise) treats the task as ready to
+	// complete by default.
+	stepID := "step-" + id
+	seedTerminalWorkflowStep(t, db, stepID)
 	_, err := db.Exec(`
 		INSERT INTO tasks (id, workspace_id, title, state, priority, identifier, workflow_step_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-	`, id, wsID, title, state, intPriorityLabel(priority), id, "step-"+id)
+	`, id, wsID, title, state, intPriorityLabel(priority), id, stepID)
 	if err != nil {
 		t.Fatalf("insert task %s: %v", id, err)
+	}
+}
+
+// seedTerminalWorkflowStep backs stepID with a single-step workflow whose
+// step is last-by-position and named "Done" — the shape
+// IsTaskWorkflowStepTerminal treats as terminal.
+func seedTerminalWorkflowStep(t *testing.T, db *sqlx.DB, stepID string) {
+	t.Helper()
+	workflowID := "wf-" + stepID
+	if _, err := db.Exec(`
+		INSERT OR IGNORE INTO workflows (id, workspace_id, name, created_at, updated_at)
+		VALUES (?, '', 'Test Workflow', datetime('now'), datetime('now'))
+	`, workflowID); err != nil {
+		t.Fatalf("seed workflow for step %s: %v", stepID, err)
+	}
+	if _, err := db.Exec(`
+		INSERT OR IGNORE INTO workflow_steps (id, workflow_id, name, position, created_at, updated_at)
+		VALUES (?, ?, 'Done', 0, datetime('now'), datetime('now'))
+	`, stepID, workflowID); err != nil {
+		t.Fatalf("seed terminal workflow_step %s: %v", stepID, err)
 	}
 }
 

--- a/apps/backend/internal/office/dashboard/service.go
+++ b/apps/backend/internal/office/dashboard/service.go
@@ -100,7 +100,7 @@ type Repository interface {
 	// fan-out queued for agentProfileID at (taskID, stepID). Used after a
 	// claim displaces an agent from a role.
 	CancelDisplacedParticipantRun(ctx context.Context, taskID, stepID, agentProfileID string) (int64, error)
-	IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (bool, error)
+	IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (terminal, hasStep bool, err error)
 }
 
 // DecisionStore is the workflow-domain decisions interface required by

--- a/apps/backend/internal/office/dashboard/service.go
+++ b/apps/backend/internal/office/dashboard/service.go
@@ -100,6 +100,7 @@ type Repository interface {
 	// fan-out queued for agentProfileID at (taskID, stepID). Used after a
 	// claim displaces an agent from a role.
 	CancelDisplacedParticipantRun(ctx context.Context, taskID, stepID, agentProfileID string) (int64, error)
+	IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (bool, error)
 }
 
 // DecisionStore is the workflow-domain decisions interface required by

--- a/apps/backend/internal/office/dashboard/service.go
+++ b/apps/backend/internal/office/dashboard/service.go
@@ -73,6 +73,7 @@ type Repository interface {
 	GetRunsByCommentIDs(ctx context.Context, commentIDs []string) (map[string]sqlite.CommentRunStatus, error)
 	UpdateTaskState(ctx context.Context, taskID, state string) error
 	GetTaskExecutionFields(ctx context.Context, taskID string) (*sqlite.TaskExecutionFields, error)
+	UpdateTaskStateIfWorkflowStep(ctx context.Context, taskID, expectedStepID, state string) (bool, error)
 	UpdateTaskAssignee(ctx context.Context, taskID, assigneeID string) error
 	UpdateTaskPriority(ctx context.Context, taskID, priority string) error
 	UpdateTaskProjectID(ctx context.Context, taskID, projectID string) error

--- a/apps/backend/internal/office/dashboard/service_tasks.go
+++ b/apps/backend/internal/office/dashboard/service_tasks.go
@@ -621,6 +621,10 @@ func (s *DashboardService) UpdateTaskStatus(ctx context.Context, req TaskStatusU
 	}
 
 	gateErr := s.applyApprovalGate(ctx, req.TaskID, &dbState, &req.NewStatus)
+	var pendingErr *ApprovalsPendingError
+	if gateErr != nil && !errors.As(gateErr, &pendingErr) {
+		return gateErr
+	}
 
 	if err := s.repo.UpdateTaskState(ctx, req.TaskID, dbState); err != nil {
 		return fmt.Errorf("update task state: %w", err)
@@ -688,9 +692,12 @@ func (s *DashboardService) logTaskStatusChangeActivity(ctx context.Context, req 
 // UpdateTaskStatus persists and emits the redirected status. Returns a
 // *ApprovalsPendingError when the gate fires; nil otherwise.
 //
-// The step-position check fails CLOSED: a read error is treated as
-// not-terminal (redirect), since this gate exists to stop a premature
-// "done" and silently proceeding would defeat that.
+// The step-position check fails CLOSED, but a lookup error is not the same
+// as a confirmed non-terminal step: it aborts the whole update (a plain,
+// non-ApprovalsPendingError error, leaving dbState/apiStatus untouched) so
+// the caller persists nothing rather than writing a redirect it cannot
+// justify. Only a successful read reporting "not terminal" persists the
+// in_review redirect.
 func (s *DashboardService) applyApprovalGate(
 	ctx context.Context, taskID string, dbState, apiStatus *string,
 ) error {
@@ -699,9 +706,7 @@ func (s *DashboardService) applyApprovalGate(
 	}
 	terminal, err := s.repo.IsTaskWorkflowStepTerminal(ctx, taskID)
 	if err != nil {
-		s.logger.Warn("approval gate: failed to resolve workflow step; redirecting to review",
-			zap.String("task_id", taskID), zap.Error(err))
-		terminal = false
+		return fmt.Errorf("approval gate: resolve workflow step: %w", err)
 	}
 	if !terminal {
 		*dbState = stateInReview

--- a/apps/backend/internal/office/dashboard/service_tasks.go
+++ b/apps/backend/internal/office/dashboard/service_tasks.go
@@ -599,12 +599,12 @@ type TaskStatusUpdateRequest struct {
 // (dependents unblocked, parent children-completed, reopen intent,
 // session interrupt for cancellation, etc.).
 //
-// Approval gate: when the requested status is "done" and the task has
-// approvers without a current approved decision, the persisted state
-// is redirected to in_review and the function returns a typed
-// *ApprovalsPendingError (the handler maps it to HTTP 409). The
-// req.NewStatus is updated in place so downstream side-effects see
-// the redirected status.
+// Approval gate: when the requested status is "done" and either the task
+// is not yet on a terminal workflow step, or it is and has approvers
+// without a current approved decision, the persisted state is redirected
+// to in_review and the function returns a typed *ApprovalsPendingError
+// (the handler maps it to HTTP 409). The req.NewStatus is updated in
+// place so downstream side-effects see the redirected status.
 //
 // Rework / reopen: transitions leaving in_review for todo|in_progress,
 // and transitions leaving done for any non-terminal state, supersede
@@ -682,15 +682,31 @@ func (s *DashboardService) logTaskStatusChangeActivity(ctx context.Context, req 
 		fmt.Sprintf(`{"new_status":%q}`, req.NewStatus), runID, "")
 }
 
-// applyApprovalGate redirects a "done" transition to in_review when
-// approvals are pending. Mutates dbState and apiStatus in place so the
-// rest of UpdateTaskStatus persists and emits the redirected status.
-// Returns a *ApprovalsPendingError when the gate fires; nil otherwise.
+// applyApprovalGate redirects a "done" transition to in_review when the
+// task is not yet on a terminal workflow step, or when it is but approvals
+// are pending. Mutates dbState and apiStatus in place so the rest of
+// UpdateTaskStatus persists and emits the redirected status. Returns a
+// *ApprovalsPendingError when the gate fires; nil otherwise.
+//
+// The step-position check fails CLOSED: a read error is treated as
+// not-terminal (redirect), since this gate exists to stop a premature
+// "done" and silently proceeding would defeat that.
 func (s *DashboardService) applyApprovalGate(
 	ctx context.Context, taskID string, dbState, apiStatus *string,
 ) error {
 	if *dbState != stateCompleted {
 		return nil
+	}
+	terminal, err := s.repo.IsTaskWorkflowStepTerminal(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("approval gate: failed to resolve workflow step; redirecting to review",
+			zap.String("task_id", taskID), zap.Error(err))
+		terminal = false
+	}
+	if !terminal {
+		*dbState = stateInReview
+		*apiStatus = statusInReviewLowercase
+		return &ApprovalsPendingError{}
 	}
 	pending, err := s.pendingApprovers(ctx, taskID)
 	if err != nil || len(pending) == 0 {

--- a/apps/backend/internal/office/dashboard/service_tasks.go
+++ b/apps/backend/internal/office/dashboard/service_tasks.go
@@ -588,6 +588,10 @@ type TaskStatusUpdateRequest struct {
 	// ResumeIntent=true is an explicit "pick this up again" with required
 	// follow-up comment. Forces task_reopened_via_comment.
 	ResumeIntent bool
+	// SuppressStatusActivity is used by the orchestrator when it will publish
+	// the canonical task.state_changed event that owns the activity row. Gate
+	// redirects still log here because they do not publish that event.
+	SuppressStatusActivity bool
 }
 
 // UpdateTaskStatus persists a new task status, optionally creates a comment,
@@ -620,18 +624,29 @@ func (s *DashboardService) UpdateTaskStatus(ctx context.Context, req TaskStatusU
 		preStatus = exec.State
 	}
 
-	gateErr := s.applyApprovalGate(ctx, req.TaskID, &dbState, &req.NewStatus)
+	expectedStepID := ""
+	gateErr := s.applyApprovalGate(ctx, req.TaskID, &dbState, &req.NewStatus, &expectedStepID)
 	var pendingErr *ApprovalsPendingError
 	if gateErr != nil && !errors.As(gateErr, &pendingErr) {
 		return gateErr
 	}
 
-	if err := s.repo.UpdateTaskState(ctx, req.TaskID, dbState); err != nil {
+	if dbState == stateCompleted {
+		updated, err := s.repo.UpdateTaskStateIfWorkflowStep(ctx, req.TaskID, expectedStepID, dbState)
+		if err != nil {
+			return fmt.Errorf("update task state: %w", err)
+		}
+		if !updated {
+			return &WorkflowStepChangedError{TaskID: req.TaskID}
+		}
+	} else if err := s.repo.UpdateTaskState(ctx, req.TaskID, dbState); err != nil {
 		return fmt.Errorf("update task state: %w", err)
 	}
 
 	commentID := s.maybeCreateStatusComment(ctx, req)
-	s.logTaskStatusChangeActivity(ctx, req)
+	if !req.SuppressStatusActivity || pendingErr != nil {
+		s.logTaskStatusChangeActivity(ctx, req)
+	}
 	s.publishTaskStatusChanged(ctx, req)
 	s.publishCanonicalTaskUpdated(ctx, req.TaskID)
 	s.runReactivityForStatus(ctx, req, commentID, preStatus)
@@ -705,11 +720,16 @@ func (s *DashboardService) logTaskStatusChangeActivity(ctx context.Context, req 
 // justify. Only a successful read reporting "not terminal" persists the
 // in_review redirect.
 func (s *DashboardService) applyApprovalGate(
-	ctx context.Context, taskID string, dbState, apiStatus *string,
+	ctx context.Context, taskID string, dbState, apiStatus, expectedStepID *string,
 ) error {
 	if *dbState != stateCompleted {
 		return nil
 	}
+	currentStepID, err := s.repo.GetTaskWorkflowStepID(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("approval gate: resolve task workflow step: %w", err)
+	}
+	*expectedStepID = currentStepID
 	terminal, hasStep, err := s.repo.IsTaskWorkflowStepTerminal(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("approval gate: resolve workflow step: %w", err)
@@ -717,7 +737,7 @@ func (s *DashboardService) applyApprovalGate(
 	if hasStep && !terminal {
 		*dbState = stateInReview
 		*apiStatus = statusInReviewLowercase
-		return &ApprovalsPendingError{}
+		return &ApprovalsPendingError{Reason: ApprovalGateReasonWorkflowStep}
 	}
 	pending, err := s.pendingApprovers(ctx, taskID)
 	if err != nil || len(pending) == 0 {
@@ -725,7 +745,7 @@ func (s *DashboardService) applyApprovalGate(
 	}
 	*dbState = stateInReview
 	*apiStatus = statusInReviewLowercase
-	return &ApprovalsPendingError{Pending: pending}
+	return &ApprovalsPendingError{Pending: pending, Reason: ApprovalGateReasonApprovals}
 }
 
 // maybeCreateStatusComment creates the optional status-change comment

--- a/apps/backend/internal/office/dashboard/service_tasks.go
+++ b/apps/backend/internal/office/dashboard/service_tasks.go
@@ -687,10 +687,16 @@ func (s *DashboardService) logTaskStatusChangeActivity(ctx context.Context, req 
 }
 
 // applyApprovalGate redirects a "done" transition to in_review when the
-// task is not yet on a terminal workflow step, or when it is but approvals
-// are pending. Mutates dbState and apiStatus in place so the rest of
-// UpdateTaskStatus persists and emits the redirected status. Returns a
-// *ApprovalsPendingError when the gate fires; nil otherwise.
+// task is on a non-terminal workflow step, or when it is terminal (or has
+// no workflow step at all) but approvals are pending. Mutates dbState and
+// apiStatus in place so the rest of UpdateTaskStatus persists and emits
+// the redirected status. Returns a *ApprovalsPendingError when the gate
+// fires; nil otherwise.
+//
+// A task with no resolvable workflow step (e.g. a channel task, which is
+// never placed on a workflow) has nowhere to advance to, so it falls
+// through to the approver check exactly like a terminal-step task rather
+// than being redirected forever.
 //
 // The step-position check fails CLOSED, but a lookup error is not the same
 // as a confirmed non-terminal step: it aborts the whole update (a plain,
@@ -704,11 +710,11 @@ func (s *DashboardService) applyApprovalGate(
 	if *dbState != stateCompleted {
 		return nil
 	}
-	terminal, err := s.repo.IsTaskWorkflowStepTerminal(ctx, taskID)
+	terminal, hasStep, err := s.repo.IsTaskWorkflowStepTerminal(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("approval gate: resolve workflow step: %w", err)
 	}
-	if !terminal {
+	if hasStep && !terminal {
 		*dbState = stateInReview
 		*apiStatus = statusInReviewLowercase
 		return &ApprovalsPendingError{}

--- a/apps/backend/internal/office/dashboard/status_change_activity_test.go
+++ b/apps/backend/internal/office/dashboard/status_change_activity_test.go
@@ -145,3 +145,20 @@ func TestUpdateTaskStatus_LogsActivityBeforePublishingEvent(t *testing.T) {
 			"the WS broadcast (and any refetch it triggers) could race ahead of the activity write")
 	}
 }
+
+func TestUpdateTaskStatus_SuppressStatusActivityLeavesCanonicalEventOwner(t *testing.T) {
+	deps := newTestDeps(t)
+	insertTestTask(t, deps.db, "suppressed-activity", "ws-suppressed", "Suppressed", "todo", 0)
+
+	if err := deps.svc.UpdateTaskStatus(context.Background(), dashboard.TaskStatusUpdateRequest{
+		TaskID:                 "suppressed-activity",
+		NewStatus:              "in_progress",
+		SuppressStatusActivity: true,
+	}); err != nil {
+		t.Fatalf("update task status: %v", err)
+	}
+
+	if hasStatusChangeActivity(t, deps, "suppressed-activity", "ws-suppressed") {
+		t.Fatal("status activity was written even though the canonical state event owns it")
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -97,17 +97,37 @@ type ParticipantWriteOutcome string
 // Returns (false, false, nil) when the task has no resolvable step — a
 // task with no workflow step at all is not the same fact as a task sitting
 // on a genuine non-terminal step, and callers must not conflate the two.
+//
+// A task can also carry a nonempty workflow_step_id that no longer resolves:
+// DeleteStep clears queued_for_step_id references but deliberately leaves
+// tasks.workflow_step_id alone for tasks that were actually sitting on the
+// deleted step, so that reference goes dangling. That is not the same fact
+// as "no step" either — treating it as hasStep=false would let a task whose
+// step vanished out from under it bypass the position gate entirely, so this
+// case returns an error instead and lets the caller fail closed.
 func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (terminal, hasStep bool, err error) {
+	var stepID sql.NullString
+	err = r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT workflow_step_id FROM tasks WHERE id = ?
+	`), taskID).Scan(&stepID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	if !stepID.Valid || stepID.String == "" {
+		return false, false, nil
+	}
+
 	var workflowID string
 	var position int
 	err = r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
-		SELECT ws.workflow_id, ws.position
-		FROM tasks t
-		JOIN workflow_steps ws ON ws.id = t.workflow_step_id
-		WHERE t.id = ?
-	`), taskID).Scan(&workflowID, &position)
+		SELECT workflow_id, position FROM workflow_steps WHERE id = ?
+	`), stepID.String).Scan(&workflowID, &position)
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, false, nil
+		return false, false, fmt.Errorf(
+			"workflow step %q referenced by task %q no longer exists", stepID.String, taskID)
 	}
 	if err != nil {
 		return false, false, err

--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -83,6 +83,41 @@ func (r *Repository) GetWorkflowStepStageType(ctx context.Context, stepID string
 // role slate.
 type ParticipantWriteOutcome string
 
+// IsTaskWorkflowStepTerminal reports whether a task's current workflow step
+// is terminal by the existing board convention: last by position and named
+// done/complete/completed/approved (models.IsTerminalStepName). Mirrors
+// orchestrator.workflowStepIsTerminal, which this package cannot reach
+// directly since it depends on the workflow step store, not this repo.
+// Returns false, nil when the task has no resolvable step.
+func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (bool, error) {
+	var workflowID, name string
+	var position int
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT ws.workflow_id, ws.position, ws.name
+		FROM tasks t
+		JOIN workflow_steps ws ON ws.id = t.workflow_step_id
+		WHERE t.id = ?
+	`), taskID).Scan(&workflowID, &position, &name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	var hasNext bool
+	err = r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT EXISTS(SELECT 1 FROM workflow_steps WHERE workflow_id = ? AND position > ?)
+	`), workflowID, position).Scan(&hasNext)
+	if err != nil {
+		return false, err
+	}
+	if hasNext {
+		return false, nil
+	}
+	return models.IsTerminalStepName(name), nil
+}
+
 const (
 	// ParticipantWriteOutcomeClaimed means an existing unclaimed "auto"
 	// seat was reassigned to the named agent profile and marked "manual".

--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -84,20 +84,25 @@ func (r *Repository) GetWorkflowStepStageType(ctx context.Context, stepID string
 type ParticipantWriteOutcome string
 
 // IsTaskWorkflowStepTerminal reports whether a task's current workflow step
-// is terminal by the existing board convention: last by position and named
-// done/complete/completed/approved (models.IsTerminalStepName). Mirrors
-// orchestrator.workflowStepIsTerminal, which this package cannot reach
-// directly since it depends on the workflow step store, not this repo.
+// is the last step, by position, in its workflow. Unlike
+// orchestrator.workflowStepIsTerminal, this does not additionally require
+// the step name to match models.IsTerminalStepName: a workflow's final
+// column is terminal regardless of what its author named it, so this gate
+// never locks a task out of completion just because the last step isn't
+// named done/complete/completed/approved.
+// workflowStepIsTerminal keeps the name test because it decides whether a
+// step *move* should auto-complete — a different decision from "may this
+// task be marked done".
 // Returns false, nil when the task has no resolvable step.
 func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (bool, error) {
-	var workflowID, name string
+	var workflowID string
 	var position int
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
-		SELECT ws.workflow_id, ws.position, ws.name
+		SELECT ws.workflow_id, ws.position
 		FROM tasks t
 		JOIN workflow_steps ws ON ws.id = t.workflow_step_id
 		WHERE t.id = ?
-	`), taskID).Scan(&workflowID, &position, &name)
+	`), taskID).Scan(&workflowID, &position)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -112,10 +117,7 @@ func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID stri
 	if err != nil {
 		return false, err
 	}
-	if hasNext {
-		return false, nil
-	}
-	return models.IsTerminalStepName(name), nil
+	return !hasNext, nil
 }
 
 const (

--- a/apps/backend/internal/office/repository/sqlite/participants.go
+++ b/apps/backend/internal/office/repository/sqlite/participants.go
@@ -84,30 +84,33 @@ func (r *Repository) GetWorkflowStepStageType(ctx context.Context, stepID string
 type ParticipantWriteOutcome string
 
 // IsTaskWorkflowStepTerminal reports whether a task's current workflow step
-// is the last step, by position, in its workflow. Unlike
-// orchestrator.workflowStepIsTerminal, this does not additionally require
-// the step name to match models.IsTerminalStepName: a workflow's final
-// column is terminal regardless of what its author named it, so this gate
-// never locks a task out of completion just because the last step isn't
-// named done/complete/completed/approved.
+// is the last step, by position, in its workflow, and whether the task has
+// a resolvable step at all. Unlike orchestrator.workflowStepIsTerminal,
+// terminal does not additionally require the step name to match
+// models.IsTerminalStepName: a workflow's final column is terminal
+// regardless of what its author named it, so this gate never locks a task
+// out of completion just because the last step isn't named
+// done/complete/completed/approved.
 // workflowStepIsTerminal keeps the name test because it decides whether a
 // step *move* should auto-complete — a different decision from "may this
 // task be marked done".
-// Returns false, nil when the task has no resolvable step.
-func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (bool, error) {
+// Returns (false, false, nil) when the task has no resolvable step — a
+// task with no workflow step at all is not the same fact as a task sitting
+// on a genuine non-terminal step, and callers must not conflate the two.
+func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID string) (terminal, hasStep bool, err error) {
 	var workflowID string
 	var position int
-	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+	err = r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
 		SELECT ws.workflow_id, ws.position
 		FROM tasks t
 		JOIN workflow_steps ws ON ws.id = t.workflow_step_id
 		WHERE t.id = ?
 	`), taskID).Scan(&workflowID, &position)
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+		return false, false, nil
 	}
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	var hasNext bool
@@ -115,9 +118,9 @@ func (r *Repository) IsTaskWorkflowStepTerminal(ctx context.Context, taskID stri
 		SELECT EXISTS(SELECT 1 FROM workflow_steps WHERE workflow_id = ? AND position > ?)
 	`), workflowID, position).Scan(&hasNext)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	return !hasNext, nil
+	return !hasNext, true, nil
 }
 
 const (

--- a/apps/backend/internal/office/repository/sqlite/tasks.go
+++ b/apps/backend/internal/office/repository/sqlite/tasks.go
@@ -120,6 +120,37 @@ func (r *Repository) UpdateTaskState(ctx context.Context, taskID, state string) 
 	return nil
 }
 
+// UpdateTaskStateIfWorkflowStep updates a task only when its workflow step
+// still matches the value read by the caller. This closes the validation-to-
+// write window for status gates that depend on the current workflow step.
+func (r *Repository) UpdateTaskStateIfWorkflowStep(
+	ctx context.Context, taskID, expectedStepID, state string,
+) (bool, error) {
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE tasks
+		SET state = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND COALESCE(workflow_step_id, '') = ?
+	`), state, taskID, expectedStepID)
+	if err != nil {
+		return false, err
+	}
+	rows, _ := result.RowsAffected()
+	if rows > 0 {
+		return true, nil
+	}
+
+	var exists int
+	if err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT 1 FROM tasks WHERE id = ?
+	`), taskID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("task not found: %s", taskID)
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 // UpdateTaskAssignee writes (or clears) the per-task runner participant
 // row for a task. ADR 0005 Wave F replaced the legacy
 // tasks.assignee_agent_profile_id column with a 'runner' row in

--- a/apps/backend/internal/office/repository/sqlite/tasks_test.go
+++ b/apps/backend/internal/office/repository/sqlite/tasks_test.go
@@ -73,7 +73,10 @@ func newSearchTestRepo(t *testing.T) *sqlite.Repository {
 	if _, err := repo.ExecRaw(ctx, `
 		CREATE TABLE IF NOT EXISTS workflow_steps (
 			id TEXT PRIMARY KEY,
-			agent_profile_id TEXT NOT NULL DEFAULT ''
+			agent_profile_id TEXT NOT NULL DEFAULT '',
+			workflow_id TEXT NOT NULL DEFAULT '',
+			position INTEGER NOT NULL DEFAULT 0,
+			name TEXT NOT NULL DEFAULT ''
 		)
 	`); err != nil {
 		t.Fatalf("create workflow_steps table: %v", err)

--- a/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
+++ b/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
@@ -30,12 +30,13 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 	seedStep(t, repo, ctx, "step-approval", "wf-office", 3, "Approval")
 	seedStep(t, repo, ctx, "step-done", "wf-office", 4, "Done")
 
-	// A single-step workflow whose one step is misleadingly named "Done"
-	// but is not last-by-position relative to a later step in the SAME
-	// workflow — exercises the position half of the check independent of
-	// the name half.
+	// A workflow whose last step is misleadingly named "Done" but is not
+	// last-by-position — exercises that position, not name, decides
+	// terminality. step-mixed-last carries a name that would fail
+	// models.IsTerminalStepName (e.g. "PR", matching improve-kandev.yml's
+	// real last step) to prove the name is no longer consulted at all.
 	seedStep(t, repo, ctx, "step-early-done", "wf-mixed", 0, "Done")
-	seedStep(t, repo, ctx, "step-mixed-last", "wf-mixed", 1, "Custom")
+	seedStep(t, repo, ctx, "step-mixed-last", "wf-mixed", 1, "PR")
 
 	seedParticipantTask(t, repo, "task-backlog", "step-backlog")
 	seedParticipantTask(t, repo, "task-work", "step-work")
@@ -57,7 +58,7 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 		{"approval: not last position", "task-approval", false},
 		{"done: last position and terminal name", "task-done", true},
 		{"named Done but not last position", "task-early-done", false},
-		{"last position but non-terminal name", "task-mixed-last", false},
+		{"last position with non-terminal name is still terminal", "task-mixed-last", true},
 		{"no workflow_step_id", "task-no-step", false},
 		{"missing task", "task-missing", false},
 	}

--- a/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
+++ b/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
@@ -48,28 +48,32 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 	seedParticipantTask(t, repo, "task-no-step", "")
 
 	cases := []struct {
-		name   string
-		taskID string
-		want   bool
+		name        string
+		taskID      string
+		want        bool
+		wantHasStep bool
 	}{
-		{"backlog: not last position", "task-backlog", false},
-		{"work: not last position", "task-work", false},
-		{"review: not last position (this is the live bug's step)", "task-review", false},
-		{"approval: not last position", "task-approval", false},
-		{"done: last position and terminal name", "task-done", true},
-		{"named Done but not last position", "task-early-done", false},
-		{"last position with non-terminal name is still terminal", "task-mixed-last", true},
-		{"no workflow_step_id", "task-no-step", false},
-		{"missing task", "task-missing", false},
+		{"backlog: not last position", "task-backlog", false, true},
+		{"work: not last position", "task-work", false, true},
+		{"review: not last position (this is the live bug's step)", "task-review", false, true},
+		{"approval: not last position", "task-approval", false, true},
+		{"done: last position and terminal name", "task-done", true, true},
+		{"named Done but not last position", "task-early-done", false, true},
+		{"last position with non-terminal name is still terminal", "task-mixed-last", true, true},
+		{"no workflow_step_id", "task-no-step", false, false},
+		{"missing task", "task-missing", false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := repo.IsTaskWorkflowStepTerminal(ctx, tc.taskID)
+			got, hasStep, err := repo.IsTaskWorkflowStepTerminal(ctx, tc.taskID)
 			if err != nil {
 				t.Fatalf("IsTaskWorkflowStepTerminal: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("got %v, want %v", got, tc.want)
+				t.Errorf("terminal = %v, want %v", got, tc.want)
+			}
+			if hasStep != tc.wantHasStep {
+				t.Errorf("hasStep = %v, want %v", hasStep, tc.wantHasStep)
 			}
 		})
 	}

--- a/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
+++ b/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
@@ -46,6 +46,10 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 	seedParticipantTask(t, repo, "task-early-done", "step-early-done")
 	seedParticipantTask(t, repo, "task-mixed-last", "step-mixed-last")
 	seedParticipantTask(t, repo, "task-no-step", "")
+	// step-deleted-xyz is never seeded into workflow_steps: this reproduces a
+	// task left behind by DeleteStep, which clears queued_for_step_id but not
+	// workflow_step_id for a task actually sitting on the deleted step.
+	seedParticipantTask(t, repo, "task-dangling-step", "step-deleted-xyz")
 
 	cases := []struct {
 		name        string
@@ -77,4 +81,11 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("dangling workflow_step_id fails closed with an error, not hasStep=false", func(t *testing.T) {
+		_, _, err := repo.IsTaskWorkflowStepTerminal(ctx, "task-dangling-step")
+		if err == nil {
+			t.Fatal("IsTaskWorkflowStepTerminal: want error for a dangling workflow_step_id, got nil")
+		}
+	})
 }

--- a/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
+++ b/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
@@ -1,0 +1,75 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// seedStep inserts a workflow_steps row with the given workflow, position,
+// and name — the three columns IsTaskWorkflowStepTerminal reads.
+func seedStep(t *testing.T, repo *sqlite.Repository, ctx context.Context, id, workflowID string, position int, name string) {
+	t.Helper()
+	if _, err := repo.ExecRaw(ctx, `
+		INSERT INTO workflow_steps (id, workflow_id, position, name)
+		VALUES (?, ?, ?, ?)
+	`, id, workflowID, position, name); err != nil {
+		t.Fatalf("insert workflow_step %s: %v", id, err)
+	}
+}
+
+func TestIsTaskWorkflowStepTerminal(t *testing.T) {
+	repo := newSearchTestRepo(t)
+	ctx := context.Background()
+
+	// office-default shape: Backlog(0) -> Work(1) -> Review(2) -> Approval(3) -> Done(4).
+	seedStep(t, repo, ctx, "step-backlog", "wf-office", 0, "Backlog")
+	seedStep(t, repo, ctx, "step-work", "wf-office", 1, "Work")
+	seedStep(t, repo, ctx, "step-review", "wf-office", 2, "Review")
+	seedStep(t, repo, ctx, "step-approval", "wf-office", 3, "Approval")
+	seedStep(t, repo, ctx, "step-done", "wf-office", 4, "Done")
+
+	// A single-step workflow whose one step is misleadingly named "Done"
+	// but is not last-by-position relative to a later step in the SAME
+	// workflow — exercises the position half of the check independent of
+	// the name half.
+	seedStep(t, repo, ctx, "step-early-done", "wf-mixed", 0, "Done")
+	seedStep(t, repo, ctx, "step-mixed-last", "wf-mixed", 1, "Custom")
+
+	seedParticipantTask(t, repo, "task-backlog", "step-backlog")
+	seedParticipantTask(t, repo, "task-work", "step-work")
+	seedParticipantTask(t, repo, "task-review", "step-review")
+	seedParticipantTask(t, repo, "task-approval", "step-approval")
+	seedParticipantTask(t, repo, "task-done", "step-done")
+	seedParticipantTask(t, repo, "task-early-done", "step-early-done")
+	seedParticipantTask(t, repo, "task-mixed-last", "step-mixed-last")
+	seedParticipantTask(t, repo, "task-no-step", "")
+
+	cases := []struct {
+		name   string
+		taskID string
+		want   bool
+	}{
+		{"backlog: not last position", "task-backlog", false},
+		{"work: not last position", "task-work", false},
+		{"review: not last position (this is the live bug's step)", "task-review", false},
+		{"approval: not last position", "task-approval", false},
+		{"done: last position and terminal name", "task-done", true},
+		{"named Done but not last position", "task-early-done", false},
+		{"last position but non-terminal name", "task-mixed-last", false},
+		{"no workflow_step_id", "task-no-step", false},
+		{"missing task", "task-missing", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := repo.IsTaskWorkflowStepTerminal(ctx, tc.taskID)
+			if err != nil {
+				t.Fatalf("IsTaskWorkflowStepTerminal: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
+++ b/apps/backend/internal/office/repository/sqlite/terminal_step_test.go
@@ -89,3 +89,38 @@ func TestIsTaskWorkflowStepTerminal(t *testing.T) {
 		}
 	})
 }
+
+func TestUpdateTaskStateIfWorkflowStepRequiresCurrentStep(t *testing.T) {
+	repo := newSearchTestRepo(t)
+	ctx := context.Background()
+	seedParticipantTask(t, repo, "task-state-cas", "step-current")
+
+	updated, err := repo.UpdateTaskStateIfWorkflowStep(ctx, "task-state-cas", "step-old", "COMPLETED")
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfWorkflowStep (stale): %v", err)
+	}
+	if updated {
+		t.Fatal("stale workflow step updated the task")
+	}
+	var state string
+	if err := repo.ReaderDB().Get(&state, `SELECT state FROM tasks WHERE id = 'task-state-cas'`); err != nil {
+		t.Fatalf("read unchanged state: %v", err)
+	}
+	if state != "TODO" {
+		t.Fatalf("state after stale write = %q, want TODO", state)
+	}
+
+	updated, err = repo.UpdateTaskStateIfWorkflowStep(ctx, "task-state-cas", "step-current", "COMPLETED")
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfWorkflowStep (current): %v", err)
+	}
+	if !updated {
+		t.Fatal("current workflow step did not update the task")
+	}
+	if err := repo.ReaderDB().Get(&state, `SELECT state FROM tasks WHERE id = 'task-state-cas'`); err != nil {
+		t.Fatalf("read updated state: %v", err)
+	}
+	if state != "COMPLETED" {
+		t.Fatalf("state after current write = %q, want COMPLETED", state)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -68,17 +68,17 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 			zap.Error(err))
 		return
 	}
-	if task.IsFromOffice {
-		s.taskRuntimeStateMu.Unlock()
-		s.markOfficeTaskCompletedForTerminalStep(ctx, task)
-		return
-	}
 	if terminalStepID != "" && task.WorkflowStepID != terminalStepID {
 		s.taskRuntimeStateMu.Unlock()
 		return
 	}
 	if models.IsTerminalTaskState(task.State) {
 		s.taskRuntimeStateMu.Unlock()
+		return
+	}
+	if task.IsFromOffice {
+		s.taskRuntimeStateMu.Unlock()
+		s.markOfficeTaskCompletedForTerminalStep(ctx, task)
 		return
 	}
 	oldState := task.State

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -77,8 +77,9 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 		return
 	}
 	if task.IsFromOffice {
+		oldState := task.State
 		s.taskRuntimeStateMu.Unlock()
-		s.markOfficeTaskCompletedForTerminalStep(ctx, task)
+		s.markOfficeTaskCompletedForTerminalStep(ctx, task, oldState)
 		return
 	}
 	oldState := task.State
@@ -103,8 +104,16 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 // UpdateTaskStatus persists a redirect to in_review and then returns a
 // typed *dashboard.ApprovalsPendingError when the gate fires — the write
 // has already succeeded, so that return is not a failure and is not
-// logged as one.
-func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, task *models.Task) {
+// logged as one, and no completion side-effects fire below: the redirect
+// is not a completion.
+//
+// A nil error means the gate did not redirect, so the seam persisted
+// "done" (state = COMPLETED). That path must still carry the same
+// side-effects the raw completion write does — publishing task.updated /
+// task.state_changed and driving the parent's on_children_completed
+// trigger — or dependency resolution, the parent workflow transition, and
+// every task.updated subscriber silently stop seeing Office completions.
+func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, task *models.Task, oldState v1.TaskState) {
 	if s.officeTaskStatusUpdater == nil {
 		// No seam wired (partial wiring, or a test): skip the write rather
 		// than falling through to the raw path, which would bypass the gate.
@@ -115,11 +124,19 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 		NewStatus: "done",
 	})
 	var pending *dashboard.ApprovalsPendingError
-	if err != nil && !errors.As(err, &pending) {
-		s.logger.Warn("terminal step completion: office status update failed",
-			zap.String("task_id", task.ID),
-			zap.Error(err))
+	if err != nil {
+		if !errors.As(err, &pending) {
+			s.logger.Warn("terminal step completion: office status update failed",
+				zap.String("task_id", task.ID),
+				zap.Error(err))
+		}
+		return
 	}
+	task.State = v1.TaskStateCompleted
+	task.UpdatedAt = time.Now().UTC()
+	s.publishTaskUpdated(ctx, task)
+	s.publishTaskStateChanged(ctx, task, oldState)
+	s.processParentChildrenCompletedForTaskState(ctx, task.ID, v1.TaskStateCompleted)
 }
 
 func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID string) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -122,6 +122,15 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 // that lock: whichever delivery gets there first does the write and fires
 // the side effects below; a second, now-redundant delivery finds the task
 // already terminal and returns without calling the seam a second time.
+//
+// The lock is released as soon as the write (or redirect) is durable and
+// before any of the side effects below run, for the same reason the caller
+// releases taskRuntimeStateMu early: processParentChildrenCompletedForTaskState
+// walks up into the parent's own on_children_completed handling, which can
+// itself reach this same lock family (for an Office parent) or
+// lockChildCompletionOperation. Holding this task's lock across that call
+// would invert lock order against a concurrent completion elsewhere in the
+// same ancestry and risk deadlock.
 func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, taskID string) {
 	if s.officeTaskStatusUpdater == nil {
 		// No seam wired (partial wiring, or a test): skip the write rather
@@ -130,16 +139,17 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 	}
 
 	unlock := s.lockOfficeTerminalCompletion(taskID)
-	defer unlock()
 
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
+		unlock()
 		s.logger.Warn("terminal step completion: failed to reload office task",
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		return
 	}
 	if models.IsTerminalTaskState(task.State) {
+		unlock()
 		return
 	}
 	oldState := task.State
@@ -150,6 +160,7 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 	})
 	var pending *dashboard.ApprovalsPendingError
 	if err != nil {
+		unlock()
 		if !errors.As(err, &pending) {
 			s.logger.Warn("terminal step completion: office status update failed",
 				zap.String("task_id", task.ID),
@@ -157,6 +168,8 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 		}
 		return
 	}
+	unlock()
+
 	task.State = v1.TaskStateCompleted
 	task.UpdatedAt = time.Now().UTC()
 	s.publishTaskUpdated(ctx, task)

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/office/dashboard"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
@@ -66,6 +68,11 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 			zap.Error(err))
 		return
 	}
+	if task.IsFromOffice {
+		s.taskRuntimeStateMu.Unlock()
+		s.markOfficeTaskCompletedForTerminalStep(ctx, task)
+		return
+	}
 	if terminalStepID != "" && task.WorkflowStepID != terminalStepID {
 		s.taskRuntimeStateMu.Unlock()
 		return
@@ -88,6 +95,31 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 	s.publishTaskUpdated(ctx, task)
 	s.publishTaskStateChanged(ctx, task, oldState)
 	s.processParentChildrenCompletedForTaskState(ctx, taskID, v1.TaskStateCompleted)
+}
+
+// markOfficeTaskCompletedForTerminalStep routes an Office task's terminal
+// step completion through Office's own status pipeline (UpdateTaskStatus)
+// instead of a raw state write, so the approval gate runs (tasks-01.md:76).
+// UpdateTaskStatus persists a redirect to in_review and then returns a
+// typed *dashboard.ApprovalsPendingError when the gate fires — the write
+// has already succeeded, so that return is not a failure and is not
+// logged as one.
+func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, task *models.Task) {
+	if s.officeTaskStatusUpdater == nil {
+		// No seam wired (partial wiring, or a test): skip the write rather
+		// than falling through to the raw path, which would bypass the gate.
+		return
+	}
+	err := s.officeTaskStatusUpdater.UpdateTaskStatus(ctx, dashboard.TaskStatusUpdateRequest{
+		TaskID:    task.ID,
+		NewStatus: "done",
+	})
+	var pending *dashboard.ApprovalsPendingError
+	if err != nil && !errors.As(err, &pending) {
+		s.logger.Warn("terminal step completion: office status update failed",
+			zap.String("task_id", task.ID),
+			zap.Error(err))
+	}
 }
 
 func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID string) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -77,9 +77,8 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 		return
 	}
 	if task.IsFromOffice {
-		oldState := task.State
 		s.taskRuntimeStateMu.Unlock()
-		s.markOfficeTaskCompletedForTerminalStep(ctx, task, oldState)
+		s.markOfficeTaskCompletedForTerminalStep(ctx, taskID)
 		return
 	}
 	oldState := task.State
@@ -113,13 +112,39 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 // task.state_changed and driving the parent's on_children_completed
 // trigger — or dependency resolution, the parent workflow transition, and
 // every task.updated subscriber silently stop seeing Office completions.
-func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, task *models.Task, oldState v1.TaskState) {
+//
+// The caller's taskRuntimeStateMu check-then-act is not atomic across this
+// call (the seam runs Office's reactivity pipeline and publishes, so
+// holding that global lock across it risks lock inversion). Two
+// deliveries for the same task can therefore both pass the caller's check
+// before either has written. lockOfficeTerminalCompletion serializes by
+// task ID instead, and the task is re-read and re-checked once inside
+// that lock: whichever delivery gets there first does the write and fires
+// the side effects below; a second, now-redundant delivery finds the task
+// already terminal and returns without calling the seam a second time.
+func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, taskID string) {
 	if s.officeTaskStatusUpdater == nil {
 		// No seam wired (partial wiring, or a test): skip the write rather
 		// than falling through to the raw path, which would bypass the gate.
 		return
 	}
-	err := s.officeTaskStatusUpdater.UpdateTaskStatus(ctx, dashboard.TaskStatusUpdateRequest{
+
+	unlock := s.lockOfficeTerminalCompletion(taskID)
+	defer unlock()
+
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("terminal step completion: failed to reload office task",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if models.IsTerminalTaskState(task.State) {
+		return
+	}
+	oldState := task.State
+
+	err = s.officeTaskStatusUpdater.UpdateTaskStatus(ctx, dashboard.TaskStatusUpdateRequest{
 		TaskID:    task.ID,
 		NewStatus: "done",
 	})
@@ -137,6 +162,33 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 	s.publishTaskUpdated(ctx, task)
 	s.publishTaskStateChanged(ctx, task, oldState)
 	s.processParentChildrenCompletedForTaskState(ctx, task.ID, v1.TaskStateCompleted)
+}
+
+// lockOfficeTerminalCompletion serializes markOfficeTaskCompletedForTerminalStep
+// calls for the same task ID, mirroring lockChildCompletionOperation.
+func (s *Service) lockOfficeTerminalCompletion(taskID string) func() {
+	s.officeTerminalCompletionLocksMu.Lock()
+	if s.officeTerminalCompletionLocks == nil {
+		s.officeTerminalCompletionLocks = make(map[string]*childCompletionOperationLock)
+	}
+	entry := s.officeTerminalCompletionLocks[taskID]
+	if entry == nil {
+		entry = &childCompletionOperationLock{}
+		s.officeTerminalCompletionLocks[taskID] = entry
+	}
+	entry.refs++
+	s.officeTerminalCompletionLocksMu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		s.officeTerminalCompletionLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(s.officeTerminalCompletionLocks, taskID)
+		}
+		s.officeTerminalCompletionLocksMu.Unlock()
+		entry.mu.Unlock()
+	}
 }
 
 func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID string) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -78,7 +78,7 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 	}
 	if task.IsFromOffice {
 		s.taskRuntimeStateMu.Unlock()
-		s.markOfficeTaskCompletedForTerminalStep(ctx, taskID)
+		s.markOfficeTaskCompletedForTerminalStep(ctx, taskID, terminalStepID)
 		return
 	}
 	oldState := task.State
@@ -131,7 +131,7 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 // lockChildCompletionOperation. Holding this task's lock across that call
 // would invert lock order against a concurrent completion elsewhere in the
 // same ancestry and risk deadlock.
-func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, taskID string) {
+func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, taskID, terminalStepID string) {
 	if s.officeTaskStatusUpdater == nil {
 		// No seam wired (partial wiring, or a test): skip the write rather
 		// than falling through to the raw path, which would bypass the gate.
@@ -152,11 +152,16 @@ func (s *Service) markOfficeTaskCompletedForTerminalStep(ctx context.Context, ta
 		unlock()
 		return
 	}
+	if terminalStepID != "" && task.WorkflowStepID != terminalStepID {
+		unlock()
+		return
+	}
 	oldState := task.State
 
 	err = s.officeTaskStatusUpdater.UpdateTaskStatus(ctx, dashboard.TaskStatusUpdateRequest{
-		TaskID:    task.ID,
-		NewStatus: "done",
+		TaskID:                 task.ID,
+		NewStatus:              "done",
+		SuppressStatusActivity: true,
 	})
 	var pending *dashboard.ApprovalsPendingError
 	if err != nil {

--- a/apps/backend/internal/orchestrator/office_task_status.go
+++ b/apps/backend/internal/orchestrator/office_task_status.go
@@ -1,0 +1,20 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/kandev/kandev/internal/office/dashboard"
+)
+
+// OfficeTaskStatusUpdater routes an Office task's status changes through
+// Office's own pipeline (approval gate included) instead of a raw task
+// write. Implemented by *dashboard.DashboardService.
+type OfficeTaskStatusUpdater interface {
+	UpdateTaskStatus(ctx context.Context, req dashboard.TaskStatusUpdateRequest) error
+}
+
+// SetOfficeTaskStatusUpdater wires the Office status pipeline used to route
+// an Office task's terminal-step completion through the approval gate.
+func (s *Service) SetOfficeTaskStatusUpdater(u OfficeTaskStatusUpdater) {
+	s.officeTaskStatusUpdater = u
+}

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -440,5 +441,152 @@ func TestMarkOfficeTaskCompleted_ApproversPending_DoesNotFireCompletionSideEffec
 	if parentAfter.WorkflowStepID != "step-wait" {
 		t.Fatalf("parent.WorkflowStepID = %q, want unchanged step-wait: a redirect must not drive on_children_completed",
 			parentAfter.WorkflowStepID)
+	}
+}
+
+// blockingOfficeStatusUpdater wraps recordingOfficeStatusUpdater so a test
+// can hold the FIRST UpdateTaskStatus call open (simulating a slow seam
+// call) while a second, concurrent delivery races in. Only the first call
+// blocks: if the fix under test fails to serialize duplicate deliveries, a
+// second call must still return promptly (recorded, not blocked) so the
+// test fails on an assertion instead of hanging.
+type blockingOfficeStatusUpdater struct {
+	inner   *recordingOfficeStatusUpdater
+	started chan struct{}
+	proceed chan struct{}
+	calls   atomic.Int32
+}
+
+func (u *blockingOfficeStatusUpdater) UpdateTaskStatus(ctx context.Context, req dashboard.TaskStatusUpdateRequest) error {
+	if u.calls.Add(1) == 1 {
+		close(u.started)
+		<-u.proceed
+	}
+	return u.inner.UpdateTaskStatus(ctx, req)
+}
+
+// waitForOfficeTerminalCompletionLockRefs polls
+// officeTerminalCompletionLocks until the named task's ref count reaches
+// want, mirroring waitForChildCompletionLockRefs in
+// event_handlers_children_completed_test.go for the twin lock.
+func waitForOfficeTerminalCompletionLockRefs(t *testing.T, svc *Service, taskID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		svc.officeTerminalCompletionLocksMu.Lock()
+		got := 0
+		if entry := svc.officeTerminalCompletionLocks[taskID]; entry != nil {
+			got = entry.refs
+		}
+		svc.officeTerminalCompletionLocksMu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for office terminal completion lock refs = %d", want)
+}
+
+// TestMarkOfficeTaskCompleted_ConcurrentDeliveries_FireSideEffectsOnce is
+// the review-round-3 MAJOR-2 regression test: two deliveries for the same
+// Office task's terminal-step completion (e.g. a duplicate event) can both
+// pass markTaskCompletedForTerminalStep's non-terminal check before either
+// has written, since that check-then-act is not atomic across the Office
+// seam call. Only one delivery may reach the seam and fire the completion
+// side effects; the other must find the task already terminal and no-op.
+func TestMarkOfficeTaskCompleted_ConcurrentDeliveries_FireSideEffectsOnce(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	stepGetter := waitStepWithChildrenCompletedTrigger()
+	seedSession(t, repo, "parent-office", "parent-office-session", "step-wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-concurrent", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent-office",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+	updater := &blockingOfficeStatusUpdater{
+		inner:   &recordingOfficeStatusUpdater{repo: repo},
+		started: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+	svc.SetOfficeTaskStatusUpdater(updater)
+	events := &recordingTaskEventPublisher{}
+	svc.SetTaskEventPublisher(events)
+
+	// Delivery A: reaches the seam first and blocks inside it, holding the
+	// per-task completion lock with the task row still IN_PROGRESS.
+	doneA := make(chan struct{})
+	go func() {
+		defer close(doneA)
+		svc.markTaskCompletedForTerminalStep(ctx, "office-concurrent", "child_done")
+	}()
+	select {
+	case <-updater.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for delivery A to reach the seam")
+	}
+
+	// Delivery B: a duplicate delivery for the same task. Its own
+	// non-terminal check (under taskRuntimeStateMu) races in while the row
+	// is still IN_PROGRESS, then it blocks behind A on the per-task lock.
+	doneB := make(chan struct{})
+	go func() {
+		defer close(doneB)
+		svc.markTaskCompletedForTerminalStep(ctx, "office-concurrent", "child_done")
+	}()
+	waitForOfficeTerminalCompletionLockRefs(t, svc, "office-concurrent", 2)
+
+	close(updater.proceed)
+
+	waitOrFatal := func(ch <-chan struct{}, who string) {
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for %s to finish", who)
+		}
+	}
+	waitOrFatal(doneA, "delivery A")
+	waitOrFatal(doneB, "delivery B")
+
+	if got := updater.calls.Load(); got != 1 {
+		t.Fatalf("seam calls = %d, want exactly 1: a duplicate delivery must not re-run the status pipeline", got)
+	}
+
+	childUpdates := 0
+	for _, id := range events.updated {
+		if id == "office-concurrent" {
+			childUpdates++
+		}
+	}
+	if childUpdates != 1 {
+		t.Fatalf("PublishTaskUpdated calls for office-concurrent = %d, want exactly 1 (both deliveries fired side effects)", childUpdates)
+	}
+	var childChanges []recordedStateChange
+	for _, c := range events.stateChanges {
+		if c.taskID == "office-concurrent" {
+			childChanges = append(childChanges, c)
+		}
+	}
+	if len(childChanges) != 1 {
+		t.Fatalf("PublishTaskStateChanged calls for office-concurrent = %+v, want exactly 1", childChanges)
+	}
+
+	task, err := repo.GetTask(ctx, "office-concurrent")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("state = %q, want COMPLETED", task.State)
+	}
+
+	svc.officeTerminalCompletionLocksMu.Lock()
+	_, exists := svc.officeTerminalCompletionLocks["office-concurrent"]
+	svc.officeTerminalCompletionLocksMu.Unlock()
+	if exists {
+		t.Fatal("expected office terminal completion lock entry to be deleted after both deliveries exit")
 	}
 }

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -1,0 +1,186 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/office/dashboard"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// recordingOfficeStatusUpdater is a test double for OfficeTaskStatusUpdater
+// that performs the same kind of write UpdateTaskStatus does (persist a
+// state via the shared repo) and returns a configurable error, so tests
+// can observe both what the orchestrator asked for and what state ends
+// up persisted — without standing up the full dashboard service.
+type recordingOfficeStatusUpdater struct {
+	repo     *sqliterepo.Repository
+	newState v1.TaskState // state to persist; defaults to COMPLETED
+	err      error        // returned after the write, mirrors UpdateTaskStatus's contract
+	calls    []dashboard.TaskStatusUpdateRequest
+}
+
+func (u *recordingOfficeStatusUpdater) UpdateTaskStatus(ctx context.Context, req dashboard.TaskStatusUpdateRequest) error {
+	u.calls = append(u.calls, req)
+	state := v1.TaskStateCompleted
+	if u.newState != "" {
+		state = u.newState
+	}
+	task, err := u.repo.GetTask(ctx, req.TaskID)
+	if err != nil {
+		return err
+	}
+	task.State = state
+	task.UpdatedAt = time.Now().UTC()
+	if err := u.repo.UpdateTask(ctx, task); err != nil {
+		return err
+	}
+	return u.err
+}
+
+// requireCreateOfficeTask creates a task with a non-empty ProjectID so the
+// repo's IsFromOffice projection reports true (see isFromOfficeProjection).
+func requireCreateOfficeTask(t *testing.T, repo *sqliterepo.Repository, task *models.Task) {
+	t.Helper()
+	if task.ProjectID == "" {
+		task.ProjectID = "proj-office"
+	}
+	requireCreateTask(t, repo, task)
+}
+
+// TestMarkOfficeTaskCompleted_NoApprovers_WritesDoneViaSeam is test-matrix
+// case (4): an orchestrator terminal-step move for an Office task with no
+// approvers pending routes through the seam and ends up COMPLETED.
+func TestMarkOfficeTaskCompleted_NoApprovers_WritesDoneViaSeam(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-done", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: repo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-done", "child_done")
+
+	if len(updater.calls) != 1 || updater.calls[0].NewStatus != "done" {
+		t.Fatalf("seam calls = %+v, want one call with NewStatus=done", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "office-done")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("state = %q, want COMPLETED", task.State)
+	}
+}
+
+// TestMarkOfficeTaskCompleted_ApproversPending_RedirectsToReview is
+// test-matrix case (3): pending approvers redirect the persisted state to
+// in_review (REVIEW), and the ApprovalsPendingError the seam returns is
+// not a failure — it must not trigger the raw completion write.
+func TestMarkOfficeTaskCompleted_ApproversPending_RedirectsToReview(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-pending", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{
+		repo:     repo,
+		newState: v1.TaskStateReview,
+		err:      &dashboard.ApprovalsPendingError{Pending: []string{"agent-A"}},
+	}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-pending", "child_done")
+
+	if len(updater.calls) != 1 || updater.calls[0].NewStatus != "done" {
+		t.Fatalf("seam calls = %+v, want one call with NewStatus=done", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "office-pending")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateReview {
+		t.Fatalf("state = %q, want REVIEW (redirected, not overwritten by the raw completion path)", task.State)
+	}
+}
+
+// TestMarkTaskCompleted_NonOfficeTask_UsesRawPathUnchanged is test-matrix
+// case (c): a non-Office task's terminal-step completion is untouched by
+// this change — it never reaches the seam and keeps the raw write.
+func TestMarkTaskCompleted_NonOfficeTask_UsesRawPathUnchanged(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID: "kanban-task", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Kanban task", State: v1.TaskStateInProgress, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: repo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "kanban-task", "child_done")
+
+	if len(updater.calls) != 0 {
+		t.Fatalf("seam calls = %+v, want none: non-Office tasks must not reach the Office seam", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "kanban-task")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("state = %q, want COMPLETED via the unchanged raw path", task.State)
+	}
+}
+
+// TestMarkOfficeTaskCompleted_SeamNil_SkipsWrite is test-matrix case (d):
+// with no seam wired, an Office task's terminal completion is skipped
+// rather than falling back to the raw write, which would bypass the
+// approval gate.
+func TestMarkOfficeTaskCompleted_SeamNil_SkipsWrite(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-no-seam", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	// No SetOfficeTaskStatusUpdater call: the seam is nil.
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-no-seam", "child_done")
+
+	task, err := repo.GetTask(ctx, "office-no-seam")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateInProgress {
+		t.Fatalf("state = %q, want unchanged IN_PROGRESS: a nil seam must skip the write, not fall through", task.State)
+	}
+}

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -155,6 +155,109 @@ func TestMarkTaskCompleted_NonOfficeTask_UsesRawPathUnchanged(t *testing.T) {
 	}
 }
 
+// TestMarkOfficeTaskCompleted_StaleStep_SkipsSeam asserts an Office task
+// whose current WorkflowStepID no longer matches the terminal step named by
+// a replayed/stale move event never reaches the seam and keeps its state.
+func TestMarkOfficeTaskCompleted_StaleStep_SkipsSeam(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-stale-step", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_work",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: repo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-stale-step", "child_done")
+
+	if len(updater.calls) != 0 {
+		t.Fatalf("seam calls = %+v, want none: a stale-step move must not reach the Office seam", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "office-stale-step")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateInProgress {
+		t.Fatalf("state = %q, want unchanged IN_PROGRESS", task.State)
+	}
+	if task.WorkflowStepID != "child_work" {
+		t.Fatalf("workflow_step_id = %q, want unchanged child_work", task.WorkflowStepID)
+	}
+}
+
+// TestMarkOfficeTaskCompleted_AlreadyCancelled_SkipsSeam asserts an Office
+// task already in a terminal state (CANCELLED) never reaches the seam and
+// is not resurrected as COMPLETED.
+func TestMarkOfficeTaskCompleted_AlreadyCancelled_SkipsSeam(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-cancelled", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateCancelled, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: repo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-cancelled", "child_done")
+
+	if len(updater.calls) != 0 {
+		t.Fatalf("seam calls = %+v, want none: an already-terminal task must not reach the Office seam", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "office-cancelled")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateCancelled {
+		t.Fatalf("state = %q, want unchanged CANCELLED (not resurrected as COMPLETED)", task.State)
+	}
+}
+
+// TestMarkOfficeTaskCompleted_AlreadyCompleted_SkipsSeam asserts a
+// redelivered terminal-step-move event for an already-COMPLETED Office task
+// never reaches the seam, so it does not re-run the status pipeline
+// (duplicate activity rows, duplicate reactivity cascades).
+func TestMarkOfficeTaskCompleted_AlreadyCompleted_SkipsSeam(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-completed", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateCompleted, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: repo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-completed", "child_done")
+
+	if len(updater.calls) != 0 {
+		t.Fatalf("seam calls = %+v, want none: a redelivered terminal move for an already-completed task must not reach the Office seam", updater.calls)
+	}
+	task, err := repo.GetTask(ctx, "office-completed")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("state = %q, want unchanged COMPLETED", task.State)
+	}
+}
+
 // TestMarkOfficeTaskCompleted_SeamNil_SkipsWrite is test-matrix case (d):
 // with no seam wired, an Office task's terminal completion is skipped
 // rather than falling back to the raw write, which would bypass the

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kandev/kandev/internal/office/dashboard"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -285,5 +286,159 @@ func TestMarkOfficeTaskCompleted_SeamNil_SkipsWrite(t *testing.T) {
 	}
 	if task.State != v1.TaskStateInProgress {
 		t.Fatalf("state = %q, want unchanged IN_PROGRESS: a nil seam must skip the write, not fall through", task.State)
+	}
+}
+
+// recordingTaskEventPublisher captures PublishTaskUpdated /
+// PublishTaskStateChanged calls so tests can assert the emitted events
+// themselves, not just the persisted task state.
+type recordingTaskEventPublisher struct {
+	updated      []string
+	stateChanges []recordedStateChange
+}
+
+type recordedStateChange struct {
+	taskID   string
+	oldState v1.TaskState
+	newState v1.TaskState
+}
+
+func (r *recordingTaskEventPublisher) PublishTaskUpdated(_ context.Context, task *models.Task, _ ...string) {
+	if task != nil {
+		r.updated = append(r.updated, task.ID)
+	}
+}
+
+func (r *recordingTaskEventPublisher) PublishTaskStateChanged(_ context.Context, task *models.Task, oldState v1.TaskState) {
+	if task == nil {
+		return
+	}
+	r.stateChanges = append(r.stateChanges, recordedStateChange{taskID: task.ID, oldState: oldState, newState: task.State})
+}
+
+func (r *recordingTaskEventPublisher) PublishTaskActivityIfChanged(context.Context, string) {}
+
+// waitStepWithChildrenCompletedTrigger seeds a two-step workflow (position 0
+// "step-wait" with an on_children_completed move-to-next action, position 1
+// "step-done") on the mockStepGetter and returns it. seedSession always
+// creates its task on workflow "wf1", so the steps are registered there.
+func waitStepWithChildrenCompletedTrigger() *mockStepGetter {
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step-wait"] = &wfmodels.WorkflowStep{
+		ID: "step-wait", WorkflowID: "wf1", Name: "Wait for children", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step-done"] = &wfmodels.WorkflowStep{
+		ID: "step-done", WorkflowID: "wf1", Name: "Done", Position: 1,
+	}
+	return stepGetter
+}
+
+// TestMarkOfficeTaskCompleted_NoApprovers_FiresTerminalSideEffects is the
+// BLOCKER-1 regression test (review round 2): the raw (non-Office)
+// completion path publishes task.updated / task.state_changed and drives
+// the parent's on_children_completed trigger. The Office seam dropped all
+// three when it landed on COMPLETED, so dependency resolution, the parent
+// workflow transition, and every task.updated subscriber silently stopped
+// seeing Office completions. Assert the emitted events and the parent's
+// resulting workflow step, not just the child's persisted state.
+func TestMarkOfficeTaskCompleted_NoApprovers_FiresTerminalSideEffects(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	stepGetter := waitStepWithChildrenCompletedTrigger()
+	seedSession(t, repo, "parent-office", "parent-office-session", "step-wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-done-fx", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent-office",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+	svc.SetOfficeTaskStatusUpdater(&recordingOfficeStatusUpdater{repo: repo})
+	events := &recordingTaskEventPublisher{}
+	svc.SetTaskEventPublisher(events)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-done-fx", "child_done")
+
+	// The parent's own on_children_completed transition legitimately
+	// republishes task.updated for the parent itself; only assert on the
+	// completed child's events, which are what BLOCKER 1 dropped.
+	childUpdates := 0
+	for _, id := range events.updated {
+		if id == "office-done-fx" {
+			childUpdates++
+		}
+	}
+	if childUpdates != 1 {
+		t.Fatalf("PublishTaskUpdated calls = %+v, want exactly one for office-done-fx", events.updated)
+	}
+	var childChanges []recordedStateChange
+	for _, c := range events.stateChanges {
+		if c.taskID == "office-done-fx" {
+			childChanges = append(childChanges, c)
+		}
+	}
+	if len(childChanges) != 1 {
+		t.Fatalf("PublishTaskStateChanged calls for office-done-fx = %+v, want exactly one", childChanges)
+	}
+	if change := childChanges[0]; change.oldState != v1.TaskStateInProgress || change.newState != v1.TaskStateCompleted {
+		t.Fatalf("state change = %+v, want IN_PROGRESS -> COMPLETED", change)
+	}
+
+	parentAfter, err := repo.GetTask(ctx, "parent-office")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parentAfter.WorkflowStepID != "step-done" {
+		t.Fatalf("parent.WorkflowStepID = %q, want step-done: on_children_completed must fire for an Office completion",
+			parentAfter.WorkflowStepID)
+	}
+}
+
+// TestMarkOfficeTaskCompleted_ApproversPending_DoesNotFireCompletionSideEffects
+// is the negative half of the BLOCKER-1 regression: a gate redirect to
+// in_review is not a completion, so it must not publish task.updated /
+// task.state_changed, nor drive the parent's on_children_completed trigger.
+func TestMarkOfficeTaskCompleted_ApproversPending_DoesNotFireCompletionSideEffects(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	stepGetter := waitStepWithChildrenCompletedTrigger()
+	seedSession(t, repo, "parent-office", "parent-office-session", "step-wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, repo, &models.Task{
+		ID: "office-pending-fx", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent-office",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+	svc.SetOfficeTaskStatusUpdater(&recordingOfficeStatusUpdater{
+		repo:     repo,
+		newState: v1.TaskStateReview,
+		err:      &dashboard.ApprovalsPendingError{Pending: []string{"agent-A"}},
+	})
+	events := &recordingTaskEventPublisher{}
+	svc.SetTaskEventPublisher(events)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-pending-fx", "child_done")
+
+	if len(events.updated) != 0 || len(events.stateChanges) != 0 {
+		t.Fatalf("events = updated=%v stateChanges=%v, want none: a gate redirect is not a completion",
+			events.updated, events.stateChanges)
+	}
+	parentAfter, err := repo.GetTask(ctx, "parent-office")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parentAfter.WorkflowStepID != "step-wait" {
+		t.Fatalf("parent.WorkflowStepID = %q, want unchanged step-wait: a redirect must not drive on_children_completed",
+			parentAfter.WorkflowStepID)
 	}
 }

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -364,8 +364,22 @@ func TestMarkOfficeTaskCompleted_NoApprovers_FiresTerminalSideEffects(t *testing
 	svc.SetOfficeTaskStatusUpdater(&recordingOfficeStatusUpdater{repo: repo})
 	events := &recordingTaskEventPublisher{}
 	svc.SetTaskEventPublisher(events)
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
 
 	svc.markTaskCompletedForTerminalStep(ctx, "office-done-fx", "child_done")
+	// The parent's on_children_completed transition launches its own step's
+	// session prep on a detached goroutine (launchProcessOnEnter); join it
+	// before reading events/parent state below, or those reads race the
+	// goroutine's own writes (recordingTaskEventPublisher is not
+	// synchronized, matching event_handlers_children_completed_test.go's
+	// waitForChildrenCompletedOnEnter pattern for the same trigger).
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
 
 	// The parent's own on_children_completed transition legitimately
 	// republishes task.updated for the parent itself; only assert on the
@@ -516,6 +530,13 @@ func TestMarkOfficeTaskCompleted_ConcurrentDeliveries_FireSideEffectsOnce(t *tes
 	svc.SetOfficeTaskStatusUpdater(updater)
 	events := &recordingTaskEventPublisher{}
 	svc.SetTaskEventPublisher(events)
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
 
 	// Delivery A: reaches the seam first and blocks inside it, holding the
 	// per-task completion lock with the task row still IN_PROGRESS.
@@ -551,6 +572,12 @@ func TestMarkOfficeTaskCompleted_ConcurrentDeliveries_FireSideEffectsOnce(t *tes
 	}
 	waitOrFatal(doneA, "delivery A")
 	waitOrFatal(doneB, "delivery B")
+	// The winning delivery's parent on_children_completed transition launches
+	// its own step's session prep on a detached goroutine
+	// (launchProcessOnEnter); join it before reading events below, or the
+	// read races that goroutine's writes to the shared, unsynchronized
+	// recordingTaskEventPublisher.
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
 
 	if got := updater.calls.Load(); got != 1 {
 		t.Fatalf("seam calls = %d, want exactly 1: a duplicate delivery must not re-run the status pipeline", got)

--- a/apps/backend/internal/orchestrator/office_task_status_test.go
+++ b/apps/backend/internal/orchestrator/office_task_status_test.go
@@ -193,6 +193,54 @@ func TestMarkOfficeTaskCompleted_StaleStep_SkipsSeam(t *testing.T) {
 	}
 }
 
+type staleOfficeTaskReloadRepo struct {
+	*sqliterepo.Repository
+	loads int
+}
+
+func (r *staleOfficeTaskReloadRepo) GetTask(ctx context.Context, taskID string) (*models.Task, error) {
+	task, err := r.Repository.GetTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	r.loads++
+	if r.loads == 2 {
+		task.WorkflowStepID = "child_work"
+	}
+	return task, nil
+}
+
+func TestMarkOfficeTaskCompleted_RechecksStepAfterPerTaskLock(t *testing.T) {
+	ctx := context.Background()
+	baseRepo := setupTestRepo(t)
+	seedSession(t, baseRepo, "parent-recheck", "parent-recheck-session", "step_wait")
+
+	now := time.Now().UTC()
+	requireCreateOfficeTask(t, baseRepo, &models.Task{
+		ID: "office-recheck", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Office task", State: v1.TaskStateInProgress, ParentID: "parent-recheck",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	repo := &staleOfficeTaskReloadRepo{Repository: baseRepo}
+	svc := &Service{logger: testLogger(), repo: repo}
+	updater := &recordingOfficeStatusUpdater{repo: baseRepo}
+	svc.SetOfficeTaskStatusUpdater(updater)
+
+	svc.markTaskCompletedForTerminalStep(ctx, "office-recheck", "child_done")
+
+	if len(updater.calls) != 0 {
+		t.Fatalf("seam calls = %+v, want none after the locked reload observes a new step", updater.calls)
+	}
+	task, err := baseRepo.GetTask(ctx, "office-recheck")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.State != v1.TaskStateInProgress {
+		t.Fatalf("state = %q, want unchanged IN_PROGRESS", task.State)
+	}
+}
+
 // TestMarkOfficeTaskCompleted_AlreadyCancelled_SkipsSeam asserts an Office
 // task already in a terminal state (CANCELLED) never reaches the seam and
 // is not resurrected as COMPLETED.

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -769,6 +769,13 @@ type Service struct {
 	// dependencies so nothing is gated.
 	dependencyReader TaskDependencyReader
 
+	// Routes an Office task's terminal-step completion through Office's own
+	// status pipeline (approval gate included) instead of the orchestrator's
+	// raw state write. Nil-safe: when unset, terminal completion for an
+	// Office task is skipped rather than falling back to the raw write,
+	// which would bypass the gate.
+	officeTaskStatusUpdater OfficeTaskStatusUpdater
+
 	// Resolves the agent family names written in configure_session rules onto
 	// canonical agent IDs. Nil-safe: when unset, rule matching falls back to an
 	// exact string comparison.

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -804,6 +804,17 @@ type Service struct {
 	// childCompletionLocks serializes duplicate on_children_completed deliveries.
 	childCompletionLocksMu sync.Mutex
 	childCompletionLocks   map[string]*childCompletionOperationLock
+	// officeTerminalCompletionLocks serializes concurrent
+	// markOfficeTaskCompletedForTerminalStep deliveries for the same task, so
+	// two deliveries racing past the taskRuntimeStateMu check above cannot
+	// both call the Office status seam and both fire completion side
+	// effects. Keyed per task rather than using taskRuntimeStateMu itself,
+	// because the seam runs Office's reactivity pipeline and publishes
+	// events — holding the global lock across that call risks lock
+	// inversion.
+	officeTerminalCompletionLocksMu sync.Mutex
+	officeTerminalCompletionLocks   map[string]*childCompletionOperationLock
+
 	// agentErrorOperationLocks serializes concurrent on_agent_error dispatches
 	// that carry the same operation id — the load -> evaluate -> commit ->
 	// mark window, held from before the task/session/MachineState load so a

--- a/apps/backend/internal/task/service/service_events_test.go
+++ b/apps/backend/internal/task/service/service_events_test.go
@@ -684,6 +684,27 @@ func TestPublishTaskUpdated_FallbackRepositoryID(t *testing.T) {
 	}
 }
 
+func TestPublishTaskUpdatedByIDLoadsCanonicalTask(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-by-id", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "step-1", Title: "By ID", Priority: "medium",
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	eventBus.ClearEvents()
+
+	svc.PublishTaskUpdatedByID(ctx, "task-by-id")
+
+	data := singlePublishedEventData(t, eventBus)
+	if got := data["task_id"]; got != "task-by-id" {
+		t.Fatalf("task_id = %v, want task-by-id", got)
+	}
+	if got := data["title"]; got != "By ID" {
+		t.Fatalf("title = %v, want By ID", got)
+	}
+}
+
 func TestPublishTaskUpdated_EmitsAutopilot(t *testing.T) {
 	svc, eventBus, _ := createTestService(t)
 	svc.PublishTaskUpdated(context.Background(), &models.Task{

--- a/apps/web/e2e/fixtures/office-fixture.ts
+++ b/apps/web/e2e/fixtures/office-fixture.ts
@@ -1,6 +1,7 @@
 import { type Page } from "@playwright/test";
 import { test as base } from "./test-base";
 import { OfficeApiClient } from "../helpers/office-api-client";
+import { ApiClient } from "../helpers/api-client";
 
 type OfficeFixtures = {
   officeApi: OfficeApiClient;
@@ -83,5 +84,20 @@ export const test = base.extend<{ testPage: Page }, OfficeFixtures>({
 test.beforeEach(async ({ officeApi, officeSeed }) => {
   await officeApi.updateAgentStatus(officeSeed.agentId, "idle");
 });
+
+// Office's approval gate (apps/backend/internal/office/dashboard/service_tasks.go
+// applyApprovalGate) redirects a "done" write to in_review unless the task is
+// on its workflow's terminal step (last by position). Tests that drive a task
+// all the way to "done" need it parked there first; this resolves the
+// highest-position step for the workflow and moves the task onto it.
+export async function moveTaskToTerminalStep(
+  apiClient: ApiClient,
+  workflowId: string,
+  taskId: string,
+): Promise<void> {
+  const { steps } = await apiClient.listWorkflowSteps(workflowId);
+  const terminalStep = steps.reduce((max, step) => (step.position > max.position ? step : max));
+  await apiClient.moveTask(taskId, workflowId, terminalStep.id);
+}
 
 export { expect } from "@playwright/test";

--- a/apps/web/e2e/tests/office/approval-flow.spec.ts
+++ b/apps/web/e2e/tests/office/approval-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../../fixtures/office-fixture";
+import { test, expect, moveTaskToTerminalStep } from "../../fixtures/office-fixture";
 
 /**
  * E2E coverage for the office task approval gate (in_review → done is
@@ -92,6 +92,12 @@ test.describe("Office task approval flow", () => {
     const task = await apiClient.createTask(officeSeed.workspaceId, "Approval Clearing Task", {
       workflow_id: officeSeed.workflowId,
     });
+    // The office approval gate first checks workflow-step position: a "done"
+    // write is redirected to in_review unless the task is already on its
+    // workflow's terminal step, regardless of approver state. Park it there
+    // so the gate below actually exercises the approver-decision check this
+    // test is about.
+    await moveTaskToTerminalStep(apiClient, officeSeed.workflowId, task.id);
     const attach = await apiClient.rawRequest("POST", `/api/v1/office/tasks/${task.id}/approvers`, {
       agent_profile_id: approverId,
     });

--- a/apps/web/e2e/tests/office/execution-stages.spec.ts
+++ b/apps/web/e2e/tests/office/execution-stages.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../../fixtures/office-fixture";
+import { test, expect, moveTaskToTerminalStep } from "../../fixtures/office-fixture";
 
 // Placeholder: set execution policy on a task.
 // The backend does not expose this via HTTP yet — SetTaskExecutionPolicy is
@@ -23,6 +23,11 @@ test.describe("Execution stages — status updates", () => {
     const task = await apiClient.createTask(officeSeed.workspaceId, "Status Done Task", {
       workflow_id: officeSeed.workflowId,
     });
+    // The office approval gate redirects a "done" write to in_review unless
+    // the task is already on its workflow's terminal step; park it there so
+    // this test exercises the (unrelated) execution-policy fallback it's
+    // named for, rather than the step-position gate.
+    await moveTaskToTerminalStep(apiClient, officeSeed.workflowId, task.id);
 
     const result = await officeApi.updateTaskStatus(task.id, "done", "Work complete");
     expect(result).toMatchObject({ ok: true });
@@ -68,6 +73,10 @@ test.describe("Execution stages — status updates", () => {
     const task = await apiClient.createTask(officeSeed.workspaceId, "Status Comment Task", {
       workflow_id: officeSeed.workflowId,
     });
+    // See "update task status to done without execution policy succeeds"
+    // above: the approval gate requires the terminal workflow step for a
+    // "done" write to persist rather than redirect to in_review.
+    await moveTaskToTerminalStep(apiClient, officeSeed.workflowId, task.id);
     const commentText = "Status updated in E2E test";
 
     await officeApi.updateTaskStatus(task.id, "done", commentText);

--- a/apps/web/e2e/tests/office/property-pickers.spec.ts
+++ b/apps/web/e2e/tests/office/property-pickers.spec.ts
@@ -478,9 +478,23 @@ test.describe("property pickers", () => {
     apiClient,
     officeSeed,
   }) => {
-    const task = await apiClient.createTask(officeSeed.workspaceId, "Picker Timeline Task", {
+    // The office approval gate only allows a "done" write once the task is on
+    // its workflow's terminal step, so this task needs to start there. Seed
+    // it directly (rather than create + move) so the test doesn't route
+    // through the generic task-move path, which treats entering the
+    // workflow's terminal step as completion in its own right (see
+    // handleTaskMoved/finalizeDone) and would pre-empt the very "todo ->
+    // in_progress -> done" transition this test is verifying.
+    const stepsResp = await apiClient.listWorkflowSteps(officeSeed.workflowId);
+    const terminalStep = stepsResp.steps.reduce((max, step) =>
+      step.position > max.position ? step : max,
+    );
+    const seeded = await apiClient.seedTask(officeSeed.workspaceId, "Picker Timeline Task", {
       workflow_id: officeSeed.workflowId,
+      workflow_step_id: terminalStep.id,
+      state: "TODO",
     });
+    const task = { id: seeded.task_id };
 
     // startedAt/completedAt are derived server-side from the status-change
     // timeline (see deriveTaskTimestamps in the backend) and delivered to

--- a/apps/web/e2e/tests/office/subtask-checklist.spec.ts
+++ b/apps/web/e2e/tests/office/subtask-checklist.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../../fixtures/office-fixture";
+import { test, expect, moveTaskToTerminalStep } from "../../fixtures/office-fixture";
 
 test.describe("Subtask checklist — stepper (blocker chain)", () => {
   test("stepper renders for children linked with a blocker chain", async ({
@@ -95,6 +95,7 @@ test.describe("Subtask checklist — stepper (blocker chain)", () => {
 
   test("completed first step highlights second step as active", async ({
     testPage,
+    apiClient,
     officeApi,
     officeSeed,
   }) => {
@@ -115,6 +116,11 @@ test.describe("Subtask checklist — stepper (blocker chain)", () => {
       blocked_by: [step1Id],
       workflow_id: officeSeed.workflowId,
     });
+
+    // The office approval gate redirects a "done" write to in_review unless
+    // the task is already on its workflow's terminal step; park step1 there
+    // so this generic-stepper-UI assertion isn't coupled to workflow position.
+    await moveTaskToTerminalStep(apiClient, officeSeed.workflowId, step1Id);
 
     // Mark first child as COMPLETED via the office status endpoint.
     await officeApi.updateTaskStatus(step1Id, "COMPLETED", "done");

--- a/apps/web/lib/api/domains/office-status-gate.test.ts
+++ b/apps/web/lib/api/domains/office-status-gate.test.ts
@@ -64,4 +64,22 @@ describe("updateTaskStatusOrTranslateGate", () => {
     expect(err).toBeInstanceOf(ApprovalGateError);
     expect((err as ApprovalGateError).redirectedStatus).toBe("blocked");
   });
+
+  it("uses the workflow-step message for a position gate", async () => {
+    updateTaskMock.mockRejectedValueOnce(
+      new ApiError("workflow step pending", 409, {
+        error: "workflow step pending",
+        reason: "workflow_step",
+        pending_approvers: [],
+        status: "in_review",
+      }),
+    );
+
+    const err = await updateTaskStatusOrTranslateGate("t-1", "done").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApprovalGateError);
+    expect((err as ApprovalGateError).message).toBe(
+      "Cannot mark done: move the task to the final workflow step first",
+    );
+    expect((err as ApprovalGateError).redirectedStatus).toBe("in_review");
+  });
 });

--- a/apps/web/lib/api/domains/office-status-gate.ts
+++ b/apps/web/lib/api/domains/office-status-gate.ts
@@ -15,6 +15,8 @@ import type { TaskStatus } from "@/app/office/tasks/[id]/types";
 
 export type PendingApprover = { agent_profile_id?: string; name?: string };
 
+type ApprovalGateReason = "approvals" | "workflow_step";
+
 // Builds the message the user sees when the approver gate rejects the move.
 // Names render in the order the backend echoed them.
 export function formatPendingApproversMessage(pending: PendingApprover[]): string {
@@ -41,6 +43,14 @@ function extractRedirectedStatus(err: unknown): (OfficeTaskStatus | TaskStatus) 
   return typeof status === "string" && status.length > 0
     ? (status as OfficeTaskStatus | TaskStatus)
     : null;
+}
+
+function extractGateReason(err: unknown): ApprovalGateReason | null {
+  if (!(err instanceof ApiError)) return null;
+  const body = err.body;
+  if (!body || typeof body !== "object") return null;
+  const reason = (body as { reason?: unknown }).reason;
+  return reason === "approvals" || reason === "workflow_step" ? reason : null;
 }
 
 // Thrown instead of a plain Error when the approver gate fires. The backend
@@ -70,6 +80,13 @@ export async function updateTaskStatusOrTranslateGate(
   try {
     await updateTask(taskId, { status });
   } catch (err) {
+    if (extractGateReason(err) === "workflow_step") {
+      const redirectedStatus = extractRedirectedStatus(err) ?? "in_review";
+      throw new ApprovalGateError(
+        t("task:cannotMarkDoneBeforeFinalWorkflowStep"),
+        redirectedStatus,
+      );
+    }
     const pending = extractPendingApprovers(err);
     if (pending) {
       // The gate always redirects to in_review today (see applyApprovalGate

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -225,6 +225,7 @@
   "cancelling": "Cancelling...",
   "cannotMarkDoneAwaitingApprovalFrom": "Cannot mark done: awaiting approval from {{names}}",
   "cannotMarkDoneAwaitingApprovals": "Cannot mark done: awaiting approvals",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "Cannot mark done: move the task to the final workflow step first",
   "cannotPreviewThisFile": "Cannot preview this file",
   "changeGithubIssue": "Change GitHub issue",
   "changes": "Changes",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -225,6 +225,7 @@
   "cancelling": "Ćàńćēĺĺĩńĝ...",
   "cannotMarkDoneAwaitingApprovalFrom": "Ćàńńōţ ḿàŕķ ďōńē: àŵàĩţĩńĝ àƥƥŕōvàĺ ƒŕōḿ {{names}}",
   "cannotMarkDoneAwaitingApprovals": "Ćàńńōţ ḿàŕķ ďōńē: àŵàĩţĩńĝ àƥƥŕōvàĺś",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "Ćàńńōţ ḿàŕķ ďōńē: ḿōvē ţħē ţàśķ ţō ţħē ƒĩńàĺ ŵōŕķƒĺōŵ śţēƥ ƒĩŕśţ",
   "cannotPreviewThisFile": "Ćàńńōţ ƥŕēvĩēŵ ţĥĩś ƒĩĺē",
   "changeGithubIssue": "Ćĥàńĝē ĜĩţĤũƀ ĩśśũē",
   "changes": "Ćĥàńĝēś",

--- a/apps/web/src/locales/pt-pt/task.json
+++ b/apps/web/src/locales/pt-pt/task.json
@@ -224,6 +224,7 @@
   "cancelling": "A cancelar...",
   "cannotMarkDoneAwaitingApprovalFrom": "Não é possível marcar como concluída: a aguardar a aprovação de {{names}}",
   "cannotMarkDoneAwaitingApprovals": "Não é possível marcar como concluída: a aguardar aprovações",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "Não é possível marcar como concluída: mova primeiro a tarefa para o passo final do fluxo de trabalho",
   "cannotPreviewThisFile": "Não é possível pré-visualizar este ficheiro",
   "changeGithubIssue": "Alterar a issue do GitHub",
   "changes": "Alterações",

--- a/apps/web/src/locales/zh-cn/task.json
+++ b/apps/web/src/locales/zh-cn/task.json
@@ -224,6 +224,7 @@
   "cancelling": "正在取消…",
   "cannotMarkDoneAwaitingApprovalFrom": "无法标记为完成：正在等待 {{names}} 的批准",
   "cannotMarkDoneAwaitingApprovals": "无法标记为完成：正在等待批准",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "无法标记为完成：请先将任务移至工作流的最后一步",
   "cannotPreviewThisFile": "无法预览此文件",
   "changeGithubIssue": "更改 GitHub 议题",
   "changes": "变更",

--- a/apps/web/src/locales/zh-hk/task.json
+++ b/apps/web/src/locales/zh-hk/task.json
@@ -224,6 +224,7 @@
   "cancelling": "正在取消…",
   "cannotMarkDoneAwaitingApprovalFrom": "無法標記為完成：正在等待 {{names}} 的批准",
   "cannotMarkDoneAwaitingApprovals": "無法標記為完成：正在等待批准",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "無法標記為完成：請先將任務移至工作流的最後一步",
   "cannotPreviewThisFile": "無法預覽此檔案",
   "changeGithubIssue": "更改 GitHub 議題",
   "changes": "變更",

--- a/apps/web/src/locales/zh-tw/task.json
+++ b/apps/web/src/locales/zh-tw/task.json
@@ -224,6 +224,7 @@
   "cancelling": "正在取消…",
   "cannotMarkDoneAwaitingApprovalFrom": "無法標記為完成：正在等待 {{names}} 的批准",
   "cannotMarkDoneAwaitingApprovals": "無法標記為完成：正在等待批准",
+  "cannotMarkDoneBeforeFinalWorkflowStep": "無法標記為完成：請先將任務移至工作流的最後一步",
   "cannotPreviewThisFile": "無法預覽此檔案",
   "changeGithubIssue": "更改 GitHub 議題",
   "changes": "變更",


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3392/da30baad973b.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** An Office task can be marked Done while its workflow is still sitting on an earlier, non-final step — the terminal-completion path only checked for pending approvers, never the step position, so a review/approval step got silently skipped and the task never surfaced as `in_review` on the board.
**After this:** Office task completion is gated on workflow step position before approvers: landing on a non-final step (with a resolvable step) redirects the write to `in_review` and fans out to reviewers/approvers instead of writing Done. Only a task on the final step, or with no workflow step at all, reaches Done.
**Who hits this:** Anyone running an Office workflow with a review or approval step ahead of the terminal step — those tasks were completing without ever passing through review.
**Scope:** standalone backend-only fix (13 files, zero `apps/web`). Conceptually the "unit 8" slice of the Office-carve sequence; ships independently of its sibling units.
**Not here:** two residuals are deferred to follow-up cards rather than expanding this fix — (1) the step-position redirect doesn't publish `task.updated`, so the All-Workflows kanban can go stale until refetch (the Office board itself still updates); (2) the 409 error body has no discriminator between "pending approvers" and "non-final step", so the frontend always renders the approvers-pending toast even when the real reason is the step position.

Office task completion previously bypassed its workflow's review step entirely: the terminal-completion path wrote `done` straight from any state as long as no approver was pending, with no check on where the task actually sat in its workflow. This routes Office completion through the same approval gate every other status write already uses, adding a step-position check ahead of the approver check, and covers both the raw completion path and the Office-specific completion seam so the behavior can't be bypassed from either side.

## Important Changes

- `office/dashboard.applyApprovalGate` now checks workflow step position before approvers: a non-terminal step (with a resolvable step) redirects `done` to `in_review`; no step at all falls through to the existing approver check; a step lookup error aborts the write (fail-closed).
- `orchestrator.markTaskCompletedForTerminalStep` now branches on `task.IsFromOffice` and routes through the `OfficeTaskStatusUpdater` seam, serialized per-task so two concurrent completions for the same task can't both fire side effects.
- `office/repository/sqlite.IsTaskWorkflowStepTerminal` reports `(terminal, hasStep, err)` so a task with no workflow step (e.g. a channel task) is distinguishable from one sitting on a genuine non-terminal step.

## Validation

- `go build -tags fts5 ./...`
- `go test -tags fts5 -count=1 ./internal/office/...` — 25 packages ok
- `go test -tags fts5 -count=1 ./internal/orchestrator/...` — ok, all subpackages
- `go test -tags fts5 -race -count=20 -run 'TestMarkOfficeTask|TestMarkTaskCompleted_NonOffice' ./internal/orchestrator/` — ok
- `go test -tags fts5 -race -count=1 ./internal/office/dashboard/... ./internal/office/repository/sqlite/...` — ok
- `make typecheck test lint` — clean except two pre-existing baseline failures unrelated to this change (`internal/task/service`, `internal/worktree`; both fail identically at the merge-base and are not part of this diff)
- `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — clean (no `apps/web` files touched)
- `make -C apps/backend lint` — 0 issues

## Possible Improvements

Low risk: change is confined to the Office completion path and its existing approval-gate seam; two known gaps (silent kanban staleness on redirect, ambiguous 409 toast text) are filed as follow-up cards rather than folded into this fix.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->