### PR TITLE
feat(plugins): add task manager to marketplace

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -32,6 +32,9 @@ plugins:
   - id: kandev-plugin-kandy
     repo: kdlbs/kandev-plugin-kandy
     categories: [tools]
+  - id: kandev-plugin-task-manager
+    repo: kdlbs/kandev-plugin-task-manager
+    categories: [tools]
   - id: kandev-plugin-slack
     repo: kdlbs/kandev-plugin-slack
     categories: [integrations, automation]


### PR DESCRIPTION
## Summary
- add Task Manager to the official Kandev marketplace registry
- resolve its latest published release, v0.1.1

Release: https://github.com/kdlbs/kandev-plugin-task-manager/releases/tag/v0.1.1

## Validation
- node --test plugin-registry/build-index.test.mjs
- node plugin-registry/build-index.mjs (11 built, 0 skipped)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

