### PR TITLE
fix(web): preserve transcript position on task switch

### DIFF
--- a/apps/web/components/task/chat/message-list-native-scroll.ts
+++ b/apps/web/components/task/chat/message-list-native-scroll.ts
@@ -26,6 +26,7 @@ import { scheduleClampedScrollRestore } from "./clamped-scroll-restore";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const paginationDebug = createDebugLogger("messages:pagination");
+const placementDebug = createDebugLogger("messages:scroll-placement");
 // i18n-exempt: IntersectionObserver root-margin configuration, not user-facing copy.
 export const TRANSCRIPT_SENTINEL_ROOT_MARGIN = "200px 0px 0px 0px";
 
@@ -1091,6 +1092,7 @@ type InitialScrollApplyParams = {
   isNearBottomRef: React.RefObject<boolean>;
   envSwitchPlacementToken: number | null;
   isProgrammaticScrollLocked: () => boolean;
+  phase: "provisional" | "final";
 };
 
 function markInitialScrollConsumed(
@@ -1103,8 +1105,78 @@ function markInitialScrollConsumed(
 
 function completeEnvSwitchPlacement(envSwitchPlacementToken: number | null): void {
   if (envSwitchPlacementToken !== null) {
+    if (isDebug()) {
+      placementDebug("placement request completed", { token: envSwitchPlacementToken });
+    }
     useDockviewStore.getState().completePendingChatInitialPlacement(envSwitchPlacementToken);
   }
+}
+
+function isCurrentEnvSwitchPlacement(
+  pending: { sessionId: string; token: number } | null,
+  sessionId: string | null,
+  token: number | null,
+): boolean {
+  if (token === null) return true;
+  return pending?.token === token && pending.sessionId === sessionId;
+}
+
+function hasCompetingInitialScrollOwner(params: {
+  hasPendingLayoutRestore: boolean;
+  hasExplicitScrollTarget: boolean;
+  isProgrammaticScrollLocked: () => boolean;
+}): boolean {
+  return (
+    params.hasPendingLayoutRestore ||
+    params.hasExplicitScrollTarget ||
+    params.isProgrammaticScrollLocked()
+  );
+}
+
+function reportInitialPlacement(
+  phase: InitialScrollApplyParams["phase"],
+  element: HTMLDivElement,
+  sessionId: string | null,
+  token: number | null,
+  enabled: boolean,
+): void {
+  if (!isDebug()) return;
+  placementDebug(`${phase} placement`, {
+    sessionId,
+    token,
+    owner: enabled ? "bottom" : "saved-position",
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+  });
+}
+
+function completeFinalEnvSwitchPlacement(
+  phase: InitialScrollApplyParams["phase"],
+  token: number | null,
+): void {
+  if (phase === "final") completeEnvSwitchPlacement(token);
+}
+
+function finishAppliedInitialPlacement(params: {
+  phase: InitialScrollApplyParams["phase"];
+  enabled: boolean;
+  scrollTop: number;
+  element: HTMLDivElement;
+  envSwitchPlacementToken: number | null;
+  syncNearBottom: () => void;
+}): void {
+  if (params.phase === "provisional") return;
+  if (params.enabled || params.scrollTop <= 0 || params.element.scrollTop >= params.scrollTop - 1) {
+    completeEnvSwitchPlacement(params.envSwitchPlacementToken);
+    return;
+  }
+  scheduleClampedScrollRestore({
+    element: params.element,
+    targetScrollTop: params.scrollTop,
+    onApply: params.syncNearBottom,
+    onComplete: () => completeEnvSwitchPlacement(params.envSwitchPlacementToken),
+  });
 }
 
 function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
@@ -1119,13 +1191,29 @@ function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
     isNearBottomRef,
     envSwitchPlacementToken,
     isProgrammaticScrollLocked,
+    phase,
   } = params;
   if (!isVisibleRef.current) return;
   const dockviewState = useDockviewStore.getState();
+  if (
+    !isCurrentEnvSwitchPlacement(
+      dockviewState.pendingChatInitialPlacement,
+      sessionId,
+      envSwitchPlacementToken,
+    )
+  )
+    return;
   const hasPendingLayoutRestore = dockviewState.pendingChatScrollTop !== null;
   const hasExplicitScrollTarget =
     sessionId !== null && dockviewState.scrollTarget?.sessionId === sessionId;
-  if (hasPendingLayoutRestore || hasExplicitScrollTarget || isProgrammaticScrollLocked()) {
+  if (
+    hasCompetingInitialScrollOwner({
+      hasPendingLayoutRestore,
+      hasExplicitScrollTarget,
+      isProgrammaticScrollLocked,
+    })
+  ) {
+    if (phase === "provisional") return;
     markInitialScrollConsumed(didInitialScroll, activationPendingRef);
     completeEnvSwitchPlacement(envSwitchPlacementToken);
     return;
@@ -1141,9 +1229,11 @@ function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
     savedScrollTop,
     scrollHeight: element.scrollHeight,
   });
-  markInitialScrollConsumed(didInitialScroll, activationPendingRef);
+  if (phase === "final") {
+    markInitialScrollConsumed(didInitialScroll, activationPendingRef);
+  }
   if (scrollTop === null) {
-    completeEnvSwitchPlacement(envSwitchPlacementToken);
+    completeFinalEnvSwitchPlacement(phase, envSwitchPlacementToken);
     return;
   }
 
@@ -1156,16 +1246,36 @@ function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
   };
   element.scrollTop = scrollTop;
   syncNearBottom();
