### PR TITLE
ci: schedule runtime pin updates for Friday

### DIFF
--- a/.github/workflows/update-agent-runtime-pins.yml
+++ b/.github/workflows/update-agent-runtime-pins.yml
@@ -2,9 +2,9 @@ name: Update managed runtime pins
 
 on:
   schedule:
-    # Refresh the reviewed runtime pins every Monday at 06:17 UTC, then open
+    # Refresh the reviewed runtime pins every Friday at 09:00 UTC, then open
     # or refresh the single grouped updater PR when a stable version changes.
-    - cron: "17 6 * * 1"
+    - cron: "0 9 * * 5"
   workflow_dispatch:
 
 # The job uses the repository-scoped workflow token for the branch, PR, and


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3422/12fe93f0219e.html)
<!-- kandev-pr-walkthrough-end -->

The managed runtime pin updater is scheduled for the start of the week, which delays the requested maintenance window. Run it every Friday at 09:00 UTC so stable agent pin refreshes happen on a predictable weekly cadence.

## Validation

- `python3 .github/scripts/update-agent-runtime-pins-workflow-contract_test.py` (9 tests passed)
- `git diff --check`
- Commit hooks passed during commit.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->