### PR TITLE
fix: make clarification retries durable across interruptions

### DIFF
--- a/.kandev/review-notes.md
+++ b/.kandev/review-notes.md
@@ -1,0 +1,3 @@
+## Fixed during review
+- apps/backend/internal/clarification/store.go:340 — closed a retry waiter that could race with cancellation and otherwise wait indefinitely after detached delivery won (commit 3e5fd27b551a6f674604d68d23ff4ef1aff62c97)
+- apps/backend/internal/mcp/handlers/handlers.go:3978 — allowed a finalized detached rejection to reconcile immediately instead of being masked by the delivery-miss receipt (commit 3e5fd27b551a6f674604d68d23ff4ef1aff62c97)

--- a/apps/backend/internal/clarification/resolver.go
+++ b/apps/backend/internal/clarification/resolver.go
@@ -685,6 +685,7 @@ func (r *Resolver) restoreFailedClarificationClaim(
 			zap.String("pending_id", pendingID))
 		return false
 	}
+	r.store.ClearDeliveryMiss(pendingID)
 	if err := r.messages.PublishClarificationBundleUpdates(persistenceCtx, restoredMessages); err != nil {
 		r.logger.Error("failed to converge restored clarification state",
 			zap.String("pending_id", pendingID), zap.Error(err))

--- a/apps/backend/internal/clarification/resolver_delivery_test.go
+++ b/apps/backend/internal/clarification/resolver_delivery_test.go
@@ -462,7 +462,7 @@ func TestResolverLiveDeliveryUsesSynchronousNotifierBeforeAsyncFanout(t *testing
 func TestResolverDetachedResumeFailureRestoresRetryableBundle(t *testing.T) {
 	const pendingID = "pending-detached-retry"
 	message := resolverDeliveryMessage(pendingID, "message-detached-retry", "turn-1")
-	resolver, _, repo, creator, eventBus := newResolverDeliveryFixture(t, pendingID, []*taskmodels.Message{message})
+	resolver, store, repo, creator, eventBus := newResolverDeliveryFixture(t, pendingID, []*taskmodels.Message{message})
 	eventBus.resumeErr = errors.New("orchestrator rejected resume")
 
 	_, claimed, err := resolver.ResolveBundle(context.Background(), pendingID, resolverAnswer())
@@ -475,6 +475,15 @@ func TestResolverDetachedResumeFailureRestoresRetryableBundle(t *testing.T) {
 	if creator.restoreCalls != 1 || len(creator.published) != 1 {
 		t.Fatalf("restore calls=%d published=%d, want 1/1", creator.restoreCalls, len(creator.published))
 	}
+	if _, created, missed := store.CreateRetryRequest(&Request{
+		PendingID: pendingID,
+		SessionID: "session-1",
+		TaskID:    "task-1",
+		Questions: []Question{{ID: "q1", Prompt: "Continue?"}},
+	}); !created || missed {
+		t.Fatalf("retry after restored detached delivery = created %v, missed %v; want true, false", created, missed)
+	}
+	store.CancelRequest(pendingID)
 
 	eventBus.resumeErr = nil
 	resolution, claimed, err := resolver.ResolveBundle(context.Background(), pendingID, resolverAnswer())

--- a/apps/backend/internal/clarification/retry.go
+++ b/apps/backend/internal/clarification/retry.go
@@ -1,0 +1,50 @@
+package clarification
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+// PendingIDForRequest derives the durable identity of one ask_user_question
+// call from the Kandev session and the transport retry key the MCP server
+// attached to the call. The retry key must already be scoped to one MCP
+// connection so that JSON-RPC ids restarting on a new connection cannot alias
+// an earlier bundle; binding the session as well keeps the identity from
+// crossing sessions even if two connections reuse the same key. An empty
+// session or retry key returns empty so callers keep the random-ID behavior.
+func PendingIDForRequest(sessionID, retryKey string) string {
+	if sessionID == "" || retryKey == "" {
+		return ""
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte("kandev/clarification/"+sessionID+"/"+retryKey)).String()
+}
+
+// RecordedOutcome reports the terminal state a bundle's durable messages
+// already carry, so an exact retry of an interrupted ask_user_question call
+// can return that outcome instead of waiting on a question nobody can answer
+// anymore. ok is false while the bundle is still answerable. For an answered
+// or rejected bundle response carries the recorded answers; for a bundle whose
+// every question was cancelled or expired response is nil and status names
+// that terminal state.
+func RecordedOutcome(pendingID string, msgs []*taskmodels.Message, log *logger.Logger) (Status, *Response, bool) {
+	if len(msgs) == 0 {
+		return "", nil, false
+	}
+	if status, response, hasWinner := reconstructWinnerResolution(pendingID, msgs, log); hasWinner {
+		return Status(status), response, true
+	}
+	closed := ""
+	for _, m := range msgs {
+		switch status := effectiveMessageStatus(m); Status(status) {
+		case StatusCancelled, StatusExpired:
+			if closed == "" {
+				closed = status
+			}
+		default:
+			return "", nil, false
+		}
+	}
+	return Status(closed), nil, true
+}

--- a/apps/backend/internal/clarification/retry_test.go
+++ b/apps/backend/internal/clarification/retry_test.go
@@ -1,0 +1,108 @@
+package clarification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+func TestPendingIDForRequest_IsStablePerSessionAndRetryKey(t *testing.T) {
+	first := PendingIDForRequest("session-a", "conn-1/int64:7")
+	require.NotEmpty(t, first, "expected a retry identity")
+	assert.Equal(t, first, PendingIDForRequest("session-a", "conn-1/int64:7"), "exact retry must map to the same identity")
+	assert.NotEqual(t, first, PendingIDForRequest("session-b", "conn-1/int64:7"), "identity must be scoped to the session")
+	assert.NotEqual(t, first, PendingIDForRequest("session-a", "conn-2/int64:7"), "a restarted id on another connection must not alias")
+	assert.NotEqual(t, first, PendingIDForRequest("session-a", "conn-1/int64:8"), "a different request on the same connection must not alias")
+}
+
+func TestPendingIDForRequest_EmptyInputsKeepRandomStoreIdentity(t *testing.T) {
+	assert.Empty(t, PendingIDForRequest("session-a", ""))
+	assert.Empty(t, PendingIDForRequest("", "conn-1/int64:7"))
+}
+
+func retryBundleMessage(id string, index int, status string, response map[string]any) *taskmodels.Message {
+	meta := map[string]any{
+		"pending_id":     "p-retry",
+		"question_id":    "q" + string(rune('1'+index)),
+		"question_index": index,
+		"status":         status,
+	}
+	if response != nil {
+		meta["response"] = response
+	}
+	return &taskmodels.Message{ID: id, TaskSessionID: "sess-1", Metadata: meta}
+}
+
+func TestRecordedOutcome_PendingBundleIsNotRecorded(t *testing.T) {
+	msgs := []*taskmodels.Message{
+		retryBundleMessage("m1", 0, "pending", nil),
+		retryBundleMessage("m2", 1, "pending", nil),
+	}
+	_, resp, ok := RecordedOutcome("p-retry", msgs, nil)
+	assert.False(t, ok)
+	assert.Nil(t, resp)
+}
+
+func TestRecordedOutcome_NoMessagesIsNotRecorded(t *testing.T) {
+	_, _, ok := RecordedOutcome("p-retry", nil, nil)
+	assert.False(t, ok)
+}
+
+func TestRecordedOutcome_AnsweredBundleReturnsRecordedAnswers(t *testing.T) {
+	msgs := []*taskmodels.Message{
+		retryBundleMessage("m2", 1, "answered", map[string]any{"custom_text": "second"}),
+		retryBundleMessage("m1", 0, "answered", map[string]any{"selected_options": []any{"opt-a"}}),
+	}
+	status, resp, ok := RecordedOutcome("p-retry", msgs, nil)
+	require.True(t, ok)
+	assert.Equal(t, StatusAnswered, status)
+	require.NotNil(t, resp)
+	assert.Equal(t, "p-retry", resp.PendingID)
+	assert.False(t, resp.Rejected)
+	require.Len(t, resp.Answers, 2)
+	assert.Equal(t, "q1", resp.Answers[0].QuestionID)
+	assert.Equal(t, []string{"opt-a"}, resp.Answers[0].SelectedOptions)
+	assert.Equal(t, "q2", resp.Answers[1].QuestionID)
+	assert.Equal(t, "second", resp.Answers[1].CustomText)
+}
+
+func TestRecordedOutcome_RejectedBundleReturnsRejection(t *testing.T) {
+	msgs := []*taskmodels.Message{retryBundleMessage("m1", 0, "rejected", nil)}
+	status, resp, ok := RecordedOutcome("p-retry", msgs, nil)
+	require.True(t, ok)
+	assert.Equal(t, StatusRejected, status)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Rejected)
+	assert.Empty(t, resp.Answers)
+}
+
+func TestRecordedOutcome_CancelledBundleReportsClosedWithoutResponse(t *testing.T) {
+	msgs := []*taskmodels.Message{
+		retryBundleMessage("m1", 0, "cancelled", nil),
+		retryBundleMessage("m2", 1, "cancelled", nil),
+	}
+	status, resp, ok := RecordedOutcome("p-retry", msgs, nil)
+	require.True(t, ok)
+	assert.Equal(t, StatusCancelled, status)
+	assert.Nil(t, resp)
+}
+
+func TestRecordedOutcome_ExpiredBundleReportsClosedWithoutResponse(t *testing.T) {
+	msgs := []*taskmodels.Message{retryBundleMessage("m1", 0, "expired", nil)}
+	status, resp, ok := RecordedOutcome("p-retry", msgs, nil)
+	require.True(t, ok)
+	assert.Equal(t, StatusExpired, status)
+	assert.Nil(t, resp)
+}
+
+func TestRecordedOutcome_PartiallyCancelledBundleStaysAnswerable(t *testing.T) {
+	msgs := []*taskmodels.Message{
+		retryBundleMessage("m1", 0, "cancelled", nil),
+		retryBundleMessage("m2", 1, "pending", nil),
+	}
+	_, _, ok := RecordedOutcome("p-retry", msgs, nil)
+	assert.False(t, ok, "a bundle with an open question must still be waited on")
+}

--- a/apps/backend/internal/clarification/store.go
+++ b/apps/backend/internal/clarification/store.go
@@ -22,9 +22,10 @@ const maxStartedDeliveryConfirmationWait = 5 * time.Minute
 // Store manages pending clarification requests.
 // It provides thread-safe storage and notification when responses arrive.
 type Store struct {
-	mu      sync.RWMutex
-	pending map[string]*PendingClarification
-	timeout time.Duration
+	mu             sync.RWMutex
+	pending        map[string]*PendingClarification
+	deliveryMisses map[string]time.Time
+	timeout        time.Duration
 
 	// onWaitEntered, if non-nil, is invoked inside WaitForResponse after the
 	// initial pending lookup and before the select blocks. Tests use it to
@@ -63,8 +64,9 @@ func NewStore(timeout time.Duration) *Store {
 		timeout = 2 * time.Hour // Default timeout — long enough for user to respond to clarification
 	}
 	return &Store{
-		pending: make(map[string]*PendingClarification),
-		timeout: timeout,
+		pending:        make(map[string]*PendingClarification),
+		deliveryMisses: make(map[string]time.Time),
+		timeout:        timeout,
 	}
 }
 
@@ -92,6 +94,37 @@ func (s *Store) SetOnRespondLoaded(fn func(pendingID string)) {
 func (s *Store) CreateRequest(req *Request) (string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.createRequestLocked(req)
+}
+
+// CreateRetryRequest registers a transport retry before its durable bundle is
+// reconciled. deliveryMissed is true when a durable responder already found no
+// live waiter and therefore chose detached delivery. That receipt makes the
+// handoff linearizable: the retry must not open a second waiter or return the
+// same answer through the tool call while detached delivery is in flight.
+func (s *Store) CreateRetryRequest(req *Request) (pendingID string, isNew, deliveryMissed bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneDeliveryMissesLocked(time.Now())
+	if req.PendingID != "" {
+		if _, missed := s.deliveryMisses[req.PendingID]; missed {
+			return req.PendingID, false, true
+		}
+	}
+	pendingID, isNew = s.createRequestLocked(req)
+	return pendingID, isNew, false
+}
+
+// ClearDeliveryMiss removes a detached-delivery receipt after durable
+// delivery recovery restored the bundle to pending. A later exact retry can
+// then adopt the restored question normally.
+func (s *Store) ClearDeliveryMiss(pendingID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.deliveryMisses, pendingID)
+}
+
+func (s *Store) createRequestLocked(req *Request) (string, bool) {
 
 	// Normalise in-place so dedup keys are stable even when the caller
 	// hasn't assigned IDs yet.
@@ -126,6 +159,16 @@ func (s *Store) CreateRequest(req *Request) (string, bool) {
 	}
 
 	return req.PendingID, true
+}
+
+func (s *Store) pruneDeliveryMissesLocked(now time.Time) {
+	retention := max(s.timeout, maxStartedDeliveryConfirmationWait)
+	cutoff := now.Add(-retention)
+	for pendingID, missedAt := range s.deliveryMisses {
+		if missedAt.Before(cutoff) {
+			delete(s.deliveryMisses, pendingID)
+		}
+	}
 }
 
 // GetRequest returns a pending clarification request by ID.
@@ -271,11 +314,16 @@ func (s *Store) respond(
 	resp *Response,
 	confirm func() error,
 ) error {
-	s.mu.RLock()
+	s.mu.Lock()
 	pending, ok := s.pending[pendingID]
 	hook := s.onRespondEntered
 	loadedHook := s.onRespondLoaded
-	s.mu.RUnlock()
+	if !ok && confirm != nil {
+		now := time.Now()
+		s.pruneDeliveryMissesLocked(now)
+		s.deliveryMisses[pendingID] = now
+	}
+	s.mu.Unlock()
 	if hook != nil {
 		hook(pendingID)
 	}

--- a/apps/backend/internal/clarification/store.go
+++ b/apps/backend/internal/clarification/store.go
@@ -339,6 +339,7 @@ func (s *Store) respond(
 
 	if pending.cancelled {
 		pending.mu.Unlock()
+		s.recordDeliveryMissAfterCancellation(pendingID, pending, confirm != nil)
 		return fmt.Errorf("%w: %s", ErrNotFound, pendingID)
 	}
 	if pending.resolved {
@@ -360,6 +361,7 @@ func (s *Store) respond(
 	select {
 	case <-pending.CancelCh:
 		pending.mu.Unlock()
+		s.recordDeliveryMissAfterCancellation(pendingID, pending, confirm != nil)
 		return fmt.Errorf("%w: %s", ErrNotFound, pendingID)
 	default:
 	}
@@ -399,6 +401,29 @@ func (s *Store) respond(
 		pending.mu.Unlock()
 		s.deletePendingIfCurrent(pendingID, pending)
 		return fmt.Errorf("wait for clarification delivery confirmation: %w", waitCtx.Err())
+	}
+}
+
+// recordDeliveryMissAfterCancellation closes a replacement retry that raced
+// between cancellation of the waiter we loaded and observing that cancellation.
+// Detached delivery has already won for this durable identity, so leaving the
+// replacement live would strand it: the responder still holds the old entry
+// and will never signal the replacement's done channel.
+func (s *Store) recordDeliveryMissAfterCancellation(
+	pendingID string,
+	loaded *PendingClarification,
+	record bool,
+) {
+	if !record {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	s.pruneDeliveryMissesLocked(now)
+	s.deliveryMisses[pendingID] = now
+	if replacement := s.pending[pendingID]; replacement != nil && replacement != loaded {
+		s.cancelPendingLocked(pendingID, replacement)
 	}
 }
 

--- a/apps/backend/internal/clarification/store.go
+++ b/apps/backend/internal/clarification/store.go
@@ -105,7 +105,15 @@ func (s *Store) CreateRequest(req *Request) (string, bool) {
 		}
 	}
 
-	if req.PendingID == "" {
+	// A preset identity that is already live is joined, never replaced:
+	// overwriting the map entry would orphan its waiters on a done channel
+	// nobody closes. Exact retries carry identical questions and are caught
+	// above; this guards a client that reused a request id for another call.
+	if req.PendingID != "" {
+		if existing, ok := s.pending[req.PendingID]; ok {
+			return existing.Request.PendingID, false
+		}
+	} else {
 		req.PendingID = uuid.New().String()
 	}
 	req.CreatedAt = time.Now()

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -49,6 +49,25 @@ func TestCreateRequest_PreservesExistingID(t *testing.T) {
 	}
 }
 
+func TestPendingIDForRequest_IsStablePerSessionAndRequest(t *testing.T) {
+	first := PendingIDForRequest("session-a", "transport-1")
+	if first == "" {
+		t.Fatal("expected a retry identity")
+	}
+	if got := PendingIDForRequest("session-a", "transport-1"); got != first {
+		t.Fatalf("retry identity changed: first=%q second=%q", first, got)
+	}
+	if got := PendingIDForRequest("session-b", "transport-1"); got == first {
+		t.Fatal("request identity must be scoped to the session")
+	}
+}
+
+func TestPendingIDForRequest_EmptyRequestIDUsesRandomStoreIdentity(t *testing.T) {
+	if got := PendingIDForRequest("session-a", ""); got != "" {
+		t.Fatalf("empty request ID = %q, want empty", got)
+	}
+}
+
 func TestGetRequest_Found(t *testing.T) {
 	s := NewStore(time.Minute)
 	id, _ := s.CreateRequest(&Request{SessionID: "s1", Questions: []Question{{Prompt: "test?"}}})

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -374,6 +374,52 @@ func TestCreateRequest_NoDedup_DifferentQuestions(t *testing.T) {
 	}
 }
 
+// TestCreateRequest_PresetID_NeverReplacesLiveEntry guards the retry identity
+// path: a request that presets a PendingID already held by a live entry must
+// join that entry, even when its questions differ (a client that reused a
+// JSON-RPC id for a different call). Replacing the map entry would orphan the
+// original waiter on a done channel nobody closes.
+func TestCreateRequest_PresetID_NeverReplacesLiveEntry(t *testing.T) {
+	s := NewStore(time.Minute)
+	first := &Request{PendingID: "preset-1", SessionID: "s1", Questions: []Question{{Prompt: "Q1?", Options: []Option{{ID: "o1", Label: "A"}, {ID: "o2", Label: "B"}}}}}
+	id1, isNew1 := s.CreateRequest(first)
+	if id1 != "preset-1" || !isNew1 {
+		t.Fatalf("first create = (%q, %v), want (preset-1, true)", id1, isNew1)
+	}
+	waited := make(chan error, 1)
+	entered := make(chan struct{})
+	s.onWaitEntered = func(string) { close(entered) }
+	go func() {
+		_, err := s.WaitForResponse(context.Background(), "preset-1")
+		waited <- err
+	}()
+	<-entered
+
+	second := &Request{PendingID: "preset-1", SessionID: "s1", Questions: []Question{{Prompt: "Different?", Options: []Option{{ID: "o1", Label: "A"}, {ID: "o2", Label: "B"}}}}}
+	id2, isNew2 := s.CreateRequest(second)
+	if id2 != "preset-1" || isNew2 {
+		t.Fatalf("second create = (%q, %v), want (preset-1, false): a live entry must be joined, not replaced", id2, isNew2)
+	}
+	if got, _ := s.GetRequest("preset-1"); got == nil || got.Questions[0].Prompt != "Q1?" {
+		t.Fatalf("live entry was replaced: %+v", got)
+	}
+	if len(s.ListPending()) != 1 {
+		t.Fatalf("expected 1 pending entry, got %d", len(s.ListPending()))
+	}
+
+	if err := s.Respond("preset-1", &Response{PendingID: "preset-1"}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	select {
+	case err := <-waited:
+		if err != nil {
+			t.Fatalf("original waiter must receive the response, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("original waiter was orphaned by the second create")
+	}
+}
+
 // TestWaitForResponse_Broadcast_MultipleWaiters verifies that close(done) in
 // Respond unblocks every parked waiter. The onWaitEntered hook lets the test
 // observe each goroutine after it has captured a *PendingClarification pointer

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -420,6 +420,77 @@ func TestCreateRequest_PresetID_NeverReplacesLiveEntry(t *testing.T) {
 	}
 }
 
+func TestRespondWithDeliveryConfirmation_CancelsRetryRegisteredAfterOriginalCancellation(t *testing.T) {
+	s := NewStore(time.Minute)
+	request := &Request{
+		PendingID: "retry-cancel-race",
+		SessionID: "session-1",
+		Questions: []Question{{
+			Prompt:  "Continue?",
+			Options: []Option{{ID: "yes", Label: "Yes"}, {ID: "no", Label: "No"}},
+		}},
+	}
+	pendingID, created := s.CreateRequest(request)
+	if !created {
+		t.Fatal("original request was not created")
+	}
+
+	respondLoaded := make(chan struct{})
+	releaseRespond := make(chan struct{})
+	s.SetOnRespondLoaded(func(string) {
+		close(respondLoaded)
+		<-releaseRespond
+	})
+	respondDone := make(chan error, 1)
+	go func() {
+		respondDone <- s.RespondWithDeliveryConfirmation(
+			context.Background(), pendingID, &Response{}, func() error { return nil },
+		)
+	}()
+	<-respondLoaded
+
+	if !s.CancelRequest(pendingID) {
+		t.Fatal("original request was not cancelled")
+	}
+	_, retryCreated, deliveryMissed := s.CreateRetryRequest(&Request{
+		PendingID: pendingID,
+		SessionID: "session-1",
+		Questions: request.Questions,
+	})
+	if !retryCreated || deliveryMissed {
+		t.Fatalf("retry registration = created %v, delivery missed %v; want true, false before responder observes cancellation", retryCreated, deliveryMissed)
+	}
+
+	waitEntered := make(chan struct{}, 1)
+	s.SetOnWaitEntered(func(string) { waitEntered <- struct{}{} })
+	waitDone := make(chan error, 1)
+	go func() {
+		_, err := s.WaitForResponse(context.Background(), pendingID)
+		waitDone <- err
+	}()
+	<-waitEntered
+	close(releaseRespond)
+
+	if err := <-respondDone; !errors.Is(err, ErrNotFound) {
+		t.Fatalf("RespondWithDeliveryConfirmation error = %v, want %v", err, ErrNotFound)
+	}
+	select {
+	case err := <-waitDone:
+		if err == nil {
+			t.Fatal("replacement retry waiter returned without cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replacement retry waiter was stranded after detached delivery won")
+	}
+	if _, created, missed := s.CreateRetryRequest(&Request{
+		PendingID: pendingID,
+		SessionID: "session-1",
+		Questions: request.Questions,
+	}); created || !missed {
+		t.Fatalf("retry after detached delivery = created %v, delivery missed %v; want false, true", created, missed)
+	}
+}
+
 // TestWaitForResponse_Broadcast_MultipleWaiters verifies that close(done) in
 // Respond unblocks every parked waiter. The onWaitEntered hook lets the test
 // observe each goroutine after it has captured a *PendingClarification pointer

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -49,25 +49,6 @@ func TestCreateRequest_PreservesExistingID(t *testing.T) {
 	}
 }
 
-func TestPendingIDForRequest_IsStablePerSessionAndRequest(t *testing.T) {
-	first := PendingIDForRequest("session-a", "transport-1")
-	if first == "" {
-		t.Fatal("expected a retry identity")
-	}
-	if got := PendingIDForRequest("session-a", "transport-1"); got != first {
-		t.Fatalf("retry identity changed: first=%q second=%q", first, got)
-	}
-	if got := PendingIDForRequest("session-b", "transport-1"); got == first {
-		t.Fatal("request identity must be scoped to the session")
-	}
-}
-
-func TestPendingIDForRequest_EmptyRequestIDUsesRandomStoreIdentity(t *testing.T) {
-	if got := PendingIDForRequest("session-a", ""); got != "" {
-		t.Fatalf("empty request ID = %q, want empty", got)
-	}
-}
-
 func TestGetRequest_Found(t *testing.T) {
 	s := NewStore(time.Minute)
 	id, _ := s.CreateRequest(&Request{SessionID: "s1", Questions: []Question{{Prompt: "test?"}}})

--- a/apps/backend/internal/clarification/types.go
+++ b/apps/backend/internal/clarification/types.go
@@ -5,21 +5,7 @@ package clarification
 import (
 	"sync"
 	"time"
-
-	"github.com/google/uuid"
 )
-
-// PendingIDForRequest returns the durable identity for an MCP request retry.
-// Agent transports reuse the request ID when retrying an interrupted call;
-// binding it to the session prevents the same transport ID in another session
-// from aliasing this clarification bundle. An empty request ID deliberately
-// returns empty so callers can retain the normal random-ID behavior.
-func PendingIDForRequest(sessionID, requestID string) string {
-	if sessionID == "" || requestID == "" {
-		return ""
-	}
-	return uuid.NewSHA1(uuid.NameSpaceURL, []byte("kandev/clarification/"+sessionID+"/"+requestID)).String()
-}
 
 // Option represents a single choice option for a question.
 type Option struct {

--- a/apps/backend/internal/clarification/types.go
+++ b/apps/backend/internal/clarification/types.go
@@ -5,7 +5,21 @@ package clarification
 import (
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
+
+// PendingIDForRequest returns the durable identity for an MCP request retry.
+// Agent transports reuse the request ID when retrying an interrupted call;
+// binding it to the session prevents the same transport ID in another session
+// from aliasing this clarification bundle. An empty request ID deliberately
+// returns empty so callers can retain the normal random-ID behavior.
+func PendingIDForRequest(sessionID, requestID string) string {
+	if sessionID == "" || requestID == "" {
+		return ""
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte("kandev/clarification/"+sessionID+"/"+requestID)).String()
+}
 
 // Option represents a single choice option for a question.
 type Option struct {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -113,6 +113,19 @@ type clarificationDurableReader interface {
 	FindMessagesByPendingID(ctx context.Context, pendingID string) ([]*models.Message, error)
 }
 
+// clarificationReattacher is an optional repository extension that clears the
+// detached marker from a still-pending bundle once a retry re-adopts it with a
+// live waiter.
+type clarificationReattacher interface {
+	ReattachActiveClarificationBundle(ctx context.Context, sessionID, pendingID string) ([]*models.Message, error)
+}
+
+// clarificationBundlePublisher is an optional message-creator extension that
+// exposes committed bundle rows to bus subscribers.
+type clarificationBundlePublisher interface {
+	PublishClarificationBundleUpdates(ctx context.Context, messages []*models.Message) error
+}
+
 // durableClarificationState is what an exact retry finds already recorded for
 // its identity. exists means the visible question messages are present and
 // must not be created again; response carries an answered/rejected outcome;
@@ -164,6 +177,40 @@ func (h *Handlers) reconcileDurableClarification(ctx context.Context, sessionID,
 		state.closed = status
 	}
 	return state, nil
+}
+
+// reattachDurableClarification runs after a retry re-adopted a still-pending
+// bundle and a live waiter exists for it again. It clears agent_disconnected
+// from the bundle's current-turn rows and publishes the change so the
+// projection and the orchestrator's live-clarification guard see a live
+// waiter. Failures are logged only: the in-memory wait is already correct and
+// the durable flag is advisory.
+func (h *Handlers) reattachDurableClarification(ctx context.Context, sessionID, pendingID string) {
+	reattacher, ok := h.sessionRepo.(clarificationReattacher)
+	if !ok {
+		return
+	}
+	messages, err := reattacher.ReattachActiveClarificationBundle(ctx, sessionID, pendingID)
+	if err != nil {
+		h.logger.Warn("failed to clear detached marker on re-adopted clarification bundle",
+			zap.String("pending_id", pendingID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return
+	}
+	if len(messages) == 0 {
+		return
+	}
+	publisher, ok := h.messageCreator.(clarificationBundlePublisher)
+	if !ok {
+		return
+	}
+	if err := publisher.PublishClarificationBundleUpdates(ctx, messages); err != nil {
+		h.logger.Warn("failed to publish re-adopted clarification bundle",
+			zap.String("pending_id", pendingID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
 }
 
 // stepCompletionTurnReader exposes the immutable workflow-step stamp on the
@@ -3863,6 +3910,11 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
 				"failed to create clarification messages: "+err.Error(), nil)
 		}
+	}
+	if durable.exists {
+		// The bundle may have been detached while no waiter was attached; this
+		// call is about to wait on it again.
+		h.reattachDurableClarification(ctx, req.SessionID, pendingID)
 	}
 
 	// Update session and task states to waiting for input

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -3975,14 +3975,7 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
 			"failed to reconcile clarification retry", nil)
 	}
-	if deliveryMissed {
-		h.logger.Info("clarification retry joined an answer already committed to detached delivery",
-			zap.String("pending_id", retryPendingID),
-			zap.String("session_id", req.SessionID))
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
-			"Clarification response is already being delivered after the interrupted wait", nil)
-	}
-	if durable.response != nil && !durable.deliveryPending {
+	if durable.response != nil && !durable.deliveryPending && (!deliveryMissed || durable.response.Rejected) {
 		if isNew {
 			h.clarificationSvc.CancelRequest(pendingID)
 		}
@@ -3992,6 +3985,13 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 			zap.String("session_id", req.SessionID),
 			zap.Bool("rejected", durable.response.Rejected))
 		return ws.NewResponse(msg.ID, msg.Action, durable.response)
+	}
+	if deliveryMissed {
+		h.logger.Info("clarification retry joined an answer already committed to detached delivery",
+			zap.String("pending_id", retryPendingID),
+			zap.String("session_id", req.SessionID))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"Clarification response is already being delivered after the interrupted wait", nil)
 	}
 	if durable.closed != "" {
 		h.clarificationSvc.CancelRequest(pendingID)

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -117,7 +117,11 @@ type clarificationDurableReader interface {
 // detached marker from a still-pending bundle once a retry re-adopts it with a
 // live waiter.
 type clarificationReattacher interface {
-	ReattachActiveClarificationBundle(ctx context.Context, sessionID, pendingID string) ([]*models.Message, error)
+	ReattachActiveClarificationBundle(ctx context.Context, sessionID, pendingID string) ([]*models.Message, bool, error)
+}
+
+type clarificationRetryRegistrar interface {
+	CreateRetryRequest(req *clarification.Request) (pendingID string, isNew, deliveryMissed bool)
 }
 
 // clarificationBundlePublisher is an optional message-creator extension that
@@ -131,9 +135,10 @@ type clarificationBundlePublisher interface {
 // must not be created again; response carries an answered/rejected outcome;
 // closed names a cancelled/expired outcome that has no answer to return.
 type durableClarificationState struct {
-	exists   bool
-	response *clarification.Response
-	closed   clarification.Status
+	exists          bool
+	response        *clarification.Response
+	closed          clarification.Status
+	deliveryPending bool
 }
 
 // reconcileDurableClarification loads whatever the durable identity already
@@ -167,6 +172,12 @@ func (h *Handlers) reconcileDurableClarification(ctx context.Context, sessionID,
 		}
 	}
 	state.exists = true
+	for _, message := range messages {
+		if metadataFlag(message.Metadata, "response_delivery_pending") {
+			state.deliveryPending = true
+			break
+		}
+	}
 	status, response, recorded := clarification.RecordedOutcome(pendingID, messages, h.logger)
 	if !recorded {
 		return state, nil
@@ -179,31 +190,40 @@ func (h *Handlers) reconcileDurableClarification(ctx context.Context, sessionID,
 	return state, nil
 }
 
+func metadataFlag(metadata map[string]interface{}, key string) bool {
+	switch value := metadata[key].(type) {
+	case bool:
+		return value
+	case string:
+		return value == "true" || value == "1"
+	case float64:
+		return value == 1
+	default:
+		return false
+	}
+}
+
 // reattachDurableClarification runs after a retry re-adopted a still-pending
 // bundle and a live waiter exists for it again. It clears agent_disconnected
 // from the bundle's current-turn rows and publishes the change so the
 // projection and the orchestrator's live-clarification guard see a live
-// waiter. Failures are logged only: the in-memory wait is already correct and
-// the durable flag is advisory.
-func (h *Handlers) reattachDurableClarification(ctx context.Context, sessionID, pendingID string) {
+// waiter. The returned active flag is authoritative: superseded bundles and
+// terminal sessions must never leave a retry parked on an unreachable waiter.
+func (h *Handlers) reattachDurableClarification(ctx context.Context, sessionID, pendingID string) (bool, error) {
 	reattacher, ok := h.sessionRepo.(clarificationReattacher)
 	if !ok {
-		return
+		return true, nil
 	}
-	messages, err := reattacher.ReattachActiveClarificationBundle(ctx, sessionID, pendingID)
+	messages, active, err := reattacher.ReattachActiveClarificationBundle(ctx, sessionID, pendingID)
 	if err != nil {
-		h.logger.Warn("failed to clear detached marker on re-adopted clarification bundle",
-			zap.String("pending_id", pendingID),
-			zap.String("session_id", sessionID),
-			zap.Error(err))
-		return
+		return false, err
 	}
 	if len(messages) == 0 {
-		return
+		return active, nil
 	}
 	publisher, ok := h.messageCreator.(clarificationBundlePublisher)
 	if !ok {
-		return
+		return active, nil
 	}
 	if err := publisher.PublishClarificationBundleUpdates(ctx, messages); err != nil {
 		h.logger.Warn("failed to publish re-adopted clarification bundle",
@@ -211,6 +231,80 @@ func (h *Handlers) reattachDurableClarification(ctx context.Context, sessionID, 
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
+	return active, nil
+}
+
+// reconcileClarificationAfterLostAdoption resolves the only race left after a
+// retry registers its waiter: an answer claim can win the durable bundle lock
+// before reattachment. A delivery-pending winner will find the registered
+// waiter, while a finalized winner can be replayed. No winner means the bundle
+// became inactive and must not be waited on.
+func (h *Handlers) reconcileClarificationAfterLostAdoption(
+	ctx context.Context,
+	sessionID, pendingID string,
+) (response *clarification.Response, wait bool, err error) {
+	latest, err := h.reconcileDurableClarification(ctx, sessionID, pendingID)
+	if err != nil {
+		return nil, false, err
+	}
+	if latest.response == nil {
+		return nil, false, nil
+	}
+	if latest.deliveryPending {
+		return nil, true, nil
+	}
+	return latest.response, false, nil
+}
+
+// adoptDurableClarificationRetry checks whether a durable pending bundle is
+// still authoritative and converts any race winner into an immediate result.
+// A nil result with wait=true means the caller owns the registered waiter.
+func (h *Handlers) adoptDurableClarificationRetry(
+	ctx context.Context,
+	msg *ws.Message,
+	sessionID, taskID, pendingID string,
+	isNew bool,
+) (result *ws.Message, resultErr error, wait bool) {
+	active, err := h.reattachDurableClarification(ctx, sessionID, pendingID)
+	if err != nil {
+		if isNew {
+			h.clarificationSvc.CancelRequest(pendingID)
+		}
+		h.logger.Error("failed to adopt durable clarification retry",
+			zap.String("pending_id", pendingID), zap.Error(err))
+		result, resultErr = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"failed to reconcile clarification retry", nil)
+		return result, resultErr, false
+	}
+	if active {
+		return nil, nil, true
+	}
+
+	recorded, deliveryPending, err := h.reconcileClarificationAfterLostAdoption(ctx, sessionID, pendingID)
+	if err != nil {
+		if isNew {
+			h.clarificationSvc.CancelRequest(pendingID)
+		}
+		result, resultErr = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"failed to reconcile clarification retry", nil)
+		return result, resultErr, false
+	}
+	if recorded != nil {
+		if isNew {
+			h.clarificationSvc.CancelRequest(pendingID)
+		}
+		h.setSessionRunning(ctx, taskID, sessionID)
+		result, resultErr = ws.NewResponse(msg.ID, msg.Action, recorded)
+		return result, resultErr, false
+	}
+	if deliveryPending {
+		return nil, nil, true
+	}
+
+	h.clarificationSvc.CancelRequest(pendingID)
+	result, resultErr = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+		"Clarification request is no longer active", nil)
+	return result, resultErr, false
 }
 
 // stepCompletionTurnReader exposes the immutable workflow-step stamp on the
@@ -3852,20 +3946,46 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		}
 	}
 
-	// Reconcile an exact transport retry before touching the in-memory store.
-	// The MCP server scopes retry_key to one connection and request id; the
-	// derived identity lets a retry find the question bundle its interrupted
-	// predecessor already committed, and return a recorded outcome instead of
-	// waiting on a question nobody can answer anymore.
+	// Register the retry before reading its durable bundle. This ordering makes
+	// the handoff to Resolver linearizable: a concurrent durable answer either
+	// finds this waiter, or records that it already chose detached delivery.
 	retryPendingID := clarification.PendingIDForRequest(req.SessionID, req.RetryKey)
+	clarificationReq := &clarification.Request{
+		PendingID: retryPendingID,
+		SessionID: req.SessionID,
+		TaskID:    taskID,
+		Questions: req.Questions,
+		Context:   req.Context,
+	}
+	pendingID, isNew := "", false
+	deliveryMissed := false
+	if registrar, ok := h.clarificationSvc.(clarificationRetryRegistrar); ok && retryPendingID != "" {
+		pendingID, isNew, deliveryMissed = registrar.CreateRetryRequest(clarificationReq)
+	} else {
+		pendingID, isNew = h.clarificationSvc.CreateRequest(clarificationReq)
+	}
+
 	durable, err := h.reconcileDurableClarification(ctx, req.SessionID, retryPendingID)
 	if err != nil {
+		if isNew {
+			h.clarificationSvc.CancelRequest(pendingID)
+		}
 		h.logger.Error("failed to reconcile clarification retry",
 			zap.String("pending_id", retryPendingID), zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
 			"failed to reconcile clarification retry", nil)
 	}
-	if durable.response != nil {
+	if deliveryMissed {
+		h.logger.Info("clarification retry joined an answer already committed to detached delivery",
+			zap.String("pending_id", retryPendingID),
+			zap.String("session_id", req.SessionID))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"Clarification response is already being delivered after the interrupted wait", nil)
+	}
+	if durable.response != nil && !durable.deliveryPending {
+		if isNew {
+			h.clarificationSvc.CancelRequest(pendingID)
+		}
 		h.setSessionRunning(ctx, taskID, req.SessionID)
 		h.logger.Info("clarification retry returned recorded outcome",
 			zap.String("pending_id", retryPendingID),
@@ -3874,6 +3994,7 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		return ws.NewResponse(msg.ID, msg.Action, durable.response)
 	}
 	if durable.closed != "" {
+		h.clarificationSvc.CancelRequest(pendingID)
 		h.logger.Warn("clarification retry found closed bundle",
 			zap.String("pending_id", retryPendingID),
 			zap.String("session_id", req.SessionID),
@@ -3881,16 +4002,6 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
 			"Clarification request timed out or was cancelled", nil)
 	}
-
-	// Create the clarification request
-	clarificationReq := &clarification.Request{
-		PendingID: retryPendingID,
-		SessionID: req.SessionID,
-		TaskID:    taskID,
-		Questions: req.Questions,
-		Context:   req.Context,
-	}
-	pendingID, isNew := h.clarificationSvc.CreateRequest(clarificationReq)
 
 	// Create one chat message per question (triggers WS events to frontend).
 	// If the create fails, the in-store pending entry must be cancelled too —
@@ -3911,10 +4022,14 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 				"failed to create clarification messages: "+err.Error(), nil)
 		}
 	}
-	if durable.exists {
-		// The bundle may have been detached while no waiter was attached; this
-		// call is about to wait on it again.
-		h.reattachDurableClarification(ctx, req.SessionID, pendingID)
+	if durable.exists && durable.response == nil {
+		// Reattachment is also the authoritative activeness check. It is
+		// serialized with answer claims and successor-turn creation.
+		if result, resultErr, wait := h.adoptDurableClarificationRetry(
+			ctx, msg, req.SessionID, taskID, pendingID, isNew,
+		); !wait {
+			return result, resultErr
+		}
 	}
 
 	// Update session and task states to waiting for input

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -107,10 +107,63 @@ type SessionRepository interface {
 }
 
 // clarificationDurableReader is an optional repository extension used to
-// reconcile an interrupted ask_user_question retry with messages already
-// committed before its MCP wait was torn down.
+// reconcile an exact retry of an interrupted ask_user_question call with the
+// question messages already committed before its MCP wait was torn down.
 type clarificationDurableReader interface {
 	FindMessagesByPendingID(ctx context.Context, pendingID string) ([]*models.Message, error)
+}
+
+// durableClarificationState is what an exact retry finds already recorded for
+// its identity. exists means the visible question messages are present and
+// must not be created again; response carries an answered/rejected outcome;
+// closed names a cancelled/expired outcome that has no answer to return.
+type durableClarificationState struct {
+	exists   bool
+	response *clarification.Response
+	closed   clarification.Status
+}
+
+// reconcileDurableClarification loads whatever the durable identity already
+// recorded. A repository without the optional reader, or an empty identity,
+// yields the zero state so the in-memory path behaves as before. A bundle
+// owned by another session is never reused: the identity already binds the
+// session, so a mismatch is treated as absent and logged.
+func (h *Handlers) reconcileDurableClarification(ctx context.Context, sessionID, pendingID string) (durableClarificationState, error) {
+	var state durableClarificationState
+	if pendingID == "" {
+		return state, nil
+	}
+	reader, ok := h.sessionRepo.(clarificationDurableReader)
+	if !ok {
+		return state, nil
+	}
+	messages, err := reader.FindMessagesByPendingID(ctx, pendingID)
+	if err != nil {
+		return state, err
+	}
+	if len(messages) == 0 {
+		return state, nil
+	}
+	for _, message := range messages {
+		if message.TaskSessionID != sessionID {
+			h.logger.Warn("ignoring clarification bundle owned by another session on retry",
+				zap.String("pending_id", pendingID),
+				zap.String("session_id", sessionID),
+				zap.String("owner_session_id", message.TaskSessionID))
+			return state, nil
+		}
+	}
+	state.exists = true
+	status, response, recorded := clarification.RecordedOutcome(pendingID, messages, h.logger)
+	if !recorded {
+		return state, nil
+	}
+	if response != nil {
+		state.response = response
+	} else {
+		state.closed = status
+	}
+	return state, nil
 }
 
 // stepCompletionTurnReader exposes the immutable workflow-step stamp on the
@@ -3722,6 +3775,9 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		TaskID    string                   `json:"task_id"`
 		Questions []clarification.Question `json:"questions"`
 		Context   string                   `json:"context"`
+		// RetryKey is the connection-scoped transport identity the MCP server
+		// attaches so an exact retry maps to the same durable bundle.
+		RetryKey string `json:"retry_key"`
 	}
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
@@ -3749,41 +3805,53 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		}
 	}
 
+	// Reconcile an exact transport retry before touching the in-memory store.
+	// The MCP server scopes retry_key to one connection and request id; the
+	// derived identity lets a retry find the question bundle its interrupted
+	// predecessor already committed, and return a recorded outcome instead of
+	// waiting on a question nobody can answer anymore.
+	retryPendingID := clarification.PendingIDForRequest(req.SessionID, req.RetryKey)
+	durable, err := h.reconcileDurableClarification(ctx, req.SessionID, retryPendingID)
+	if err != nil {
+		h.logger.Error("failed to reconcile clarification retry",
+			zap.String("pending_id", retryPendingID), zap.Error(err))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"failed to reconcile clarification retry", nil)
+	}
+	if durable.response != nil {
+		h.setSessionRunning(ctx, taskID, req.SessionID)
+		h.logger.Info("clarification retry returned recorded outcome",
+			zap.String("pending_id", retryPendingID),
+			zap.String("session_id", req.SessionID),
+			zap.Bool("rejected", durable.response.Rejected))
+		return ws.NewResponse(msg.ID, msg.Action, durable.response)
+	}
+	if durable.closed != "" {
+		h.logger.Warn("clarification retry found closed bundle",
+			zap.String("pending_id", retryPendingID),
+			zap.String("session_id", req.SessionID),
+			zap.String("status", string(durable.closed)))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"Clarification request timed out or was cancelled", nil)
+	}
+
 	// Create the clarification request
 	clarificationReq := &clarification.Request{
-		PendingID: clarification.PendingIDForRequest(req.SessionID, msg.ID),
+		PendingID: retryPendingID,
 		SessionID: req.SessionID,
 		TaskID:    taskID,
 		Questions: req.Questions,
 		Context:   req.Context,
 	}
 	pendingID, isNew := h.clarificationSvc.CreateRequest(clarificationReq)
-	// A transport retry may arrive after the durable question messages were
-	// committed but before the original MCP call returned. Reconcile that
-	// durable identity before creating messages so the retry cannot publish a
-	// second visible question bundle. Repositories without this optional
-	// extension retain the in-memory behavior used by lightweight test doubles.
-	durableMessagesExist := false
-	if pendingID != "" {
-		if reader, ok := h.sessionRepo.(clarificationDurableReader); ok {
-			messages, readErr := reader.FindMessagesByPendingID(ctx, pendingID)
-			if readErr != nil {
-				h.logger.Error("failed to reconcile clarification retry",
-					zap.String("pending_id", pendingID), zap.Error(readErr))
-				h.clarificationSvc.CancelRequest(pendingID)
-				return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
-					"failed to reconcile clarification retry", nil)
-			}
-			durableMessagesExist = len(messages) > 0
-		}
-	}
 
 	// Create one chat message per question (triggers WS events to frontend).
 	// If the create fails, the in-store pending entry must be cancelled too —
 	// otherwise the agent's WaitForResponse would block for the full 2-hour
 	// timeout while the user never sees clarification cards.
-	// When dedup fires (isNew=false) the messages already exist, so skip creation.
-	if isNew && !durableMessagesExist && h.messageCreator != nil {
+	// When dedup fires (isNew=false) the messages already exist, so skip
+	// creation; likewise when the retry identity already has durable messages.
+	if isNew && !durable.exists && h.messageCreator != nil {
 		if _, err := h.messageCreator.CreateClarificationRequestMessages(
 			ctx, taskID, req.SessionID, pendingID, req.Questions, req.Context,
 		); err != nil {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -106,6 +106,13 @@ type SessionRepository interface {
 	SetSessionMetadataKeyIfAbsentOrDifferentStep(ctx context.Context, sessionID, key, stepID string, value interface{}) (bool, error)
 }
 
+// clarificationDurableReader is an optional repository extension used to
+// reconcile an interrupted ask_user_question retry with messages already
+// committed before its MCP wait was torn down.
+type clarificationDurableReader interface {
+	FindMessagesByPendingID(ctx context.Context, pendingID string) ([]*models.Message, error)
+}
+
 // stepCompletionTurnReader exposes the immutable workflow-step stamp on the
 // latest turn. Production SQLite implements this through the turn repository,
 // while small handler fakes can omit it and retain legacy behavior.
@@ -3744,19 +3751,39 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 
 	// Create the clarification request
 	clarificationReq := &clarification.Request{
+		PendingID: clarification.PendingIDForRequest(req.SessionID, msg.ID),
 		SessionID: req.SessionID,
 		TaskID:    taskID,
 		Questions: req.Questions,
 		Context:   req.Context,
 	}
 	pendingID, isNew := h.clarificationSvc.CreateRequest(clarificationReq)
+	// A transport retry may arrive after the durable question messages were
+	// committed but before the original MCP call returned. Reconcile that
+	// durable identity before creating messages so the retry cannot publish a
+	// second visible question bundle. Repositories without this optional
+	// extension retain the in-memory behavior used by lightweight test doubles.
+	durableMessagesExist := false
+	if pendingID != "" {
+		if reader, ok := h.sessionRepo.(clarificationDurableReader); ok {
+			messages, readErr := reader.FindMessagesByPendingID(ctx, pendingID)
+			if readErr != nil {
+				h.logger.Error("failed to reconcile clarification retry",
+					zap.String("pending_id", pendingID), zap.Error(readErr))
+				h.clarificationSvc.CancelRequest(pendingID)
+				return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+					"failed to reconcile clarification retry", nil)
+			}
+			durableMessagesExist = len(messages) > 0
+		}
+	}
 
 	// Create one chat message per question (triggers WS events to frontend).
 	// If the create fails, the in-store pending entry must be cancelled too —
 	// otherwise the agent's WaitForResponse would block for the full 2-hour
 	// timeout while the user never sees clarification cards.
 	// When dedup fires (isNew=false) the messages already exist, so skip creation.
-	if isNew && h.messageCreator != nil {
+	if isNew && !durableMessagesExist && h.messageCreator != nil {
 		if _, err := h.messageCreator.CreateClarificationRequestMessages(
 			ctx, taskID, req.SessionID, pendingID, req.Questions, req.Context,
 		); err != nil {

--- a/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/clarification"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	"github.com/kandev/kandev/internal/task/service"
@@ -26,6 +27,38 @@ type countingMessageCreator struct {
 	calls     atomic.Int32
 	mu        sync.Mutex
 	published [][]*models.Message
+}
+
+type retryReadAnswerRepo struct {
+	*sqliterepo.Repository
+	onRead func()
+	once   sync.Once
+}
+
+func (r *retryReadAnswerRepo) FindMessagesByPendingID(ctx context.Context, pendingID string) ([]*models.Message, error) {
+	messages, err := r.Repository.FindMessagesByPendingID(ctx, pendingID)
+	if err == nil && len(messages) > 0 {
+		r.once.Do(r.onRead)
+	}
+	return messages, err
+}
+
+type countingDetachedResumer struct {
+	calls atomic.Int32
+}
+
+type askUserQuestionResult struct {
+	response *ws.Message
+	err      error
+}
+
+func (r *countingDetachedResumer) Publish(context.Context, string, *bus.Event) error {
+	return nil
+}
+
+func (r *countingDetachedResumer) ResumeDetachedClarification(context.Context, clarification.DetachedClarificationResume) error {
+	r.calls.Add(1)
+	return nil
 }
 
 func (c *countingMessageCreator) CreateClarificationRequestMessages(context.Context, string, string, string, []clarification.Question, string) ([]string, error) {
@@ -201,6 +234,174 @@ func TestHandleAskUserQuestion_RetryReattachesDetachedBundle(t *testing.T) {
 
 	require.NoError(t, store.Respond(pendingID, &clarification.Response{PendingID: pendingID, Answers: []clarification.Answer{{QuestionID: "q1", SelectedOptions: []string{"opt-red"}}}}))
 	wg.Wait()
+}
+
+func TestHandleAskUserQuestion_RetryRejectsSupersededPendingBundleWithoutWaiting(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-superseded")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+	require.NoError(t, repo.CreateTurn(ctx, &models.Turn{
+		ID:            "turn-retry-superseded-newer",
+		TaskSessionID: sessionID,
+		TaskID:        taskID,
+	}))
+
+	store := clarification.NewStore(time.Minute)
+	waitEntered := make(chan struct{}, 1)
+	store.SetOnWaitEntered(func(string) { waitEntered <- struct{}{} })
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	responseDone := make(chan askUserQuestionResult, 1)
+	go func() {
+		resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		responseDone <- askUserQuestionResult{response: resp, err: err}
+	}()
+	select {
+	case <-waitEntered:
+		cancel()
+		<-responseDone
+		t.Fatal("a superseded durable bundle opened an in-memory wait")
+	case result := <-responseDone:
+		require.NoError(t, result.err)
+		assertWSError(t, result.response, ws.ErrorCodeInternalError)
+	}
+	assert.Empty(t, store.ListPending())
+}
+
+func TestHandleAskUserQuestion_RetryRejectsTerminalSessionBundleWithoutWaiting(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-terminal-session")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+	require.NoError(t, repo.UpdateTaskSessionState(ctx, sessionID, models.TaskSessionStateCompleted, ""))
+
+	store := clarification.NewStore(time.Minute)
+	waitEntered := make(chan struct{}, 1)
+	store.SetOnWaitEntered(func(string) { waitEntered <- struct{}{} })
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	responseDone := make(chan askUserQuestionResult, 1)
+	go func() {
+		resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		responseDone <- askUserQuestionResult{response: resp, err: err}
+	}()
+	select {
+	case <-waitEntered:
+		cancel()
+		<-responseDone
+		t.Fatal("a terminal session's durable bundle opened an in-memory wait")
+	case result := <-responseDone:
+		require.NoError(t, result.err)
+		assertWSError(t, result.response, ws.ErrorCodeInternalError)
+	}
+	assert.Empty(t, store.ListPending())
+}
+
+func TestHandleAskUserQuestion_AnswerBetweenRetryReadAndRegistrationUsesOneDeliveryPath(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-answer-race")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+
+	store := clarification.NewStore(time.Minute)
+	resumer := &countingDetachedResumer{}
+	resolver := clarification.NewResolver(
+		store,
+		repo,
+		&svcMessageUpdater{Service: svc},
+		svc,
+		resumer,
+		resumer,
+		nil,
+		testLogger(t),
+	)
+	respondLoaded := make(chan struct{})
+	releaseRespond := make(chan struct{})
+	store.SetOnRespondLoaded(func(string) {
+		close(respondLoaded)
+		<-releaseRespond
+	})
+	answerDone := make(chan error, 1)
+	tracingRepo := &retryReadAnswerRepo{Repository: repo}
+	tracingRepo.onRead = func() {
+		hadWaiter := len(store.ListPending()) > 0
+		go func() {
+			_, _, err := resolver.ResolveBundle(ctx, pendingID, clarification.Outcome{Answers: []clarification.Answer{{
+				QuestionID:      "q1",
+				SelectedOptions: []string{"opt-blue"},
+			}}})
+			answerDone <- err
+		}()
+		<-respondLoaded
+		close(releaseRespond)
+		if !hadWaiter {
+			answerErr := <-answerDone
+			answerDone <- answerErr
+		}
+	}
+
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, tracingRepo, repo, nil, nil, nil, nil, nil, testLogger(t))
+	responseDone := make(chan askUserQuestionResult, 1)
+	go func() {
+		resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		responseDone <- askUserQuestionResult{response: resp, err: err}
+	}()
+
+	select {
+	case result := <-responseDone:
+		require.NoError(t, result.err)
+		require.Equal(t, ws.MessageTypeResponse, result.response.Type)
+		var body clarification.Response
+		require.NoError(t, json.Unmarshal(result.response.Payload, &body))
+		require.Equal(t, pendingID, body.PendingID)
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("retry waiter was registered after the durable answer had already chosen detached delivery")
+	}
+	require.NoError(t, <-answerDone)
+	require.Zero(t, resumer.calls.Load(), "one answer must not produce both a detached resume and a tool response")
+}
+
+// TestHandleAskUserQuestion_RetryAfterDetachedDeliveryDoesNotReplayToolResponse
+// is reviewer-requested contract coverage for the other side of the atomic
+// handoff: when the responder observed no waiter first, detached delivery owns
+// the answer and the later exact retry must not also return it through MCP.
+func TestHandleAskUserQuestion_RetryAfterDetachedDeliveryDoesNotReplayToolResponse(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-after-detached")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+
+	store := clarification.NewStore(time.Minute)
+	resumer := &countingDetachedResumer{}
+	resolver := clarification.NewResolver(
+		store,
+		repo,
+		&svcMessageUpdater{Service: svc},
+		svc,
+		resumer,
+		resumer,
+		nil,
+		testLogger(t),
+	)
+	_, claimed, err := resolver.ResolveBundle(ctx, pendingID, clarification.Outcome{Answers: []clarification.Answer{{
+		QuestionID:      "q1",
+		SelectedOptions: []string{"opt-blue"},
+	}}})
+	require.NoError(t, err)
+	require.True(t, claimed)
+	require.EqualValues(t, 1, resumer.calls.Load())
+
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+	resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+	require.Empty(t, store.ListPending())
+	require.EqualValues(t, 1, resumer.calls.Load(), "retry must not dispatch or return the detached answer twice")
 }
 
 func TestHandleAskUserQuestion_RetryReturnsRecordedAnswerWithoutWaiting(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
@@ -404,6 +404,39 @@ func TestHandleAskUserQuestion_RetryAfterDetachedDeliveryDoesNotReplayToolRespon
 	require.EqualValues(t, 1, resumer.calls.Load(), "retry must not dispatch or return the detached answer twice")
 }
 
+func TestHandleAskUserQuestion_RetryReturnsFinalizedDetachedRejection(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-after-detached-rejection")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+
+	store := clarification.NewStore(time.Minute)
+	resumer := &countingDetachedResumer{}
+	resolver := clarification.NewResolver(
+		store,
+		repo,
+		&svcMessageUpdater{Service: svc},
+		svc,
+		resumer,
+		resumer,
+		nil,
+		testLogger(t),
+	)
+	_, claimed, err := resolver.ResolveBundle(ctx, pendingID, clarification.Outcome{Rejected: true})
+	require.NoError(t, err)
+	require.True(t, claimed)
+	require.Zero(t, resumer.calls.Load(), "a detached rejection is finalized without resuming the agent")
+
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+	resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	var body clarification.Response
+	require.NoError(t, json.Unmarshal(resp.Payload, &body))
+	assert.True(t, body.Rejected)
+	assert.Empty(t, store.ListPending())
+}
+
 func TestHandleAskUserQuestion_RetryReturnsRecordedAnswerWithoutWaiting(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
@@ -1,0 +1,265 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/clarification"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// countingMessageCreator records how many bundles the handler asked it to
+// create; the retry tests assert it stays untouched when durable messages
+// already exist for the retry identity.
+type countingMessageCreator struct {
+	calls atomic.Int32
+}
+
+func (c *countingMessageCreator) CreateClarificationRequestMessages(context.Context, string, string, string, []clarification.Question, string) ([]string, error) {
+	c.calls.Add(1)
+	return []string{"m-created"}, nil
+}
+
+const retryTestKey = "conn-a/int64:7"
+
+var retryTestQuestions = []map[string]interface{}{{
+	"id":     "q1",
+	"prompt": "Which color?",
+	"options": []map[string]interface{}{
+		{"label": "Red", "description": "R"},
+		{"label": "Blue", "description": "B"},
+	},
+}}
+
+// seedRetrySession creates a task and running session and returns the retry
+// identity an exact retry of retryTestKey would derive for that session.
+func seedRetrySession(t *testing.T, ctx context.Context, svc *service.Service, repo *sqliterepo.Repository, suffix string) (taskID, sessionID, pendingID string) {
+	t.Helper()
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-" + suffix, Name: "WS"}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-" + suffix, WorkspaceID: "ws-" + suffix, Name: "Board"}))
+	taskResult, err := svc.CreateTask(ctx, &service.CreateTaskRequest{WorkspaceID: "ws-" + suffix, WorkflowID: "wf-" + suffix, Title: "Task"})
+	require.NoError(t, err)
+	sess := &models.TaskSession{ID: "sess-" + suffix, TaskID: taskResult.Task.ID, IsPrimary: true, State: models.TaskSessionStateRunning}
+	require.NoError(t, repo.CreateTaskSession(ctx, sess))
+	return taskResult.Task.ID, sess.ID, clarification.PendingIDForRequest(sess.ID, retryTestKey)
+}
+
+// seedRetryMessage commits the durable question message an interrupted
+// ask_user_question call would already have created, in the recorded status.
+func seedRetryMessage(t *testing.T, ctx context.Context, repo *sqliterepo.Repository, taskID, sessionID, pendingID, status string, response map[string]interface{}) {
+	t.Helper()
+	meta := map[string]interface{}{
+		"pending_id":     pendingID,
+		"question_id":    "q1",
+		"question_index": 0,
+		"status":         status,
+		"question": map[string]interface{}{
+			"id": "q1", "title": "Color", "prompt": "Which color?",
+			"options": []interface{}{
+				map[string]interface{}{"option_id": "opt-red", "label": "Red", "description": "R"},
+				map[string]interface{}{"option_id": "opt-blue", "label": "Blue", "description": "B"},
+			},
+		},
+	}
+	if response != nil {
+		meta["response"] = response
+	}
+	turn := &models.Turn{ID: "turn-" + sessionID, TaskSessionID: sessionID, TaskID: taskID}
+	require.NoError(t, repo.CreateTurn(ctx, turn))
+	require.NoError(t, repo.CreateMessage(ctx, &models.Message{
+		TaskSessionID: sessionID,
+		TaskID:        taskID,
+		TurnID:        turn.ID,
+		AuthorType:    "agent",
+		Type:          "clarification_request",
+		Content:       "Which color?",
+		Metadata:      meta,
+	}))
+}
+
+func retryAskPayload(sessionID, taskID string) map[string]interface{} {
+	return map[string]interface{}{
+		"session_id": sessionID,
+		"task_id":    taskID,
+		"retry_key":  retryTestKey,
+		"questions":  retryTestQuestions,
+	}
+}
+
+func TestHandleAskUserQuestion_RetryReusesDurableBundleWithoutRecreatingMessages(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-pending")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+
+	store := clarification.NewStore(time.Minute)
+	creator := &countingMessageCreator{}
+	h := NewHandlers(svc, nil, store, nil, creator, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	var wg sync.WaitGroup
+	var resp *ws.Message
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		resp, err = h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		require.NoError(t, err)
+	}()
+
+	require.Eventually(t, func() bool { return len(store.ListPending()) == 1 }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, pendingID, store.ListPending()[0].PendingID, "the store entry must adopt the durable identity so the visible bundle's answer reaches this waiter")
+	assert.Equal(t, int32(0), creator.calls.Load(), "no second visible question bundle may be published")
+
+	messages, err := repo.FindMessagesByPendingID(ctx, pendingID)
+	require.NoError(t, err)
+	assert.Len(t, messages, 1)
+
+	answer := &clarification.Response{PendingID: pendingID, Answers: []clarification.Answer{{QuestionID: "q1", SelectedOptions: []string{"opt-blue"}}}}
+	require.NoError(t, store.Respond(pendingID, answer))
+	wg.Wait()
+
+	require.NotNil(t, resp)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	var body clarification.Response
+	require.NoError(t, json.Unmarshal(resp.Payload, &body))
+	assert.Equal(t, pendingID, body.PendingID)
+	require.Len(t, body.Answers, 1)
+	assert.Equal(t, []string{"opt-blue"}, body.Answers[0].SelectedOptions)
+}
+
+func TestHandleAskUserQuestion_RetryReturnsRecordedAnswerWithoutWaiting(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-answered")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "answered", map[string]interface{}{
+		"question_id": "q1", "selected_options": []interface{}{"opt-red"}, "custom_text": "because",
+	})
+
+	store := clarification.NewStore(time.Minute)
+	creator := &countingMessageCreator{}
+	h := NewHandlers(svc, nil, store, nil, creator, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	done := make(chan *ws.Message, 1)
+	go func() {
+		resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		require.NoError(t, err)
+		done <- resp
+	}()
+
+	var resp *ws.Message
+	select {
+	case resp = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry of an answered bundle must return immediately, not wait for a new answer")
+	}
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	var body clarification.Response
+	require.NoError(t, json.Unmarshal(resp.Payload, &body))
+	assert.Equal(t, pendingID, body.PendingID)
+	assert.False(t, body.Rejected)
+	require.Len(t, body.Answers, 1)
+	assert.Equal(t, "q1", body.Answers[0].QuestionID)
+	assert.Equal(t, []string{"opt-red"}, body.Answers[0].SelectedOptions)
+	assert.Equal(t, "because", body.Answers[0].CustomText)
+
+	assert.Empty(t, store.ListPending(), "a recorded outcome must not open a new in-memory wait")
+	assert.Equal(t, int32(0), creator.calls.Load())
+}
+
+func TestHandleAskUserQuestion_RetryReturnsRecordedRejection(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-rejected")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "rejected", nil)
+
+	store := clarification.NewStore(time.Minute)
+	h := NewHandlers(svc, nil, store, nil, &countingMessageCreator{}, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	var body clarification.Response
+	require.NoError(t, json.Unmarshal(resp.Payload, &body))
+	assert.True(t, body.Rejected)
+	assert.Empty(t, store.ListPending())
+}
+
+func TestHandleAskUserQuestion_RetryOfCancelledBundleReturnsCancelledError(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-cancelled")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "cancelled", nil)
+
+	store := clarification.NewStore(time.Minute)
+	creator := &countingMessageCreator{}
+	h := NewHandlers(svc, nil, store, nil, creator, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	resp, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+	assert.Empty(t, store.ListPending(), "a cancelled bundle must not be re-opened by a retry")
+	assert.Equal(t, int32(0), creator.calls.Load(), "a retry must not re-ask a cancelled question")
+}
+
+func TestHandleAskUserQuestion_RetryIgnoresBundleOwnedByAnotherSession(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-owner")
+	other := &models.TaskSession{ID: "sess-other", TaskID: taskID, State: models.TaskSessionStateRunning}
+	require.NoError(t, repo.CreateTaskSession(ctx, other))
+	// A bundle under this identity but owned by another session must never be
+	// adopted, even though the identity already binds the session.
+	seedRetryMessage(t, ctx, repo, taskID, other.ID, pendingID, "answered", map[string]interface{}{"selected_options": []interface{}{"opt-red"}})
+
+	store := clarification.NewStore(time.Minute)
+	creator := &countingMessageCreator{}
+	h := NewHandlers(svc, nil, store, nil, creator, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		require.NoError(t, err)
+	}()
+	require.Eventually(t, func() bool { return len(store.ListPending()) == 1 }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, int32(1), creator.calls.Load(), "the foreign bundle must not suppress this session's own question")
+	store.CancelSession(sessionID)
+	wg.Wait()
+}
+
+func TestHandleAskUserQuestion_WithoutRetryKeyUsesRandomIdentity(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, derived := seedRetrySession(t, ctx, svc, repo, "retry-none")
+
+	store := clarification.NewStore(time.Minute)
+	h := NewHandlers(svc, nil, store, nil, nil, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	payload := retryAskPayload(sessionID, taskID)
+	delete(payload, "retry_key")
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, payload))
+		require.NoError(t, err)
+	}()
+	require.Eventually(t, func() bool { return len(store.ListPending()) == 1 }, time.Second, 5*time.Millisecond)
+	got := store.ListPending()[0].PendingID
+	assert.NotEmpty(t, got)
+	assert.NotEqual(t, derived, got, "without a transport retry key the identity must stay random")
+	assert.NotEqual(t, clarification.PendingIDForRequest(sessionID, "test-id"), got, "the backend's own ws message id is not a retry identity")
+	store.CancelSession(sessionID)
+	wg.Wait()
+}

--- a/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_ask_retry_test.go
@@ -20,14 +20,30 @@ import (
 
 // countingMessageCreator records how many bundles the handler asked it to
 // create; the retry tests assert it stays untouched when durable messages
-// already exist for the retry identity.
+// already exist for the retry identity. It also records bundle updates the
+// handler publishes when a retry re-adopts a detached bundle.
 type countingMessageCreator struct {
-	calls atomic.Int32
+	calls     atomic.Int32
+	mu        sync.Mutex
+	published [][]*models.Message
 }
 
 func (c *countingMessageCreator) CreateClarificationRequestMessages(context.Context, string, string, string, []clarification.Question, string) ([]string, error) {
 	c.calls.Add(1)
 	return []string{"m-created"}, nil
+}
+
+func (c *countingMessageCreator) PublishClarificationBundleUpdates(_ context.Context, messages []*models.Message) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.published = append(c.published, messages)
+	return nil
+}
+
+func (c *countingMessageCreator) publishedBatches() [][]*models.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]*models.Message(nil), c.published...)
 }
 
 const retryTestKey = "conn-a/int64:7"
