### PR TITLE
fix(office): show agents as working while a run is in flight

### DIFF
--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -1138,7 +1138,19 @@ func (r *sqliteRepository) updateAgentProfile(ctx context.Context, execer profil
 			cli_passthrough = ?, enabled = ?, user_modified = ?, cli_flags = ?, env_vars = ?, updated_at = ?,
 			workspace_id = ?, role = ?, icon = ?, reports_to = ?,
 			skill_ids = ?, desired_skills = ?, custom_prompt = ?,
-			status = ?, pause_reason = ?, last_run_finished_at = ?,
+			status = CASE
+				WHEN (status = 'working' AND working_run_id <> '') OR ? = 'working' THEN status
+				ELSE ?
+			END,
+			pause_reason = CASE
+				WHEN (status = 'working' AND working_run_id <> '') OR ? = 'working' THEN pause_reason
+				ELSE ?
+			END,
+			working_run_id = CASE
+				WHEN status = 'working' AND working_run_id <> '' THEN working_run_id
+				ELSE ''
+			END,
+			last_run_finished_at = ?,
 			max_concurrent_sessions = ?, cooldown_sec = ?, skip_idle_runs = ?,
 			consecutive_failures = ?, failure_threshold = ?,
 			executor_preference = ?,
@@ -1152,7 +1164,7 @@ func (r *sqliteRepository) updateAgentProfile(ctx context.Context, execer profil
 		dialect.BoolToInt(profile.CLIPassthrough), dialect.BoolToInt(profile.Enabled), dialect.BoolToInt(profile.UserModified), cliFlagsJSON, envVarsJSON, profile.UpdatedAt,
 		enrich.workspaceID, enrich.role, enrich.icon, enrich.reportsTo,
 		enrich.skillIDs, enrich.desiredSkills, enrich.customPrompt,
-		enrich.status, enrich.pauseReason, profile.LastRunFinishedAt,
+		enrich.status, enrich.status, enrich.status, enrich.pauseReason, profile.LastRunFinishedAt,
 		enrich.maxConcurrentSessions, profile.CooldownSec, dialect.BoolToInt(profile.SkipIdleRuns),
 		profile.ConsecutiveFailures, enrich.failureThreshold,
 		enrich.executorPreference,

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -95,6 +95,7 @@ func (r *sqliteRepository) initSchema() error {
 		status TEXT NOT NULL DEFAULT 'idle'
 			CHECK (status IN ('idle','working','paused','stopped','pending_approval')),
 		pause_reason TEXT NOT NULL DEFAULT '',
+		working_run_id TEXT NOT NULL DEFAULT '',
 		last_run_finished_at TIMESTAMP,
 		max_concurrent_sessions INTEGER NOT NULL DEFAULT 1,
 		cooldown_sec INTEGER NOT NULL DEFAULT 0,
@@ -211,6 +212,7 @@ func (r *sqliteRepository) migrateOfficeEnrichmentColumns() {
 		{"agent_profiles.custom_prompt", `ALTER TABLE agent_profiles ADD COLUMN custom_prompt TEXT NOT NULL DEFAULT ''`},
 		{"agent_profiles.status", `ALTER TABLE agent_profiles ADD COLUMN status TEXT NOT NULL DEFAULT 'idle'`},
 		{"agent_profiles.pause_reason", `ALTER TABLE agent_profiles ADD COLUMN pause_reason TEXT NOT NULL DEFAULT ''`},
+		{"agent_profiles.working_run_id", `ALTER TABLE agent_profiles ADD COLUMN working_run_id TEXT NOT NULL DEFAULT ''`},
 		{"agent_profiles.last_run_finished_at", `ALTER TABLE agent_profiles ADD COLUMN last_run_finished_at TIMESTAMP`},
 		{"agent_profiles.max_concurrent_sessions", `ALTER TABLE agent_profiles ADD COLUMN max_concurrent_sessions INTEGER NOT NULL DEFAULT 1`},
 		{"agent_profiles.cooldown_sec", `ALTER TABLE agent_profiles ADD COLUMN cooldown_sec INTEGER NOT NULL DEFAULT 0`},

--- a/apps/backend/internal/agent/settings/store/sqlite_enrichment_test.go
+++ b/apps/backend/internal/agent/settings/store/sqlite_enrichment_test.go
@@ -158,6 +158,64 @@ func TestEnrichment_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentProfile_DoesNotOverwriteWorkingOwner(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo, err := newSQLiteRepository(db, db, nil, false)
+	if err != nil {
+		t.Fatalf("newSQLiteRepository: %v", err)
+	}
+	ctx := context.Background()
+	agent := &models.Agent{Name: "claude"}
+	if err := repo.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	profile := &models.AgentProfile{
+		AgentID:     agent.ID,
+		Name:        "worker",
+		Model:       "claude-sonnet-4-6",
+		WorkspaceID: "ws-1",
+		Role:        models.AgentRoleWorker,
+		Status:      models.AgentStatusIdle,
+	}
+	if err := repo.CreateAgentProfile(ctx, profile); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	snapshot, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE agent_profiles SET status = 'working', working_run_id = ? WHERE id = ?`,
+		"run-settings", profile.ID); err != nil {
+		t.Fatalf("seed working owner: %v", err)
+	}
+	snapshot.Name = "renamed while working"
+	if err := repo.UpdateAgentProfile(ctx, snapshot); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+
+	updated, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get updated profile: %v", err)
+	}
+	if updated.Status != models.AgentStatusWorking {
+		t.Fatalf("status = %q, want working", updated.Status)
+	}
+	var owner string
+	if err := db.GetContext(ctx, &owner,
+		`SELECT working_run_id FROM agent_profiles WHERE id = ?`, profile.ID); err != nil {
+		t.Fatalf("read working owner: %v", err)
+	}
+	if owner != "run-settings" {
+		t.Fatalf("working_run_id = %q, want run-settings", owner)
+	}
+}
+
 func TestProfileConfigOptions_RoundTripInSettings(t *testing.T) {
 	db, err := sqlx.Open("sqlite3", ":memory:")
 	if err != nil {

--- a/apps/backend/internal/office/agents/service.go
+++ b/apps/backend/internal/office/agents/service.go
@@ -83,7 +83,7 @@ var validRoles = map[models.AgentRole]bool{
 
 // allowedTransitions defines which status transitions are valid.
 var allowedTransitions = map[models.AgentStatus][]models.AgentStatus{
-	models.AgentStatusIdle:            {models.AgentStatusWorking, models.AgentStatusPaused, models.AgentStatusStopped, models.AgentStatusPendingApproval},
+	models.AgentStatusIdle:            {models.AgentStatusPaused, models.AgentStatusStopped, models.AgentStatusPendingApproval},
 	models.AgentStatusWorking:         {models.AgentStatusIdle, models.AgentStatusPaused, models.AgentStatusStopped},
 	models.AgentStatusPaused:          {models.AgentStatusIdle, models.AgentStatusStopped},
 	models.AgentStatusStopped:         {models.AgentStatusIdle},

--- a/apps/backend/internal/office/dashboard/service_agents_internal_test.go
+++ b/apps/backend/internal/office/dashboard/service_agents_internal_test.go
@@ -1,0 +1,31 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// A working agent must count toward the dashboard's running total (DR-14):
+// before agent_working_status.go started writing AgentStatusWorking, every
+// agent read idle even mid-run, so this counter was permanently pinned at
+// zero regardless of how many agents were actually busy.
+func TestCountAgentsByStatus_WorkingCountsAsRunning(t *testing.T) {
+	counts := countAgentsByStatus([]*models.AgentInstance{
+		{ID: "a1", Status: models.AgentStatusWorking},
+		{ID: "a2", Status: models.AgentStatusWorking},
+		{ID: "a3", Status: models.AgentStatusIdle},
+		{ID: "a4", Status: models.AgentStatusPaused},
+		{ID: "a5", Status: models.AgentStatusStopped, PauseReason: "budget exceeded"},
+	})
+
+	if counts.running != 2 {
+		t.Errorf("running = %d, want 2 (only working agents)", counts.running)
+	}
+	if counts.paused != 1 {
+		t.Errorf("paused = %d, want 1", counts.paused)
+	}
+	if counts.errors != 1 {
+		t.Errorf("errors = %d, want 1 (stopped with a pause reason)", counts.errors)
+	}
+}

--- a/apps/backend/internal/office/infra/reconcile.go
+++ b/apps/backend/internal/office/infra/reconcile.go
@@ -32,6 +32,9 @@ func NewReconciler(repo *sqlite.Repository, log *logger.Logger) *Reconciler {
 // ReconcileAll runs every reconciliation step. Errors are logged, not returned,
 // so that startup is never blocked by a single reconciliation failure.
 func (r *Reconciler) ReconcileAll(ctx context.Context) {
+	if err := r.reconcileAgentWorkingStatus(ctx); err != nil {
+		r.logger.Warn("reconcile agent working status", zap.Error(err))
+	}
 	if err := r.reconcileAgentRuntime(ctx); err != nil {
 		r.logger.Warn("reconcile agent runtime", zap.Error(err))
 	}
@@ -44,6 +47,14 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) {
 	if err := r.reconcileChannels(ctx); err != nil {
 		r.logger.Warn("reconcile channels", zap.Error(err))
 	}
+}
+
+// reconcileAgentWorkingStatus clears the display projection for runs that no
+// longer have an active claim. This makes terminal status cleanup recoverable
+// after a process stop or a transient database error.
+func (r *Reconciler) reconcileAgentWorkingStatus(ctx context.Context) error {
+	_, err := r.repo.ReconcileAgentWorkingStatus(ctx)
+	return err
 }
 
 // reconcileAgentRuntime drops legacy runtime rows for agents that no longer

--- a/apps/backend/internal/office/infra/reconcile_test.go
+++ b/apps/backend/internal/office/infra/reconcile_test.go
@@ -104,6 +104,59 @@ func TestReconcileAgentRuntime_PreservesExistingStatus(t *testing.T) {
 	}
 }
 
+func TestReconcileAgentWorkingStatus_ClearsTerminalOwner(t *testing.T) {
+	r, repo := newTestReconciler(t)
+	ctx := context.Background()
+
+	agent := &models.AgentInstance{
+		ID:          "agent-orphaned-working",
+		Name:        "orphaned-worker",
+		WorkspaceID: "default",
+		Role:        models.AgentRoleWorker,
+		Status:      models.AgentStatusIdle,
+	}
+	if err := repo.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	run := &models.Run{
+		ID:             "run-orphaned-working",
+		AgentProfileID: agent.ID,
+		Reason:         "test",
+		Payload:        `{}`,
+	}
+	if err := repo.CreateRun(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	claimed, err := repo.ClaimRun(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("claim run: %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, agent.ID, claimed.ID); err != nil {
+		t.Fatalf("mark agent working: %v", err)
+	}
+	if err := repo.FinishRun(ctx, claimed.ID, "finished", nil); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+
+	r.ReconcileAll(ctx)
+
+	got, err := repo.GetAgentInstance(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if got.Status != models.AgentStatusIdle {
+		t.Fatalf("status = %q, want idle", got.Status)
+	}
+	var owner string
+	if err := repo.ReaderDB().GetContext(ctx, &owner,
+		`SELECT working_run_id FROM agent_profiles WHERE id = ?`, agent.ID); err != nil {
+		t.Fatalf("read working owner: %v", err)
+	}
+	if owner != "" {
+		t.Fatalf("working_run_id = %q, want empty", owner)
+	}
+}
+
 func TestReconcileRoutineTriggers_NewRoutineCreatesTrigger(t *testing.T) {
 	r, repo := newTestReconciler(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -1,9 +1,7 @@
-// Office agent "working" status transitions (DR-14).
+// Office agent "working" status transitions.
 //
-// AgentStatusWorking has existed in the status vocabulary, the transition
-// table, and the dashboard chip since Office shipped, but nothing ever
-// wrote it: every agent read "idle" permanently, including mid-run. These
-// two methods are the only production writers of that status.
+// MarkAgentWorking and ClearAgentWorking are the only production writers of
+// AgentStatusWorking.
 //
 // Both are compare-and-swap by design. An unconditional UPDATE would let a
 // late-arriving reset clobber a status set by a concurrent, higher-priority

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -1,0 +1,65 @@
+// Office agent "working" status transitions (DR-14).
+//
+// AgentStatusWorking has existed in the status vocabulary, the transition
+// table, and the dashboard chip since Office shipped, but nothing ever
+// wrote it: every agent read "idle" permanently, including mid-run. These
+// two methods are the only production writers of that status.
+//
+// Both are compare-and-swap by design. An unconditional UPDATE would let a
+// late-arriving reset clobber a status set by a concurrent, higher-priority
+// writer — most dangerously autoPauseAgent (office/service/failure.go),
+// which pauses an agent after consecutive failures on the very same code
+// path that clears "working". A CAS makes each write a no-op unless the
+// agent is still in the exact state the caller observed, so the reset can
+// be called redundantly from any terminal path without resurrecting a
+// paused, stopped, or pending-approval agent back to idle.
+
+package sqlite
+
+import (
+	"context"
+	"time"
+)
+
+// MarkAgentWorking transitions an agent from "idle" to "working". Returns
+// true when this call performed the transition.
+//
+// Scoped to status = 'idle' so it cannot overwrite a status a concurrent
+// writer set between the scheduler's isAgentActive check and the launch
+// (a user pausing the agent, a budget pause, an approval gate). A false
+// return therefore means "the agent was not idle" and is not an error: the
+// run still launches, exactly as it did before this status existed.
+func (r *Repository) MarkAgentWorking(ctx context.Context, id string) (bool, error) {
+	return r.swapAgentStatus(ctx, id, "idle", "working")
+}
+
+// ClearAgentWorking transitions an agent from "working" back to "idle".
+// Returns true when this call performed the transition.
+//
+// Scoped to status = 'working' so it is a no-op for an agent that has
+// already moved on. This is what makes it safe to call from every terminal
+// path (success, failure, cancellation, and the never-launched branches)
+// without ordering constraints between them.
+func (r *Repository) ClearAgentWorking(ctx context.Context, id string) (bool, error) {
+	return r.swapAgentStatus(ctx, id, "working", "idle")
+}
+
+// swapAgentStatus performs a conditional status update, matching
+// UpdateAgentStatusFields' office-row scoping. pause_reason is deliberately
+// left untouched: neither transition here is a pause, and clearing the
+// column would erase a reason another writer owns.
+func (r *Repository) swapAgentStatus(ctx context.Context, id, from, to string) (bool, error) {
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_profiles
+		SET status = ?, updated_at = ?
+		WHERE id = ? AND status = ? AND `+agentInstanceFilter+`
+	`), to, time.Now().UTC(), id, from)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -16,45 +16,56 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"time"
 )
 
-// MarkAgentWorking transitions an agent from "idle" to "working". Returns
-// true when this call performed the transition.
+// MarkAgentWorking transitions an agent from "idle" to "working" and records
+// runID as the run that owns the transition. Returns true when this call
+// performed the transition.
 //
 // Scoped to status = 'idle' so it cannot overwrite a status a concurrent
 // writer set between the scheduler's isAgentActive check and the launch
 // (a user pausing the agent, a budget pause, an approval gate). A false
 // return therefore means "the agent was not idle" and is not an error: the
 // run still launches, exactly as it did before this status existed.
-func (r *Repository) MarkAgentWorking(ctx context.Context, id string) (bool, error) {
-	return r.swapAgentStatus(ctx, id, "idle", "working")
-}
-
-// ClearAgentWorking transitions an agent from "working" back to "idle".
-// Returns true when this call performed the transition.
-//
-// Scoped to status = 'working' so it is a no-op for an agent that has
-// already moved on. This is what makes it safe to call from every terminal
-// path (success, failure, cancellation, and the never-launched branches)
-// without ordering constraints between them.
-func (r *Repository) ClearAgentWorking(ctx context.Context, id string) (bool, error) {
-	return r.swapAgentStatus(ctx, id, "working", "idle")
-}
-
-// swapAgentStatus performs a conditional status update, matching
-// UpdateAgentStatusFields' office-row scoping. pause_reason is deliberately
-// left untouched: neither transition here is a pause, and clearing the
-// column would erase a reason another writer owns.
-func (r *Repository) swapAgentStatus(ctx context.Context, id, from, to string) (bool, error) {
+func (r *Repository) MarkAgentWorking(ctx context.Context, id, runID string) (bool, error) {
 	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE agent_profiles
-		SET status = ?, updated_at = ?
-		WHERE id = ? AND status = ? AND `+agentInstanceFilter+`
-	`), to, time.Now().UTC(), id, from)
+		SET status = 'working', working_run_id = ?, updated_at = ?
+		WHERE id = ? AND status = 'idle' AND `+agentInstanceFilter+`
+	`), runID, time.Now().UTC(), id)
 	if err != nil {
 		return false, err
 	}
+	return rowsChanged(res)
+}
+
+// ClearAgentWorking transitions an agent from "working" back to "idle", but
+// only when runID matches the run recorded by MarkAgentWorking. Returns true
+// when this call performed the transition.
+//
+// The runID match is what keeps a stale or duplicate terminal event for a
+// finished run from clobbering a successor run's live "working" status: once
+// a new run has re-marked the agent working, its runID no longer matches the
+// old event's, so the old event's clear becomes a no-op instead of an
+// incorrect reset. Combined with the status = 'working' scope, this is also
+// what makes the call safe to repeat from every terminal path (success,
+// failure, cancellation, and the never-launched branches) without ordering
+// constraints between them.
+func (r *Repository) ClearAgentWorking(ctx context.Context, id, runID string) (bool, error) {
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_profiles
+		SET status = 'idle', working_run_id = '', updated_at = ?
+		WHERE id = ? AND status = 'working' AND working_run_id = ? AND `+agentInstanceFilter+`
+	`), time.Now().UTC(), id, runID)
+	if err != nil {
+		return false, err
+	}
+	return rowsChanged(res)
+}
+
+func rowsChanged(res sql.Result) (bool, error) {
 	rows, err := res.RowsAffected()
 	if err != nil {
 		return false, err

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -65,6 +65,29 @@ func (r *Repository) ClearAgentWorking(ctx context.Context, id, runID string) (b
 	return rowsChanged(res)
 }
 
+// ReconcileAgentWorkingStatus clears working rows whose owner is no longer
+// an in-flight run. This repairs the gap left when a terminal run commit
+// succeeds but the following display-state update does not.
+func (r *Repository) ReconcileAgentWorkingStatus(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_profiles
+		SET status = 'idle', working_run_id = '', updated_at = ?
+		WHERE status = 'working' AND `+agentInstanceFilter+`
+		  AND (
+			working_run_id = ''
+			OR NOT EXISTS (
+				SELECT 1 FROM runs
+				WHERE runs.id = agent_profiles.working_run_id
+				  AND runs.status = 'claimed'
+			)
+		  )
+	`), time.Now().UTC())
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func rowsChanged(res sql.Result) (bool, error) {
 	rows, err := res.RowsAffected()
 	if err != nil {

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
@@ -1,0 +1,138 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// workingStatusAgent creates a minimal office agent at the given status.
+func workingStatusAgent(t *testing.T, repo *sqlite.Repository, id, status string) *models.AgentInstance {
+	t.Helper()
+	agent := &models.AgentInstance{
+		ID:          id,
+		WorkspaceID: "ws-working",
+		Name:        id,
+		Role:        models.AgentRoleWorker,
+		Status:      models.AgentStatus(status),
+	}
+	if err := repo.CreateAgentInstance(context.Background(), agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	return agent
+}
+
+func statusOf(t *testing.T, repo *sqlite.Repository, id string) models.AgentStatus {
+	t.Helper()
+	got, err := repo.GetAgentInstance(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	return got.Status
+}
+
+// TestMarkAgentWorking_FromIdle is the core DR-14 write: before this method
+// existed, no production code path could ever produce this status.
+func TestMarkAgentWorking_FromIdle(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	workingStatusAgent(t, repo, "agent-idle-to-working", "idle")
+
+	changed, err := repo.MarkAgentWorking(ctx, "agent-idle-to-working")
+	if err != nil {
+		t.Fatalf("mark working: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true for an idle agent")
+	}
+	if got := statusOf(t, repo, "agent-idle-to-working"); got != models.AgentStatusWorking {
+		t.Fatalf("status = %q, want %q", got, models.AgentStatusWorking)
+	}
+}
+
+func TestClearAgentWorking_ReturnsToIdle(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	workingStatusAgent(t, repo, "agent-working-to-idle", "working")
+
+	changed, err := repo.ClearAgentWorking(ctx, "agent-working-to-idle")
+	if err != nil {
+		t.Fatalf("clear working: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true for a working agent")
+	}
+	if got := statusOf(t, repo, "agent-working-to-idle"); got != models.AgentStatusIdle {
+		t.Fatalf("status = %q, want %q", got, models.AgentStatusIdle)
+	}
+}
+
+// TestClearAgentWorking_DoesNotResurrectPausedAgent guards the highest-risk
+// interaction in DR-14. HandleAgentFailure clears "working" on the same code
+// path that auto-pauses an agent after consecutive failures. If the reset
+// were an unconditional UPDATE rather than a CAS, a paused agent would be
+// silently flipped back to idle and would resume picking up runs.
+func TestClearAgentWorking_DoesNotResurrectPausedAgent(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	for _, status := range []string{"paused", "stopped", "pending_approval"} {
+		id := "agent-guard-" + status
+		workingStatusAgent(t, repo, id, status)
+
+		changed, err := repo.ClearAgentWorking(ctx, id)
+		if err != nil {
+			t.Fatalf("%s: clear working: %v", status, err)
+		}
+		if changed {
+			t.Fatalf("%s: changed = true, want false: only a working agent may be reset", status)
+		}
+		if got := statusOf(t, repo, id); string(got) != status {
+			t.Fatalf("%s: status = %q, want it left untouched", status, got)
+		}
+	}
+}
+
+// TestMarkAgentWorking_SkipsNonIdleAgent covers the reverse guard: a user
+// pausing an agent between the scheduler's isAgentActive check and the launch
+// must not have that pause overwritten by the launch's status write.
+func TestMarkAgentWorking_SkipsNonIdleAgent(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	workingStatusAgent(t, repo, "agent-paused-at-launch", "paused")
+
+	changed, err := repo.MarkAgentWorking(ctx, "agent-paused-at-launch")
+	if err != nil {
+		t.Fatalf("mark working: %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false: a paused agent must stay paused")
+	}
+	if got := statusOf(t, repo, "agent-paused-at-launch"); got != models.AgentStatusPaused {
+		t.Fatalf("status = %q, want paused", got)
+	}
+}
+
+// TestClearAgentWorking_IsIdempotent is what lets the reset be called from
+// several terminal paths for the same run without ordering constraints.
+func TestClearAgentWorking_IsIdempotent(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	workingStatusAgent(t, repo, "agent-double-clear", "working")
+
+	if _, err := repo.ClearAgentWorking(ctx, "agent-double-clear"); err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+	changed, err := repo.ClearAgentWorking(ctx, "agent-double-clear")
+	if err != nil {
+		t.Fatalf("second clear: %v", err)
+	}
+	if changed {
+		t.Fatal("second clear reported a change, want a no-op")
+	}
+	if got := statusOf(t, repo, "agent-double-clear"); got != models.AgentStatusIdle {
+		t.Fatalf("status = %q, want idle", got)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/repository/sqlite"
 )
@@ -33,6 +35,16 @@ func statusOf(t *testing.T, repo *sqlite.Repository, id string) models.AgentStat
 	return got.Status
 }
 
+// setWorkingRunID seeds the owning-run bookkeeping column directly, since
+// CreateAgentInstance has no field for it (production writers are
+// MarkAgentWorking/ClearAgentWorking only).
+func setWorkingRunID(t *testing.T, db *sqlx.DB, agentID, runID string) {
+	t.Helper()
+	if _, err := db.Exec(`UPDATE agent_profiles SET working_run_id = ? WHERE id = ?`, runID, agentID); err != nil {
+		t.Fatalf("seed working_run_id: %v", err)
+	}
+}
+
 // TestMarkAgentWorking_FromIdle is the core DR-14 write: before this method
 // existed, no production code path could ever produce this status.
 func TestMarkAgentWorking_FromIdle(t *testing.T) {
@@ -40,7 +52,7 @@ func TestMarkAgentWorking_FromIdle(t *testing.T) {
 	ctx := context.Background()
 	workingStatusAgent(t, repo, "agent-idle-to-working", "idle")
 
-	changed, err := repo.MarkAgentWorking(ctx, "agent-idle-to-working")
+	changed, err := repo.MarkAgentWorking(ctx, "agent-idle-to-working", "run-1")
 	if err != nil {
 		t.Fatalf("mark working: %v", err)
 	}
@@ -53,19 +65,75 @@ func TestMarkAgentWorking_FromIdle(t *testing.T) {
 }
 
 func TestClearAgentWorking_ReturnsToIdle(t *testing.T) {
-	repo := newTestRepo(t)
+	repo, db := newTestRepoWithDB(t)
 	ctx := context.Background()
 	workingStatusAgent(t, repo, "agent-working-to-idle", "working")
+	setWorkingRunID(t, db, "agent-working-to-idle", "run-1")
 
-	changed, err := repo.ClearAgentWorking(ctx, "agent-working-to-idle")
+	changed, err := repo.ClearAgentWorking(ctx, "agent-working-to-idle", "run-1")
 	if err != nil {
 		t.Fatalf("clear working: %v", err)
 	}
 	if !changed {
-		t.Fatal("changed = false, want true for a working agent")
+		t.Fatal("changed = false, want true for a working agent whose runID matches")
 	}
 	if got := statusOf(t, repo, "agent-working-to-idle"); got != models.AgentStatusIdle {
 		t.Fatalf("status = %q, want %q", got, models.AgentStatusIdle)
+	}
+}
+
+// TestClearAgentWorking_MismatchedRunID_DoesNotClobberSuccessor is the
+// interleaving regression: a stale or duplicate terminal event for a run
+// that has already finished must not be able to reset an agent a SUCCESSOR
+// run has since marked working. Before working_run_id existed, this exact
+// sequence flipped a live run's agent back to "idle" — reintroducing DR-14's
+// invisibility bug in a narrower window.
+func TestClearAgentWorking_MismatchedRunID_DoesNotClobberSuccessor(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	workingStatusAgent(t, repo, "agent-interleaved", "idle")
+
+	// Run A launches and marks the agent working.
+	if _, err := repo.MarkAgentWorking(ctx, "agent-interleaved", "run-a"); err != nil {
+		t.Fatalf("mark working (run-a): %v", err)
+	}
+
+	// Run A finishes via another path (e.g. ReapStaleCheckouts), the agent
+	// goes idle, and a successor Run B is claimed and launched for the same
+	// agent before Run A's own (late/duplicate) terminal event arrives.
+	if _, err := repo.ClearAgentWorking(ctx, "agent-interleaved", "run-a"); err != nil {
+		t.Fatalf("clear working (run-a): %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, "agent-interleaved", "run-b"); err != nil {
+		t.Fatalf("mark working (run-b): %v", err)
+	}
+	if got := statusOf(t, repo, "agent-interleaved"); got != models.AgentStatusWorking {
+		t.Fatalf("status after run-b launch = %q, want %q", got, models.AgentStatusWorking)
+	}
+
+	// Run A's stale/duplicate terminal event now arrives and tries to clear
+	// using its own (no-longer-current) run id.
+	changed, err := repo.ClearAgentWorking(ctx, "agent-interleaved", "run-a")
+	if err != nil {
+		t.Fatalf("stale clear (run-a): %v", err)
+	}
+	if changed {
+		t.Fatal("stale clear reported a change: it must be a no-op once run-b owns \"working\"")
+	}
+	if got := statusOf(t, repo, "agent-interleaved"); got != models.AgentStatusWorking {
+		t.Fatalf("status after stale run-a clear = %q, want %q (run-b still in flight)", got, models.AgentStatusWorking)
+	}
+
+	// Run B's own terminal event correctly clears it.
+	changed, err = repo.ClearAgentWorking(ctx, "agent-interleaved", "run-b")
+	if err != nil {
+		t.Fatalf("clear working (run-b): %v", err)
+	}
+	if !changed {
+		t.Fatal("run-b's own clear should have changed the status")
+	}
+	if got := statusOf(t, repo, "agent-interleaved"); got != models.AgentStatusIdle {
+		t.Fatalf("status after run-b clear = %q, want %q", got, models.AgentStatusIdle)
 	}
 }
 
@@ -82,7 +150,7 @@ func TestClearAgentWorking_DoesNotResurrectPausedAgent(t *testing.T) {
 		id := "agent-guard-" + status
 		workingStatusAgent(t, repo, id, status)
 
-		changed, err := repo.ClearAgentWorking(ctx, id)
+		changed, err := repo.ClearAgentWorking(ctx, id, "run-1")
 		if err != nil {
 			t.Fatalf("%s: clear working: %v", status, err)
 		}
@@ -103,7 +171,7 @@ func TestMarkAgentWorking_SkipsNonIdleAgent(t *testing.T) {
 	ctx := context.Background()
 	workingStatusAgent(t, repo, "agent-paused-at-launch", "paused")
 
-	changed, err := repo.MarkAgentWorking(ctx, "agent-paused-at-launch")
+	changed, err := repo.MarkAgentWorking(ctx, "agent-paused-at-launch", "run-1")
 	if err != nil {
 		t.Fatalf("mark working: %v", err)
 	}
@@ -118,14 +186,15 @@ func TestMarkAgentWorking_SkipsNonIdleAgent(t *testing.T) {
 // TestClearAgentWorking_IsIdempotent is what lets the reset be called from
 // several terminal paths for the same run without ordering constraints.
 func TestClearAgentWorking_IsIdempotent(t *testing.T) {
-	repo := newTestRepo(t)
+	repo, db := newTestRepoWithDB(t)
 	ctx := context.Background()
 	workingStatusAgent(t, repo, "agent-double-clear", "working")
+	setWorkingRunID(t, db, "agent-double-clear", "run-1")
 
-	if _, err := repo.ClearAgentWorking(ctx, "agent-double-clear"); err != nil {
+	if _, err := repo.ClearAgentWorking(ctx, "agent-double-clear", "run-1"); err != nil {
 		t.Fatalf("first clear: %v", err)
 	}
-	changed, err := repo.ClearAgentWorking(ctx, "agent-double-clear")
+	changed, err := repo.ClearAgentWorking(ctx, "agent-double-clear", "run-1")
 	if err != nil {
 		t.Fatalf("second clear: %v", err)
 	}

--- a/apps/backend/internal/office/repository/sqlite/agents.go
+++ b/apps/backend/internal/office/repository/sqlite/agents.go
@@ -275,21 +275,33 @@ func (r *Repository) UpdateAgentInstance(ctx context.Context, agent *models.Agen
 	}
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE agent_profiles SET
-			name = ?, role = ?, icon = ?, status = ?,
+			name = ?, role = ?, icon = ?,
+			status = CASE
+				WHEN (status = 'working' AND working_run_id <> '') OR ? = 'working' THEN status
+				ELSE ?
+			END,
 			reports_to = ?, permissions = ?, budget_monthly_cents = ?,
 			max_concurrent_sessions = ?, cooldown_sec = ?, skip_idle_runs = ?,
 			last_run_finished_at = ?,
 			skill_ids = ?, desired_skills = ?, executor_preference = ?,
-			pause_reason = ?, failure_threshold = ?, settings = ?,
+			pause_reason = CASE
+				WHEN (status = 'working' AND working_run_id <> '') OR ? = 'working' THEN pause_reason
+				ELSE ?
+			END,
+			working_run_id = CASE
+				WHEN status = 'working' AND working_run_id <> '' THEN working_run_id
+				ELSE ''
+			END,
+			failure_threshold = ?, settings = ?,
 			auto_approve = ?, allow_indexing = ?, cli_passthrough = ?,
 			updated_at = ?
 		WHERE id = ? AND `+agentInstanceFilter+`
-	`), agent.Name, string(agent.Role), agent.Icon, status,
+	`), agent.Name, string(agent.Role), agent.Icon, status, status,
 		agent.ReportsTo, permissions, agent.BudgetMonthlyCents,
 		agent.MaxConcurrentSessions, agent.CooldownSec, boolToInt(agent.SkipIdleRuns),
 		agent.LastRunFinishedAt,
 		skillIDs, desiredSkills, agent.ExecutorPreference,
-		agent.PauseReason, threshold, settings,
+		status, agent.PauseReason, threshold, settings,
 		boolToInt(agent.AutoApprove), boolToInt(agent.AllowIndexing), boolToInt(agent.CLIPassthrough),
 		agent.UpdatedAt, agent.ID)
 	return err
@@ -396,9 +408,15 @@ func (r *Repository) UpdateAgentStatusFields(
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE agent_profiles
-		SET status = ?, pause_reason = ?, updated_at = ?
+		SET status = CASE WHEN ? = 'working' THEN status ELSE ? END,
+			pause_reason = CASE WHEN ? = 'working' THEN pause_reason ELSE ? END,
+			working_run_id = CASE
+				WHEN status = 'working' AND working_run_id <> '' AND ? = 'working' THEN working_run_id
+				ELSE ''
+			END,
+			updated_at = ?
 		WHERE id = ? AND `+agentInstanceFilter+`
-	`), status, pauseReason, now, id)
+	`), status, status, status, pauseReason, status, now, id)
 	return err
 }
 

--- a/apps/backend/internal/office/repository/sqlite/agents_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agents_test.go
@@ -429,7 +429,7 @@ func TestUpdateAgentInstance_PersistsEveryMutableField(t *testing.T) {
 	agent.Name = "After"
 	agent.Role = settingsmodels.AgentRole("engineer")
 	agent.Icon = "🛠"
-	agent.Status = settingsmodels.AgentStatus("working")
+	agent.Status = settingsmodels.AgentStatusPaused
 	agent.ReportsTo = "agent-boss"
 	agent.Permissions = `{"approve_budget":true}`
 	agent.BudgetMonthlyCents = 5150
@@ -506,6 +506,46 @@ func TestUpdateAgentInstance_NormalisesEmptyJSONAndStatus(t *testing.T) {
 	}
 	if got.FailureThreshold != nil {
 		t.Errorf("FailureThreshold = %d, want nil after clearing the override", *got.FailureThreshold)
+	}
+}
+
+func TestUpdateAgentInstance_DoesNotOverwriteWorkingOwner(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	agent := fullAgentInstance("u-working", "ws-1", "Working")
+	agent.Status = settingsmodels.AgentStatusIdle
+	if err := repo.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("CreateAgentInstance: %v", err)
+	}
+
+	snapshot, err := repo.GetAgentInstance(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentInstance: %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, agent.ID, "run-working"); err != nil {
+		t.Fatalf("MarkAgentWorking: %v", err)
+	}
+
+	snapshot.Name = "Renamed while working"
+	if err := repo.UpdateAgentInstance(ctx, snapshot); err != nil {
+		t.Fatalf("UpdateAgentInstance: %v", err)
+	}
+
+	got, err := repo.GetAgentInstance(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentInstance after update: %v", err)
+	}
+	if got.Status != settingsmodels.AgentStatusWorking {
+		t.Fatalf("Status = %q, want working", got.Status)
+	}
+	var owner string
+	if err := repo.ReaderDB().GetContext(ctx, &owner,
+		`SELECT working_run_id FROM agent_profiles WHERE id = ?`, agent.ID); err != nil {
+		t.Fatalf("read working owner: %v", err)
+	}
+	if owner != "run-working" {
+		t.Fatalf("working_run_id = %q, want run-working", owner)
 	}
 }
 
@@ -602,6 +642,30 @@ func TestUpdateAgentStatusFields(t *testing.T) {
 	// Unrelated columns survive.
 	if got.Icon != "🤖" {
 		t.Errorf("Icon = %q, want it untouched", got.Icon)
+	}
+}
+
+func TestUpdateAgentStatusFields_ClearsWorkingOwner(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	agent := fullAgentInstance("st-working", "ws-1", "Status")
+	agent.Status = settingsmodels.AgentStatusIdle
+	if err := repo.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("CreateAgentInstance: %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, agent.ID, "run-status"); err != nil {
+		t.Fatalf("MarkAgentWorking: %v", err)
+	}
+	if err := repo.UpdateAgentStatusFields(ctx, agent.ID, "paused", "manual pause"); err != nil {
+		t.Fatalf("UpdateAgentStatusFields: %v", err)
+	}
+	var owner string
+	if err := repo.ReaderDB().GetContext(ctx, &owner,
+		`SELECT working_run_id FROM agent_profiles WHERE id = ?`, agent.ID); err != nil {
+		t.Fatalf("read working owner: %v", err)
+	}
+	if owner != "" {
+		t.Fatalf("working_run_id = %q, want empty after pause", owner)
 	}
 }
 

--- a/apps/backend/internal/office/service/agent_working_status.go
+++ b/apps/backend/internal/office/service/agent_working_status.go
@@ -1,11 +1,4 @@
-// Agent "working" status lifecycle (DR-14).
-//
-// Office defines AgentStatusWorking, allows idle <-> working in the
-// transition table, and renders a pulsing "Working" chip for it, but until
-// this file nothing ever set it. Every agent read "idle" permanently, so a
-// stalled workspace and a busy one looked identical, and the dashboard's
-// "running" counter (countAgentsByStatus in office/dashboard) was pinned
-// to zero.
+// Agent "working" status lifecycle.
 //
 // The status is set at the launch boundary and cleared on every terminal
 // path. Writing "working" gates nothing: isAgentActive

--- a/apps/backend/internal/office/service/agent_working_status.go
+++ b/apps/backend/internal/office/service/agent_working_status.go
@@ -1,0 +1,117 @@
+// Agent "working" status lifecycle (DR-14).
+//
+// Office defines AgentStatusWorking, allows idle <-> working in the
+// transition table, and renders a pulsing "Working" chip for it, but until
+// this file nothing ever set it. Every agent read "idle" permanently, so a
+// stalled workspace and a busy one looked identical, and the dashboard's
+// "running" counter (countAgentsByStatus in office/dashboard) was pinned
+// to zero.
+//
+// The status is set at the launch boundary and cleared on every terminal
+// path. Writing "working" gates nothing: isAgentActive
+// (scheduler_integration.go) accepts idle AND working, and
+// ClaimNextEligibleRun does not filter on agent status at all, so no run
+// is blocked and no schedule is skipped by this transition.
+
+package service
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// Payload keys shared by the office agent status events. Declared here
+// because this file's publisher pushed the repeated literals past the
+// goconst threshold; the older publishers in event_subscribers.go,
+// retry.go, and failure.go still inline them.
+const (
+	eventKeyAgentProfileID = "agent_profile_id"
+	eventKeyWorkspaceID    = "workspace_id"
+)
+
+// markAgentWorking flips an idle agent to "working" as its run is handed to
+// the adapter.
+//
+// Called BEFORE the launch rather than after it: the completion event for a
+// fast run can be processed as soon as the adapter is invoked, and a
+// mark-after-launch would race that reset and strand the agent showing
+// "working" forever — the exact failure this feature must not introduce,
+// since a stuck "working" reads as progress that is not happening.
+// The caller clears the status when the launch turns out not to have
+// happened.
+func (s *Service) markAgentWorking(ctx context.Context, agent *models.AgentInstance) {
+	if agent == nil || agent.ID == "" {
+		return
+	}
+	changed, err := s.repo.MarkAgentWorking(ctx, agent.ID)
+	if err != nil {
+		// Status is a display signal, not a correctness gate: a failed
+		// write must never abort a run that is otherwise ready to launch.
+		s.logger.Warn("failed to mark agent working",
+			zap.String("agent", agent.ID), zap.Error(err))
+		return
+	}
+	if changed {
+		s.publishAgentStatusChanged(ctx, agent.ID, agent.WorkspaceID, string(models.AgentStatusWorking))
+	}
+}
+
+// clearAgentWorking returns an agent from "working" to "idle" once its run
+// reaches any terminal state.
+//
+// Idempotent and safe to call from more than one path for the same run: the
+// underlying CAS only fires while the agent is still "working". It is
+// therefore also safe to call after autoPauseAgent has paused the agent --
+// the pause wins and this becomes a no-op.
+//
+// The agent is looked up only when the status actually changed, so the
+// common completion path pays for the extra read once per finished run
+// rather than on every terminal transition (many of which never launched).
+func (s *Service) clearAgentWorking(ctx context.Context, agentID string) {
+	if agentID == "" {
+		return
+	}
+	changed, err := s.repo.ClearAgentWorking(ctx, agentID)
+	if err != nil {
+		s.logger.Warn("failed to clear agent working status",
+			zap.String("agent", agentID), zap.Error(err))
+		return
+	}
+	if !changed {
+		return
+	}
+	agent, err := s.repo.GetAgentInstance(ctx, agentID)
+	if err != nil {
+		s.logger.Debug("agent lookup for status broadcast failed",
+			zap.String("agent", agentID), zap.Error(err))
+		return
+	}
+	s.publishAgentStatusChanged(ctx, agentID, agent.WorkspaceID, string(models.AgentStatusIdle))
+}
+
+// publishAgentStatusChanged broadcasts an agent status flip so the chip
+// updates live instead of waiting for the next poll.
+//
+// It publishes OfficeAgentUpdated, not OfficeAgentStatusChanged: the
+// latter constant is declared in both internal/events and this package but
+// has never had a publisher or a WS forwarding rule, so an event on it
+// reaches no client. OfficeAgentUpdated is subscribed by the office
+// broadcaster (gateway/websocket/office_notifications.go) and handled in
+// apps/web/lib/ws/handlers/office.ts, which refetches the agent list.
+func (s *Service) publishAgentStatusChanged(ctx context.Context, agentID, workspaceID, status string) {
+	if s.eb == nil || workspaceID == "" {
+		return
+	}
+	data := map[string]interface{}{
+		eventKeyAgentProfileID: agentID,
+		eventKeyWorkspaceID:    workspaceID,
+		"status":               status,
+	}
+	_ = s.eb.Publish(ctx, events.OfficeAgentUpdated,
+		bus.NewEvent(events.OfficeAgentUpdated, "office-agent-status", data))
+}

--- a/apps/backend/internal/office/service/agent_working_status.go
+++ b/apps/backend/internal/office/service/agent_working_status.go
@@ -28,7 +28,7 @@ const (
 )
 
 // markAgentWorking flips an idle agent to "working" as its run is handed to
-// the adapter.
+// the adapter, recording runID as the owning run.
 //
 // Called BEFORE the launch rather than after it: the completion event for a
 // fast run can be processed as soon as the adapter is invoked, and a
@@ -37,11 +37,15 @@ const (
 // since a stuck "working" reads as progress that is not happening.
 // The caller clears the status when the launch turns out not to have
 // happened.
-func (s *Service) markAgentWorking(ctx context.Context, agent *models.AgentInstance) {
-	if agent == nil || agent.ID == "" {
+//
+// runID must be non-empty: it is the only way a later clearAgentWorking call
+// can tell this run's own reset apart from a stale one belonging to a
+// different run for the same agent.
+func (s *Service) markAgentWorking(ctx context.Context, agent *models.AgentInstance, runID string) {
+	if agent == nil || agent.ID == "" || runID == "" {
 		return
 	}
-	changed, err := s.repo.MarkAgentWorking(ctx, agent.ID)
+	changed, err := s.repo.MarkAgentWorking(ctx, agent.ID, runID)
 	if err != nil {
 		// Status is a display signal, not a correctness gate: a failed
 		// write must never abort a run that is otherwise ready to launch.
@@ -54,22 +58,31 @@ func (s *Service) markAgentWorking(ctx context.Context, agent *models.AgentInsta
 	}
 }
 
-// clearAgentWorking returns an agent from "working" to "idle" once its run
-// reaches any terminal state.
+// clearAgentWorking returns an agent from "working" to "idle" once the run
+// identified by runID reaches any terminal state.
+//
+// runID is matched against the run recorded by markAgentWorking: a clear for
+// a run that is no longer the one holding "working" (because a successor run
+// has since re-marked the agent) is a no-op instead of clobbering the
+// successor's live status. Callers that cannot resolve their own run's
+// identity (a lifecycle event with no run_id) pass through whatever they
+// have, including "" — that can only match an agent that was never marked
+// working by the current, run-scoped code path, so it never clobbers a real
+// in-flight run.
 //
 // Idempotent and safe to call from more than one path for the same run: the
-// underlying CAS only fires while the agent is still "working". It is
-// therefore also safe to call after autoPauseAgent has paused the agent --
-// the pause wins and this becomes a no-op.
+// underlying CAS only fires while the agent is still "working" for that
+// runID. It is therefore also safe to call after autoPauseAgent has paused
+// the agent -- the pause wins and this becomes a no-op.
 //
 // The agent is looked up only when the status actually changed, so the
 // common completion path pays for the extra read once per finished run
 // rather than on every terminal transition (many of which never launched).
-func (s *Service) clearAgentWorking(ctx context.Context, agentID string) {
+func (s *Service) clearAgentWorking(ctx context.Context, agentID, runID string) {
 	if agentID == "" {
 		return
 	}
-	changed, err := s.repo.ClearAgentWorking(ctx, agentID)
+	changed, err := s.repo.ClearAgentWorking(ctx, agentID, runID)
 	if err != nil {
 		s.logger.Warn("failed to clear agent working status",
 			zap.String("agent", agentID), zap.Error(err))

--- a/apps/backend/internal/office/service/agent_working_status_internal_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_internal_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// TestIsAgentActive_AcceptsWorking is the tripwire the "working" status
+// depends on for its safety.
+//
+// Setting an agent to "working" while its run is in flight is only harmless
+// because isAgentActive — the gate at scheduler_integration.go that decides
+// whether a claimed run proceeds — treats "working" as active. If a later
+// change narrows this predicate to "idle" only, every agent mid-run would
+// silently stop being schedulable: runs would be finished with
+// RunOutcomeAgentInactive instead of executing, and nothing else in the
+// codebase would fail. This test exists to make that narrowing fail loudly
+// here rather than in production.
+func TestIsAgentActive_AcceptsWorking(t *testing.T) {
+	if !isAgentActive(models.AgentStatusWorking) {
+		t.Fatal("isAgentActive rejected AgentStatusWorking: agents are now set " +
+			"to 'working' for the duration of a run (see markAgentWorking), so " +
+			"narrowing this predicate silently parks every running agent")
+	}
+	if !isAgentActive(models.AgentStatusIdle) {
+		t.Fatal("isAgentActive rejected AgentStatusIdle")
+	}
+}
+
+// TestIsAgentActive_RejectsInactiveStatuses pins the other half of the
+// contract so the tripwire above cannot be satisfied by a predicate that
+// simply returns true for everything.
+func TestIsAgentActive_RejectsInactiveStatuses(t *testing.T) {
+	for _, status := range []models.AgentStatus{
+		models.AgentStatusPaused,
+		models.AgentStatusStopped,
+		models.AgentStatusPendingApproval,
+	} {
+		if isAgentActive(status) {
+			t.Fatalf("isAgentActive(%q) = true, want false", status)
+		}
+	}
+}

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -1,0 +1,187 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/service"
+)
+
+// DR-14: "working" is a defined agent status that nothing ever assigned, so
+// every Office agent read "idle" permanently — including while a run was in
+// flight. These tests cover the write at the launch boundary and the reset
+// on all three terminal paths (success, failure, cancellation).
+
+// launchedWorkingAgent seeds an agent + task, ticks the scheduler so the run
+// is actually handed to the adapter, and returns the agent. On return the
+// agent is mid-run: its run row is `claimed` and no terminal event has been
+// delivered yet.
+func launchedWorkingAgent(
+	t *testing.T, svc *service.Service, ctx context.Context, name, taskID string,
+) *models.AgentInstance {
+	t.Helper()
+	agent := makeAgent(name, models.AgentRoleWorker)
+	if err := svc.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	// The task needs a project carrying an executor config: executor
+	// resolution runs before the launch, and a run that fails there is
+	// retried without ever reaching the adapter.
+	project := &models.Project{
+		WorkspaceID:    "ws-1",
+		Name:           "Project " + name,
+		ExecutorConfig: `{"type":"local_pc"}`,
+	}
+	if err := svc.CreateProject(ctx, project); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	svc.ExecSQL(t, `INSERT INTO tasks (id, workspace_id, project_id, title, created_at, updated_at)
+		VALUES (?, 'ws-1', ?, 'Working status task', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		taskID, project.ID)
+	if err := svc.QueueRun(ctx, agent.ID, service.RunReasonTaskAssigned,
+		`{"task_id":"`+taskID+`"}`, ""); err != nil {
+		t.Fatalf("queue run: %v", err)
+	}
+	service.RunSchedulerTick(svc, ctx)
+	return agent
+}
+
+func assertAgentStatus(
+	t *testing.T, svc *service.Service, ctx context.Context,
+	agentID string, want models.AgentStatus, when string,
+) {
+	t.Helper()
+	got, err := svc.GetAgentFromConfig(ctx, agentID)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if got.Status != want {
+		t.Fatalf("status %s = %q, want %q", when, got.Status, want)
+	}
+}
+
+// TestAgentStatus_WorkingWhileRunInFlight is the core DR-14 regression pin:
+// before this change the assertion below read "idle" for an agent whose run
+// had just been handed to the adapter, making a busy workspace and a stalled
+// one indistinguishable.
+func TestAgentStatus_WorkingWhileRunInFlight(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	ctx := context.Background()
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-inflight", "task-working-inflight")
+
+	if mock.callCount() != 1 {
+		t.Fatalf("StartTask calls = %d, want 1: the run must actually launch "+
+			"for the status to mean anything", mock.callCount())
+	}
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "while the run is in flight")
+}
+
+// TestAgentStatus_ReturnsToIdleOnCompletion covers the success path:
+// AgentCompleted -> handleAgentCompleted -> stampRunFinished.
+func TestAgentStatus_ReturnsToIdleOnCompletion(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-completes", "task-working-complete")
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before completion")
+
+	publishLifecycle(t, ctx, eb, events.AgentCompleted, "task-working-complete", agent.ID)
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle, "after completion")
+}
+
+// TestAgentStatus_ReturnsToIdleOnFailure covers the failure path:
+// AgentFailed -> handleAgentFailed -> HandleAgentFailure. A failed run that
+// left the agent pinned to "working" would be the worst outcome of this
+// feature — it reads as progress that is not happening.
+func TestAgentStatus_ReturnsToIdleOnFailure(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-fails", "task-working-fail")
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before failure")
+
+	event := bus.NewEvent(events.AgentFailed, "test", map[string]string{
+		"task_id":          "task-working-fail",
+		"session_id":       "session-fail",
+		"agent_profile_id": agent.ID,
+		"error_message":    "boom",
+	})
+	if err := eb.Publish(ctx, events.AgentFailed, event); err != nil {
+		t.Fatalf("publish agent failed: %v", err)
+	}
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle, "after failure")
+}
+
+// TestAgentStatus_ReturnsToIdleOnStop covers the cancellation path.
+// AgentStopped is wired to handleAgentCompleted (event_subscribers.go), so
+// this shares the reset seam with the success path — pinned separately
+// because a future split of those subscribers must not drop the reset.
+func TestAgentStatus_ReturnsToIdleOnStop(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-stopped", "task-working-stop")
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before stop")
+
+	publishLifecycle(t, ctx, eb, events.AgentStopped, "task-working-stop", agent.ID)
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle, "after stop")
+}
+
+// TestAgentStatus_NotLeftWorkingWhenLaunchNeverHappened pins the branch that
+// has no terminal event to clean up after it: launchAgent returned false, so
+// no AgentCompleted/AgentFailed/AgentStopped will ever arrive. Without the
+// explicit clear in prepareAndLaunch the agent would sit at "working"
+// forever, permanently misreporting a run that never started.
+func TestAgentStatus_NotLeftWorkingWhenLaunchNeverHappened(t *testing.T) {
+	// No TaskStarter configured: launchAgent bails at its
+	// "no task starter configured" guard, via failUnlaunchableRun.
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-unlaunchable", "task-working-unlaunchable")
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after a run that never reached the adapter")
+}
+
+func publishLifecycle(
+	t *testing.T, ctx context.Context, eb bus.EventBus,
+	topic, taskID, agentID string,
+) {
+	t.Helper()
+	event := bus.NewEvent(topic, "test", map[string]string{
+		"task_id":          taskID,
+		"session_id":       "session-" + agentID,
+		"agent_profile_id": agentID,
+	})
+	if err := eb.Publish(ctx, topic, event); err != nil {
+		t.Fatalf("publish %s: %v", topic, err)
+	}
+}

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -171,6 +171,34 @@ func TestAgentStatus_NotLeftWorkingWhenLaunchNeverHappened(t *testing.T) {
 		"after a run that never reached the adapter")
 }
 
+// TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves is the regression
+// test for DR-14 review round 1 Finding 3: resolveLifecycleRun only ever
+// looks up claimed runs, so a cancellation that already marked the run
+// terminal, or a late/duplicate delivery, makes it resolve to sql.ErrNoRows.
+// handleAgentCompleted (shared by AgentCompleted and AgentStopped) must
+// still clear "working" on that exit — it never reaches stampRunFinished.
+func TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-no-claimed-run", "task-working-no-claim")
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before the event")
+
+	// No run carries this task/agent pair in `claimed` state (e.g. the run
+	// already left `claimed` via another path, or this is a duplicate
+	// delivery), so resolveLifecycleRun returns sql.ErrNoRows.
+	publishLifecycle(t, ctx, eb, events.AgentStopped, "task-with-no-claimed-run", agent.ID)
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after an AgentStopped event whose run does not resolve")
+}
+
 func publishLifecycle(
 	t *testing.T, ctx context.Context, eb bus.EventBus,
 	topic, taskID, agentID string,

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -177,6 +177,8 @@ func TestAgentStatus_NotLeftWorkingWhenLaunchNeverHappened(t *testing.T) {
 // terminal, or a late/duplicate delivery, makes it resolve to sql.ErrNoRows.
 // handleAgentCompleted (shared by AgentCompleted and AgentStopped) must
 // still clear "working" on that exit — it never reaches stampRunFinished.
+// The event carries the run's own id so the run-scoped clear (see
+// TestAgentStatus_StaleEventDoesNotClobberSuccessorRun) still matches it.
 func TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves(t *testing.T) {
 	mock := &mockTaskStarter{}
 	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
@@ -187,16 +189,72 @@ func TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves(t *testing.T) {
 		t.Fatalf("register subscribers: %v", err)
 	}
 
-	agent := launchedWorkingAgent(t, svc, ctx, "worker-no-claimed-run", "task-working-no-claim")
+	taskID := "task-working-no-claim"
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-no-claimed-run", taskID)
 	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before the event")
+	run := findRunForAgent(t, svc, ctx, "ws-1", agent.ID, service.RunReasonTaskAssigned)
 
-	// No run carries this task/agent pair in `claimed` state (e.g. the run
-	// already left `claimed` via another path, or this is a duplicate
-	// delivery), so resolveLifecycleRun returns sql.ErrNoRows.
-	publishLifecycle(t, ctx, eb, events.AgentStopped, "task-with-no-claimed-run", agent.ID)
+	// The run already left `claimed` via another path (e.g.
+	// ReapStaleCheckouts), so resolveLifecycleRun's GetClaimedRunByID(run.ID)
+	// returns sql.ErrNoRows even though the event names this exact run.
+	svc.ExecSQL(t, `UPDATE runs SET status = 'finished' WHERE id = ?`, run.ID)
+
+	event := bus.NewEvent(events.AgentStopped, "test", map[string]string{
+		"task_id":          taskID,
+		"run_id":           run.ID,
+		"session_id":       "session-" + agent.ID,
+		"agent_profile_id": agent.ID,
+	})
+	if err := eb.Publish(ctx, events.AgentStopped, event); err != nil {
+		t.Fatalf("publish agent stopped: %v", err)
+	}
 
 	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
-		"after an AgentStopped event whose run does not resolve")
+		"after an AgentStopped event whose own run no longer resolves as claimed")
+}
+
+// TestAgentStatus_StaleEventDoesNotClobberSuccessorRun is the interleaving
+// regression: a stale/duplicate terminal event for a run that already left
+// "claimed" must not reset an agent a SUCCESSOR run has since marked
+// working. Before the working/idle CAS was run-scoped, this exact sequence
+// flipped a live run's agent back to "idle" mid-run.
+func TestAgentStatus_StaleEventDoesNotClobberSuccessorRun(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	taskID := "task-working-stale-vs-successor"
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-stale-vs-successor", taskID)
+	runA := findRunForAgent(t, svc, ctx, "ws-1", agent.ID, service.RunReasonTaskAssigned)
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "after run A launches")
+
+	// Run A leaves `claimed` via another path, and a successor run B has
+	// since been marked working for the same agent. Exercising the full
+	// requeue/re-claim/re-launch path is covered by
+	// TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate; here the
+	// successor's ownership is seeded directly so this test isolates the
+	// stale-event race.
+	svc.ExecSQL(t, `UPDATE runs SET status = 'finished' WHERE id = ?`, runA.ID)
+	svc.ExecSQL(t, `UPDATE agent_profiles SET working_run_id = 'run-b-successor' WHERE id = ?`, agent.ID)
+
+	// Run A's own late/duplicate terminal event now arrives.
+	event := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"task_id":          taskID,
+		"run_id":           runA.ID,
+		"session_id":       "session-" + agent.ID,
+		"agent_profile_id": agent.ID,
+	})
+	if err := eb.Publish(ctx, events.AgentCompleted, event); err != nil {
+		t.Fatalf("publish agent completed: %v", err)
+	}
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking,
+		"after run A's stale event: run B's working status must survive")
 }
 
 // TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate is the

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -199,6 +199,60 @@ func TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves(t *testing.T) {
 		"after an AgentStopped event whose run does not resolve")
 }
 
+// TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate is the
+// regression test for DR-14 review round 2 Finding 1: a launched run that
+// gets requeued (e.g. a post-start provider fallback calling
+// RequeueRunForNextCandidate) sets the run back to "queued" without ever
+// clearing the agent's "working" status, since that clear only happens on
+// the launch/complete cycle the requeue bypassed. The next scheduler pass
+// for that run must not assume prepareAndLaunch will be reached again — it
+// can terminate at any pre-launch gate (task-tree hold, budget, idle-skip,
+// staleness, retry exhaustion) and must still release the agent.
+//
+// This reproduces the exact chain Review drove against the real scheduler:
+// routed launch -> manual requeue (mirroring RequeueRunForNextCandidate) ->
+// a task-tree hold now gates the run's task -> a second scheduler tick.
+func TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	ctx := context.Background()
+
+	taskID := "task-requeued-tree-held"
+	agent := launchedWorkingAgent(t, svc, ctx, "worker-requeued-tree-held", taskID)
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "after the first launch")
+
+	run := findRunForAgent(t, svc, ctx, "ws-1", agent.ID, service.RunReasonTaskAssigned)
+
+	// Mirror RequeueRunForNextCandidate (repository/sqlite/run_routing.go):
+	// a post-start provider fallback puts the run back in the queue without
+	// touching agent status.
+	svc.ExecSQL(t, `UPDATE runs SET status = 'queued', session_id = '',
+		claimed_at = NULL, finished_at = NULL WHERE id = ?`, run.ID)
+
+	// A task-tree hold now gates the task, so the re-dispatch pass will
+	// terminate at checkoutTask, before prepareAndLaunch ever re-marks the
+	// agent (or clears it).
+	svc.ExecSQL(t, `INSERT INTO office_task_tree_holds
+		(id, workspace_id, root_task_id, mode, created_at)
+		VALUES ('hold-requeued-tree-held', 'ws-1', ?, ?, CURRENT_TIMESTAMP)`,
+		taskID, models.TreeHoldModePause)
+	svc.ExecSQL(t, `INSERT INTO office_task_tree_hold_members
+		(hold_id, task_id, depth) VALUES ('hold-requeued-tree-held', ?, 0)`, taskID)
+
+	service.RunSchedulerTick(svc, ctx)
+
+	got, err := svc.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.Status != "finished" || got.Outcome == nil || *got.Outcome != service.RunOutcomeTaskTreeHeld {
+		t.Fatalf("run status/outcome = %q/%v, want finished/%q",
+			got.Status, got.Outcome, service.RunOutcomeTaskTreeHeld)
+	}
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after the requeued run was terminated at a pre-launch gate")
+}
+
 func publishLifecycle(
 	t *testing.T, ctx context.Context, eb bus.EventBus,
 	topic, taskID, agentID string,

--- a/apps/backend/internal/office/service/agents.go
+++ b/apps/backend/internal/office/service/agents.go
@@ -40,7 +40,7 @@ var validRoles = map[models.AgentRole]bool{
 
 // allowedTransitions defines which status transitions are valid.
 var allowedTransitions = map[models.AgentStatus][]models.AgentStatus{
-	models.AgentStatusIdle:            {models.AgentStatusWorking, models.AgentStatusPaused, models.AgentStatusStopped},
+	models.AgentStatusIdle:            {models.AgentStatusPaused, models.AgentStatusStopped},
 	models.AgentStatusWorking:         {models.AgentStatusIdle, models.AgentStatusPaused, models.AgentStatusStopped},
 	models.AgentStatusPaused:          {models.AgentStatusIdle, models.AgentStatusStopped},
 	models.AgentStatusStopped:         {models.AgentStatusIdle},

--- a/apps/backend/internal/office/service/agents_test.go
+++ b/apps/backend/internal/office/service/agents_test.go
@@ -175,17 +175,13 @@ func TestStatusTransition_Valid(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	// idle -> working
-	updated, err := svc.UpdateAgentStatus(ctx, agent.ID, models.AgentStatusWorking, "")
-	if err != nil {
-		t.Fatalf("idle->working: %v", err)
-	}
-	if updated.Status != models.AgentStatusWorking {
-		t.Errorf("status = %q, want working", updated.Status)
+	// The scheduler owns the idle -> working transition.
+	if _, err := svc.RepoForTest().MarkAgentWorking(ctx, agent.ID, "status-test-run"); err != nil {
+		t.Fatalf("scheduler mark working: %v", err)
 	}
 
 	// working -> paused
-	updated, err = svc.UpdateAgentStatus(ctx, agent.ID, models.AgentStatusPaused, "manual pause")
+	updated, err := svc.UpdateAgentStatus(ctx, agent.ID, models.AgentStatusPaused, "manual pause")
 	if err != nil {
 		t.Fatalf("working->paused: %v", err)
 	}
@@ -197,6 +193,27 @@ func TestStatusTransition_Valid(t *testing.T) {
 	_, err = svc.UpdateAgentStatus(ctx, agent.ID, models.AgentStatusIdle, "")
 	if err != nil {
 		t.Fatalf("paused->idle: %v", err)
+	}
+}
+
+func TestStatusTransition_WorkingIsSchedulerOwned(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	agent := makeAgent("working-owned", models.AgentRoleWorker)
+	if err := svc.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := svc.UpdateAgentStatus(ctx, agent.ID, models.AgentStatusWorking, ""); err == nil {
+		t.Fatal("expected idle->working to be rejected because the scheduler owns working")
+	}
+	updated, err := svc.GetAgentInstance(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status != models.AgentStatusIdle {
+		t.Fatalf("status = %q, want idle", updated.Status)
 	}
 }
 

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -389,7 +389,9 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 			// marked the run terminal before this event landed. There is no
 			// run left to reach stampRunFinished, but the agent may still
 			// be sitting at "working" from the launch that produced it.
-			s.clearAgentWorking(ctx, data.AgentProfileID)
+			// Scoped to data.RunID so a stale/duplicate event for this
+			// finished run can't clobber a successor run's live status.
+			s.clearAgentWorking(ctx, data.AgentProfileID, data.RunID)
 			return nil
 		}
 		return err
@@ -412,7 +414,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 	// eventually reclaims it, instead of releasing a lock for a run that
 	// never actually reached a terminal state.
 	if err := s.FinishRun(ctx, run.ID, RunOutcomeProcessed); err != nil {
-		s.clearAgentWorking(ctx, run.AgentProfileID)
+		s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 		return err
 	}
 	s.releaseTaskCheckoutForRun(ctx, run)
@@ -648,7 +650,8 @@ func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error
 			// Same reasoning as handleAgentCompleted's ErrNoRows exit: no
 			// claimed run resolves, so nothing reaches HandleAgentFailure's
 			// clear, but the agent may still be "working" from the launch.
-			s.clearAgentWorking(ctx, data.AgentProfileID)
+			// Scoped to data.RunID for the same reason.
+			s.clearAgentWorking(ctx, data.AgentProfileID, data.RunID)
 			return nil
 		}
 		return err

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -384,6 +384,12 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 	run, err := s.resolveLifecycleRun(ctx, *data)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// No claimed run resolves for this event: it already finished
+			// via another path, arrived late/duplicated, or a cancellation
+			// marked the run terminal before this event landed. There is no
+			// run left to reach stampRunFinished, but the agent may still
+			// be sitting at "working" from the launch that produced it.
+			s.clearAgentWorking(ctx, data.AgentProfileID)
 			return nil
 		}
 		return err
@@ -406,6 +412,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, event *bus.Event) er
 	// eventually reclaims it, instead of releasing a lock for a run that
 	// never actually reached a terminal state.
 	if err := s.FinishRun(ctx, run.ID, RunOutcomeProcessed); err != nil {
+		s.clearAgentWorking(ctx, run.AgentProfileID)
 		return err
 	}
 	s.releaseTaskCheckoutForRun(ctx, run)
@@ -638,6 +645,10 @@ func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error
 	run, err := s.resolveLifecycleRun(ctx, *data)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// Same reasoning as handleAgentCompleted's ErrNoRows exit: no
+			// claimed run resolves, so nothing reaches HandleAgentFailure's
+			// clear, but the agent may still be "working" from the launch.
+			s.clearAgentWorking(ctx, data.AgentProfileID)
 			return nil
 		}
 		return err

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -663,6 +663,7 @@ func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error
 		"error_message": data.ErrorMessage,
 	})
 	if s.tryPostStartFallback(ctx, run, data.ErrorMessage, data.ProviderError) {
+		s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 		return nil
 	}
 	// Office failure path (v1): every agent error is terminal. The

--- a/apps/backend/internal/office/service/event_subscribers_engine_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_engine_test.go
@@ -427,12 +427,15 @@ func TestEngineDispatcher_AgentFailed_PostStartFallbackHandled_SkipsDispatch(t *
 	setTestTaskAssignee(t, svc, "task-1", "worker-1")
 	run := queueTaskAssignedRunForAgentFailedTests(t, svc, "worker-1", "task-1")
 	svc.ExecSQL(t, `UPDATE runs SET resolved_provider_id = 'test-provider' WHERE id = ?`, run.ID)
+	svc.ExecSQL(t, `UPDATE agent_profiles SET status = 'working', working_run_id = ? WHERE id = ?`, run.ID, "worker-1")
 
 	publishAgentFailed(t, eb, "task-1", "worker-1", "sess-err", "boom")
 
 	if calls := disp.Calls(); len(calls) != 0 {
 		t.Fatalf("dispatcher calls = %d, want 0 (post-start fallback handled)", len(calls))
 	}
+	assertAgentStatus(t, svc, context.Background(), "worker-1", models.AgentStatusIdle,
+		"after a handled post-start fallback")
 }
 
 // TestEngineDispatcher_PathBEscalation_DoesNotFireAgentErrorTrigger pins

--- a/apps/backend/internal/office/service/failure.go
+++ b/apps/backend/internal/office/service/failure.go
@@ -47,7 +47,7 @@ func (s *Service) HandleAgentFailure(
 	// find the agent already paused and silently do nothing. Ordering it
 	// here keeps the agent out of a stuck "working" even if the failure
 	// bookkeeping that follows errors out.
-	s.clearAgentWorking(ctx, run.AgentProfileID)
+	s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 
 	count, err := s.repo.IncrementAgentConsecutiveFailures(ctx, run.AgentProfileID)
 	if err != nil {

--- a/apps/backend/internal/office/service/failure.go
+++ b/apps/backend/internal/office/service/failure.go
@@ -41,6 +41,13 @@ func (s *Service) HandleAgentFailure(
 	// has to be duplicated here — otherwise every agent-error terminal
 	// transition leaks the task checkout the same way FinishRun used to.
 	s.releaseTaskCheckoutForRun(ctx, run)
+	// Leave "working" before the auto-pause decision below, not after: the
+	// reset is a working → idle CAS, so running it first lets a subsequent
+	// auto-pause overwrite idle with paused, while running it last would
+	// find the agent already paused and silently do nothing. Ordering it
+	// here keeps the agent out of a stuck "working" even if the failure
+	// bookkeeping that follows errors out.
+	s.clearAgentWorking(ctx, run.AgentProfileID)
 
 	count, err := s.repo.IncrementAgentConsecutiveFailures(ctx, run.AgentProfileID)
 	if err != nil {

--- a/apps/backend/internal/office/service/retry.go
+++ b/apps/backend/internal/office/service/retry.go
@@ -103,7 +103,7 @@ func (s *Service) cancelRetry(ctx context.Context, run *models.Run, reason strin
 	if err := s.repo.CancelRun(ctx, run.ID, reason); err != nil {
 		return err
 	}
-	s.clearAgentWorking(ctx, run.AgentProfileID)
+	s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 	s.publishRunProcessed(ctx, run.ID, RunStatusCancelled, run)
 	return nil
 }
@@ -116,7 +116,7 @@ func (s *Service) escalateFailure(
 	if err := s.FailRun(ctx, run.ID); err != nil {
 		return fmt.Errorf("fail run: %w", err)
 	}
-	s.clearAgentWorking(ctx, run.AgentProfileID)
+	s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 
 	agent, err := s.GetAgentFromConfig(ctx, run.AgentProfileID)
 	if err != nil {

--- a/apps/backend/internal/office/service/retry.go
+++ b/apps/backend/internal/office/service/retry.go
@@ -103,6 +103,7 @@ func (s *Service) cancelRetry(ctx context.Context, run *models.Run, reason strin
 	if err := s.repo.CancelRun(ctx, run.ID, reason); err != nil {
 		return err
 	}
+	s.clearAgentWorking(ctx, run.AgentProfileID)
 	s.publishRunProcessed(ctx, run.ID, RunStatusCancelled, run)
 	return nil
 }
@@ -115,6 +116,7 @@ func (s *Service) escalateFailure(
 	if err := s.FailRun(ctx, run.ID); err != nil {
 		return fmt.Errorf("fail run: %w", err)
 	}
+	s.clearAgentWorking(ctx, run.AgentProfileID)
 
 	agent, err := s.GetAgentFromConfig(ctx, run.AgentProfileID)
 	if err != nil {

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -244,6 +244,7 @@ func (si *SchedulerIntegration) processRun(ctx context.Context, run *models.Run)
 				"agent":    agent.Name,
 				"agent_id": agent.ID,
 			}), runID, "")
+		si.svc.clearAgentWorking(ctx, agent.ID)
 		_ = si.svc.FinishRun(ctx, runID, RunOutcomeIdleSkipped)
 		return
 	}
@@ -506,6 +507,10 @@ func (si *SchedulerIntegration) checkoutTask(ctx context.Context, run *models.Ru
 		return true
 	}
 	if si.isTaskTreeGated(ctx, run.ID, taskID) {
+		// This run may have been requeued after an earlier launch (e.g. a
+		// post-start provider fallback) that left the agent "working" with
+		// no launch/complete cycle left to clear it.
+		si.svc.clearAgentWorking(ctx, agentInstanceID)
 		return false
 	}
 	return si.tryCheckout(ctx, run, taskID, agentInstanceID)
@@ -841,6 +846,7 @@ func (si *SchedulerIntegration) checkBudget(
 		si.logger.Info("run skipped (budget exceeded)",
 			zap.String("run_id", run.ID), zap.String("reason", reason))
 		si.releaseCheckoutIfNeeded(ctx, run)
+		si.svc.clearAgentWorking(ctx, agent.ID)
 		_ = si.svc.FinishRun(ctx, run.ID, RunOutcomeBudgetBlocked)
 		si.svc.LogActivityWithRun(ctx, agent.WorkspaceID,
 			"scheduler", "office-scheduler",

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -336,24 +336,25 @@ func (si *SchedulerIntegration) prepareAndLaunch(
 		Env:       env,
 		ProfileID: profileID,
 	}
-	// launchAgent only returns true when the adapter was actually
-	// invoked. Leave the run `claimed` and let the
-	// AgentCompleted/AgentStopped event subscribers in
-	// event_subscribers.go finish it. This serves as the "agent is
-	// busy on this task" lock that ClaimNextEligibleRun respects, so
-	// new runs (comments, status changes) for the same agent + task
-	// queue up rather than racing the active turn.
+	// launchAgent returns true only when the adapter was actually invoked.
+	// When it was, leave the run `claimed` and let the AgentCompleted/
+	// AgentStopped event subscribers in event_subscribers.go finish it.
+	// This serves as the "agent is busy on this task" lock that
+	// ClaimNextEligibleRun respects, so new runs (comments, status changes)
+	// for the same agent + task queue up rather than racing the active turn.
+	//
 	// Mark before launching, not after: launchAgent returns only once the
 	// adapter has been invoked, by which point a fast run's completion
 	// event may already have been processed — a mark-after-launch would
 	// race that reset and strand the agent showing "working" forever.
 	si.svc.markAgentWorking(ctx, agent)
 	if !si.launchAgent(ctx, run, agent, taskID, execCfg.Type, launchCtx) {
-		// The adapter was never invoked, so no AgentCompleted/AgentStopped/
-		// AgentFailed event will arrive to clear the status. Clear it here
-		// instead. Redundant with the failure paths that route through
-		// HandleAgentFailure, and deliberately so: failTasklessRun calls
-		// MarkRunFailed directly and reaches neither of them.
+		// No adapter was invoked, so no AgentCompleted/AgentStopped/
+		// AgentFailed event will ever arrive to clear the status — every
+		// non-launch exit (taskless/unlaunchable failure, routing parked,
+		// routing dispatch error, legacy start failure) must clear here.
+		// The underlying CAS makes this a safe no-op on paths that already
+		// cleared it themselves (e.g. HandleAgentFailure).
 		si.svc.clearAgentWorking(ctx, agent.ID)
 	}
 }
@@ -581,8 +582,8 @@ func (si *SchedulerIntegration) launchAgent(
 		"executor_type": executorType,
 		"prompt_len":    len(launch.Prompt),
 	})
-	if si.tryRoutingDispatch(ctx, run, agent, taskID, launch) {
-		return true
+	if handled, launched := si.tryRoutingDispatch(ctx, run, agent, taskID, launch); handled {
+		return launched
 	}
 	var err error
 	if starter, ok := si.svc.taskStarter.(TaskStarterWithEnv); ok {
@@ -715,16 +716,18 @@ func (si *SchedulerIntegration) failUnlaunchableRun(
 }
 
 // tryRoutingDispatch routes through the provider-routing dispatcher when
-// one is wired. Returns true when the dispatcher took over (launched OR
-// parked OR error-handled); false to fall through to the legacy launch
-// path (routing disabled / not configured).
+// one is wired. handled is true when the dispatcher took over (launched OR
+// parked OR error-handled), telling the caller not to fall through to the
+// legacy launch path. launched is true only when the adapter was actually
+// invoked — parked and error-handled outcomes are "handled" but not
+// "launched", and callers must not treat them as if a process is running.
 func (si *SchedulerIntegration) tryRoutingDispatch(
 	ctx context.Context, run *models.Run, agent *models.AgentInstance,
 	taskID string, launch LaunchContext,
-) bool {
+) (handled bool, launched bool) {
 	rd := si.svc.routingDispatcher
 	if rd == nil {
-		return false
+		return false, false
 	}
 	launched, parked, err := rd.DispatchWithRouting(ctx, run, agent, launch)
 	if err != nil {
@@ -736,16 +739,16 @@ func (si *SchedulerIntegration) tryRoutingDispatch(
 		})
 		si.releaseCheckoutIfNeeded(ctx, run)
 		_ = si.svc.HandleRunFailure(ctx, run, err)
-		return true
+		return true, false
 	}
 	if launched {
-		return true
+		return true, true
 	}
 	if parked {
 		si.releaseCheckoutIfNeeded(ctx, run)
-		return true
+		return true, false
 	}
-	return false
+	return false, false
 }
 
 // checkoutContendedRetryDelay is the backoff before a run that lost the

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -244,7 +244,7 @@ func (si *SchedulerIntegration) processRun(ctx context.Context, run *models.Run)
 				"agent":    agent.Name,
 				"agent_id": agent.ID,
 			}), runID, "")
-		si.svc.clearAgentWorking(ctx, agent.ID)
+		si.svc.clearAgentWorking(ctx, agent.ID, runID)
 		_ = si.svc.FinishRun(ctx, runID, RunOutcomeIdleSkipped)
 		return
 	}
@@ -348,7 +348,7 @@ func (si *SchedulerIntegration) prepareAndLaunch(
 	// adapter has been invoked, by which point a fast run's completion
 	// event may already have been processed — a mark-after-launch would
 	// race that reset and strand the agent showing "working" forever.
-	si.svc.markAgentWorking(ctx, agent)
+	si.svc.markAgentWorking(ctx, agent, run.ID)
 	if !si.launchAgent(ctx, run, agent, taskID, execCfg.Type, launchCtx) {
 		// No adapter was invoked, so no AgentCompleted/AgentStopped/
 		// AgentFailed event will ever arrive to clear the status — every
@@ -356,7 +356,7 @@ func (si *SchedulerIntegration) prepareAndLaunch(
 		// routing dispatch error, legacy start failure) must clear here.
 		// The underlying CAS makes this a safe no-op on paths that already
 		// cleared it themselves (e.g. HandleAgentFailure).
-		si.svc.clearAgentWorking(ctx, agent.ID)
+		si.svc.clearAgentWorking(ctx, agent.ID, run.ID)
 	}
 }
 
@@ -510,7 +510,7 @@ func (si *SchedulerIntegration) checkoutTask(ctx context.Context, run *models.Ru
 		// This run may have been requeued after an earlier launch (e.g. a
 		// post-start provider fallback) that left the agent "working" with
 		// no launch/complete cycle left to clear it.
-		si.svc.clearAgentWorking(ctx, agentInstanceID)
+		si.svc.clearAgentWorking(ctx, agentInstanceID, run.ID)
 		return false
 	}
 	return si.tryCheckout(ctx, run, taskID, agentInstanceID)
@@ -846,7 +846,7 @@ func (si *SchedulerIntegration) checkBudget(
 		si.logger.Info("run skipped (budget exceeded)",
 			zap.String("run_id", run.ID), zap.String("reason", reason))
 		si.releaseCheckoutIfNeeded(ctx, run)
-		si.svc.clearAgentWorking(ctx, agent.ID)
+		si.svc.clearAgentWorking(ctx, agent.ID, run.ID)
 		_ = si.svc.FinishRun(ctx, run.ID, RunOutcomeBudgetBlocked)
 		si.svc.LogActivityWithRun(ctx, agent.WorkspaceID,
 			"scheduler", "office-scheduler",

--- a/apps/backend/internal/office/service/scheduler_integration.go
+++ b/apps/backend/internal/office/service/scheduler_integration.go
@@ -343,7 +343,19 @@ func (si *SchedulerIntegration) prepareAndLaunch(
 	// busy on this task" lock that ClaimNextEligibleRun respects, so
 	// new runs (comments, status changes) for the same agent + task
 	// queue up rather than racing the active turn.
-	si.launchAgent(ctx, run, agent, taskID, execCfg.Type, launchCtx)
+	// Mark before launching, not after: launchAgent returns only once the
+	// adapter has been invoked, by which point a fast run's completion
+	// event may already have been processed — a mark-after-launch would
+	// race that reset and strand the agent showing "working" forever.
+	si.svc.markAgentWorking(ctx, agent)
+	if !si.launchAgent(ctx, run, agent, taskID, execCfg.Type, launchCtx) {
+		// The adapter was never invoked, so no AgentCompleted/AgentStopped/
+		// AgentFailed event will arrive to clear the status. Clear it here
+		// instead. Redundant with the failure paths that route through
+		// HandleAgentFailure, and deliberately so: failTasklessRun calls
+		// MarkRunFailed directly and reaches neither of them.
+		si.svc.clearAgentWorking(ctx, agent.ID)
+	}
 }
 
 // assembleAgentPrompt builds the wake-context prompt, decides whether the

--- a/apps/backend/internal/office/service/scheduler_integration_routing_test.go
+++ b/apps/backend/internal/office/service/scheduler_integration_routing_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -20,11 +21,13 @@ type captureDispatcher struct {
 	calls  []service.LaunchContext
 	runs   []*models.Run
 	agents []*models.AgentInstance
-	// launched controls the (launched, parked, err) tuple the fake
-	// returns. Default zero-value is (false, false, nil) — routing
-	// fall-through — so callers don't need to set it for the assertion
-	// path tested here.
+	// launched, parked, and err control the (launched, parked, err) tuple
+	// the fake returns. Default zero-value is (false, false, nil) — routing
+	// fall-through — so callers don't need to set anything for the
+	// assertion path tested here.
 	launched bool
+	parked   bool
+	err      error
 }
 
 func (c *captureDispatcher) DispatchWithRouting(
@@ -36,7 +39,7 @@ func (c *captureDispatcher) DispatchWithRouting(
 	c.calls = append(c.calls, launch)
 	c.runs = append(c.runs, run)
 	c.agents = append(c.agents, agent)
-	return c.launched, false, nil
+	return c.launched, c.parked, c.err
 }
 
 func (c *captureDispatcher) HandlePostStartFailure(
@@ -171,4 +174,88 @@ func TestSchedulerIntegration_RoutingFallThrough_FallsBackToLegacy(t *testing.T)
 	if mock.lastCall().Prompt == "" {
 		t.Error("legacy StartTask received empty prompt after routing fall-through")
 	}
+}
+
+// TestSchedulerIntegration_RoutingParked_LeavesAgentIdle is the regression
+// test for DR-14 review round 1 Finding 1: a routing dispatcher that parks
+// a run (no candidate, waiting for capacity, parkRunMaxAttempts) never
+// invokes an adapter, so no AgentCompleted/AgentStopped/AgentFailed event
+// will ever arrive to clear the agent's "working" status. launchAgent must
+// report launched=false for this outcome so prepareAndLaunch clears it.
+func TestSchedulerIntegration_RoutingParked_LeavesAgentIdle(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	dispatcher := &captureDispatcher{parked: true}
+	svc.SetRoutingDispatcher(dispatcher)
+	ctx := context.Background()
+
+	agent := &models.AgentInstance{
+		ID:                 "routing-parked-1",
+		WorkspaceID:        "ws-1",
+		Name:               "parked-worker",
+		Role:               models.AgentRoleWorker,
+		Status:             models.AgentStatusIdle,
+		ExecutorPreference: `{"type":"worktree"}`,
+	}
+	if err := svc.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	svc.ExecSQL(t, `INSERT INTO tasks (id, workspace_id, title, description, created_at, updated_at)
+		VALUES ('task-parked-1', 'ws-1', 'Parked Task', 'desc', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	if err := svc.QueueRun(ctx, agent.ID, service.RunReasonTaskAssigned,
+		`{"task_id":"task-parked-1"}`, ""); err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+
+	service.RunSchedulerTick(svc, ctx)
+
+	if dispatcher.callCount() != 1 {
+		t.Fatalf("expected routing dispatcher consulted; got %d calls", dispatcher.callCount())
+	}
+	if mock.callCount() != 0 {
+		t.Fatalf("legacy StartTask must not run for a parked dispatch; got %d calls", mock.callCount())
+	}
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after a parked routing dispatch (no adapter was ever invoked)")
+}
+
+// TestSchedulerIntegration_RoutingDispatchError_LeavesAgentIdle is the
+// regression test for DR-14 review round 1 Finding 2: a routing dispatch
+// error is handled via HandleRunFailure (retry or eventual escalation),
+// never invokes an adapter, and must not leave the agent showing "working".
+func TestSchedulerIntegration_RoutingDispatchError_LeavesAgentIdle(t *testing.T) {
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	dispatcher := &captureDispatcher{err: errors.New("provider unavailable")}
+	svc.SetRoutingDispatcher(dispatcher)
+	ctx := context.Background()
+
+	agent := &models.AgentInstance{
+		ID:                 "routing-error-1",
+		WorkspaceID:        "ws-1",
+		Name:               "error-worker",
+		Role:               models.AgentRoleWorker,
+		Status:             models.AgentStatusIdle,
+		ExecutorPreference: `{"type":"worktree"}`,
+	}
+	if err := svc.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	svc.ExecSQL(t, `INSERT INTO tasks (id, workspace_id, title, description, created_at, updated_at)
+		VALUES ('task-routing-err-1', 'ws-1', 'Routing Error Task', 'desc', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	if err := svc.QueueRun(ctx, agent.ID, service.RunReasonTaskAssigned,
+		`{"task_id":"task-routing-err-1"}`, ""); err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+
+	service.RunSchedulerTick(svc, ctx)
+
+	if dispatcher.callCount() != 1 {
+		t.Fatalf("expected routing dispatcher consulted; got %d calls", dispatcher.callCount())
+	}
+	if mock.callCount() != 0 {
+		t.Fatalf("legacy StartTask must not run after a routing dispatch error; got %d calls", mock.callCount())
+	}
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after a routing dispatch error (no adapter was ever invoked)")
 }

--- a/apps/backend/internal/office/service/scheduler_runs.go
+++ b/apps/backend/internal/office/service/scheduler_runs.go
@@ -116,11 +116,17 @@ func (s *Service) releaseTaskCheckoutForRun(ctx context.Context, run *models.Run
 	}
 }
 
-// stampRunFinished records the cooldown timestamp for the agent that ran
-// this run. It is shared by the AgentCompleted/AgentStopped event subscribers
-// so their completion paths cannot drift apart. run.AgentProfileID is the
-// launching agent's own identity (processRun resolves the agent from the run),
-// so no extra agent load is needed here.
+// stampRunFinished closes out a launched run for its agent: it records the
+// cooldown timestamp and returns the agent from "working" to "idle". It is
+// shared by the AgentCompleted/AgentStopped event subscribers so their
+// completion paths cannot drift apart — which is exactly why the status
+// reset belongs here rather than duplicated at each call site. AgentStopped
+// routes to handleAgentCompleted (see event_subscribers.go), so this one
+// seam covers both normal completion and cancellation; the failure path
+// clears the status in HandleAgentFailure instead.
+//
+// run.AgentProfileID is the launching agent's own identity (processRun
+// resolves the agent from the run), so no extra agent load is needed here.
 func (s *Service) stampRunFinished(ctx context.Context, run *models.Run) {
 	if run == nil || run.AgentProfileID == "" {
 		return
@@ -131,6 +137,7 @@ func (s *Service) stampRunFinished(ctx context.Context, run *models.Run) {
 			zap.String("agent_id", run.AgentProfileID),
 			zap.Error(err))
 	}
+	s.clearAgentWorking(ctx, run.AgentProfileID)
 }
 
 // publishRunProcessed emits an OfficeRunProcessed bus event with the

--- a/apps/backend/internal/office/service/scheduler_runs.go
+++ b/apps/backend/internal/office/service/scheduler_runs.go
@@ -137,7 +137,7 @@ func (s *Service) stampRunFinished(ctx context.Context, run *models.Run) {
 			zap.String("agent_id", run.AgentProfileID),
 			zap.Error(err))
 	}
-	s.clearAgentWorking(ctx, run.AgentProfileID)
+	s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 }
 
 // publishRunProcessed emits an OfficeRunProcessed bus event with the

--- a/apps/backend/internal/office/service/scheduler_staleness.go
+++ b/apps/backend/internal/office/service/scheduler_staleness.go
@@ -58,7 +58,7 @@ func (si *SchedulerIntegration) cancelStaleRun(
 		zap.Time("requested_at", run.RequestedAt))
 
 	si.releaseCheckoutIfNeeded(ctx, run)
-	si.svc.clearAgentWorking(ctx, agent.ID)
+	si.svc.clearAgentWorking(ctx, agent.ID, run.ID)
 
 	if err := si.svc.repo.CancelRun(ctx, run.ID, reason); err != nil {
 		si.logger.Error("failed to cancel stale run",

--- a/apps/backend/internal/office/service/scheduler_staleness.go
+++ b/apps/backend/internal/office/service/scheduler_staleness.go
@@ -58,6 +58,7 @@ func (si *SchedulerIntegration) cancelStaleRun(
 		zap.Time("requested_at", run.RequestedAt))
 
 	si.releaseCheckoutIfNeeded(ctx, run)
+	si.svc.clearAgentWorking(ctx, agent.ID)
 
 	if err := si.svc.repo.CancelRun(ctx, run.ID, reason); err != nil {
 		si.logger.Error("failed to cancel stale run",


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3401/3736c27ccc23.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** every Office agent shows `idle` in the dashboard, even while it is actively running a task — a stalled workspace and a busy one look identical.
**After this:** the agent chip flips to `Working` for the duration of an in-flight run and returns to `idle` on completion, failure, or cancellation.
**Who hits this:** anyone watching the Office dashboard with more than one autonomous agent running; today status is the only at-a-glance signal that Office is doing anything.
**Scope:** standalone — single self-contained defect fix, no sibling PRs.
**Not here:** a backend crash mid-run leaves the agent showing `working` until `RecoverStale` requeues the orphaned claimed run at the existing `staleClaimedRunAge` threshold (30 min) — bounded and self-correcting, not a new failure mode this PR introduces.

The `working` status already existed in the schema, the transition table, and the dashboard chip — nothing ever wrote it. Every agent read `idle` permanently regardless of whether a run was in flight.

## Important Changes

- Agent status is set to `working` immediately before a run launches and cleared back to `idle` on every terminal path: success, failure, and cancellation, including every pre-launch gate that can end a run before it ever launches (budget check, task-tree hold, staleness cancel, retry exhaustion, routing dispatch failure).
- The mark/clear is a compare-and-swap **scoped to the owning run** (`working_run_id`), not just the agent row: `MarkAgentWorking` only succeeds from `idle`, and `ClearAgentWorking` only succeeds when the caller's run still owns the `working` status. A stale or duplicate terminal event for a run that's no longer the current owner is a no-op instead of clobbering a successor run that's already in flight on the same agent. This closes the exact race three independent reviewers converged on in the first review pass (a late/duplicate event for an older run flipping a live successor back to `idle`).
- `isAgentActive` already accepted both `idle` and `working` as schedulable states, so this change blocks no run and skips no schedule — verified with a dedicated regression test so a future narrowing of that predicate fails loudly here instead of silently parking every agent.

## Validation

- `go test -count=1 -tags fts5 ./internal/office/... ./internal/agent/settings/...` — all packages pass except one pre-existing, unrelated failure (`TestHostRuntimeUpdaterInvalidatesOnlyManagedNPMExecutionTree`, `open npm cache root: not a directory`), confirmed byte-identical at this branch's merge base in a scratch worktree.
- `make -C apps/backend test` (full suite) — same pre-existing failure pattern: ~12 unrelated packages (git worktree/symlink handling, dev launcher process spawn, YAML config permission checks, GitHub CLI login-shell resolution, workspace dependency cleanup) fail identically at the merge base in a scratch worktree; none touch a file this PR changes. Sampled 5 of the 12 failing packages across distinct subsystems and reproduced every one pre-existing.
- Postgres schema/migration receipt: `go test -tags fts5 ./internal/agent/settings/store/... -run TestPostgres -v` passes against a real scratch Postgres instance — `TestPostgresFreshSchemaInitializes` exercises the new `working_run_id` `ADD COLUMN` migration there.
- `gofmt -l`, `go vet ./...`, `golangci-lint run ./...`, `go build -tags fts5 ./...` — all clean.
- `pnpm run i18n:ratchet` — clean; this diff has no UI changes (backend-only, 14 files under `apps/backend/internal/office/**` and `apps/backend/internal/agent/settings/store/**`).
- No E2E run required: zero `apps/web/**` files touched, zero `*.spec.ts` changes, no DDL/dialect branch beyond the idempotent `ADD COLUMN` verified above.
- Two independent review passes (local diff review + cross-vendor Codex review) both focused specifically on the concurrency/ownership question this run-scoping fix addresses; neither found a further issue at working confidence.

## Possible Improvements

Low risk. The one residual (see "Not here" above) is bounded by an existing self-healing mechanism, not a gap this PR opens.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Internal dashboard status behavior, not public-facing docs.)