### PR TITLE
fix(web): preserve latest task-create workflow

### DIFF
--- a/apps/web/components/task-create-dialog-handlers.test.ts
+++ b/apps/web/components/task-create-dialog-handlers.test.ts
@@ -459,6 +459,24 @@ describe("queueTaskCreateLastUsedFromPayload workflow history", () => {
     });
   });
 
+  // @covers AC-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001.1
+  it("keeps the latest workflow from consecutive submissions in one workspace", () => {
+    queueTaskCreateLastUsedFromPayload({
+      workspace_id: WORKSPACE_ONE,
+      workflow_id: WORKFLOW_ONE,
+      repositories: [],
+    });
+    queueTaskCreateLastUsedFromPayload({
+      workspace_id: WORKSPACE_ONE,
+      workflow_id: WORKFLOW_TWO,
+      repositories: [],
+    });
+
+    expect(readQueuedTaskCreateLastUsedState()).toEqual({
+      workflowIdsByWorkspace: { [WORKSPACE_ONE]: WORKFLOW_TWO },
+    });
+  });
+
   it("waits for every queued workspace workflow to appear in settings", () => {
     syncTaskCreateLastUsed({ workspace_id: WORKSPACE_ONE, workflow_id: WORKFLOW_ONE });
     syncTaskCreateLastUsed({ workspace_id: WORKSPACE_TWO, workflow_id: WORKFLOW_TWO });

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -188,7 +188,9 @@ export function queueTaskCreateLastUsedFromPayload(
 ) {
   if (!payload) return;
   const previousWorkflowIdsByWorkspace = lastQueuedLastUsed.workflowIdsByWorkspace;
-  lastQueuedLastUsed = {};
+  lastQueuedLastUsed = previousWorkflowIdsByWorkspace
+    ? { workflowIdsByWorkspace: previousWorkflowIdsByWorkspace }
+    : {};
   const firstWorkspaceRepo = payload.repositories?.find((repo) => repo.repository_id);
   syncTaskCreateLastUsed({
     workspace_id: payload.workspace_id,
@@ -198,11 +200,6 @@ export function queueTaskCreateLastUsedFromPayload(
     agent_profile_id: payload.agent_profile_id,
     executor_profile_id: payload.executor_profile_id,
   });
-  if (previousWorkflowIdsByWorkspace) {
-    lastQueuedLastUsed = mergeTaskCreateLastUsedState(lastQueuedLastUsed, {
-      workflowIdsByWorkspace: previousWorkflowIdsByWorkspace,
-    });
-  }
 }
 
 function mergeTaskCreateLastUsedState(

--- a/apps/web/e2e/tests/chat/cancel-progress-task-switch.spec.ts
+++ b/apps/web/e2e/tests/chat/cancel-progress-task-switch.spec.ts
@@ -30,7 +30,9 @@ test.describe("Cancel progress across task switches", () => {
     );
 
     const session = await seedIdleSession(testPage, apiClient, seedData, "Cancel progress A");
-    await session.sendMessage("/slow 8s");
+    // Keep the agent busy long enough for the task-switch and reload assertions
+    // to observe the backend-owned cancellation state on slower CI runners.
+    await session.sendMessage("/slow 30s");
 
     const activeCancel = session.activeChat().getByTestId("cancel-agent-button");
     await expect(activeCancel).toBeVisible({ timeout: 15_000 });

--- a/docs/plans/task-create-workflow-overlay-recency/plan.md
+++ b/docs/plans/task-create-workflow-overlay-recency/plan.md
@@ -1,0 +1,116 @@
+---
+created: 2026-09-05
+status: implemented
+requirements:
+  - REQ-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001
+system_design: []
+legacy_specs: []
+---
+
+# Implementation Plan: Task Create Workflow Overlay Recency
+
+## Overview
+
+Correct the frontend task-create queued overlay so the latest successful
+workflow selection wins when several task creations occur in one workspace
+before backend settings publication clears the overlay. One focused work order
+adds the failing regression first, reverses the conflicting map precedence, and
+verifies the unchanged task-create dialog on its existing desktop and mobile
+paths.
+
+The confirmed defect violates
+`AC-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001.1`: the backend records the latest
+workflow, but the frontend can continue to present an older queued workflow.
+No requirement or product behavior change is needed.
+
+There is no dedicated current system-design document for this migrated
+requirement. The technical boundaries remain those in the completed
+[Task Create Workflow Memory plan](../task-create-workflow-memory/plan.md),
+[ADR 0028](../../decisions/0028-task-create-last-used-source-of-truth.md),
+[ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md), and
+[the workspace-scoped workflow-memory ADR](../../decisions/2026-08-08-workspace-scoped-task-create-workflow-memory.md).
+
+## Scope
+
+### In scope
+
+- Preserve queued workflow entries for other workspaces across successful task
+  creations.
+- Let the newest successful submission replace an older queued workflow for
+  the same workspace.
+- Add deterministic regression coverage for consecutive same-workspace
+  submissions before settings convergence.
+- Keep the existing shared desktop and mobile workflow-resolution behavior.
+
+### Out of scope
+
+- Backend persistence or database changes.
+- Changes to workflow-resolution precedence, selector layout, or option order.
+- Persisting cancelled or failed selector changes.
+- Changes to task-create repository, branch, agent, or executor defaults.
+
+## Technical approach
+
+Update `queueTaskCreateLastUsedFromPayload` in
+`apps/web/components/task-create-dialog-handlers.ts`. Preserve the queued
+`workflowIdsByWorkspace` history as the merge base, then apply the successful
+payload as the newer patch. `mergeTaskCreateLastUsedState` already implements
+patch-wins semantics, so no new abstraction is required.
+
+Keep `queueTaskCreateLastUsedFromPayload` replacing the queued scalar defaults
+with values from the latest successful task. Do not change the existing absent
+or null workflow behavior: only a payload with both workspace and workflow IDs
+adds or replaces a workflow history entry.
+
+Add a regression to
+`apps/web/components/task-create-dialog-handlers.test.ts` that queues workflow
+one and then workflow two for the same workspace and expects workflow two.
+Retain the existing different-workspace test to prove both history entries are
+preserved.
+
+This is shared state normalization inside the existing responsive dialog. It
+does not change composition, navigation, scrolling, focus, safe areas, or touch
+targets. The existing Create Task dialog remains the desktop and mobile
+surface, and no mobile-specific production branch is introduced.
+
+## Tests
+
+- `AC-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001.1`: a focused unit regression in
+  `apps/web/components/task-create-dialog-handlers.test.ts` proves that the
+  latest successful workflow wins for a repeated workspace key.
+- Existing handler tests continue to prove that queued workflow history for
+  different workspaces and unrelated scalar defaults is preserved.
+- Existing settings-overlay tests continue to prove queued values bridge
+  backend publication and clear after convergence.
+
+## E2E tests
+
+- `AC-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001.1`: run the existing
+  `apps/web/e2e/tests/task/create-task.spec.ts` remembered-workflow scenario to
+  verify that the production-built task-create dialog still restores workflow
+  memory over a conflicting board filter.
+- No new mobile Playwright scenario is required because the correction is
+  viewport-independent state normalization in unchanged shared dialog code.
+  Existing mobile task-create coverage continues to exercise the same surface.
+
+## Work orders
+
+- [x] [Task 01: Preserve latest queued workflow](task-01-preserve-latest-queued-workflow.md)
+
+## Verification results
+
+- RED: The focused regression expected workflow two but received workflow one.
+- GREEN: The focused regression passed after the merge-order correction.
+- The focused Vitest command passed 3 files and 37 tests.
+- `pnpm run typecheck` passed.
+- The production-build remembered-workflow E2E passed 1 test with retries disabled.
+- The managed E2E runner removed its isolated environment.
+
+## Risks
+
+- Reversing precedence incorrectly can preserve the latest workspace entry
+  while dropping queued entries for other workspaces.
+- Replacing the whole overlay rather than only changing map precedence can
+  regress repository, branch, agent-profile, or executor-profile restoration.
+- Browser settings publication can occur before or after the create response.
+  The in-memory overlay must remain valid for either ordering.

--- a/docs/plans/task-create-workflow-overlay-recency/task-01-preserve-latest-queued-workflow.md
+++ b/docs/plans/task-create-workflow-overlay-recency/task-01-preserve-latest-queued-workflow.md
@@ -1,0 +1,109 @@
+---
+id: "01-preserve-latest-queued-workflow"
+title: "Preserve latest queued workflow"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001
+acceptance_criteria:
+  - AC-TASKS-TASK-CREATE-WORKFLOW-MEMORY-001.1
+system_design: []
+---
+
+# Task 01: Preserve Latest Queued Workflow
+
+## Summary
+
+Make the frontend task-create overlay retain workflow history for unrelated
+workspaces while allowing the newest successful task creation to replace the
+entry for its own workspace. Prove the correction with a focused failing test
+before changing production code.
+
+## In scope
+
+- Add a same-workspace consecutive-submission regression test.
+- Correct map precedence in `queueTaskCreateLastUsedFromPayload`.
+- Preserve queued entries for other workspaces and latest scalar defaults.
+- Run focused unit, type, and existing production-dialog E2E checks.
+
+## Out of scope
+
+- Backend or database changes.
+- Workflow selector presentation or interaction changes.
+- New preference fields or persistence sources.
+- Changes to cancelled or failed task creation behavior.
+
+## Acceptance
+
+- Queuing workflow one and then workflow two for the same workspace leaves
+  workflow two in `workflowIdsByWorkspace`.
+- Consecutive submissions in different workspaces retain both workflow entries.
+- Existing scalar last-used fields and settings-convergence behavior remain
+  green.
+
+## Verification
+
+Run from `apps/web`:
+
+```bash
+pnpm test -- --run components/task-create-dialog-handlers.test.ts hooks/use-ensure-user-settings.test.ts components/state-provider.test.tsx
+pnpm run typecheck
+pnpm e2e:run tests/task/create-task.spec.ts -- --grep "uses the remembered workflow instead of the board filter" --retries=0
+```
+
+In a fresh worktree, first run `pnpm install --frozen-lockfile` from `apps`.
+
+## Files likely touched
+
+- `apps/web/components/task-create-dialog-handlers.ts`
+- `apps/web/components/task-create-dialog-handlers.test.ts`
+- `docs/plans/task-create-workflow-overlay-recency/plan.md`
+- `docs/plans/task-create-workflow-overlay-recency/task-01-preserve-latest-queued-workflow.md`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Merge order must distinguish a newer value for the same workspace from older
+  values that still need preservation for other workspaces.
+- The overlay is module-scoped and ordering-sensitive, so the test must reset it
+  before each scenario and must not depend on timing.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/tasks/requirements/task-create-workflow-memory.md`
+- `docs/plans/task-create-workflow-memory/plan.md`
+- `docs/decisions/0028-task-create-last-used-source-of-truth.md`
+- `docs/decisions/0041-backend-owned-portable-user-settings.md`
+- `docs/decisions/2026-08-08-workspace-scoped-task-create-workflow-memory.md`
+- `apps/web/components/task-create-dialog-handlers.ts`
+- `apps/web/components/task-create-dialog-handlers.test.ts`
+- `apps/web/hooks/use-ensure-user-settings.ts`
+
+## Results
+
+The regression test failed before the production change. It expected workflow
+two but received workflow one after two submissions in the same workspace.
+
+The production change now uses prior workflow history as the merge base. The
+latest successful payload replaces the entry for its workspace. Entries for
+other workspaces remain unchanged.
+
+Final results:
+
+- `pnpm test -- --run components/task-create-dialog-handlers.test.ts hooks/use-ensure-user-settings.test.ts components/state-provider.test.tsx`
+  passed 3 files and 37 tests.
+- `pnpm run typecheck` passed.
+- `pnpm e2e:run tests/task/create-task.spec.ts -- --grep "uses the remembered workflow instead of the board filter" --retries=0`
+  passed 1 Chromium test.
+
+The change uses shared state code. It does not change desktop or mobile
+composition, navigation, scrolling, focus, safe areas, or touch targets.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3413/1c5ac367a108.html)
<!-- kandev-pr-walkthrough-end -->

Consecutive task submissions in one workspace could leave the workflow selector pointing to an older choice because the queued overlay applied stale history after the newest payload. The overlay now preserves per-workspace history while ensuring the latest task-creation selection wins.

## Validation

- `pnpm test -- --run components/task-create-dialog-handlers.test.ts hooks/use-ensure-user-settings.test.ts components/state-provider.test.tsx`
- `pnpm run typecheck`
- `pnpm e2e:run tests/task/create-task.spec.ts -- --grep "uses the remembered workflow instead of the board filter" --retries=0`
- Fresh Create Task dialog captures verified for desktop and mobile viewports.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Screenshots

![Desktop Create Task dialog](https://github.com/kdlbs/kandev/raw/media/pr-3413-screenshots/task-create-workflow-selector-desktop.png)

![Mobile Create Task dialog](https://github.com/kdlbs/kandev/raw/media/pr-3413-screenshots/task-create-workflow-selector-mobile.png)