@@ -135,6 +151,56 @@ func TestHandleAskUserQuestion_RetryReusesDurableBundleWithoutRecreatingMessages
 	assert.Equal(t, pendingID, body.PendingID)
 	require.Len(t, body.Answers, 1)
 	assert.Equal(t, []string{"opt-blue"}, body.Answers[0].SelectedOptions)
+}
+
+// TestHandleAskUserQuestion_RetryReattachesDetachedBundle covers a retry that
+// adopts a bundle the canceller already detached (agent_disconnected=true).
+// The live waiter is back, so the durable rows must stop advertising the
+// detachment and the change must be published; otherwise the projection shows
+// a disconnected agent and the orchestrator's live-clarification guard would
+// let a queued prompt interrupt the in-flight tool call.
+func TestHandleAskUserQuestion_RetryReattachesDetachedBundle(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	taskID, sessionID, pendingID := seedRetrySession(t, ctx, svc, repo, "retry-detached")
+	seedRetryMessage(t, ctx, repo, taskID, sessionID, pendingID, "pending", nil)
+	seeded, err := repo.FindMessagesByPendingID(ctx, pendingID)
+	require.NoError(t, err)
+	require.Len(t, seeded, 1)
+	seeded[0].Metadata["agent_disconnected"] = true
+	require.NoError(t, repo.UpdateMessage(ctx, seeded[0]))
+
+	store := clarification.NewStore(time.Minute)
+	creator := &countingMessageCreator{}
+	h := NewHandlers(svc, nil, store, nil, creator, repo, repo, nil, nil, nil, nil, nil, testLogger(t))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := h.handleAskUserQuestion(ctx, makeWSMessage(t, ws.ActionMCPAskUserQuestion, retryAskPayload(sessionID, taskID)))
+		require.NoError(t, err)
+	}()
+	require.Eventually(t, func() bool { return len(store.ListPending()) == 1 }, time.Second, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		messages, err := repo.FindMessagesByPendingID(ctx, pendingID)
+		if err != nil || len(messages) != 1 {
+			return false
+		}
+		_, detached := messages[0].Metadata["agent_disconnected"]
+		return !detached
+	}, time.Second, 5*time.Millisecond, "the adopted bundle must no longer be marked agent_disconnected")
+	batches := creator.publishedBatches()
+	require.Len(t, batches, 1, "the reattached rows must be published once")
+	require.Len(t, batches[0], 1)
+	assert.Equal(t, seeded[0].ID, batches[0][0].ID)
+	_, stillDetached := batches[0][0].Metadata["agent_disconnected"]
+	assert.False(t, stillDetached, "published row must carry the reattached metadata")
+	assert.Equal(t, int32(0), creator.calls.Load())
+
+	require.NoError(t, store.Respond(pendingID, &clarification.Response{PendingID: pendingID, Answers: []clarification.Answer{{QuestionID: "q1", SelectedOptions: []string{"opt-red"}}}}))
+	wg.Wait()
 }
 
 func TestHandleAskUserQuestion_RetryReturnsRecordedAnswerWithoutWaiting(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -3149,6 +3149,7 @@ func TestHandleAskUserQuestion_Dedup_CreatesOnePendingBundle(t *testing.T) {
 	payload := map[string]interface{}{
 		"session_id": sess.ID,
 		"task_id":    task.ID,
+		"retry_key":  "conn-dedup/int64:1",
 		"questions": []map[string]interface{}{
 			{"prompt": "What colour?", "options": []map[string]interface{}{
 				{"label": "Red", "description": "R"},
@@ -3177,8 +3178,8 @@ func TestHandleAskUserQuestion_Dedup_CreatesOnePendingBundle(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(store.ListPending()) == 1
 	}, time.Second, 5*time.Millisecond)
-	if got := store.ListPending()[0].PendingID; got != clarification.PendingIDForRequest(sess.ID, "test-id") {
-		t.Fatalf("pending ID = %q, want retry-stable identity %q", got, clarification.PendingIDForRequest(sess.ID, "test-id"))
+	if got, want := store.ListPending()[0].PendingID, clarification.PendingIDForRequest(sess.ID, "conn-dedup/int64:1"); got != want {
+		t.Fatalf("pending ID = %q, want transport retry identity %q", got, want)
 	}
 	store.CancelSession(sess.ID)
 	wg.Wait()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -3177,6 +3177,9 @@ func TestHandleAskUserQuestion_Dedup_CreatesOnePendingBundle(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(store.ListPending()) == 1
 	}, time.Second, 5*time.Millisecond)
+	if got := store.ListPending()[0].PendingID; got != clarification.PendingIDForRequest(sess.ID, "test-id") {
+		t.Fatalf("pending ID = %q, want retry-stable identity %q", got, clarification.PendingIDForRequest(sess.ID, "test-id"))
+	}
 	store.CancelSession(sess.ID)
 	wg.Wait()
 

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -15,6 +15,7 @@ import (
 	mcpprofile "github.com/kandev/kandev/internal/mcp/profile"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	mcplib "github.com/mark3labs/mcp-go/mcp"
+	mcpsrv "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -468,4 +469,91 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, progressSeen, 1, "expected at least one keepalive progress notification")
 	assert.True(t, finalSeen, "expected the final tool result to be delivered")
+}
+
+// askThroughTransport drives a real tools/call JSON-RPC frame through the mcp-go
+// server (hooks included) on behalf of the given client session and returns the
+// payload the ask_user_question handler forwarded to the backend.
+func askThroughTransport(t *testing.T, s *Server, backend *testBackend, session mcpsrv.ClientSession, rawID string) map[string]interface{} {
+	t.Helper()
+	ctx := context.Background()
+	if session != nil {
+		ctx = s.mcpServer.WithContext(ctx, session)
+	}
+	frame := `{"jsonrpc":"2.0","id":` + rawID + `,"method":"tools/call","params":{"name":"ask_user_question_kandev","arguments":{"questions":[{"prompt":"Which color?","options":[{"label":"Red","description":"R"},{"label":"Blue","description":"B"}]}]}}}`
+	response := s.mcpServer.HandleMessage(ctx, []byte(frame))
+	raw, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "not found")
+	require.Equal(t, ws.ActionMCPAskUserQuestion, backend.lastAction)
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok, "backend payload should be a map, got %T", backend.lastPayload)
+	return payload
+}
+
+func newAskTransportSession(id string) *providerRefreshTestSession {
+	return &providerRefreshTestSession{id: id, notifications: make(chan mcplib.JSONRPCNotification, 8)}
+}
+
+// TestAskUserQuestion_RetryKeyIsStableForExactTransportRetry proves the
+// production path (JSON-RPC frame -> BeforeCallTool hook -> handler -> backend
+// payload) forwards the same retry_key when the agent re-sends the same request
+// id on the same MCP connection, and a different key otherwise.
+func TestAskUserQuestion_RetryKeyIsStableForExactTransportRetry(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"answers": []interface{}{}}}
+	s := newTaskModeServer(t, backend, "task-current")
+	conn := newAskTransportSession("conn-a")
+
+	first := askThroughTransport(t, s, backend, conn, "7")
+	firstKey, _ := first["retry_key"].(string)
+	require.NotEmpty(t, firstKey, "retry_key must be forwarded when connection and request id are known")
+	assert.Contains(t, firstKey, "conn-a/")
+	assert.Contains(t, firstKey, "int64:7")
+
+	retry := askThroughTransport(t, s, backend, conn, "7")
+	assert.Equal(t, firstKey, retry["retry_key"], "exact retry must reuse the identity")
+
+	next := askThroughTransport(t, s, backend, conn, "8")
+	assert.NotEqual(t, firstKey, next["retry_key"], "a different request id must not alias")
+
+	stringID := askThroughTransport(t, s, backend, conn, `"7"`)
+	assert.NotEqual(t, firstKey, stringID["retry_key"], "string and numeric ids are distinct JSON-RPC ids")
+}
+
+// TestAskUserQuestion_RetryKeyIsScopedToConnection guards the collision case
+// where a reconnecting client restarts its JSON-RPC ids at the same value.
+func TestAskUserQuestion_RetryKeyIsScopedToConnection(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"answers": []interface{}{}}}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	onA := askThroughTransport(t, s, backend, newAskTransportSession("conn-a"), "1")
+	onB := askThroughTransport(t, s, backend, newAskTransportSession("conn-b"), "1")
+	require.NotEmpty(t, onA["retry_key"])
+	require.NotEmpty(t, onB["retry_key"])
+	assert.NotEqual(t, onA["retry_key"], onB["retry_key"])
+}
+
+// TestAskUserQuestion_RetryKeyOmittedWithoutConnection keeps the backend on its
+// random identity when the call has no client session (direct handler use).
+func TestAskUserQuestion_RetryKeyOmittedWithoutConnection(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"answers": []interface{}{}}}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	payload := askThroughTransport(t, s, backend, nil, "7")
+	_, present := payload["retry_key"]
+	assert.False(t, present, "retry_key must be absent without a connection scope")
+}
+
+func TestStampTransportRequestID_PreservesExistingMeta(t *testing.T) {
+	req := &mcplib.CallToolRequest{}
+	req.Params.Meta = &mcplib.Meta{ProgressToken: "tok", AdditionalFields: map[string]any{"other": 1}}
+	stampTransportRequestID(req, float64(3))
+	assert.Equal(t, mcplib.ProgressToken("tok"), req.Params.Meta.ProgressToken)
+	assert.Equal(t, 1, req.Params.Meta.AdditionalFields["other"])
+	assert.Equal(t, "int64:3", req.Params.Meta.AdditionalFields[transportRequestIDMetaKey])
+
+	stampTransportRequestID(nil, 1)
+	untouched := &mcplib.CallToolRequest{}
+	stampTransportRequestID(untouched, nil)
+	assert.Nil(t, untouched.Params.Meta, "a nil id must not allocate meta")
 }

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -46,7 +46,47 @@ const (
 	reqKey               = "required"
 	typeKey              = "type"
 	stringType           = "string"
+	retryKeyArg          = "retry_key"
 )