-  if (enabled || scrollTop <= 0 || element.scrollTop >= scrollTop - 1) {
-    completeEnvSwitchPlacement(envSwitchPlacementToken);
-    return;
-  }
-  scheduleClampedScrollRestore({
+  reportInitialPlacement(phase, element, sessionId, envSwitchPlacementToken, enabled);
+  finishAppliedInitialPlacement({
+    phase,
+    enabled,
+    scrollTop,
     element,
-    targetScrollTop: scrollTop,
-    onApply: syncNearBottom,
-    onComplete: () => completeEnvSwitchPlacement(envSwitchPlacementToken),
+    envSwitchPlacementToken,
+    syncNearBottom,
   });
+}
+
+function shouldSkipProvisionalPlacement(
+  phase: InitialScrollApplyParams["phase"],
+  hasUnreadDivider: boolean,
+  appliedToken: number | null,
+  currentToken: number | null,
+): boolean {
+  return phase === "provisional" && (hasUnreadDivider || appliedToken === currentToken);
+}
+
+function useInitialPlacementLatches(envSwitchPlacementToken: number | null) {
+  const didInitialScroll = useRef(false);
+  const lastTokenRef = useRef<number | null>(null);
+  const provisionalTokenRef = useRef<number | null>(null);
+  if (envSwitchPlacementToken !== null && envSwitchPlacementToken !== lastTokenRef.current) {
+    lastTokenRef.current = envSwitchPlacementToken;
+    provisionalTokenRef.current = null;
+    didInitialScroll.current = false;
+  }
+  return { didInitialScroll, provisionalTokenRef };
 }
 
 function useInitialScrollPosition({
@@ -1173,6 +1283,7 @@ function useInitialScrollPosition({
   itemCount,
   sessionId,
   enabled,
+  hasUnreadDivider,
   isNearBottomRef,
   isVisible,
   historyRefreshPending,
@@ -1184,6 +1295,7 @@ function useInitialScrollPosition({
   itemCount: number;
   sessionId: string | null;
   enabled: boolean;
+  hasUnreadDivider: boolean;
   isNearBottomRef: React.RefObject<boolean>;
   isVisible: boolean;
   historyRefreshPending: boolean;
@@ -1192,15 +1304,8 @@ function useInitialScrollPosition({
   isProgrammaticScrollLocked: () => boolean;
 }) {
   const storeApi = useAppStoreApi();
-  const didInitialScroll = useRef(false);
-  const lastEnvSwitchPlacementTokenRef = useRef<number | null>(null);
-  if (
-    envSwitchPlacementToken !== null &&
-    envSwitchPlacementToken !== lastEnvSwitchPlacementTokenRef.current
-  ) {
-    lastEnvSwitchPlacementTokenRef.current = envSwitchPlacementToken;
-    didInitialScroll.current = false;
-  }
+  const { didInitialScroll, provisionalTokenRef } =
+    useInitialPlacementLatches(envSwitchPlacementToken);
   const { isVisibleRef, activationPendingRef } = useActivationPending(
     isVisible,
     envSwitchPlacementToken,
@@ -1209,8 +1314,9 @@ function useInitialScrollPosition({
     if (!isVisible) {
       return;
     }
-    if (envSwitchPlacementToken !== null && (isRestoringLayout || historyRefreshPending)) return;
+    if (envSwitchPlacementToken !== null && isRestoringLayout) return;
     if (envSwitchPlacementToken !== null && itemCount === 0) {
+      if (historyRefreshPending) return;
       markInitialScrollConsumed(didInitialScroll, activationPendingRef);
       completeEnvSwitchPlacement(envSwitchPlacementToken);
       return;
@@ -1219,7 +1325,19 @@ function useInitialScrollPosition({
     const el = scrollRef.current;
     if (!el) return;
 
-    const applyInitialScroll = () =>
+    const phase =
+      envSwitchPlacementToken !== null && historyRefreshPending ? "provisional" : "final";
+    if (
+      shouldSkipProvisionalPlacement(
+        phase,
+        hasUnreadDivider,
+        provisionalTokenRef.current,
+        envSwitchPlacementToken,
+      )
+    ) {
+      return;
+    }
+    const applyInitialScroll = () => {
       applyInitialScrollPosition({
         element: el,
         sessionId,
@@ -1231,7 +1349,12 @@ function useInitialScrollPosition({
         isNearBottomRef,
         envSwitchPlacementToken,
         isProgrammaticScrollLocked,
+        phase,
       });
+      if (phase === "provisional") {
+        provisionalTokenRef.current = envSwitchPlacementToken;
+      }
+    };
 
     if (activationPendingRef.current) {
       return scheduleAfterPanelRestore(applyInitialScroll);
@@ -1241,6 +1364,7 @@ function useInitialScrollPosition({
     itemCount,
     sessionId,
     enabled,
+    hasUnreadDivider,
     isNearBottomRef,
     storeApi,
     isVisible,
@@ -1351,6 +1475,7 @@ export function useNativeScrollManagement(params: NativeScrollManagementParams) 
     itemCount: items.length,
     sessionId,
     enabled,
+    hasUnreadDivider,
     isNearBottomRef,
     isVisible,
     historyRefreshPending,

--- a/apps/web/components/task/chat/message-list-native-scroll.ts
+++ b/apps/web/components/task/chat/message-list-native-scroll.ts
@@ -1091,6 +1091,7 @@ type InitialScrollApplyParams = {
   isVisibleRef: React.RefObject<boolean>;
   isNearBottomRef: React.RefObject<boolean>;
   envSwitchPlacementToken: number | null;
+  hasUnreadDivider: boolean;
   isProgrammaticScrollLocked: () => boolean;
   phase: "provisional" | "final";
 };
@@ -1124,11 +1125,13 @@ function isCurrentEnvSwitchPlacement(
 function hasCompetingInitialScrollOwner(params: {
   hasPendingLayoutRestore: boolean;
   hasExplicitScrollTarget: boolean;
+  hasUnreadDivider: boolean;
   isProgrammaticScrollLocked: () => boolean;
 }): boolean {
   return (
     params.hasPendingLayoutRestore ||
     params.hasExplicitScrollTarget ||
+    params.hasUnreadDivider ||
     params.isProgrammaticScrollLocked()
   );
 }
@@ -1190,6 +1193,7 @@ function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
     isVisibleRef,
     isNearBottomRef,
     envSwitchPlacementToken,
+    hasUnreadDivider,
     isProgrammaticScrollLocked,
     phase,
   } = params;
@@ -1210,6 +1214,7 @@ function applyInitialScrollPosition(params: InitialScrollApplyParams): void {
     hasCompetingInitialScrollOwner({
       hasPendingLayoutRestore,
       hasExplicitScrollTarget,
+      hasUnreadDivider,
       isProgrammaticScrollLocked,
     })
   ) {
@@ -1348,6 +1353,7 @@ function useInitialScrollPosition({
         isVisibleRef,
         isNearBottomRef,
         envSwitchPlacementToken,
+        hasUnreadDivider,
         isProgrammaticScrollLocked,
         phase,
       });

--- a/apps/web/components/task/chat/message-list-native.test.tsx
+++ b/apps/web/components/task/chat/message-list-native.test.tsx
@@ -518,6 +518,55 @@ describe("useNativeScrollManagement transcript pagination", () => {
     }
   });
 
+  it("leaves final placement to an unread-divider target when refresh settles", () => {
+    const frames: Array<FrameRequestCallback> = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const metrics = { scrollHeight: 900, scrollTop: 210, clientHeight: 400 };
+    mockDockviewState.pendingChatInitialPlacement = { sessionId: "session-b", token: 10 };
+    try {
+      const { rerender } = render(
+        <NativeScrollManagementHarness
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
+          metrics={metrics}
+          sessionId="session-b"
+          enabled
+          historyRefreshPending
+        />,
+      );
+      act(() => {
+        for (let frame = frames.shift(); frame; frame = frames.shift()) frame(0);
+      });
+
+      expect(metrics.scrollTop).toBe(900);
+      expect(mockDockviewState.pendingChatInitialPlacement).toEqual({
+        sessionId: "session-b",
+        token: 10,
+      });
+
+      metrics.scrollTop = 480;
+      rerender(
+        <NativeScrollManagementHarness
+          items={[transcriptMessage("settled-message")]}
+          metrics={metrics}
+          sessionId="session-b"
+          enabled
+          hasUnreadDivider
+        />,
+      );
+      act(() => {
+        for (let frame = frames.shift(); frame; frame = frames.shift()) frame(0);
+      });
+
+      expect(metrics.scrollTop).toBe(480);
+      expect(mockDockviewState.pendingChatInitialPlacement).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13
   it("does not defer a same-env session placement without an env-switch token", () => {
     const metrics = { scrollHeight: 900, scrollTop: 125, clientHeight: 400 };

--- a/apps/web/components/task/chat/message-list-native.test.tsx
+++ b/apps/web/components/task/chat/message-list-native.test.tsx
@@ -85,6 +85,7 @@ const HANDLE_RENDER_ERROR = "handle did not render";
 const HARNESS_RENDER_ERROR = "harness did not render";
 const NATIVE_SCROLL_MANAGEMENT_TEST_ID = "native-scroll-management-container";
 const AUTO_SCROLL_CONTAINER_TEST_ID = "auto-scroll-container";
+const CACHED_MESSAGE_ID = "cached-message";
 const TEST_MESSAGES = [{} as Message];
 /** Always returns false: the harness never locks programmatic scrolling. */
 const NEVER_LOCKED = () => false;
@@ -278,6 +279,7 @@ function NativeScrollManagementHarness({
   isVisible = true,
   enabled = false,
   historyRefreshPending = false,
+  hasUnreadDivider = false,
 }: {
   items: RenderItem[];
   metrics?: NativeScrollMetrics;
@@ -288,6 +290,7 @@ function NativeScrollManagementHarness({
   isVisible?: boolean;
   enabled?: boolean;
   historyRefreshPending?: boolean;
+  hasUnreadDivider?: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   useNativeScrollMetrics(scrollRef, metrics);
@@ -298,7 +301,7 @@ function NativeScrollManagementHarness({
     isWorking: false,
     sessionId,
     enabled,
-    hasUnreadDivider: false,
+    hasUnreadDivider,
     messagesLoading: false,
     hasMore: true,
     isLoadingMore,
@@ -354,7 +357,8 @@ describe("isElementInPreloadRegion", () => {
 // eslint-disable-next-line max-lines-per-function -- pagination invariants share one fixture and lifecycle.
 describe("useNativeScrollManagement transcript pagination", () => {
   // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.11
-  it("places an env-switched enabled transcript after layout and history settle", () => {
+  // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.14
+  it("places cached enabled history before refresh and reconciles after it settles", () => {
     const frames: Array<FrameRequestCallback> = [];
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       frames.push(callback);
@@ -366,7 +370,7 @@ describe("useNativeScrollManagement transcript pagination", () => {
     try {
       const { rerender } = render(
         <NativeScrollManagementHarness
-          items={[transcriptMessage("cached-message")]}
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
           metrics={metrics}
           sessionId="session-b"
           enabled
@@ -379,6 +383,25 @@ describe("useNativeScrollManagement transcript pagination", () => {
       expect(sharedSentinelCalls.at(-1)?.[2]).toBe(true);
 
       mockDockviewState.isRestoringLayout = false;
+      rerender(
+        <NativeScrollManagementHarness
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
+          metrics={metrics}
+          sessionId="session-b"
+          enabled
+          historyRefreshPending
+        />,
+      );
+      act(() => {
+        for (let frame = frames.shift(); frame; frame = frames.shift()) frame(0);
+      });
+
+      expect(scrollContainer.scrollTop).toBe(600);
+      expect(mockDockviewState.pendingChatInitialPlacement).toEqual({
+        sessionId: "session-b",
+        token: 7,
+      });
+
       metrics.scrollHeight = 1400;
       rerender(
         <NativeScrollManagementHarness
@@ -400,7 +423,8 @@ describe("useNativeScrollManagement transcript pagination", () => {
   });
 
   // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.12
-  it("restores only the incoming session offset after an env switch", () => {
+  // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.14
+  it("restores the incoming saved offset before refresh and reconciles afterward", () => {
     const frames: Array<FrameRequestCallback> = [];
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       frames.push(callback);
@@ -414,7 +438,7 @@ describe("useNativeScrollManagement transcript pagination", () => {
     try {
       const { rerender } = render(
         <NativeScrollManagementHarness
-          items={[transcriptMessage("cached-message")]}
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
           metrics={metrics}
           sessionId="session-b"
           historyRefreshPending
@@ -424,6 +448,25 @@ describe("useNativeScrollManagement transcript pagination", () => {
       expect(scrollContainer.scrollTop).toBe(810);
 
       mockDockviewState.isRestoringLayout = false;
+      rerender(
+        <NativeScrollManagementHarness
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
+          metrics={metrics}
+          sessionId="session-b"
+          historyRefreshPending
+        />,
+      );
+      act(() => {
+        for (let frame = frames.shift(); frame; frame = frames.shift()) frame(0);
+      });
+
+      expect(scrollContainer.scrollTop).toBe(320);
+      expect(mockDockviewState.pendingChatInitialPlacement).toEqual({
+        sessionId: "session-b",
+        token: 8,
+      });
+
+      metrics.scrollTop = 915;
       rerender(
         <NativeScrollManagementHarness
           items={[transcriptMessage("settled-message")]}
@@ -442,13 +485,46 @@ describe("useNativeScrollManagement transcript pagination", () => {
     }
   });
 
+  it("leaves provisional placement to an active unread-divider target", () => {
+    const frames: Array<FrameRequestCallback> = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const metrics = { scrollHeight: 900, scrollTop: 210, clientHeight: 400 };
+    mockDockviewState.pendingChatInitialPlacement = { sessionId: "session-b", token: 9 };
+    try {
+      render(
+        <NativeScrollManagementHarness
+          items={[transcriptMessage(CACHED_MESSAGE_ID)]}
+          metrics={metrics}
+          sessionId="session-b"
+          enabled
+          hasUnreadDivider
+          historyRefreshPending
+        />,
+      );
+      act(() => {
+        for (let frame = frames.shift(); frame; frame = frames.shift()) frame(0);
+      });
+
+      expect(screen.getByTestId(NATIVE_SCROLL_MANAGEMENT_TEST_ID).scrollTop).toBe(210);
+      expect(mockDockviewState.pendingChatInitialPlacement).toEqual({
+        sessionId: "session-b",
+        token: 9,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13
   it("does not defer a same-env session placement without an env-switch token", () => {
     const metrics = { scrollHeight: 900, scrollTop: 125, clientHeight: 400 };
 
     render(
       <NativeScrollManagementHarness
-        items={[transcriptMessage("cached-message")]}
+        items={[transcriptMessage(CACHED_MESSAGE_ID)]}
         metrics={metrics}
         sessionId="session-b"
         enabled

--- a/apps/web/e2e/helpers/ws-response-hold.ts
+++ b/apps/web/e2e/helpers/ws-response-hold.ts
@@ -1,0 +1,105 @@
+import type { Page } from "@playwright/test";
+
+type WireFrame = {
+  id?: unknown;
+  type?: unknown;
+  action?: unknown;
+  payload?: unknown;
+};
+
+export type MessageListResponseHold = {
+  holdNextLatestWindow: (sessionId: string) => void;
+  heldCount: () => number;
+  releaseHeldResponse: () => void;
+};
+
+function parseFrame(value: string): WireFrame | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as WireFrame) : null;
+  } catch {
+    return null;
+  }
+}
+
+function framePayload(frame: WireFrame | null): Record<string, unknown> | null {
+  return typeof frame?.payload === "object" && frame.payload !== null
+    ? (frame.payload as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Holds one correlated latest-window `message.list` response while keeping the
+ * gateway socket and every unrelated frame live. Install before navigation,
+ * then arm immediately before the task switch under test.
+ */
+export async function routeMainWebSocketWithMessageListResponseHold(
+  page: Page,
+): Promise<MessageListResponseHold> {
+  let armedSessionId: string | null = null;
+  const requestIds = new Set<string>();
+  const heldFrames: string[] = [];
+  let releaseToClient: ((frames: readonly string[]) => void) | null = null;
+
+  await page.routeWebSocket(/\/ws$/, (ws) => {
+    const server = ws.connectToServer();
+    releaseToClient = (frames) => {
+      for (const frame of frames) ws.send(frame);
+    };
+    ws.onMessage((message) => {
+      if (typeof message === "string" && armedSessionId) {
+        for (const part of message.split("\n")) {
+          const frame = parseFrame(part.trim());
+          const payload = framePayload(frame);
+          if (
+            frame?.type === "request" &&
+            frame.action === "message.list" &&
+            typeof frame.id === "string" &&
+            payload?.session_id === armedSessionId &&
+            payload.before === undefined
+          ) {
+            requestIds.add(frame.id);
+          }
+        }
+      }
+      server.send(message);
+    });
+    server.onMessage((message) => {
+      if (typeof message !== "string" || requestIds.size === 0) {
+        ws.send(message);
+        return;
+      }
+      const kept: string[] = [];
+      for (const part of message.split("\n")) {
+        const trimmed = part.trim();
+        const frame = parseFrame(trimmed);
+        if (
+          frame?.type === "response" &&
+          frame.action === "message.list" &&
+          typeof frame.id === "string" &&
+          requestIds.delete(frame.id)
+        ) {
+          heldFrames.push(trimmed);
+        } else if (trimmed) {
+          kept.push(part);
+        }
+      }
+      if (kept.length > 0) ws.send(kept.join("\n"));
+    });
+  });
+
+  return {
+    holdNextLatestWindow: (sessionId) => {
+      armedSessionId = sessionId;
+      requestIds.clear();
+      heldFrames.length = 0;
+    },
+    heldCount: () => heldFrames.length,
+    releaseHeldResponse: () => {
+      const frames = heldFrames.splice(0);
+      armedSessionId = null;
+      requestIds.clear();
+      releaseToClient?.(frames);
+    },
+  };
+}

--- a/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
@@ -7,6 +7,7 @@ import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
 import { dwell } from "../../helpers/causal-waits";
 import { waitForStableActiveSession } from "../../helpers/session-store";
+import { routeMainWebSocketWithMessageListResponseHold } from "../../helpers/ws-response-hold";
 
 type E2EMessageStoreWindow = Window & {
   __KANDEV_E2E_STORE__?: {
@@ -194,6 +195,18 @@ test.describe("Transcript auto-scroll toggle", () => {
     expect(envB).toBeTruthy();
     expect(envA).not.toBe(envB);
 
+    const refreshHold = await routeMainWebSocketWithMessageListResponseHold(testPage);
+    const olderPageRequests: string[] = [];
+    testPage.on("request", (request) => {
+      const url = new URL(request.url());
+      if (
+        url.pathname === `/api/v1/task-sessions/${taskA.session_id}/messages` &&
+        url.searchParams.has("before")
+      ) {
+        olderPageRequests.push(url.toString());
+      }
+    });
+
     await testPage.goto(`/t/${taskA.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
@@ -204,17 +217,41 @@ test.describe("Transcript auto-scroll toggle", () => {
     await waitForStableActiveSession(testPage, taskB.session_id);
     await session.showSessionContext();
     await waitForOverflow(testPage);
+    refreshHold.holdNextLatestWindow(taskA.session_id);
+    olderPageRequests.length = 0;
     await session.sidebarTaskItem("Env switch transcript A").click();
     await waitForStableActiveSession(testPage, taskA.session_id);
     await session.showSessionContext();
     const list = chatList(testPage);
     await waitForOverflow(testPage);
     await expect
+      .poll(refreshHold.heldCount, {
+        timeout: 5_000,
+        message: "returning task should issue a latest-window refresh",
+      })
+      .toBe(1);
+    await expect
+      .poll(async () => list.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
+        timeout: 2_000,
+        message: "cached enabled transcript should be at the bottom before refresh release",
+      })
+      .toBeLessThan(10);
+    expect(olderPageRequests).toHaveLength(0);
+
+    refreshHold.releaseHeldResponse();
+    await expect
       .poll(async () => list.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
         timeout: 15_000,
         message: "enabled transcript should settle at the bottom after an environment switch",
       })
       .toBeLessThan(10);
+    await dwell(
+      testPage,
+      500,
+      "negative-assertion",
+      "negative assertion window for an unwanted older-page request after placement unlock",
+    );
+    expect(olderPageRequests).toHaveLength(0);
 
     const targetScrollTop = await list.evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2);
@@ -228,15 +265,39 @@ test.describe("Transcript auto-scroll toggle", () => {
 
     await session.sidebarTaskItem("Env switch transcript B").click();
     await waitForStableActiveSession(testPage, taskB.session_id);
+    refreshHold.holdNextLatestWindow(taskA.session_id);
+    olderPageRequests.length = 0;
     await session.sidebarTaskItem("Env switch transcript A").click();
     await waitForStableActiveSession(testPage, taskA.session_id);
     await session.showSessionContext();
+    await expect
+      .poll(refreshHold.heldCount, {
+        timeout: 5_000,
+        message: "disabled return should issue a latest-window refresh",
+      })
+      .toBe(1);
+    await expect
+      .poll(async () => Math.abs((await list.evaluate((el) => el.scrollTop)) - targetScrollTop), {
+        timeout: 2_000,
+        message: "cached disabled transcript should restore its position before refresh release",
+      })
+      .toBeLessThanOrEqual(20);
+    expect(olderPageRequests).toHaveLength(0);
+
+    refreshHold.releaseHeldResponse();
     await expect
       .poll(async () => Math.abs((await list.evaluate((el) => el.scrollTop)) - targetScrollTop), {
         timeout: 15_000,
         message: "disabled transcript should restore its own offset after an environment switch",
       })
       .toBeLessThanOrEqual(20);
+    await dwell(
+      testPage,
+      500,
+      "negative-assertion",
+      "negative assertion window for pagination after disabled position restoration",
+    );
+    expect(olderPageRequests).toHaveLength(0);
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 

--- a/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
@@ -4,6 +4,27 @@ import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { waitForSessionDone } from "../../helpers/session";
 import { SessionPage } from "../../pages/session-page";
+import { waitForStableActiveSession } from "../../helpers/session-store";
+import { routeMainWebSocketWithMessageListResponseHold } from "../../helpers/ws-response-hold";
+
+const MOBILE_END_TOLERANCE_PX = 10;
+
+function mobileOverflowScript(prefix: string): string {
+  return Array.from(
+    { length: 30 },
+    (_, index) =>
+      `e2e:message("${prefix} ${index + 1} - lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua")`,
+  ).join("\n");
+}
+
+async function switchMobileTask(testPage: Page, title: string): Promise<void> {
+  await testPage.getByTestId("mobile-session-menu").tap();
+  const sheet = testPage.getByRole("dialog", { name: "Tasks" });
+  const taskRow = sheet.getByTestId("sidebar-task-item").filter({ hasText: title });
+  await expect(taskRow).toBeVisible({ timeout: 15_000 });
+  await taskRow.tap();
+  await expect(sheet).not.toBeVisible({ timeout: 10_000 });
+}
 
 /**
  * Seed a task whose mock-agent script emits enough distinct messages to
@@ -78,6 +99,118 @@ test.describe("Mobile transcript auto-scroll toggle", () => {
     await expect
       .poll(async () => list.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight))
       .toBeLessThan(25);
+  });
+
+  test("task switch places cached history before its refresh settles", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(240_000);
+    const taskA = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile cached transcript A",
+      seedData.agentProfileId,
+      {
+        description: mobileOverflowScript("Mobile environment A history"),
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    const taskB = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile cached transcript B",
+      seedData.agentProfileId,
+      {
+        description: mobileOverflowScript("Mobile environment B history"),
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!taskA.session_id || !taskB.session_id) {
+      throw new Error("createTaskWithAgent did not return both session ids");
+    }
+    await waitForSessionDone(apiClient, taskA.id, taskA.session_id, "mobile task A should finish");
+    await waitForSessionDone(apiClient, taskB.id, taskB.session_id, "mobile task B should finish");
+
+    const refreshHold = await routeMainWebSocketWithMessageListResponseHold(testPage);
+    await testPage.goto(`/t/${taskA.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await waitForStableActiveSession(testPage, taskA.session_id);
+    const list = session.activeChat().locator(".chat-message-list");
+    await expect
+      .poll(async () => list.evaluate((element) => element.scrollHeight - element.clientHeight), {
+        timeout: 15_000,
+        message: "mobile task A transcript should overflow",
+      })
+      .toBeGreaterThan(200);
+
+    await switchMobileTask(testPage, "Mobile cached transcript B");
+    await waitForStableActiveSession(testPage, taskB.session_id);
+    refreshHold.holdNextLatestWindow(taskA.session_id);
+    await switchMobileTask(testPage, "Mobile cached transcript A");
+    await waitForStableActiveSession(testPage, taskA.session_id);
+    await expect.poll(refreshHold.heldCount, { timeout: 5_000 }).toBe(1);
+    await expect
+      .poll(
+        async () =>
+          list.evaluate(
+            (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+          ),
+        {
+          timeout: 2_000,
+          message: "mobile cached transcript should be at the bottom before refresh release",
+        },
+      )
+      .toBeLessThan(MOBILE_END_TOLERANCE_PX);
+    refreshHold.releaseHeldResponse();
+    await expect
+      .poll(async () =>
+        list.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight),
+      )
+      .toBeLessThan(MOBILE_END_TOLERANCE_PX);
+
+    const targetScrollTop = await list.evaluate((element) => {
+      element.scrollTop = Math.floor((element.scrollHeight - element.clientHeight) / 2);
+      element.dispatchEvent(new Event("scroll"));
+      return element.scrollTop;
+    });
+    const toggle = session.chatStatusBar().getByTestId("auto-scroll-toggle-button");
+    await toggle.tap();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await switchMobileTask(testPage, "Mobile cached transcript B");
+    await waitForStableActiveSession(testPage, taskB.session_id);
+    refreshHold.holdNextLatestWindow(taskA.session_id);
+    await switchMobileTask(testPage, "Mobile cached transcript A");
+    await waitForStableActiveSession(testPage, taskA.session_id);
+    await expect.poll(refreshHold.heldCount, { timeout: 5_000 }).toBe(1);
+    await expect
+      .poll(
+        async () =>
+          Math.abs((await list.evaluate((element) => element.scrollTop)) - targetScrollTop),
+        {
+          timeout: 2_000,
+          message:
+            "mobile cached transcript should restore its saved position before refresh release",
+        },
+      )
+      .toBeLessThanOrEqual(20);
+    refreshHold.releaseHeldResponse();
+    await expect
+      .poll(async () =>
+        Math.abs((await list.evaluate((element) => element.scrollTop)) - targetScrollTop),
+      )
+      .toBeLessThanOrEqual(20);
+
+    const documentWidth = await testPage.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(documentWidth.scrollWidth).toBeLessThanOrEqual(documentWidth.clientWidth);
   });
 
   test("is reachable and toggles by touch", async ({ testPage, apiClient, seedData }) => {

--- a/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts
@@ -2,10 +2,12 @@ import { type Page } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
+import { dwell } from "../../helpers/causal-waits";
 import { waitForSessionDone } from "../../helpers/session";
 import { SessionPage } from "../../pages/session-page";
 import { waitForStableActiveSession } from "../../helpers/session-store";
 import { routeMainWebSocketWithMessageListResponseHold } from "../../helpers/ws-response-hold";
+import { watchOlderMessageRequests } from "./message-pagination-helpers";
 
 const MOBILE_END_TOLERANCE_PX = 10;
 
@@ -136,6 +138,7 @@ test.describe("Mobile transcript auto-scroll toggle", () => {
     await waitForSessionDone(apiClient, taskB.id, taskB.session_id, "mobile task B should finish");
 
     const refreshHold = await routeMainWebSocketWithMessageListResponseHold(testPage);
+    const olderRequests = watchOlderMessageRequests(testPage, taskA.session_id);
     await testPage.goto(`/t/${taskA.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
@@ -172,6 +175,13 @@ test.describe("Mobile transcript auto-scroll toggle", () => {
         list.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight),
       )
       .toBeLessThan(MOBILE_END_TOLERANCE_PX);
+    await dwell(
+      testPage,
+      500,
+      "negative-assertion",
+      "observe mobile pagination after first refresh release",
+    );
+    expect(olderRequests).toHaveLength(0);
 
     const targetScrollTop = await list.evaluate((element) => {
       element.scrollTop = Math.floor((element.scrollHeight - element.clientHeight) / 2);
@@ -205,6 +215,13 @@ test.describe("Mobile transcript auto-scroll toggle", () => {
         Math.abs((await list.evaluate((element) => element.scrollTop)) - targetScrollTop),
       )
       .toBeLessThanOrEqual(20);
+    await dwell(
+      testPage,
+      500,
+      "negative-assertion",
+      "observe mobile pagination after second refresh release",
+    );
+    expect(olderRequests).toHaveLength(0);
 
     const documentWidth = await testPage.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,

--- a/apps/web/hooks/use-lazy-load-sentinel.test.ts
+++ b/apps/web/hooks/use-lazy-load-sentinel.test.ts
@@ -790,6 +790,24 @@ describe("useLazyLoadSentinel — stale view handoff", () => {
 
     expect(loadB).not.toHaveBeenCalled();
   });
+
+  it("rejects a queued positive intersection when current geometry is ineligible", () => {
+    const scrollRef = makeScrollRef();
+    let geometryEligible = true;
+    const loadMore = vi.fn(async () => 20);
+    const { result } = renderHook(() =>
+      useLazyLoadSentinel(scrollRef, true, false, false, loadMore, {
+        isCurrentGeometryEligible: () => geometryEligible,
+      }),
+    );
+    const node = document.createElement("div");
+    act(() => result.current.sentinelRef(node));
+
+    geometryEligible = false;
+    fire(records[0], true, node);
+
+    expect(loadMore).not.toHaveBeenCalled();
+  });
 });
 
 describe("useLazyLoadSentinel — stale observers", () => {

--- a/apps/web/hooks/use-lazy-load-sentinel.test.ts
+++ b/apps/web/hooks/use-lazy-load-sentinel.test.ts
@@ -231,6 +231,7 @@ describe("useLazyLoadSentinel — scroller lifecycle", () => {
   });
 });
 
+// eslint-disable-next-line max-lines-per-function -- eligibility, disarm, and stale-completion cases share one lifecycle fixture
 describe("useLazyLoadSentinel — re-arm, disarm, and stale completions", () => {
   it("retries when loading becomes eligible while the sentinel remains intersecting", async () => {
     const scrollRef = makeScrollRef();
@@ -254,6 +255,28 @@ describe("useLazyLoadSentinel — re-arm, disarm, and stale completions", () => 
     // must retry the still-visible sentinel itself.
     rerender({ blocked: false });
     await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(2));
+  });
+
+  // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13
+  it("does not retry a blocked intersection that is outside current geometry", async () => {
+    const scrollRef = makeScrollRef();
+    const loadMore = vi.fn(async () => 20);
+    const { result, rerender } = renderHook(
+      ({ blocked }: { blocked: boolean }) =>
+        useLazyLoadSentinel(scrollRef, true, blocked, false, loadMore, {
+          rearmWhileIntersecting: true,
+          isCurrentGeometryEligible: () => false,
+        }),
+      { initialProps: { blocked: true } },
+    );
+    const node = document.createElement("div");
+    act(() => result.current.sentinelRef(node));
+
+    fire(records[0], true, node);
+    rerender({ blocked: false });
+    await act(async () => {});
+
+    expect(loadMore).not.toHaveBeenCalled();
   });
 
   it("re-arms only when enabled: unobserves before loading and re-observes after a positive result", async () => {
@@ -729,6 +752,43 @@ describe("useLazyLoadSentinel — stale view handoff", () => {
     // No exit/re-entry or recovery click: releasing A must replay B's current
     // intersection through the normal sentinel path.
     await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+  });
+
+  // @covers AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13
+  it("does not hand off a stale intersection that left current geometry", async () => {
+    const scrollRef = makeScrollRef();
+    let activeView = "A";
+    let geometryEligible = true;
+    let resolveA: (value: number) => void = () => {};
+    const loadA = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveA = resolve;
+        }),
+    );
+    const loadB = vi.fn(async () => 0);
+    const { result, rerender } = renderHook(
+      ({ view }: { view: string }) =>
+        useLazyLoadSentinel(scrollRef, true, false, false, view === "A" ? loadA : loadB, {
+          rearmWhileIntersecting: true,
+          isCurrentGeometryEligible: () => geometryEligible,
+          isRequestCurrent: () => activeView === view,
+        }),
+      { initialProps: { view: "A" } },
+    );
+    const node = document.createElement("div");
+    act(() => result.current.sentinelRef(node));
+
+    fire(records[0], true, node);
+    activeView = "B";
+    rerender({ view: "B" });
+    fire(records[1], true, node);
+    geometryEligible = false;
+
+    await act(async () => resolveA(20));
+    await act(async () => {});
+
+    expect(loadB).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/hooks/use-lazy-load-sentinel.ts
+++ b/apps/web/hooks/use-lazy-load-sentinel.ts
@@ -321,6 +321,21 @@ function useScrollPinnedToBottom(scrollRef: React.RefObject<HTMLDivElement | nul
 }
 
 /** Retries an eligible, still-visible sentinel after a firing guard clears. */
+function isCurrentSentinelGeometryEligible(refs: SentinelMutableRefs): boolean {
+  return refs.optionsRef.current.isCurrentGeometryEligible?.() ?? true;
+}
+
+function sentinelBecameEligible(
+  previous: { hasMore: boolean; blocked: boolean; isLoadingMore: boolean },
+  current: { hasMore: boolean; blocked: boolean; isLoadingMore: boolean },
+): boolean {
+  return (
+    (!previous.hasMore && current.hasMore) ||
+    (previous.blocked && !current.blocked) ||
+    (previous.isLoadingMore && !current.isLoadingMore)
+  );
+}
+
 function shouldRetrySentinel(
   previous: { hasMore: boolean; blocked: boolean; isLoadingMore: boolean },
   current: { hasMore: boolean; blocked: boolean; isLoadingMore: boolean },
@@ -329,12 +344,10 @@ function shouldRetrySentinel(
   const { optionsRef, intersectingRef, disarmedRef } = refs;
   if (!optionsRef.current.rearmWhileIntersecting) return false;
   if (!intersectingRef.current || disarmedRef.current) return false;
-  const becameEligible =
-    (!previous.hasMore && current.hasMore) ||
-    (previous.blocked && !current.blocked) ||
-    (previous.isLoadingMore && !current.isLoadingMore);
-  if (!becameEligible || !current.hasMore || current.blocked) return false;
+  if (!sentinelBecameEligible(previous, current) || !current.hasMore || current.blocked)
+    return false;
   if (current.isLoadingMore && !optionsRef.current.joinInFlightWhileLoading) return false;
+  if (!isCurrentSentinelGeometryEligible(refs)) return false;
   return !refs.loadInFlightRef.current && !refs.continuationScheduledRef.current;
 }
 
@@ -383,7 +396,8 @@ function shouldReplayCurrentIntersection(
     !refs.continuationScheduledRef.current &&
     hasMore &&
     !blocked &&
-    (!isLoadingMore || joinInFlightWhileLoading),
+    (!isLoadingMore || joinInFlightWhileLoading) &&
+    isCurrentSentinelGeometryEligible(refs),
   );
 }
 

--- a/apps/web/hooks/use-lazy-load-sentinel.ts
+++ b/apps/web/hooks/use-lazy-load-sentinel.ts
@@ -131,7 +131,8 @@ function useSentinelObserver(opts: {
           !entry.isIntersecting ||
           !hasMore ||
           blocked ||
-          (isLoadingMore && !joinInFlightWhileLoading)
+          (isLoadingMore && !joinInFlightWhileLoading) ||
+          !isCurrentSentinelGeometryEligible(opts.refs)
         ) {
           return;
         }

--- a/docs/plans/transcript-task-switch-continuity/plan.md
+++ b/docs/plans/transcript-task-switch-continuity/plan.md
@@ -1,0 +1,178 @@
+---
+created: 2026-09-04
+status: completed
+requirements:
+  - ../../specs/ui/requirements/transcript-auto-scroll.md
+  - ../../specs/ui/requirements/task-prompt-transcript-visibility.md
+system_design:
+  - ../../specs/ui/system-design/transcript-auto-scroll.md
+  - ../../specs/ui/system-design/task-prompt-transcript-visibility.md
+legacy_specs: []
+---
+
+# Implementation Plan: Transcript Task-switch Continuity
+
+## Overview
+
+Make an incoming task transcript appear at its intended reading position as
+soon as cached rows are measurable. Keep that position correct when the latest
+message window arrives, and prevent the older-history sentinel from turning a
+stale pre-placement intersection into an unnecessary pagination request.
+
+The confirmed failure has two parts. First, cached rows stay visible at the
+browser-default top while the latest-window refresh blocks initial placement.
+Second, releasing the placement block can replay an intersection recorded at
+that temporary top without checking the sentinel's current geometry.
+
+## Scope
+
+### In scope
+
+- Provisional task-entry placement from cached transcript rows.
+- Final placement after the latest-window refresh settles.
+- Enabled auto-scroll placement at the newest message.
+- Disabled auto-scroll restoration from the incoming session's saved position.
+- Placement-token ownership through both phases.
+- Current-geometry validation before an observed sentinel intersection can
+  start or transfer older-history pagination.
+- Development diagnostics for placement phase, owner, token, and geometry.
+- Focused unit, desktop browser, and mobile browser regression coverage.
+
+### Out of scope
+
+- Unread-divider behavior or its setting.
+- The auto-scroll control, persistence format, or same-environment activation
+  semantics.
+- Backend message ordering, cursor contracts, or page size.
+- Explicit transcript navigation and saved-layout behavior except for
+  regressions caused by shared scroll ownership.
+- Dockview architecture, mobile navigation, layout, or user-facing copy.
+
+## Technical approach
+
+### Split task-entry placement into provisional and final phases
+
+Extend the initial-placement coordinator in
+`apps/web/components/task/chat/message-list-native-scroll.ts` with
+token-scoped provisional and final completion state. When cached rows exist,
+the panel is measurable, and no unread-divider target owns entry, run a
+provisional placement without clearing the environment-switch token:
+
+- enabled auto-scroll selects the newest cached message;
+- disabled auto-scroll restores the incoming session's saved position.
+
+After the latest-window refresh settles, run the existing ownership decision
+against the reconciled rows and conditionally clear the same token. Re-check
+the live session, visibility, and competing scroll owners before both writes.
+If no cached rows exist, keep the existing loading path and perform only the
+final phase.
+
+Keep `useSessionMessages` as the source of cached-history and refresh readiness.
+Do not copy history state into a second store or replay the outgoing
+transcript's absolute offset.
+
+### Require live geometry before pagination replay
+
+Update `useLazyLoadSentinel` so eligibility retries and stale-view handoffs
+invoke `isCurrentGeometryEligible` when a consumer supplies it. A historical
+`IntersectionObserver` entry remains a wake-up signal, not proof that the
+sentinel is currently inside the preload region. Preserve existing behavior for
+consumers that do not supply a current-geometry predicate.
+
+The transcript already owns the scroll-root-aware geometry predicate. Keep the
+placement token active through final placement so the sentinel cannot paginate
+between the provisional and final phases. A transcript restored at its actual
+top must still load older history.
+
+### Add bounded diagnostics
+
+Add development logging for provisional placement, final placement, request
+completion, and pagination eligibility. Include the session identifier,
+placement token, selected owner, and scroll geometry. Do not log message
+content or saved offsets.
+
+## Tests
+
+| Acceptance criteria                              | Evidence                                                                                                                                       |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.11` and `.14`  | Coordinator tests hold the refresh pending while cached rows are measurable, then prove immediate enabled placement and final reconciliation.  |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.12` and `.14`  | Coordinator and browser tests prove disabled task entry uses the incoming session's saved position before and after refresh.                   |
+| `AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13`            | Sentinel tests prove eligibility release and stale-view transfer reject old intersections when current geometry is outside the preload region. |
+| `AC-UI-TASK-PROMPT-TRANSCRIPT-VISIBILITY-001.10` | Browser request tracing proves task entry does not request older pages before real upward navigation.                                          |
+| `AC-UI-TASK-PROMPT-TRANSCRIPT-VISIBILITY-001.14` | Existing and focused sentinel coverage proves a transcript currently restored at the top still paginates.                                      |
+
+Use TDD. Add the pending-refresh and stale-intersection regressions first and
+record their failures before changing production behavior.
+
+## E2E tests
+
+- Extend `apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts` with a cached
+  environment-changing task switch. Hold the return task's latest-window
+  `message.list` response, prove the transcript is already at the newest cached
+  message, release the response, and prove it remains at the final newest
+  message.
+- Capture outgoing `message.list` requests and prove no request with an older
+  `before` cursor occurs during entry or block release.
+- Cover disabled auto-scroll by proving the incoming task's saved reading
+  position is used while refresh is held and after it settles.
+- Extend `apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts` with the
+  same cached-entry contract through the current mobile task switcher.
+- Reuse the current WebSocket routing helpers. Add a narrowly scoped response
+  hold helper only if desktop and mobile need the same control.
+
+Use causal waits for the held response and rendered geometry. Do not replace
+the regression with a long eventual-bottom poll.
+
+## Mobile design contract
+
+- **Desktop outcome:** the existing Dockview session panel places cached rows
+  immediately and reconciles them after refresh.
+- **Mobile entry:** the existing task switcher opens the full-height task Chat
+  tab; no new control or navigation surface is introduced.
+- **Exemplar:** `TaskLayout` remains the responsive composition owner.
+- **Scroll ownership:** the transcript remains the only vertical scroll region;
+  the header and composer keep their current safe-area behavior.
+- **Shared behavior:** cached placement, refresh reconciliation, auto-scroll
+  preference, and sentinel geometry checks use the same coordinator rules.
+  Mobile does not consume Dockview's environment-switch token.
+- **Mobile proof:** mobile-chrome verifies immediate cached placement, final
+  reconciliation, disabled position restoration, and no document overflow.
+
+## Work orders
+
+- [x] [Task 01: Stabilize task-switch transcript entry](task-01-stabilize-task-switch-transcript.md)
+
+The work order is sequential because placement ownership and pagination
+eligibility share one transcript lifecycle.
+
+## Results
+
+Implemented provisional cached-history placement and final refresh
+reconciliation for environment-changing task switches. Enabled transcripts now
+open at the newest cached message; disabled transcripts restore the incoming
+session's saved reader position. The placement token remains active until the
+final phase, and an unread-divider target keeps priority.
+
+Eligibility retries and stale-view handoffs now require the sentinel's current
+geometry when the consumer supplies that predicate. The desktop browser
+regression holds the latest-window response and proves both placement modes plus
+the absence of older-page requests. The mobile regression proves the same user
+value through the task-switcher sheet and checks document width.
+
+Verification passed: 142 focused unit tests, targeted ESLint, TypeScript
+typecheck, one Chromium E2E, one mobile-chrome E2E, specification lint, Prettier,
+and diff checks.
+
+## Risks
+
+- Clearing the placement token after provisional placement can reopen the
+  original pagination race. Only final placement can clear it.
+- A provisional write must not override unread-divider or explicit-navigation
+  ownership.
+- Cached row heights can change after refresh. Final placement must recompute
+  against current DOM geometry instead of preserving a stale pixel delta.
+- Applying the geometry predicate to every sentinel consumer could change
+  Prompt History behavior. Keep it optional and test the supplied-predicate
+  path independently.
+- Browser tests can pass while still showing a top flash if they only assert an
+  eventual position. Hold the refresh response and assert before release.

--- a/docs/plans/transcript-task-switch-continuity/task-01-stabilize-task-switch-transcript.md
+++ b/docs/plans/transcript-task-switch-continuity/task-01-stabilize-task-switch-transcript.md
@@ -1,0 +1,149 @@
+---
+id: "01-stabilize-task-switch-transcript"
+title: "Stabilize task-switch transcript entry"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-TRANSCRIPT-AUTO-SCROLL-001
+  - REQ-UI-TASK-PROMPT-TRANSCRIPT-VISIBILITY-001
+acceptance_criteria:
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.11
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.12
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13
+  - AC-UI-TRANSCRIPT-AUTO-SCROLL-001.14
+  - AC-UI-TASK-PROMPT-TRANSCRIPT-VISIBILITY-001.10
+  - AC-UI-TASK-PROMPT-TRANSCRIPT-VISIBILITY-001.14
+system_design:
+  - ../../specs/ui/system-design/transcript-auto-scroll.md
+  - ../../specs/ui/system-design/task-prompt-transcript-visibility.md
+---
+
+# Task 01: Stabilize Task-switch Transcript Entry
+
+## Summary
+
+Place cached transcript rows at the incoming task's intended position before
+the latest-window refresh resolves. Reconcile the position afterward, and
+require current sentinel geometry before older-history pagination starts.
+
+## In scope
+
+- Add token-scoped provisional and final task-entry placement phases.
+- Use the incoming session's auto-scroll preference and saved position.
+- Preserve unread-divider, explicit-navigation, and layout-restore priority.
+- Keep older-history pagination blocked through final placement.
+- Validate current geometry on eligibility retry and stale-view handoff.
+- Add bounded development diagnostics.
+- Add TDD regressions and desktop/mobile Playwright coverage.
+
+## Out of scope
+
+- Changing unread-divider behavior, auto-scroll persistence, backend cursors,
+  message page size, or task navigation UI.
+
+## Acceptance
+
+- With cached messages and auto-scroll enabled, switching tasks shows the
+  incoming task's newest cached message before a held refresh response and the
+  final newest message after release. The browser-default top is never exposed.
+- With auto-scroll disabled, the same flow uses the incoming session's saved
+  reading position before and after refresh. It never reuses the outgoing
+  transcript's offset.
+- Releasing the placement block or transferring a stale view cannot start
+  pagination from an old observer entry. A sentinel currently inside the
+  preload region still loads older history.
+- Desktop and mobile browser tests prove the cached-entry behavior, and request
+  tracing proves task entry sends no unwanted older-page request.
+
+## Files likely touched
+
+- `apps/web/components/task/chat/message-list-native-scroll.ts`
+- `apps/web/components/task/chat/message-list-native.tsx`
+- `apps/web/components/task/chat/message-list-native.test.tsx`
+- `apps/web/components/task/chat/transcript-auto-scroll.ts`
+- `apps/web/components/task/chat/transcript-auto-scroll.test.ts`
+- `apps/web/hooks/use-lazy-load-sentinel.ts`
+- `apps/web/hooks/use-lazy-load-sentinel.test.ts`
+- `apps/web/hooks/domains/session/use-session-messages.ts`
+- `apps/web/hooks/domains/session/use-session-messages.test.ts`
+- `apps/web/e2e/helpers/ws-response-hold.ts`
+- `apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts`
+- `apps/web/e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts`
+
+The response-hold helper is optional. Keep the WebSocket control local to a
+single test file if it is not shared by both viewport suites.
+
+## Verification
+
+Follow TDD. Run the new focused tests before the production change and record
+the expected failures. Then run:
+
+```bash
+(cd apps && pnpm --filter @kandev/web test -- --run hooks/use-lazy-load-sentinel.test.ts components/task/chat/message-list-native.test.tsx components/task/chat/transcript-auto-scroll.test.ts hooks/domains/session/use-session-messages.test.ts)
+(cd apps/web && pnpm run typecheck)
+(cd apps/web && pnpm exec eslint hooks/use-lazy-load-sentinel.ts hooks/use-lazy-load-sentinel.test.ts components/task/chat/message-list-native-scroll.ts components/task/chat/message-list-native.tsx components/task/chat/message-list-native.test.tsx components/task/chat/transcript-auto-scroll.ts components/task/chat/transcript-auto-scroll.test.ts hooks/domains/session/use-session-messages.ts hooks/domains/session/use-session-messages.test.ts e2e/helpers/ws-response-hold.ts e2e/tests/chat/auto-scroll-toggle.spec.ts e2e/tests/chat/mobile-auto-scroll-toggle.spec.ts)
+(cd apps/web && pnpm e2e:run --host --project chromium tests/chat/auto-scroll-toggle.spec.ts -- --grep "environment-changing task switch" --retries=0)
+(cd apps/web && pnpm e2e:run --host --no-build --project mobile-chrome tests/chat/mobile-auto-scroll-toggle.spec.ts -- --grep "task switch" --retries=0)
+python3 scripts/lint-spec-files.test.py
+python3 scripts/lint-spec-files.py --all
+git diff --check
+```
+
+If the optional helper is not created, omit it from the ESLint command. If the
+managed Playwright runner does not accept `--no-build` after the desktop run,
+remove only that flag and keep the same mobile project and grep.
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. This task owns the shared placement and pagination lifecycle.
+
+## Risks
+
+- Do not clear the switch token during provisional placement.
+- Do not let provisional placement override an unread-divider target.
+- Re-resolve the live scroll element and session before every deferred write.
+- Keep the geometry predicate optional for non-transcript sentinel consumers.
+- Assert geometry while the refresh is held. An eventual-bottom assertion does
+  not detect the visible top flash.
+
+## Mobile design contract
+
+- Use the current mobile task switcher and full-height Chat tab.
+- Keep the transcript as the only vertical scroll owner.
+- Keep the existing header, composer, touch targets, and safe-area geometry.
+- Exercise the same cached-entry and final-reconciliation contract as desktop.
+- Prove the task view has no horizontal document overflow after both phases.
+
+## Output contract
+
+Report the red and green evidence, placement ownership changes, sentinel
+geometry rule, changed files, desktop/mobile browser results, and remaining
+risks. Update this work order and `plan.md` with implementation results in the
+same conversation.
+
+## Results
+
+- Added token-scoped provisional and final transcript placement. Cached enabled
+  transcripts place at the bottom before refresh; cached disabled transcripts
+  use the incoming session's saved position. Final placement reconciles current
+  rows and clears only the matching token.
+- Preserved unread-divider, layout-restore, explicit-navigation, and
+  programmatic-scroll ownership.
+- Added current-geometry checks to sentinel eligibility retry and stale-view
+  handoff. Consumers without a geometry predicate retain their previous
+  behavior.
+- Added a correlated WebSocket latest-window response hold for browser tests.
+  Desktop and mobile tests exercise both enabled and disabled cached returns.
+  Desktop request tracing also proves no older-page HTTP request starts during
+  placement release.
+- Red evidence: four focused unit assertions failed on the old behavior. The
+  desktop E2E remained 1,892 px from the bottom while refresh was held.
+- Green evidence: 142 focused unit tests passed; targeted ESLint and typecheck
+  passed; focused Chromium and mobile-chrome runs each passed one test with
+  retries disabled; specification lint and diff checks passed.

--- a/docs/specs/ui/requirements/transcript-auto-scroll.md
+++ b/docs/specs/ui/requirements/transcript-auto-scroll.md
@@ -2,7 +2,7 @@
 status: active
 system: ui
 created: 2026-07-30
-updated: 2026-09-03
+updated: 2026-09-04
 owners:
   - cfl
 ---
@@ -14,6 +14,8 @@ owners:
 Users expect an enabled transcript to follow the newest message, including when
 they activate a long-running session tab that was mounted outside the visible
 Dockview layout or return to a task whose environment rebuilds that layout.
+When cached history is already available, task entry must not expose the
+browser's default top position while a latest-window refresh is pending.
 Users who turn off transcript auto-scroll expect the visible conversation to
 stay fixed while new content arrives and to reopen at that session's own saved
 position. Chrome can still adjust the view through its native overflow
@@ -61,9 +63,15 @@ hand-off it is designed to protect.
   user switches to that task, **THEN** the transcript restores that session's
   saved position and does not apply the outgoing session's position.
 - **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.13:** **GIVEN** a task switch that rebuilds
-  the Dockview layout, **WHEN** the incoming transcript has not completed its
-  initial placement, **THEN** automatic older-history pagination does not start
-  from the transient pre-placement geometry.
+  the Dockview layout, **WHEN** the incoming transcript is placed and
+  pagination becomes eligible, **THEN** automatic older-history pagination
+  does not start from transient or stale pre-placement geometry.
+- **AC-UI-TRANSCRIPT-AUTO-SCROLL-001.14:** **GIVEN** an incoming transcript with
+  cached messages and no active unread-divider target, **WHEN** a task switch
+  starts a latest-window refresh, **THEN** an enabled transcript shows its
+  newest cached message and a disabled transcript shows its saved reader
+  position as soon as the panel is measurable, without first exposing the
+  browser's default top position.
 
 ## Migrated source detail
 
@@ -86,10 +94,11 @@ the asynchronous hand-off it is designed to protect.
   message after the panel becomes measurable.
 - Activating a reader-owned transcript position preserves that position.
 - Returning to a task in another environment repeats initial placement after
-  that session's current message history is ready without replaying the
-  outgoing transcript's absolute offset.
+  its cached history becomes measurable and reconciles placement after the
+  latest-window refresh without replaying the outgoing transcript's absolute
+  offset.
 - Automatic older-history pagination waits until environment-switch placement
-  has completed.
+  has completed and validates current sentinel geometry before retrying.
 - The clarification-recovery concurrency regression waits for its asynchronous
   completion signal within a bounded interval instead of treating scheduler
   timing as a product failure.
@@ -116,13 +125,15 @@ the asynchronous hand-off it is designed to protect.
   **THEN** the prior reading position remains visible.
 - **GIVEN** two tasks in different environments with overflowing transcripts,
   **WHEN** the user switches between them and returns, **THEN** the incoming
-  enabled transcript opens at the newest message after its history refresh.
+  enabled transcript shows the newest cached message immediately and remains
+  at the newest message after its history refresh.
 - **GIVEN** the incoming transcript has auto-scroll disabled, **WHEN** that
   environment-switch placement runs, **THEN** it restores the incoming
   session's saved position rather than the outgoing transcript's position.
 - **GIVEN** incoming history and layout are still settling, **WHEN** the
-  older-history sentinel is temporarily at the viewport top, **THEN** the
-  sentinel does not start an automatic pagination cascade.
+  older-history sentinel was temporarily at the viewport top, **THEN** the
+  sentinel does not start an automatic pagination cascade unless its current
+  geometry remains inside the preload region.
 
 ## Out of scope
 

--- a/docs/specs/ui/system-design/transcript-auto-scroll.md
+++ b/docs/specs/ui/system-design/transcript-auto-scroll.md
@@ -4,7 +4,7 @@ system: ui
 requirements:
   - REQ-UI-TRANSCRIPT-AUTO-SCROLL-001
 created: 2026-08-27
-updated: 2026-09-03
+updated: 2026-09-04
 owners:
   - kandev
 ---
@@ -22,8 +22,8 @@ restoration, and catch-up after the user enables auto-scroll again.
 
 ## Requirement mapping
 
-| Requirement                         | Design section                                                                                                                        |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Requirement                         | Design section                                                                                                                                                                                                                                                                                        |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `REQ-UI-TRANSCRIPT-AUTO-SCROLL-001` | [Bottom placement](#bottom-placement), [Persistent-panel visibility lifecycle](#persistent-panel-visibility-lifecycle), [Environment-change rebuild lifecycle](#environment-change-rebuild-lifecycle), [Interaction boundaries](#interaction-boundaries), [Responsive behavior](#responsive-behavior) |
 
 ## Bottom placement
@@ -102,14 +102,27 @@ owning same-transcript layout rebuilds, while the environment-switch request
 must never capture or replay the outgoing session's absolute offset.
 
 The incoming native transcript treats a matching request as a reactivation even
-when its panel remains logically visible through the rebuild. It does not
-consume the one-shot initial-placement latch while Dockview is restoring or the
-incoming session's entry history refresh is pending. A cached-history refresh
-therefore exposes a placement-readiness signal even when the cached rows remain
-rendered and the normal loading presentation stays unchanged.
+when its panel remains logically visible through the rebuild. The request owns
+two bounded placement phases whenever cached rows are already available and no
+unread-divider target owns entry:
 
-After layout restoration and history refresh complete, the transcript uses
-`scheduleAfterPanelRestore` and re-resolves placement from the incoming session:
+1. After Dockview restoration makes the panel measurable, provisional
+   placement resolves against the incoming session's cached rows. Enabled
+   auto-scroll selects the newest cached message; disabled auto-scroll selects
+   the incoming session's saved offset. This phase does not clear the request.
+2. After the latest-window refresh settles, final placement resolves against
+   the reconciled rows and clears the request conditionally.
+
+Both phases use `scheduleAfterPanelRestore` and re-check the live session,
+visibility, and competing owners before writing. This prevents cached content
+from appearing at the browser's default `scrollTop = 0` while preserving a
+final correction when the refresh changes the current window. A transcript
+without cached rows keeps the existing loading presentation and performs only
+the final phase. An active unread-divider target keeps its existing
+visit-scoped placement and does not receive the provisional bottom or saved-
+offset write.
+
+Each placement resolves ownership in this order:
 
 1. A pending explicit navigation target or same-transcript layout restore keeps
    priority.
@@ -118,10 +131,15 @@ After layout restoration and history refresh complete, the transcript uses
    `getStoredAutoScrollTop(sessionId)` as its storage fallback.
 3. Enabled auto-scroll places the transcript at its current native maximum.
 
-Completion conditionally clears the same token so a superseded switch cannot
-consume a newer request. While a matching request remains pending, the
-older-history intersection sentinel is blocked. It can observe geometry again
-only after the incoming transcript has been placed.
+Final completion conditionally clears the same token so a superseded switch
+cannot consume a newer request. While a matching request remains pending, the
+older-history intersection sentinel is blocked. Releasing that block is an
+eligibility transition, not proof that the sentinel remains at the top. Before
+replaying an intersection observed while blocked, `useLazyLoadSentinel` invokes
+the consumer's current-geometry predicate. The transcript starts pagination
+only if the current sentinel and scroll root remain inside the preload region.
+The same current-geometry rule applies when a stale request hands an observed
+intersection to a replacement view.
 
 Same-environment session switches return before arming this lifecycle.
 Maximize, un-maximize, preset, and custom-layout rebuilds retain the existing
@@ -144,7 +162,8 @@ placement:
 - The reader is near the bottom.
 - No user programmatic scroll lock is active.
 - No layout restoration is pending.
-- No environment-switch initial placement is pending for the session.
+- No environment-switch initial placement is pending for the session, except
+  when that matching request is executing its own provisional or final write.
 
 Disabled auto-scroll continues to restore the captured `scrollTop`. New
 content cannot move that frozen position through application code or browser
@@ -159,15 +178,18 @@ control, copy, layout, or touch target changes.
 The inactive persistent-portal state exists only in the desktop Dockview
 workbench. Mobile renders one selected `TaskChatPanel` and replaces its session
 input instead of keeping inactive session panels mounted. Mobile therefore
-keeps `isVisible` true and retains its current initial, enabled, and disabled
-scroll behavior through the shared coordinator. It does not consume Dockview's
-environment-switch placement requests.
+keeps `isVisible` true and retains its initial, enabled, and disabled scroll
+behavior through the shared coordinator. A mobile task switch with cached rows
+must also place the incoming transcript before a background refresh can expose
+the browser-default top, but it does not consume Dockview's environment-switch
+placement request.
 
-The nearest mobile exemplar is the current task Chat tab in
-`apps/web/components/task/task-layout.tsx`. Existing desktop and mobile
-auto-scroll Playwright scenarios remain the browser contract. Both viewports
-must prove enabled bottom pinning and disabled position freezing after the
-change.
+The nearest mobile exemplar is the current full-height task Chat tab selected
+by `TaskLayout` in `apps/web/components/task/task-layout.tsx`. The transcript is
+the only vertical scroll region; the task header and composer retain their
+existing safe-area handling. Desktop and mobile Playwright scenarios must prove
+immediate cached placement, final refresh reconciliation, enabled bottom
+pinning, and disabled position restoration.
 
 ## Failure modes
 
@@ -184,9 +206,19 @@ change.
   guards suppress bottom placement until that owner releases control.
 - If a newer environment switch supersedes a pending placement, the older
   token cannot clear or position the newer session.
+- If the latest-window refresh is slow, cached rows remain at their provisional
+  position and automatic older-history pagination stays blocked.
 - If the incoming history refresh fails, the request resolves against the
   session history that remains available; it does not fall back to the outgoing
   session's offset.
+
+## Observability
+
+Debug logging records provisional placement, final placement, and request
+completion with the session identifier, placement token, selected owner, and
+scroll geometry. Pagination start logging retains its trigger and geometry so
+diagnostics can distinguish a real top reach from a rejected stale
+intersection. Message content and saved offsets are not logged.
 
 ## Related decisions
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3405/28465ca9a138.html)
<!-- kandev-pr-walkthrough-end -->

Task switching could leave a cached transcript at the top while its refresh was pending, which made recent messages hard to find. This keeps the cached view useful immediately and preserves the correct session position after refresh.

## Important Changes

- Add two-phase initial placement for cached task transcripts.
- Preserve per-session scroll positions when transcript auto-scroll is disabled.
- Prevent stale sentinel geometry from triggering older-history loads during placement.
- Add desktop and mobile regression coverage for refresh races and task switching.

## Validation

- Focused unit tests: 142 passed.
- Desktop Chromium E2E: environment-changing task switch with held refresh passed.
- Mobile Chrome E2E: cached history placement during task switch passed.
- `pnpm run typecheck`
- `pnpm run i18n:ratchet`
- Prettier, ESLint, specification lint, and `git diff --check`

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop transcript after task switch](https://raw.githubusercontent.com/kdlbs/kandev/9b7c442c4143648ff0b0d46c77e1e93d8f1e72e4/desktop-transcript-task-switch.png)

![Mobile transcript after task switch](https://raw.githubusercontent.com/kdlbs/kandev/9b7c442c4143648ff0b0d46c77e1e93d8f1e72e4/mobile-transcript-task-switch.png)
<!-- kandev-screenshots-end -->