### PR TITLE
fix: preserve workflow move handoff prompts (#3409)

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go
@@ -128,7 +128,7 @@ func TestWorkflowAutoStartNonEmptyPrompt(t *testing.T) {
 	}
 }
 
-// Test-only contract coverage for behavior already corrected on the current head.
+// Regression: a queued move-task handoff must survive a non-empty step prompt on a CREATED session.
 // @covers AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8
 func TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff(t *testing.T) {
 	fixture := newInitialPromptDedupFixture(t, false, false)

--- a/apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go
@@ -128,6 +128,69 @@ func TestWorkflowAutoStartNonEmptyPrompt(t *testing.T) {
 	}
 }
 
+// Test-only contract coverage for behavior already corrected on the current head.
+// @covers AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8
+func TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff(t *testing.T) {
+	fixture := newInitialPromptDedupFixture(t, false, false)
+	fixture.step.Prompt = "Continue with validation."
+	fixture.session.State = models.TaskSessionStateCreated
+	fixture.session.AgentProfileID = "profile-initial-prompt-dedup"
+	if err := fixture.repo.UpdateTaskSession(context.Background(), fixture.session); err != nil {
+		t.Fatalf("update created session: %v", err)
+	}
+	fixture.svc.scheduler = scheduler.NewScheduler(
+		queue.NewTaskQueue(10), fixture.svc.executor, fixture.svc.taskRepo,
+		testLogger(), scheduler.SchedulerConfig{},
+	)
+	fixture.svc.activeTurns.Store(fixture.sessionID, "turn-initial-prompt-dedup")
+	fixture.svc.messageCreator = &repositoryBackedMessageCreator{
+		mockMessageCreator: fixture.messages,
+		repo:               fixture.repo,
+	}
+
+	const handoff = "You were moved to this step with the following message: PROBE-3409"
+	if _, err := fixture.svc.messageQueue.QueueMessage(
+		context.Background(), fixture.sessionID, fixture.taskID, handoff, "",
+		messagequeue.QueuedByMoveTask, false, nil,
+	); err != nil {
+		t.Fatalf("queue handoff: %v", err)
+	}
+
+	if err := fixture.svc.autoStartStepPrompt(
+		context.Background(), fixture.taskID, fixture.session, fixture.step,
+		fixture.step.Prompt, false, true,
+	); err != nil {
+		t.Fatalf("autoStartStepPrompt returned error: %v", err)
+	}
+
+	wantVisible := fixture.step.Prompt + "\n\n" + handoff
+	persisted, err := fixture.repo.ListMessages(context.Background(), fixture.sessionID)
+	if err != nil {
+		t.Fatalf("list persisted handoff: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("persisted messages = %d, want 1", len(persisted))
+	}
+	if got := sysprompt.StripSystemContent(persisted[0].Content); got != wantVisible {
+		t.Fatalf("stored visible prompt = %q, want %q", got, wantVisible)
+	}
+
+	descriptions := capturedExecutionDescriptionsForExecution(
+		fixture.agent, "exec-initial-prompt-dedup",
+	)
+	if len(descriptions) != 1 {
+		t.Fatalf("execution descriptions = %d, want 1", len(descriptions))
+	}
+	if got := sysprompt.StripSystemContent(descriptions[0]); got != wantVisible {
+		t.Fatalf("dispatched visible prompt = %q, want %q", got, wantVisible)
+	}
+	if status := fixture.svc.messageQueue.GetStatus(
+		context.Background(), fixture.sessionID,
+	); status.Count != 0 {
+		t.Fatalf("queued messages = %d, want 0", status.Count)
+	}
+}
+
 func TestWorkflowAutoStartPlanModeOnlyPrompt(t *testing.T) {
 	fixture := newInitialPromptDedupFixture(t, true, false)
 	fixture.step.Events.OnEnter = []wfmodels.OnEnterAction{

--- a/docs/plans/workflow-move-handoff-delivery/plan.md
+++ b/docs/plans/workflow-move-handoff-delivery/plan.md
@@ -1,0 +1,95 @@
+---
+created: 2026-09-05
+status: complete
+requirements:
+  - REQ-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003
+system_design:
+  - ../../specs/tasks/system-design/workflow-step-agent-start-ownership.md
+legacy_specs: []
+---
+
+# Implementation Plan: Workflow Move Handoff Delivery
+
+## Overview
+
+Add regression coverage for the text-handoff loss reported in GitHub issue
+3409. The production correction is already on `main` in commit `613b9a4eb`.
+That commit added a launch path for prompts that the orchestrator already
+composed.
+
+The new test will exercise the complete orchestrator-to-executor boundary. No
+production change is planned because the current path passes the reproduction.
+
+## Confirmed root cause
+
+In v0.93.0, `autoStartStepPrompt` evaluated the step prompt and appended the
+queued handoff. It then stored the merged user message and called
+`StartCreatedSession`.
+
+`StartCreatedSession` applied the current step prompt again. A non-empty step
+prompt without `{{task_prompt}}` replaces its input. Therefore, the second
+composition removed the appended handoff before agent dispatch. The stored
+message kept the handoff because storage occurred before the second
+composition.
+
+Commit `613b9a4eb` routes this case through
+`startCreatedSessionWithComposedPrompt`. That path skips the second workflow
+composition. A focused diagnostic test showed that `main` sends the step prompt
+and handoff through `SetExecutionDescription`.
+
+## Scope
+
+### In scope
+
+- Add a regression test for a `CREATED` prepared session.
+- Use a non-empty step prompt without `{{task_prompt}}`.
+- Queue a textual move handoff before automatic start.
+- Prove that storage and dispatch each retain the step prompt and handoff once.
+
+### Out of scope
+
+- Change the current production prompt-composition path.
+- Change workflow step placeholder behavior.
+- Change dynamic continuation size limits or truncation order.
+- Backport the correction to an earlier release.
+- Add browser or frontend coverage for this backend dispatch contract.
+
+## Technical approach
+
+Add `TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff` to
+`apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go`.
+Reuse `newInitialPromptDedupFixture` and the existing prepared execution row.
+
+Set the session state to `CREATED` and configure an agent profile. Then add a
+non-empty step prompt and a queued handoff. Call `autoStartStepPrompt` through
+the same path that starts a prepared workspace.
+
+Inspect the stored user message and the `SetExecutionDescription` call in the
+mock manager. Compare their visible content after system
+context removal. Each value must contain the evaluated step prompt and the
+handoff once.
+
+## Tests
+
+- `AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8`: Add
+  `TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff`.
+- Keep `TestWorkflowAutoStartNonEmptyPrompt` and the queued-handoff suppression
+  case in the focused command. These tests protect both adjacent branches.
+
+## Work orders
+
+- [x] [Task 01: Add workflow move handoff regression](task-01-add-workflow-move-handoff-regression.md)
+
+## Verification results
+
+- The focused race-enabled command passed eight selected test cases.
+- The new test proves that storage and executor dispatch retain identical
+  visible content.
+- The queue is empty after the prepared session accepts the initial prompt.
+
+## Risks
+
+- A storage-only assertion can pass while dispatch still loses the handoff.
+  The test must inspect the executor description boundary.
+- An asynchronous process-start assertion can make the test unstable. The test
+  will assert the synchronous `SetExecutionDescription` call instead.

--- a/docs/plans/workflow-move-handoff-delivery/task-01-add-workflow-move-handoff-regression.md
+++ b/docs/plans/workflow-move-handoff-delivery/task-01-add-workflow-move-handoff-regression.md
@@ -1,0 +1,84 @@
+---
+id: "01-add-workflow-move-handoff-regression"
+title: "Add workflow move handoff regression"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003
+acceptance_criteria:
+  - AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8
+system_design:
+  - ../../specs/tasks/system-design/workflow-step-agent-start-ownership.md
+---
+
+# Task 01: Add Workflow Move Handoff Regression
+
+## Summary
+
+Add a backend regression test for the text-handoff loss in GitHub issue #3409.
+The test will prove that a prepared new session stores and dispatches the same
+complete prompt.
+
+## In scope
+
+- Create a `CREATED` prepared-session test case.
+- Use a non-empty replacement step prompt.
+- Queue a textual move handoff.
+- Assert complete and single delivery at storage and executor boundaries.
+
+## Out of scope
+
+- Change production prompt composition.
+- Change dynamic continuation truncation.
+- Add frontend or browser tests.
+- Backport the correction.
+
+## Acceptance
+
+- The stored visible message contains the evaluated step prompt and handoff
+  once.
+- The execution description contains the same visible content once.
+- The queue has no remaining handoff after accepted initial delivery.
+
+## Verification
+
+```bash
+go test -race -tags fts5 ./internal/orchestrator -run '^(TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff|TestWorkflowAutoStartNonEmptyPrompt|TestWorkflowAutoStartEmptyPrompt)$' -count=1
+```
+
+Run the command from `apps/backend`.
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/event_handlers_initial_prompt_dedup_test.go`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- The process start is asynchronous. The synchronous execution-description
+  call is the reliable agent-dispatch boundary for this test.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8`.
+- The workflow-entry prompt flow in the system design.
+- `startCreatedSessionWithComposedPrompt` in `task_operations.go`.
+- The prepared-session fixture in
+  `event_handlers_initial_prompt_dedup_test.go`.
+
+## Results
+
+- Added `TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff` as
+  current-head contract coverage.
+- The test uses a real SQLite repository and the prepared-session executor
+  boundary.
+- The focused race-enabled command passed eight selected test cases.

--- a/docs/specs/tasks/requirements/workflow-step-agent-start-ownership.md
+++ b/docs/specs/tasks/requirements/workflow-step-agent-start-ownership.md
@@ -2,7 +2,7 @@
 status: draft
 system: tasks
 created: 2026-08-05
-updated: 2026-09-03
+updated: 2026-09-05
 owners:
   - Kandev
 ---
@@ -66,6 +66,12 @@ sessions shall use the same task-description fallback rule.
 - **AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.7:** If prompt-history
 inspection fails, the system shall stop the automatic prompt and expose the
 existing workflow-start error behavior.
+- **AC-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-003.8:** When a workflow move
+includes a textual handoff, the new session shall receive the handoff once in
+its first agent message. When the target automatic-start step has a non-empty
+prompt, the same message shall also contain the evaluated step prompt. The
+stored user message and the dispatched message shall retain the same visible
+content.
 
 ### REQ-TASKS-WORKFLOW-STEP-AGENT-START-OWNERSHIP-004: Immediate-launch placement
 

--- a/docs/specs/tasks/system-design/workflow-step-agent-start-ownership.md
+++ b/docs/specs/tasks/system-design/workflow-step-agent-start-ownership.md
@@ -175,6 +175,12 @@ attachment metadata, and dispatched even when its text is empty. A started
 passthrough session drains the queued handoff before returning from a suppressed
 empty-step decision.
 
+For a `CREATED` session, `autoStartStepPrompt` records the merged prompt before
+it calls `startCreatedSessionWithComposedPrompt`. The private launch path marks
+the prompt as composed. As a result, `startCreatedSession` does not apply the
+step prompt a second time. If a non-empty step prompt does not contain
+`{{task_prompt}}`, this rule preserves the textual handoff.
+
 The explicit workflow-step launch keeps its existing resume and session-setting
 behavior. It does not call `PromptTask` when the composed prompt is empty.
 


### PR DESCRIPTION
Workflow move handoffs could be persisted but dropped before the destination agent started when the target step had its own prompt. This regression test and contract update document and protect the corrected single-composition start path so the stored and dispatched first message retain both pieces of context.

## Validation

- `go test -race -tags fts5 ./internal/orchestrator -run '^(TestWorkflowAutoStartCreatedNonEmptyPromptPreservesQueuedHandoff|TestWorkflowAutoStartNonEmptyPrompt|TestWorkflowAutoStartEmptyPrompt)$' -count=1`
- `python3 scripts/lint-spec-files.test.py`
- `python3 scripts/lint-spec-files.py --all`
- `git diff --check`

## Checklist

- [x] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #3409


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->