+
+// transportRequestIDMetaKey is the Kandev-private `_meta` key under which the
+// BeforeCallTool hook records the agent's JSON-RPC request id. mcp-go hands the
+// id to hooks but not to tool handlers, so the hook stamps it onto the request
+// the handler receives.
+const transportRequestIDMetaKey = "kandev.transport_request_id"
+
+// stampTransportRequestID records the JSON-RPC request id on the call request
+// so handlers can build a retry-stable identity. RequestId.String() renders
+// numeric and string ids deterministically regardless of JSON decoding.
+func stampTransportRequestID(request *mcp.CallToolRequest, id any) {
+	if request == nil || id == nil {
+		return
+	}
+	if request.Params.Meta == nil {
+		request.Params.Meta = &mcp.Meta{}
+	}
+	if request.Params.Meta.AdditionalFields == nil {
+		request.Params.Meta.AdditionalFields = map[string]any{}
+	}
+	request.Params.Meta.AdditionalFields[transportRequestIDMetaKey] = mcp.NewRequestId(id).String()
+}
+
+// clarificationRetryKey identifies one agent tool call across exact transport
+// retries: the MCP connection (client session) plus the JSON-RPC request id the
+// agent chose. JSON-RPC ids restart on every new connection, so the connection
+// scope keeps two different calls from aliasing each other. Empty when either
+// component is unavailable, which leaves the backend on its random identity.
+func clarificationRetryKey(ctx context.Context, req mcp.CallToolRequest) string {
+	connectionID := mcpConnectionID(ctx)
+	if connectionID == "" || req.Params.Meta == nil {
+		return ""
+	}
+	requestID, _ := req.Params.Meta.AdditionalFields[transportRequestIDMetaKey].(string)
+	if requestID == "" {
+		return ""
+	}
+	return connectionID + "/" + requestID
+}
 
 func (s *Server) listWorkspacesHandler() server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -653,6 +693,11 @@ func (s *Server) askUserQuestionHandler() server.ToolHandlerFunc {
 			"session_id": s.sessionID,
 			questionsArg: questions,
 			"context":    questionCtx,
+		}
+		// Carry the connection-scoped transport identity so an exact retry of
+		// an interrupted call reconciles to the bundle it already created.
+		if retryKey := clarificationRetryKey(ctx, req); retryKey != "" {
+			payload[retryKeyArg] = retryKey
 		}
 
 		// Waiting on a human answer routinely outlasts the agent MCP client's

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -261,8 +261,9 @@ func newServerWithProfile(backend BackendClient, sessionID, taskID string, log *
 	hooks.AddAfterInitialize(func(ctx context.Context, _ any, _ *mcp.InitializeRequest, _ *mcp.InitializeResult) {
 		s.observeMCPConnection(mcpConnectionID(ctx), streams.MCPAttachmentEvidenceInitializeObserved, 0, "")
 	})
-	hooks.AddBeforeCallTool(func(_ context.Context, _ any, request *mcp.CallToolRequest) {
+	hooks.AddBeforeCallTool(func(_ context.Context, id any, request *mcp.CallToolRequest) {
 		s.restoreCanonicalToolName(request)
+		stampTransportRequestID(request, id)
 	})
 	hooks.AddAfterListTools(func(ctx context.Context, _ any, _ *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
 		s.presentTransportToolNames(result)

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_reattach_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_reattach_test.go
@@ -52,9 +52,12 @@ func TestReattachActiveClarificationBundleClearsDetachedFlagOnlyForCurrentPendin
 	mutationTime := base.Add(time.Hour)
 	repo.clockNow = func() time.Time { return mutationTime }
 
-	updated, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
+	updated, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
 	if err != nil {
 		t.Fatalf("ReattachActiveClarificationBundle: %v", err)
+	}
+	if !active {
+		t.Fatal("current pending bundle was not reported active")
 	}
 	if ids := messageIDs(updated); len(ids) != 2 || ids[0] != "message-current-1" || ids[1] != "message-current-2" {
 		t.Fatalf("reattached message IDs = %v, want both current pending rows", ids)
@@ -91,9 +94,12 @@ func TestReattachActiveClarificationBundleClearsDetachedFlagOnlyForCurrentPendin
 	if detached, _ := answered.Metadata["agent_disconnected"].(bool); !detached {
 		t.Fatalf("terminal row was reattached: %#v", answered.Metadata)
 	}
-	repeated, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
+	repeated, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
 	if err != nil {
 		t.Fatalf("repeated reattach: %v", err)
+	}
+	if !active {
+		t.Fatal("already-attached current pending bundle was not reported active")
 	}
 	if len(repeated) != 0 {
 		t.Fatalf("repeated reattach changed rows: %v", messageIDs(repeated))
@@ -113,9 +119,12 @@ func TestReattachActiveClarificationBundleIgnoresNeverDetachedBundle(t *testing.
 		"pending-live", "q-live", base,
 	)
 
-	updated, err := repo.ReattachActiveClarificationBundle(ctx, "session-live", "pending-live")
+	updated, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-live", "pending-live")
 	if err != nil {
 		t.Fatalf("ReattachActiveClarificationBundle: %v", err)
+	}
+	if !active {
+		t.Fatal("never-detached current pending bundle was not reported active")
 	}
 	if len(updated) != 0 {
 		t.Fatalf("live bundle was rewritten: %v", messageIDs(updated))

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_reattach_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_reattach_test.go
@@ -1,0 +1,123 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestReattachActiveClarificationBundleClearsDetachedFlagOnlyForCurrentPendingRows
+// covers the exact-retry adoption path: a detached, still-pending bundle on the
+// session's current turn regains a live waiter, so its rows must stop
+// advertising agent_disconnected. Superseded, terminal, and never-detached rows
+// are left alone, and a repeated call changes nothing.
+func TestReattachActiveClarificationBundleClearsDetachedFlagOnlyForCurrentPendingRows(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	base := time.Date(2026, time.September, 5, 6, 0, 0, 0, time.UTC)
+	seedPendingActionSession(t, repo, "task-reattach", "session-reattach")
+	createPendingActionTurn(t, repo, "task-reattach", "session-reattach", "turn-old", base, base)
+	createClarificationBundleMessage(
+		t, repo, "message-old", "task-reattach", "session-reattach", "turn-old",
+		"pending-old", "q-old", base,
+	)
+	setClarificationMessageMetadata(t, repo, "message-old", func(metadata map[string]interface{}) {
+		metadata["agent_disconnected"] = true
+	})
+	createPendingActionTurn(
+		t, repo, "task-reattach", "session-reattach", "turn-current",
+		base.Add(time.Minute), base.Add(time.Minute),
+	)
+	createClarificationBundleMessage(
+		t, repo, "message-current-1", "task-reattach", "session-reattach", "turn-current",
+		"pending-current", "q1", base.Add(time.Minute),
+	)
+	createClarificationBundleMessage(
+		t, repo, "message-current-2", "task-reattach", "session-reattach", "turn-current",
+		"pending-current", "q2", base.Add(time.Minute+time.Second),
+	)
+	for _, id := range []string{"message-current-1", "message-current-2"} {
+		setClarificationMessageMetadata(t, repo, id, func(metadata map[string]interface{}) {
+			metadata["agent_disconnected"] = true
+		})
+	}
+	createClarificationBundleMessage(
+		t, repo, "message-answered", "task-reattach", "session-reattach", "turn-current",
+		"pending-answered", "q-answered", base.Add(time.Minute+2*time.Second),
+	)
+	setClarificationMessageMetadata(t, repo, "message-answered", func(metadata map[string]interface{}) {
+		metadata["status"] = "answered"
+		metadata["agent_disconnected"] = true
+	})
+	mutationTime := base.Add(time.Hour)
+	repo.clockNow = func() time.Time { return mutationTime }
+
+	updated, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
+	if err != nil {
+		t.Fatalf("ReattachActiveClarificationBundle: %v", err)
+	}
+	if ids := messageIDs(updated); len(ids) != 2 || ids[0] != "message-current-1" || ids[1] != "message-current-2" {
+		t.Fatalf("reattached message IDs = %v, want both current pending rows", ids)
+	}
+	for _, message := range updated {
+		if _, detached := message.Metadata["agent_disconnected"]; detached {
+			t.Fatalf("returned row %s still carries agent_disconnected: %#v", message.ID, message.Metadata)
+		}
+		if status, _ := message.Metadata["status"].(string); status != "pending" {
+			t.Fatalf("returned row %s status = %q, want pending", message.ID, status)
+		}
+		if !message.UpdatedAt.Equal(mutationTime) {
+			t.Fatalf("reattached updated_at = %v, want injected mutation time %v", message.UpdatedAt, mutationTime)
+		}
+	}
+	current, err := repo.GetMessage(ctx, "message-current-1")
+	if err != nil {
+		t.Fatalf("GetMessage(current): %v", err)
+	}
+	if _, detached := current.Metadata["agent_disconnected"]; detached {
+		t.Fatalf("persisted current row still detached: %#v", current.Metadata)
+	}
+	old, err := repo.GetMessage(ctx, "message-old")
+	if err != nil {
+		t.Fatalf("GetMessage(old): %v", err)
+	}
+	if detached, _ := old.Metadata["agent_disconnected"].(bool); !detached {
+		t.Fatalf("superseded-turn row was reattached: %#v", old.Metadata)
+	}
+	answered, err := repo.GetMessage(ctx, "message-answered")
+	if err != nil {
+		t.Fatalf("GetMessage(answered): %v", err)
+	}
+	if detached, _ := answered.Metadata["agent_disconnected"].(bool); !detached {
+		t.Fatalf("terminal row was reattached: %#v", answered.Metadata)
+	}
+	repeated, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach", "pending-current")
+	if err != nil {
+		t.Fatalf("repeated reattach: %v", err)
+	}
+	if len(repeated) != 0 {
+		t.Fatalf("repeated reattach changed rows: %v", messageIDs(repeated))
+	}
+}
+
+// TestReattachActiveClarificationBundleIgnoresNeverDetachedBundle proves the
+// call is a no-op for a bundle that still has its original waiter.
+func TestReattachActiveClarificationBundleIgnoresNeverDetachedBundle(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	base := time.Date(2026, time.September, 5, 6, 0, 0, 0, time.UTC)
+	seedPendingActionSession(t, repo, "task-live", "session-live")
+	createPendingActionTurn(t, repo, "task-live", "session-live", "turn-live", base, base)
+	createClarificationBundleMessage(
+		t, repo, "message-live", "task-live", "session-live", "turn-live",
+		"pending-live", "q-live", base,
+	)
+
+	updated, err := repo.ReattachActiveClarificationBundle(ctx, "session-live", "pending-live")
+	if err != nil {
+		t.Fatalf("ReattachActiveClarificationBundle: %v", err)
+	}
+	if len(updated) != 0 {
+		t.Fatalf("live bundle was rewritten: %v", messageIDs(updated))
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
@@ -161,17 +161,21 @@ func (r *Repository) ExpireActiveClarificationBundle(
 func (r *Repository) ReattachActiveClarificationBundle(
 	ctx context.Context,
 	sessionID, pendingID string,
-) ([]*models.Message, error) {
+) ([]*models.Message, bool, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("begin clarification reattach: %w", err)
+		return nil, false, fmt.Errorf("begin clarification reattach: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 	drv := r.db.DriverName()
 	if err := lockSessionTurnWrites(ctx, tx, drv, sessionID); err != nil {
-		return nil, err
+		return nil, false, err
+	}
+	if err := lockClarificationSessionRow(ctx, tx, drv, sessionID); err != nil {
+		return nil, false, err
 	}
 	updatedAt := r.nowUTC()
+	bundlePendingIDExpr := dialect.JSONExtract(drv, "bundle.metadata", "pending_id")
 	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
 	query := fmt.Sprintf(`
 		UPDATE task_session_messages
@@ -180,6 +184,7 @@ func (r *Repository) ReattachActiveClarificationBundle(
 		  AND type = 'clarification_request'
 		  AND COALESCE(%s, '') IN ('', 'pending')
 		  AND %s = ?
+		  AND %s
 		  AND NOT (%s)
 		  AND turn_id = (
 			SELECT turn_row.id
@@ -189,29 +194,89 @@ func (r *Repository) ReattachActiveClarificationBundle(
 			ORDER BY %s
 			LIMIT 1
 		  )
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM task_session_messages bundle
+			WHERE %s = ?
+			  AND (
+				bundle.type != 'clarification_request'
+				OR bundle.task_session_id != task_session_messages.task_session_id
+				OR bundle.turn_id != task_session_messages.turn_id
+			  )
+		  )
 		RETURNING id, task_session_id, task_id, turn_id, author_type, author_id,
 		          content, requests_input, type, metadata, created_at, updated_at
 	`, clarificationReattachedMetadataExpr(drv),
 		dialect.JSONExtract(drv, "task_session_messages.metadata", "status"),
 		dialect.JSONExtract(drv, "task_session_messages.metadata", "pending_id"),
+		nonTerminalSessionPredicate("task_session_messages"),
 		clarificationNotDetachedPredicate(drv),
-		predicate, orderBy)
-	rows, err := tx.QueryxContext(ctx, r.db.Rebind(query), updatedAt, sessionID, pendingID)
+		predicate, orderBy, bundlePendingIDExpr)
+	rows, err := tx.QueryxContext(ctx, r.db.Rebind(query), updatedAt, sessionID, pendingID, pendingID)
 	if err != nil {
-		return nil, fmt.Errorf("reattach active clarification messages: %w", err)
+		return nil, false, fmt.Errorf("reattach active clarification messages: %w", err)
 	}
 	messages, _, err := scanMessageRows(rows, 0)
 	closeErr := rows.Close()
 	if err != nil {
-		return nil, fmt.Errorf("scan reattached clarification messages: %w", err)
+		return nil, false, fmt.Errorf("scan reattached clarification messages: %w", err)
 	}
 	if closeErr != nil {
-		return nil, fmt.Errorf("close reattached clarification rows: %w", closeErr)
+		return nil, false, fmt.Errorf("close reattached clarification rows: %w", closeErr)
+	}
+	active, err := r.activeClarificationBundleExists(ctx, tx, drv, sessionID, pendingID)
+	if err != nil {
+		return nil, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit clarification reattach: %w", err)
+		return nil, false, fmt.Errorf("commit clarification reattach: %w", err)
 	}
-	return messages, nil
+	return messages, active, nil
+}
+
+func (r *Repository) activeClarificationBundleExists(
+	ctx context.Context,
+	tx *sqlx.Tx,
+	drv, sessionID, pendingID string,
+) (bool, error) {
+	pendingIDExpr := dialect.JSONExtract(drv, "m.metadata", "pending_id")
+	statusExpr := dialect.JSONExtract(drv, "m.metadata", "status")
+	bundlePendingIDExpr := dialect.JSONExtract(drv, "bundle.metadata", "pending_id")
+	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM task_session_messages m
+			WHERE m.task_session_id = ?
+			  AND m.type = 'clarification_request'
+			  AND %[1]s = ?
+			  AND COALESCE(%[2]s, '') IN ('', 'pending')
+			  AND %[3]s
+			  AND m.turn_id = (
+				SELECT turn_row.id
+				FROM task_session_turns turn_row
+				WHERE turn_row.task_session_id = m.task_session_id
+				  AND %[4]s
+				ORDER BY %[5]s
+				LIMIT 1
+			  )
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM task_session_messages bundle
+				WHERE %[6]s = ?
+				  AND (
+					bundle.type != 'clarification_request'
+					OR bundle.task_session_id != m.task_session_id
+					OR bundle.turn_id != m.turn_id
+				  )
+			  )
+		)
+	`, pendingIDExpr, statusExpr, nonTerminalSessionPredicate("m"), predicate, orderBy, bundlePendingIDExpr)
+	var active bool
+	if err := tx.GetContext(ctx, &active, r.db.Rebind(query), sessionID, pendingID, pendingID); err != nil {
+		return false, fmt.Errorf("check active clarification bundle: %w", err)
+	}
+	return active, nil
 }
 
 func clarificationDetachedMetadataExpr(driverName string) string {
@@ -381,15 +446,29 @@ func (r *Repository) lockClarificationBundleTurnWrites(
 	// same rows before evaluating the non-terminal claim predicate forces one
 	// side to observe the other's committed state.
 	for _, sessionID := range sessionIDs {
-		var lockedSessionID string
-		if err := tx.GetContext(
-			ctx,
-			&lockedSessionID,
-			r.db.Rebind(`SELECT id FROM task_sessions WHERE id = ? FOR UPDATE`),
-			sessionID,
-		); err != nil {
-			return fmt.Errorf("lock clarification session %q: %w", sessionID, err)
+		if err := lockClarificationSessionRow(ctx, tx, driverName, sessionID); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func lockClarificationSessionRow(
+	ctx context.Context,
+	tx *sqlx.Tx,
+	driverName, sessionID string,
+) error {
+	if !dialect.IsPostgres(driverName) {
+		return nil
+	}
+	var lockedSessionID string
+	if err := tx.GetContext(
+		ctx,
+		&lockedSessionID,
+		`SELECT id FROM task_sessions WHERE id = $1 FOR UPDATE`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("lock clarification session %q: %w", sessionID, err)
 	}
 	return nil
 }

--- a/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
+++ b/apps/backend/internal/task/repository/sqlite/message_clarification_response.go
@@ -152,11 +152,82 @@ func (r *Repository) ExpireActiveClarificationBundle(
 	return messages, nil
 }
 
+// ReattachActiveClarificationBundle clears the detached marker from one exact
+// pending bundle after a live waiter re-adopted it, so the projection and the
+// orchestrator's live-clarification guard stop treating the bundle as
+// abandoned. Only pending, currently detached rows on the session's current
+// durable turn change; a superseded, terminal, or never-detached bundle is
+// left untouched and yields no rows.
+func (r *Repository) ReattachActiveClarificationBundle(
+	ctx context.Context,
+	sessionID, pendingID string,
+) ([]*models.Message, error) {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin clarification reattach: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	drv := r.db.DriverName()
+	if err := lockSessionTurnWrites(ctx, tx, drv, sessionID); err != nil {
+		return nil, err
+	}
+	updatedAt := r.nowUTC()
+	predicate, orderBy := currentTurnAuthority(drv, "turn_row")
+	query := fmt.Sprintf(`
+		UPDATE task_session_messages
+		SET metadata = %s, updated_at = ?
+		WHERE task_session_id = ?
+		  AND type = 'clarification_request'
+		  AND COALESCE(%s, '') IN ('', 'pending')
+		  AND %s = ?
+		  AND NOT (%s)
+		  AND turn_id = (
+			SELECT turn_row.id
+			FROM task_session_turns turn_row
+			WHERE turn_row.task_session_id = task_session_messages.task_session_id
+			  AND %s
+			ORDER BY %s
+			LIMIT 1
+		  )
+		RETURNING id, task_session_id, task_id, turn_id, author_type, author_id,
+		          content, requests_input, type, metadata, created_at, updated_at
+	`, clarificationReattachedMetadataExpr(drv),
+		dialect.JSONExtract(drv, "task_session_messages.metadata", "status"),
+		dialect.JSONExtract(drv, "task_session_messages.metadata", "pending_id"),
+		clarificationNotDetachedPredicate(drv),
+		predicate, orderBy)
+	rows, err := tx.QueryxContext(ctx, r.db.Rebind(query), updatedAt, sessionID, pendingID)
+	if err != nil {
+		return nil, fmt.Errorf("reattach active clarification messages: %w", err)
+	}
+	messages, _, err := scanMessageRows(rows, 0)
+	closeErr := rows.Close()
+	if err != nil {
+		return nil, fmt.Errorf("scan reattached clarification messages: %w", err)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close reattached clarification rows: %w", closeErr)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit clarification reattach: %w", err)
+	}
+	return messages, nil
+}
+
 func clarificationDetachedMetadataExpr(driverName string) string {
 	if dialect.IsPostgres(driverName) {
 		return "jsonb_set(metadata::jsonb, '{agent_disconnected}', 'true'::jsonb)::text"
 	}
 	return "json_set(metadata, '$.agent_disconnected', json('true'))"
+}
+
+// clarificationReattachedMetadataExpr removes the detached marker so the row
+// reads exactly like a bundle whose waiter never went away.
+func clarificationReattachedMetadataExpr(driverName string) string {
+	if dialect.IsPostgres(driverName) {
+		return "(metadata::jsonb - 'agent_disconnected')::text"
+	}
+	return "json_remove(metadata, '$.agent_disconnected')"
 }
 
 func clarificationExpiredMetadataExpr(driverName string) string {

--- a/apps/backend/internal/task/repository/sqlite/message_pending_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_pending_postgres_test.go
@@ -140,6 +140,85 @@ func TestPostgresCompleteActiveClarificationBundleClaimsOnce(t *testing.T) {
 	}
 }
 
+func TestPostgresReattachActiveClarificationBundleMatchesLifecycleAuthority(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	base := time.Date(2026, time.September, 5, 8, 0, 0, 0, time.UTC)
+
+	seedPendingActionSession(t, repo, "task-reattach-pg", "session-reattach-pg")
+	createPendingActionTurn(t, repo, "task-reattach-pg", "session-reattach-pg", "turn-old-reattach-pg", base, base)
+	createClarificationBundleMessage(t, repo, "message-old-reattach-pg", "task-reattach-pg", "session-reattach-pg", "turn-old-reattach-pg", "pending-old-reattach-pg", "q-old", base)
+	setClarificationMessageMetadata(t, repo, "message-old-reattach-pg", func(metadata map[string]interface{}) {
+		metadata["agent_disconnected"] = true
+	})
+	createPendingActionTurn(t, repo, "task-reattach-pg", "session-reattach-pg", "turn-current-reattach-pg", base.Add(time.Minute), base.Add(time.Minute))
+	createClarificationBundleMessage(t, repo, "message-current-reattach-pg", "task-reattach-pg", "session-reattach-pg", "turn-current-reattach-pg", "pending-current-reattach-pg", "q-current", base.Add(time.Minute))
+	setClarificationMessageMetadata(t, repo, "message-current-reattach-pg", func(metadata map[string]interface{}) {
+		metadata["agent_disconnected"] = true
+	})
+	createClarificationBundleMessage(t, repo, "message-live-reattach-pg", "task-reattach-pg", "session-reattach-pg", "turn-current-reattach-pg", "pending-live-reattach-pg", "q-live", base.Add(time.Minute+time.Second))
+	createClarificationBundleMessage(t, repo, "message-answered-reattach-pg", "task-reattach-pg", "session-reattach-pg", "turn-current-reattach-pg", "pending-answered-reattach-pg", "q-answered", base.Add(time.Minute+2*time.Second))
+	setClarificationMessageMetadata(t, repo, "message-answered-reattach-pg", func(metadata map[string]interface{}) {
+		metadata["status"] = clarificationStatusAnswered
+		metadata["agent_disconnected"] = true
+	})
+
+	seedPendingActionSession(t, repo, "task-terminal-reattach-pg", "session-terminal-reattach-pg")
+	createPendingActionTurn(t, repo, "task-terminal-reattach-pg", "session-terminal-reattach-pg", "turn-terminal-reattach-pg", base, base)
+	createClarificationBundleMessage(t, repo, "message-terminal-reattach-pg", "task-terminal-reattach-pg", "session-terminal-reattach-pg", "turn-terminal-reattach-pg", "pending-terminal-reattach-pg", "q-terminal", base)
+	setClarificationMessageMetadata(t, repo, "message-terminal-reattach-pg", func(metadata map[string]interface{}) {
+		metadata["agent_disconnected"] = true
+	})
+	if err := repo.UpdateTaskSessionState(ctx, "session-terminal-reattach-pg", models.TaskSessionStateCompleted, ""); err != nil {
+		t.Fatalf("complete terminal session: %v", err)
+	}
+
+	updated, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach-pg", "pending-current-reattach-pg")
+	if err != nil || !active || len(updated) != 1 {
+		t.Fatalf("reattach current Postgres bundle = active %v rows %d err %v; want true, 1, nil", active, len(updated), err)
+	}
+	if _, detached := updated[0].Metadata["agent_disconnected"]; detached {
+		t.Fatalf("reattached Postgres row retained marker: %#v", updated[0].Metadata)
+	}
+	repeated, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach-pg", "pending-current-reattach-pg")
+	if err != nil || !active || len(repeated) != 0 {
+		t.Fatalf("repeated Postgres reattach = active %v rows %d err %v; want true, 0, nil", active, len(repeated), err)
+	}
+	liveRows, active, err := repo.ReattachActiveClarificationBundle(ctx, "session-reattach-pg", "pending-live-reattach-pg")
+	if err != nil || !active || len(liveRows) != 0 {
+		t.Fatalf("never-detached Postgres bundle = active %v rows %d err %v; want true, 0, nil", active, len(liveRows), err)
+	}
+
+	for _, test := range []struct {
+		name      string
+		sessionID string
+		pendingID string
+		messageID string
+	}{
+		{name: "superseded", sessionID: "session-reattach-pg", pendingID: "pending-old-reattach-pg", messageID: "message-old-reattach-pg"},
+		{name: "answered", sessionID: "session-reattach-pg", pendingID: "pending-answered-reattach-pg", messageID: "message-answered-reattach-pg"},
+		{name: "terminal session", sessionID: "session-terminal-reattach-pg", pendingID: "pending-terminal-reattach-pg", messageID: "message-terminal-reattach-pg"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rows, active, err := repo.ReattachActiveClarificationBundle(ctx, test.sessionID, test.pendingID)
+			if err != nil || active || len(rows) != 0 {
+				t.Fatalf("inactive Postgres reattach = active %v rows %d err %v; want false, 0, nil", active, len(rows), err)
+			}
+			message, err := repo.GetMessage(ctx, test.messageID)
+			if err != nil {
+				t.Fatalf("GetMessage(%s): %v", test.messageID, err)
+			}
+			if detached, _ := message.Metadata["agent_disconnected"].(bool); !detached {
+				t.Fatalf("inactive Postgres row was reattached: %#v", message.Metadata)
+			}
+		})
+	}
+}
+
 func TestPostgresClarificationClaimWaitsForTerminalSessionWrite(t *testing.T) {
 	db := openIsolatedPostgresMultiConn(t, testutil.PostgresDSNFromEnv(t), 5)
 	repo, err := NewWithDB(db, db, nil)

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -746,14 +746,16 @@ Each returned bundle carries `pending_id`, `task_id`, `session_id`, `created_at`
 `context`, and an ordered `questions` array; each question carries `question_id`, `title`,
 `prompt`, `status`, and its `options` (`option_id`, `label`, `description`).
 
-The bundle's `pending_id` is the durable identity of the visible question group. If an agent's
-MCP transport closes or times out while `ask_user_question_kandev` is waiting, the question stays
-visible and answerable. When the agent re-sends the same JSON-RPC request (same request id on the
-same MCP connection), Kandev maps the retry to the bundle its interrupted call created: no second
-question is published, and if the person already answered, rejected, or cancelled it, the retry
-returns that recorded outcome immediately instead of waiting again. A call with a new request id
-is a new question; an identical question re-asked while the original is still pending is
-deduplicated to the pending bundle.
+The bundle's `pending_id` is the durable identity of the visible question group. If the request
+carrying an `ask_user_question_kandev` call is interrupted or times out while the call is waiting,
+the question stays visible and answerable. When the agent re-sends the same JSON-RPC request (same
+request id) within the same MCP session, Kandev maps the retry to the bundle its interrupted call
+created: no second question is published, the bundle is marked attached again if the interruption
+had detached it, and if the person already answered, rejected, or cancelled it, the retry returns
+that recorded outcome immediately instead of waiting again. A new MCP session (for example after a
+stdio agent restarts or a client drops its `Mcp-Session-Id`) starts fresh: a re-sent request id is a
+new question there. A call with a new request id is a new question; an identical question re-asked
+while the original is still pending is deduplicated to the pending bundle.
 
 After the person answers, pass the bundle's `pending_id` plus one entry per question to
 `answer_question_kandev`:

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -747,11 +747,13 @@ Each returned bundle carries `pending_id`, `task_id`, `session_id`, `created_at`
 `prompt`, `status`, and its `options` (`option_id`, `label`, `description`).
 
 The bundle's `pending_id` is the durable identity of the visible question group. If an agent's
-MCP transport closes or times out while `ask_user_question_kandev` is waiting, the question remains
-answerable and an exact retry is reconciled to the existing visible messages. Clients should retry
-the exact request rather than create a second question. A successful answer is recorded before the
-live agent waiter is released; a losing retry receives the recorded outcome and does not publish a
-duplicate answer or resume.
+MCP transport closes or times out while `ask_user_question_kandev` is waiting, the question stays
+visible and answerable. When the agent re-sends the same JSON-RPC request (same request id on the
+same MCP connection), Kandev maps the retry to the bundle its interrupted call created: no second
+question is published, and if the person already answered, rejected, or cancelled it, the retry
+returns that recorded outcome immediately instead of waiting again. A call with a new request id
+is a new question; an identical question re-asked while the original is still pending is
+deduplicated to the pending bundle.
 
 After the person answers, pass the bundle's `pending_id` plus one entry per question to
 `answer_question_kandev`:

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -748,11 +748,18 @@ Each returned bundle carries `pending_id`, `task_id`, `session_id`, `created_at`
 
 The bundle's `pending_id` is the durable identity of the visible question group. If the request
 carrying an `ask_user_question_kandev` call is interrupted or times out while the call is waiting,
-the question stays visible and answerable. When the agent re-sends the same JSON-RPC request (same
-request id) within the same MCP session, Kandev maps the retry to the bundle its interrupted call
-created: no second question is published, the bundle is marked attached again if the interruption
-had detached it, and if the person already answered, rejected, or cancelled it, the retry returns
-that recorded outcome immediately instead of waiting again. A new MCP session (for example after a
+the question remains durably recorded. It stays visible and answerable while its bundle belongs to
+the session's current turn and the session is non-terminal. When the agent re-sends the same
+JSON-RPC request (same request id) within the same MCP session, Kandev maps the retry to the bundle
+its interrupted call created: no second question is published, the bundle is marked attached again
+if the interruption had detached it, and a previously recorded answer, rejection, or cancellation
+is reconciled instead of opening another wait. A superseded bundle or a bundle on a completed,
+failed, or cancelled session is reported as no longer active.
+
+Registration and answer delivery use one atomic handoff. If an answer commits during retry
+reconciliation, it either reaches the re-registered tool waiter or continues through detached
+delivery, never both. When detached delivery won first, the retry reports that delivery is already
+in progress instead of returning a duplicate tool response. A new MCP session (for example after a
 stdio agent restarts or a client drops its `Mcp-Session-Id`) starts fresh: a re-sent request id is a
 new question there. A call with a new request id is a new question; an identical question re-asked
 while the original is still pending is deduplicated to the pending bundle.

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -746,6 +746,13 @@ Each returned bundle carries `pending_id`, `task_id`, `session_id`, `created_at`
 `context`, and an ordered `questions` array; each question carries `question_id`, `title`,
 `prompt`, `status`, and its `options` (`option_id`, `label`, `description`).
 
+The bundle's `pending_id` is the durable identity of the visible question group. If an agent's
+MCP transport closes or times out while `ask_user_question_kandev` is waiting, the question remains
+answerable and an exact retry is reconciled to the existing visible messages. Clients should retry
+the exact request rather than create a second question. A successful answer is recorded before the
+live agent waiter is released; a losing retry receives the recorded outcome and does not publish a
+duplicate answer or resume.
+
 After the person answers, pass the bundle's `pending_id` plus one entry per question to
 `answer_question_kandev`:
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3404/4032e322edb0.html)
<!-- kandev-pr-walkthrough-end -->

Interrupted `ask_user_question_kandev` calls could leave a visible durable question that an exact MCP retry could neither reclaim nor resolve. Retry identity, durable reconciliation, and atomic delivery handoff now preserve one authoritative question lifecycle across interruption, timeout, answer, rejection, and cancellation.

## Important Changes

- Derive retry identity from the MCP connection and JSON-RPC request so exact retries converge without aliasing other connections.
- Reconcile durable pending and finalized clarification bundles, including safe reattachment and authoritative session/turn ownership checks.
- Linearize waiter registration, cancellation, and response delivery to prevent lost wakeups or duplicate detached responses.
- Document the supported retry lifecycle and same-MCP-session boundary.

## Validation

- `go test -race -count=1 ./internal/clarification/ ./internal/mcp/handlers/ ./internal/mcp/server/ ./internal/task/repository/sqlite/`
- Focused retry, authorization, lifecycle, SQLite reattachment, and MCP transport identity tests under `-race`
- 100 repetitions of the cancellation-versus-retry handoff race
- 50 repetitions of handler answer, detached-delivery, rejection, and deduplication races
- `go vet` on the four changed backend packages
- `golangci-lint run` on changed code: 0 issues
- `node --test scripts/validate-public-docs.test.mjs`: 61 passed
- `node scripts/validate-public-docs.mjs`: 41 pages validated
- `gofmt` and `git diff --check`: clean
- PostgreSQL parity test compiles and is discovered; live execution requires `KANDEV_TEST_POSTGRES_DSN`, which was unavailable in this task environment.

## Possible Improvements

Low risk: run the environment-gated PostgreSQL parity case in CI with a configured test DSN.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3404-bwo7.sprites.app |
| **Commit** | `4032e32` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->