### PR TITLE
fix(web): keep new-file input focused after menu close

### DIFF
--- a/apps/web/components/task/file-browser-toolbar.test.tsx
+++ b/apps/web/components/task/file-browser-toolbar.test.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { FileBrowserToolbar } from "./file-browser-toolbar";
+import { InlineFileInput } from "./inline-file-input";
 
 let isMobile = false;
 
@@ -121,24 +123,58 @@ describe("FileBrowserToolbar workspace actions", () => {
 });
 
 const CREATE_MENU_TESTID = "files-create-menu";
+const createMenuBaseProps = {
+  displayPath: "workspace",
+  fullPath: "/workspace",
+  copied: false,
+  expandedPathsSize: 0,
+  onCopyPath: vi.fn(),
+  onOpenFolder: vi.fn(),
+  onStartSearch: vi.fn(),
+  onCollapseAll: vi.fn(),
+};
+
+async function openCreateMenu(trigger: HTMLElement) {
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+  fireEvent.click(trigger);
+  return screen.findByRole("menuitem", { name: "New file" });
+}
+
+function CreateMenuInlineInputHarness() {
+  const [creating, setCreating] = useState(false);
+
+  return (
+    <TooltipProvider>
+      <FileBrowserToolbar
+        displayPath="workspace"
+        fullPath="/workspace"
+        copied={false}
+        expandedPathsSize={0}
+        onCopyPath={vi.fn()}
+        onOpenFolder={vi.fn()}
+        onStartSearch={vi.fn()}
+        onCollapseAll={vi.fn()}
+        showCreateButton
+        onStartCreate={() => setCreating(true)}
+        onUploadFiles={vi.fn()}
+      />
+      {creating && (
+        <InlineFileInput depth={0} onSubmit={vi.fn()} onCancel={() => setCreating(false)} />
+      )}
+    </TooltipProvider>
+  );
+}
 
 describe("FileBrowserToolbar create menu", () => {
-  const baseProps = {
-    displayPath: "workspace",
-    fullPath: "/workspace",
-    copied: false,
-    expandedPathsSize: 0,
-    onCopyPath: vi.fn(),
-    onOpenFolder: vi.fn(),
-    onStartSearch: vi.fn(),
-    onCollapseAll: vi.fn(),
-  };
-
   it("keeps one-click New File when upload is unavailable", () => {
     const onStartCreate = vi.fn();
     render(
       <TooltipProvider>
-        <FileBrowserToolbar {...baseProps} showCreateButton onStartCreate={onStartCreate} />
+        <FileBrowserToolbar
+          {...createMenuBaseProps}
+          showCreateButton
+          onStartCreate={onStartCreate}
+        />
       </TooltipProvider>,
     );
 
@@ -153,7 +189,7 @@ describe("FileBrowserToolbar create menu", () => {
     render(
       <TooltipProvider>
         <FileBrowserToolbar
-          {...baseProps}
+          {...createMenuBaseProps}
           showCreateButton
           onStartCreate={onStartCreate}
           onUploadFiles={onUploadFiles}
@@ -162,19 +198,65 @@ describe("FileBrowserToolbar create menu", () => {
     );
 
     const menuTrigger = screen.getByTestId(CREATE_MENU_TESTID);
-    fireEvent.pointerDown(menuTrigger, { button: 0, ctrlKey: false });
-    fireEvent.click(menuTrigger);
-    await waitFor(() => expect(screen.getByRole("menuitem", { name: "New file" })).toBeTruthy());
+    await openCreateMenu(menuTrigger);
     expect(screen.getByRole("menuitem", { name: "Upload files" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Upload folder" })).toBeTruthy();
   });
 
-  it("still begins inline creation from the menu, unchanged", async () => {
+  it("keeps inline creation focused after the create menu closes", async () => {
+    // @covers AC-UI-WORKSPACE-FILE-TRANSFER-001.1
+    render(<CreateMenuInlineInputHarness />);
+
+    const menuTrigger = screen.getByTestId(CREATE_MENU_TESTID);
+    fireEvent.click(await openCreateMenu(menuTrigger));
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: "New file" })).toBeNull());
+
+    const input = await screen.findByPlaceholderText("filename...");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByPlaceholderText("filename...")).toBeNull());
+    await openCreateMenu(menuTrigger);
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: "New file" })).toBeNull());
+    expect(screen.queryByPlaceholderText("filename...")).toBeNull();
+  });
+
+  it("requests the right picker for each upload item", async () => {
+    const onUploadFiles = vi.fn();
     const onStartCreate = vi.fn();
     render(
       <TooltipProvider>
         <FileBrowserToolbar
-          {...baseProps}
+          {...createMenuBaseProps}
+          showCreateButton
+          onStartCreate={onStartCreate}
+          onUploadFiles={onUploadFiles}
+        />
+      </TooltipProvider>,
+    );
+
+    const menuTrigger = screen.getByTestId(CREATE_MENU_TESTID);
+    await openCreateMenu(menuTrigger);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Upload folder" }));
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith("folder"));
+    await waitFor(() => expect(document.activeElement).toBe(menuTrigger));
+    expect(onStartCreate).not.toHaveBeenCalled();
+
+    onUploadFiles.mockClear();
+    await openCreateMenu(menuTrigger);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Upload files" }));
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith("files"));
+    await waitFor(() => expect(document.activeElement).toBe(menuTrigger));
+    expect(onStartCreate).not.toHaveBeenCalled();
+  });
+
+  it("restores the create-menu trigger when the menu is dismissed", async () => {
+    const onStartCreate = vi.fn();
+    render(
+      <TooltipProvider>
+        <FileBrowserToolbar
+          {...createMenuBaseProps}
           showCreateButton
           onStartCreate={onStartCreate}
           onUploadFiles={vi.fn()}
@@ -183,35 +265,11 @@ describe("FileBrowserToolbar create menu", () => {
     );
 
     const menuTrigger = screen.getByTestId(CREATE_MENU_TESTID);
-    fireEvent.pointerDown(menuTrigger, { button: 0, ctrlKey: false });
-    fireEvent.click(menuTrigger);
-    fireEvent.click(await screen.findByRole("menuitem", { name: "New file" }));
-    await waitFor(() => expect(onStartCreate).toHaveBeenCalledTimes(1));
-  });
+    await openCreateMenu(menuTrigger);
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
 
-  it("requests the right picker for each upload item", async () => {
-    const onUploadFiles = vi.fn();
-    render(
-      <TooltipProvider>
-        <FileBrowserToolbar
-          {...baseProps}
-          showCreateButton
-          onStartCreate={vi.fn()}
-          onUploadFiles={onUploadFiles}
-        />
-      </TooltipProvider>,
-    );
-
-    const menuTrigger = screen.getByTestId(CREATE_MENU_TESTID);
-    fireEvent.pointerDown(menuTrigger, { button: 0, ctrlKey: false });
-    fireEvent.click(menuTrigger);
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Upload folder" }));
-    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith("folder"));
-
-    onUploadFiles.mockClear();
-    fireEvent.pointerDown(menuTrigger, { button: 0, ctrlKey: false });
-    fireEvent.click(menuTrigger);
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Upload files" }));
-    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith("files"));
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: "New file" })).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(menuTrigger));
+    expect(onStartCreate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task/file-browser-toolbar.test.tsx
+++ b/apps/web/components/task/file-browser-toolbar.test.tsx
@@ -146,14 +146,7 @@ function CreateMenuInlineInputHarness() {
   return (
     <TooltipProvider>
       <FileBrowserToolbar
-        displayPath="workspace"
-        fullPath="/workspace"
-        copied={false}
-        expandedPathsSize={0}
-        onCopyPath={vi.fn()}
-        onOpenFolder={vi.fn()}
-        onStartSearch={vi.fn()}
-        onCollapseAll={vi.fn()}
+        {...createMenuBaseProps}
         showCreateButton
         onStartCreate={() => setCreating(true)}
         onUploadFiles={vi.fn()}

--- a/apps/web/components/task/file-browser-toolbar.tsx
+++ b/apps/web/components/task/file-browser-toolbar.tsx
@@ -140,6 +140,19 @@ function CreateMenu({
   onUploadFiles?: (mode: "files" | "folder") => void;
 }) {
   const { t } = useTranslation();
+  const createAfterCloseRef = useRef(false);
+  const handleCreateSelect = useCallback(() => {
+    createAfterCloseRef.current = true;
+  }, []);
+  const handleCloseAutoFocus = useCallback(
+    (event: Event) => {
+      if (!createAfterCloseRef.current) return;
+      event.preventDefault();
+      createAfterCloseRef.current = false;
+      onStartCreate();
+    },
+    [onStartCreate],
+  );
 
   // Without an upload handler there is only one action, so keep the original
   // one-click button rather than burying New File behind a menu.
@@ -170,10 +183,10 @@ function CreateMenu({
         </TooltipTrigger>
         <TooltipContent>{t("task:addToWorkspace")}</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align="end" className="w-56" onCloseAutoFocus={handleCloseAutoFocus}>
         <DropdownMenuItem
           className="min-h-[44px] cursor-pointer gap-2 sm:min-h-8"
-          onSelect={onStartCreate}
+          onSelect={handleCreateSelect}
         >
           <IconFilePlus className="h-3.5 w-3.5" />
           {t("task:newFile")}

--- a/apps/web/e2e/tests/task/file-tree-create.spec.ts
+++ b/apps/web/e2e/tests/task/file-tree-create.spec.ts
@@ -51,6 +51,7 @@ async function startCreateAtRoot(testPage: Page) {
     const menuItem = testPage.getByRole("menuitem", { name: "New file" });
     await expect(menuItem).toBeVisible({ timeout: 5_000 });
     await menuItem.click();
+    await expect(menuItem).toHaveCount(0);
   }
   const input = testPage.getByPlaceholder("filename...");
   await expect(input).toBeVisible({ timeout: 5_000 });

--- a/apps/web/e2e/tests/task/mobile-file-viewer.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-file-viewer.spec.ts
@@ -92,7 +92,9 @@ test.describe("Mobile file tree keyboard shortcuts", () => {
       await directNewFile.tap();
     } else {
       await testPage.getByTestId("files-create-menu").tap();
-      await testPage.getByRole("menuitem", { name: "New file" }).tap();
+      const menuItem = testPage.getByRole("menuitem", { name: "New file" });
+      await menuItem.tap();
+      await expect(menuItem).toHaveCount(0);
     }
     const input = testPage.getByPlaceholder("filename...");
     await expect(input).toBeFocused({ timeout: 5_000 });

--- a/docs/plans/file-create-menu-focus/plan.md
+++ b/docs/plans/file-create-menu-focus/plan.md
@@ -1,0 +1,128 @@
+---
+created: 2026-09-05
+status: complete
+requirements:
+  - REQ-UI-WORKSPACE-FILE-TRANSFER-001
+system_design:
+  - ../../specs/ui/system-design/workspace-file-transfer.md
+legacy_specs: []
+---
+
+# Implementation Plan: File Create Menu Focus
+
+## Overview
+
+Keep the Files-panel filename input focused after a person chooses **New File**
+from the upload-enabled create menu. One sequential frontend slice defers inline
+creation until the dropdown finishes closing and proves the shared desktop and
+mobile behavior.
+
+## Confirmed root cause
+
+`CreateMenu` calls `onStartCreate` from `DropdownMenuItem.onSelect`. This mounts
+`InlineFileInput` while Radix is still closing the dropdown. The input focuses
+itself on the next animation frame, then Radix restores focus to the create-menu
+trigger. `InlineFileInput.onBlur` interprets the empty value as cancellation and
+removes the input.
+
+An isolated browser reproduction observed the input focus, trigger focus
+restoration, and input removal in sequence. The input lost focus after about
+163 ms on desktop and 97 ms on a Pixel-sized mobile viewport. No console error
+or file API request accompanied the disappearance.
+
+## Scope
+
+### In scope
+
+- Defer the **New File** callback until the create dropdown closes.
+- Suppress Radix trigger-focus restoration only for a pending **New File**
+  selection so the freshly mounted filename input keeps focus.
+- Preserve default trigger-focus restoration for upload selections, Escape,
+  and outside dismissal.
+- Prove filename-input persistence and focus on desktop and mobile.
+
+### Out of scope
+
+- File creation, upload, download, rename, tree selection, or filesystem API
+  semantics.
+- Changes to `InlineFileInput` blur-to-submit and blur-to-cancel behavior.
+- Menu layout, touch-target sizing, responsive composition, copy, or
+  localization.
+- Backend, persistence, feature flags, and public documentation.
+
+## Technical approach
+
+- Add a pending-create ref and focused close handler to `CreateMenu` in
+  `apps/web/components/task/file-browser-toolbar.tsx`.
+- Make the **New File** item mark creation as pending. In
+  `DropdownMenuContent.onCloseAutoFocus`, prevent default focus restoration,
+  consume the pending state, and call `onStartCreate`.
+- Leave all non-create closes on Radix's default path. This mirrors the shipped
+  deferred inline-rename pattern in `FileContextMenuSurface` and the original
+  workspace-file-transfer plan's requirement to use `onCloseAutoFocus`.
+- Keep `InlineFileInput` unchanged; once it mounts after the dropdown closes,
+  its existing animation-frame focus and blur semantics are correct.
+
+## Mobile design contract
+
+- Desktop enters through the Files-panel create dropdown; mobile enters through
+  the same shared toolbar after selecting Files from the bottom navigation.
+- The shared `CreateMenu`, file-browser state, and inline input own the behavior
+  on both viewports. No mobile-specific presentation branch is added.
+- The existing Radix menu remains the nearest shipped contextual-action
+  exemplar, including its 44px mobile trigger and menu-item hit areas.
+- Information hierarchy, scroll ownership, safe-area handling, and menu geometry
+  are unchanged. The only repaired outcome is that the primary filename input
+  remains visible and focused after the menu closes.
+
+## Tests
+
+- `AC-UI-WORKSPACE-FILE-TRANSFER-001.1`: extend
+  `apps/web/components/task/file-browser-toolbar.test.tsx` with a stateful
+  harness that uses the real inline input. Before the correction, choosing
+  **New File** lets close-autofocus blur and remove the input; after the
+  correction, the menu is closed and the input remains focused.
+- Preserve default focus restoration after upload selection and menu dismissal
+  in the same component suite so the create-only exception cannot leak.
+
+## E2E tests
+
+- Desktop Chromium: strengthen
+  `apps/web/e2e/tests/task/file-tree-create.spec.ts` so the helper waits for the
+  dropdown to finish closing before asserting that the filename input remains
+  visible and focused.
+- Mobile Chromium: strengthen the existing new-file flow in
+  `apps/web/e2e/tests/task/mobile-file-viewer.spec.ts` with the same post-close
+  persistence and focus assertion. The shared behavior changes without a new
+  mobile composition or screenshot contract.
+
+## Work orders
+
+- [x] [Task 01: Preserve new-file focus after menu close](task-01-preserve-new-file-focus.md)
+
+## Verification results
+
+- Component regression: 8 tests passed. The regression failed before the
+  production change because the filename input disappeared during dropdown
+  close-autofocus.
+- Desktop Chromium E2E: 1 test passed after waiting for the create menu to
+  detach before checking the input.
+- Mobile Chromium E2E: 1 test passed with the same post-close focus contract.
+- Web typecheck: passed.
+- Targeted ESLint: passed with no warnings.
+- `git diff --check`: passed.
+
+## Risks
+
+- An unconditional `preventDefault()` would strand focus on ordinary upload or
+  dismissal paths. The pending state must scope both deferral and focus
+  suppression to **New File**.
+- A pending flag that survives one close could replay creation on a later menu
+  close. Consume it exactly once and cover the next-close behavior.
+- Immediate E2E assertions can race the closing animation and report a false
+  pass. Assertions must wait for the menu item to detach before checking the
+  filename input.
+
+## Open questions
+
+None.

--- a/docs/plans/file-create-menu-focus/task-01-preserve-new-file-focus.md
+++ b/docs/plans/file-create-menu-focus/task-01-preserve-new-file-focus.md
@@ -1,0 +1,103 @@
+---
+id: "01-preserve-new-file-focus"
+title: "Preserve new-file focus after menu close"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-UI-WORKSPACE-FILE-TRANSFER-001
+acceptance_criteria:
+  - AC-UI-WORKSPACE-FILE-TRANSFER-001.1
+system_design:
+  - ../../specs/ui/system-design/workspace-file-transfer.md
+---
+
+# Task 01: Preserve New-File Focus After Menu Close
+
+## Summary
+
+Make the create dropdown finish closing before it mounts the inline filename
+input. Add component, desktop, and mobile regressions that prove the input
+remains visible and focused after close-autofocus completes.
+
+## In scope
+
+- Add create-only pending state and `onCloseAutoFocus` handling to
+  `CreateMenu`.
+- Add a failing component regression before changing production code.
+- Strengthen the existing desktop and mobile new-file E2E flows to assert the
+  post-close state.
+- Preserve default trigger-focus restoration for non-create menu closes.
+
+## Out of scope
+
+- Changing inline input blur semantics or filesystem operations.
+- Changing upload pickers, menu content, responsive layout, or copy.
+- Adding a new mobile surface or modifying touch-target geometry.
+- Backend and public-documentation changes.
+
+## Acceptance
+
+- Choosing **New File** closes the menu, then mounts and focuses one filename
+  input that remains available for typing on desktop and mobile.
+- Upload actions and ordinary dismissal retain Radix's normal focus restoration
+  and never start inline creation.
+- A consumed pending create cannot replay on a later menu close.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run components/task/file-browser-toolbar.test.tsx
+cd apps/web && pnpm e2e:run --host tests/task/file-tree-create.spec.ts -- --grep "New file at root"
+cd apps/web && pnpm e2e:run --host --no-build --project mobile-chrome tests/task/mobile-file-viewer.spec.ts -- --grep "select-all stays in the new-file name input"
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm exec eslint components/task/file-browser-toolbar.tsx components/task/file-browser-toolbar.test.tsx e2e/tests/task/file-tree-create.spec.ts e2e/tests/task/mobile-file-viewer.spec.ts
+```
+
+## Files likely touched
+
+- `apps/web/components/task/file-browser-toolbar.tsx`
+- `apps/web/components/task/file-browser-toolbar.test.tsx`
+- `apps/web/e2e/tests/task/file-tree-create.spec.ts`
+- `apps/web/e2e/tests/task/mobile-file-viewer.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Suppressing close-autofocus outside the pending-create branch would regress
+  keyboard focus for upload and dismissal paths.
+- Waiting on elapsed time instead of the menu-close event would make the E2E
+  regression timing-dependent.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- [Workspace File Transfer Requirements](../../specs/ui/requirements/workspace-file-transfer.md),
+  especially `AC-UI-WORKSPACE-FILE-TRANSFER-001.1`.
+- [Workspace File Transfer System Design](../../specs/ui/system-design/workspace-file-transfer.md),
+  especially the frontend `CreateMenu` responsibility.
+- `FileContextMenuSurface` as the shipped pending-action and close-autofocus
+  exemplar.
+- Isolated desktop and Pixel-sized browser focus traces from the diagnostic
+  turn.
+
+## Results
+
+- Added a create-only pending ref to `CreateMenu`. **New File** now mounts the
+  inline input from `onCloseAutoFocus`, after the dropdown has closed, and
+  suppresses trigger focus restoration for that close only.
+- Added a stateful component regression using the real `InlineFileInput`. The
+  test failed before the production change because the input was removed, then
+  passed after the fix. It also proves the consumed create state does not
+  replay and that upload and Escape paths retain normal trigger focus.
+- Strengthened desktop and mobile E2E flows to wait for the menu item to detach
+  before asserting filename-input focus.
+- Verification passed: 8 focused component tests, 1 desktop Chromium E2E, 1
+  mobile Chromium E2E, web typecheck, targeted ESLint, and `git diff --check`.


### PR DESCRIPTION
Selecting **New file** from the Files panel could mount the filename input before the dropdown finished closing; Radix then restored focus to the trigger, causing the empty input to blur and disappear. The create action now waits for menu close-autofocus before mounting the input, while upload and dismissal behavior remains unchanged.

## Important Changes

- Defer inline file-input creation until the create menu closes, with a create-only focus handoff.
- Add component, desktop Chromium, and mobile Chromium regressions for focus persistence and default focus restoration.

## Validation

- `pnpm --filter @kandev/web test -- --run components/task/file-browser-toolbar.test.tsx`
- `pnpm e2e:run --host tests/task/file-tree-create.spec.ts -- --grep "New file at root"`
- `pnpm e2e:run --host --no-build --project mobile-chrome tests/task/mobile-file-viewer.spec.ts -- --grep "select-all stays in the new-file name input"`
- `pnpm run typecheck`
- Targeted ESLint for the changed web and E2E files
- `git diff --check`
- Fresh desktop and mobile PR screenshots captured, inspected, and compressed

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop Files panel with the new-file input focused](https://raw.githubusercontent.com/kdlbs/kandev/dff6daef2864331e3f92a0e4ce0fdf72e9469051/desktop-new-file-input.png)

![Mobile Files panel with the new-file input focused](https://raw.githubusercontent.com/kdlbs/kandev/dff6daef2864331e3f92a0e4ce0fdf72e9469051/mobile-new-file-input.png)
<!-- kandev-screenshots-end -->