### PR TITLE
feat: add Task Manager host monitor support

### DIFF
--- a/apps/backend/internal/plugins/config.go
+++ b/apps/backend/internal/plugins/config.go
@@ -16,6 +16,7 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
 	"strings"
@@ -178,10 +179,10 @@ func mergeMaskedSecrets(incoming, existing map[string]any, schema map[string]any
 
 // validateConfigSchema checks config against the author-declared
 // config_schema for pluginID. Deliberately a small JSON-Schema subset —
-// required fields, primitive types (string/boolean/number/integer), and enum
-// membership on declared properties. Undeclared keys and richer schema
-// constructs are permitted: the schema is advisory authoring metadata, not a
-// hard sandbox.
+// required fields, primitive types (string/boolean/number/integer), numeric
+// minimum/maximum bounds, and enum membership on declared properties.
+// Undeclared keys and richer schema constructs are permitted: the schema is
+// advisory authoring metadata, not a hard sandbox.
 //
 // A secret field that was left unchanged carries its own vault reference (an
 // internal storage marker) rather than a user value — the cleartext was
@@ -251,11 +252,15 @@ func checkRequiredKeys(config map[string]any, schema map[string]any) error {
 }
 
 // checkPropertyValue validates one present value against its declared
-// property: primitive type match plus enum membership.
+// property: primitive type match, numeric bounds, and enum membership.
 func checkPropertyValue(name string, value any, prop map[string]any) error {
-	if typeName, ok := prop["type"].(string); ok {
+	typeName, hasType := prop["type"].(string)
+	if hasType {
 		if !valueMatchesType(value, typeName) {
 			return fmt.Errorf("%w: field %q must be a %s", ErrConfigInvalid, name, typeName)
+		}
+		if err := checkNumericBounds(name, value, prop, typeName); err != nil {
+			return err
 		}
 	}
 	if enum, ok := prop["enum"].([]any); ok && len(enum) > 0 {
@@ -267,6 +272,33 @@ func checkPropertyValue(name string, value any, prop map[string]any) error {
 		return fmt.Errorf("%w: field %q must be one of the declared enum values", ErrConfigInvalid, name)
 	}
 	return nil
+}
+
+// checkNumericBounds applies the subset of JSON-Schema numeric constraints
+// understood by the generic plugin settings form. Malformed bounds are
+// ignored because config_schema is authoring metadata; a valid manifest
+// cannot produce one, and ignoring it preserves the existing permissive
+// behavior for richer or malformed schemas.
+func checkNumericBounds(name string, value any, prop map[string]any, typeName string) error {
+	if typeName != "number" && typeName != "integer" {
+		return nil
+	}
+	valueNumber, ok := numericValue(value)
+	if !ok || math.IsNaN(valueNumber) || math.IsInf(valueNumber, 0) {
+		return fmt.Errorf("%w: field %q must be finite", ErrConfigInvalid, name)
+	}
+	if minimum, ok := numericSchemaBound(prop["minimum"]); ok && valueNumber < minimum {
+		return fmt.Errorf("%w: field %q must be at least %v", ErrConfigInvalid, name, minimum)
+	}
+	if maximum, ok := numericSchemaBound(prop["maximum"]); ok && valueNumber > maximum {
+		return fmt.Errorf("%w: field %q must be at most %v", ErrConfigInvalid, name, maximum)
+	}
+	return nil
+}
+
+func numericSchemaBound(value any) (float64, bool) {
+	bound, ok := numericValue(value)
+	return bound, ok && !math.IsNaN(bound) && !math.IsInf(bound, 0)
 }
 
 // enumValueMatches compares a submitted value against a declared enum
@@ -284,14 +316,31 @@ func enumValueMatches(value, allowed any) bool {
 }
 
 // numericValue converts the numeric types a config value can realistically
-// carry (JSON float64, YAML int/int64/uint64) to float64 for comparison.
+// carry (JSON float64, YAML integers, and programmatic integer/float values)
+// to float64 for comparison.
 func numericValue(v any) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
 		return n, true
+	case float32:
+		return float64(n), true
 	case int:
 		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
 	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
 		return float64(n), true
 	case uint64:
 		return float64(n), true
@@ -325,15 +374,21 @@ func valueMatchesType(value any, typeName string) bool {
 }
 
 func isNumeric(value any) bool {
-	if _, ok := value.(float64); ok {
-		return true
+	if _, ok := numericValue(value); !ok {
+		return false
+	}
+	_, isFloat := value.(float32)
+	if !isFloat {
+		if _, isFloat = value.(float64); isFloat {
+			return true
+		}
 	}
 	return isInt(value)
 }
 
 func isInt(value any) bool {
 	switch value.(type) {
-	case int, int64, uint64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return true
 	default:
 		return false

--- a/apps/backend/internal/plugins/config_test.go
+++ b/apps/backend/internal/plugins/config_test.go
@@ -176,6 +176,39 @@ func TestValidateConfigSchema(t *testing.T) {
 	}
 }
 
+func TestValidateConfigSchemaEnforcesNumericBounds(t *testing.T) {
+	schema := map[string]any{
+		"properties": map[string]any{
+			"interval": map[string]any{
+				"type":    "integer",
+				"minimum": 1,
+				"maximum": 300,
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name    string
+		value   any
+		wantErr bool
+	}{
+		{name: "below minimum", value: float64(0), wantErr: true},
+		{name: "minimum", value: float64(1)},
+		{name: "within range", value: float64(90)},
+		{name: "maximum", value: float64(300)},
+		{name: "above maximum", value: float64(301), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfigSchema("test-plugin", map[string]any{"interval": tc.value}, schema)
+			if tc.wantErr && !errors.Is(err, ErrConfigInvalid) {
+				t.Fatalf("error = %v, want ErrConfigInvalid", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateConfigSchemaNilSchemaIsPermissive(t *testing.T) {
 	if err := validateConfigSchema("test-plugin", map[string]any{"anything": 1}, nil); err != nil {
 		t.Fatalf("nil schema should accept anything, got %v", err)

--- a/apps/packages/plugin-sdk/src/index.ts
+++ b/apps/packages/plugin-sdk/src/index.ts
@@ -27,6 +27,10 @@ export type PluginIcon = string | Component<PluginIconProps>;
 /** Placement for a registered nav item; see `PluginRegistry.registerNavItem`. */
 export type PluginNavSection = "main" | "settings" | "integrations" | "sidebar-footer";
 
+// On mobile, the host normalizes ordinary `host.ui.Button` contributions to
+// a 32px icon action. A rich status control with text may opt out by setting
+// `data-main-top-bar-rich` on its root and must own its compact layout and
+// minimum 44px touch height. Rich controls must not add a nested scroller.
 /** Context passed to components registered for the `main-top-bar` slot. */
 export interface MainTopBarSlotProps {
   workspaceId: string | null;

--- a/apps/web/components/kanban/main-top-bar-plugin-actions.test.tsx
+++ b/apps/web/components/kanban/main-top-bar-plugin-actions.test.tsx
@@ -59,7 +59,7 @@ describe("MainTopBarPluginActions", () => {
 
     expect(screen.getByTestId("plugin-button").textContent).toBe("mobile");
     expect(screen.getByTestId("mobile-main-top-bar-plugin-actions").className).toContain(
-      "[&_[data-slot=button]]:!size-8",
+      "[&_[data-slot=button]:not([data-main-top-bar-rich])]:!size-8",
     );
   });
 });

--- a/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
+++ b/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
@@ -60,7 +60,7 @@ export function MainTopBarPluginActions(props: {
 
   return (
     <div
-      className="flex shrink-0 items-center gap-2 [&_[data-slot=button]]:!size-8 [&_[data-slot=button]]:!p-0 [&_[data-slot=button]_svg]:!size-4"
+      className="flex shrink-0 items-center gap-2 [&_[data-slot=button]:not([data-main-top-bar-rich])]:!size-8 [&_[data-slot=button]:not([data-main-top-bar-rich])]:!p-0 [&_[data-slot=button]:not([data-main-top-bar-rich])_svg]:!size-4"
       data-testid="mobile-main-top-bar-plugin-actions"
     >
       {content}

--- a/apps/web/components/settings/plugins/plugin-config-form.tsx
+++ b/apps/web/components/settings/plugins/plugin-config-form.tsx
@@ -162,6 +162,8 @@ function ConfigFieldControl({
       // step="1" on integer fields nudges the browser to flag non-integral
       // input in-place; serializeConfigValues still rejects it as a backstop.
       step={!field.secret && field.type === "integer" ? "1" : undefined}
+      min={field.minimum}
+      max={field.maximum}
       value={typeof value === "string" ? value : ""}
       disabled={disabled}
       data-settings-dirty={isDirty}

--- a/apps/web/components/settings/plugins/plugin-detail.test.tsx
+++ b/apps/web/components/settings/plugins/plugin-detail.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  isAdmin: false,
+  plugin: {
+    id: "task-manager",
+    version: "1.0.0",
+    display_name: "Task Manager",
+    description: "",
+    status: "active",
+    signed: true,
+  },
+}));
+
+vi.mock("@/hooks/domains/auth/use-is-admin", () => ({
+  useIsAdmin: () => state.isAdmin,
+}));
+
+vi.mock("@/hooks/domains/plugins/use-plugins", () => ({
+  usePlugins: () => ({ items: [state.plugin], loaded: true }),
+}));
+
+vi.mock("@/lib/routing/client-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isFinePointer: true }),
+}));
+
+vi.mock("@/components/plugins/plugin-slot", () => ({
+  PluginSlot: () => <div data-testid="owner-scoped-plugin-settings" />,
+}));
+
+vi.mock("@/components/settings/settings-save-provider", () => ({
+  useSettingsSaveContributor: vi.fn(),
+}));
+
+vi.mock("./use-plugin-actions", () => ({
+  usePluginActions: () => ({
+    busyId: null,
+    uninstallBusy: false,
+    confirmUninstall: vi.fn(),
+  }),
+}));
+
+vi.mock("./use-plugin-config-form", () => ({
+  usePluginConfigForm: () => ({
+    fields: [],
+    values: {},
+    initialValues: {},
+    configLoading: false,
+    configError: null,
+    saveStatus: "idle",
+    isDirty: false,
+    canSave: false,
+    invalidReason: undefined,
+    revision: "",
+    handleChange: vi.fn(),
+    handleSave: vi.fn(),
+    discard: vi.fn(),
+  }),
+}));
+
+vi.mock("./plugin-error-diagnostic", () => ({ PluginErrorDiagnostic: () => null }));
+vi.mock("./plugin-manifest-card", () => ({ PluginManifestCard: () => null }));
+vi.mock("./plugin-repo-link", () => ({ PluginRepoLink: () => null }));
+vi.mock("./plugin-shortcuts-card", () => ({ PluginShortcutsCard: () => null }));
+vi.mock("./uninstall-plugin-dialog", () => ({ PluginUninstallConfirmation: () => null }));
+
+import { PluginDetail } from "./plugin-detail";
+
+afterEach(() => {
+  cleanup();
+  state.isAdmin = false;
+});
+
+describe("PluginDetail personal settings visibility", () => {
+  it("renders the owner-scoped settings slot for a non-admin without operator controls", () => {
+    render(<PluginDetail pluginId={state.plugin.id} />);
+
+    expect(screen.getByTestId("owner-scoped-plugin-settings")).not.toBeNull();
+    expect(screen.queryByTestId("plugin-settings-card")).toBeNull();
+  });
+});

--- a/apps/web/components/settings/plugins/plugin-detail.tsx
+++ b/apps/web/components/settings/plugins/plugin-detail.tsx
@@ -65,14 +65,15 @@ export function PluginDetail({ pluginId }: { pluginId: string }) {
       <PluginDetailHeader plugin={plugin} />
       <Separator />
 
+      {/* Owner-scoped personal settings are available to every signed-in user;
+          the schema-driven operator form below remains administrator-only. */}
+      <PluginSlot
+        name="plugin-settings"
+        ownerPluginId={plugin.id}
+        slotProps={{ pluginId: plugin.id, status: plugin.status }}
+      />
       {canManage && (
         <>
-          {/* Owner-scoped inline slot for the plugin's own settings UI, at the top (see PLUGIN-API.md). */}
-          <PluginSlot
-            name="plugin-settings"
-            ownerPluginId={plugin.id}
-            slotProps={{ pluginId: plugin.id, status: plugin.status }}
-          />
           <PluginSettingsCard
             plugin={plugin}
             form={form}

--- a/apps/web/lib/plugins/config-schema.test.ts
+++ b/apps/web/lib/plugins/config-schema.test.ts
@@ -45,6 +45,24 @@ describe("parseConfigSchema", () => {
     expect(byName.verbose.type).toBe("boolean");
   });
 
+  it("preserves finite numeric bounds for numeric controls", () => {
+    const fields = parseConfigSchema({
+      properties: {
+        interval: { type: "integer", minimum: 1, maximum: 300 },
+        ratio: { type: "number", minimum: -1.5, maximum: 2.5 },
+        text: { type: "string", minimum: 1, maximum: 2 },
+        malformed: { type: "integer", minimum: "1", maximum: Number.NaN },
+      },
+    });
+
+    expect(fields).toEqual([
+      expect.objectContaining({ name: "interval", minimum: 1, maximum: 300 }),
+      expect.objectContaining({ name: "ratio", minimum: -1.5, maximum: 2.5 }),
+      expect.objectContaining({ name: "text", minimum: undefined, maximum: undefined }),
+      expect.objectContaining({ name: "malformed", minimum: undefined, maximum: undefined }),
+    ]);
+  });
+
   it("returns [] for missing or unusable schemas", () => {
     expect(parseConfigSchema(undefined)).toEqual([]);
     expect(parseConfigSchema({})).toEqual([]);

--- a/apps/web/lib/plugins/config-schema.ts
+++ b/apps/web/lib/plugins/config-schema.ts
@@ -33,6 +33,10 @@ export interface PluginConfigField {
    * round trip — the backend validates against these, not their string
    * forms). */
   enumRawValues?: unknown[];
+  /** Inclusive numeric lower bound from the manifest schema. */
+  minimum?: number;
+  /** Inclusive numeric upper bound from the manifest schema. */
+  maximum?: number;
   defaultValue?: unknown;
 }
 
@@ -55,6 +59,10 @@ function fieldType(prop: SchemaObject): PluginConfigFieldType {
 
 function isSecretProp(prop: SchemaObject): boolean {
   return prop.secret === true || prop.format === "password";
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function requiredNames(schema: SchemaObject): Set<string> {
@@ -83,15 +91,19 @@ export function parseConfigSchema(
   for (const [name, raw] of Object.entries(properties)) {
     const prop = asObject(raw);
     if (!prop) continue;
+    const type = fieldType(prop);
+    const numeric = type === "number" || type === "integer";
     fields.push({
       name,
-      type: fieldType(prop),
+      type,
       label: typeof prop.title === "string" && prop.title !== "" ? prop.title : name,
       description: typeof prop.description === "string" ? prop.description : undefined,
       required: required.has(name),
       secret: isSecretProp(prop),
       enumValues: Array.isArray(prop.enum) ? prop.enum.map((v) => String(v)) : undefined,
       enumRawValues: Array.isArray(prop.enum) ? prop.enum : undefined,
+      minimum: numeric ? finiteNumber(prop.minimum) : undefined,
+      maximum: numeric ? finiteNumber(prop.maximum) : undefined,
       defaultValue: prop.default,
     });
   }

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -125,9 +125,12 @@ export interface IntegrationSettingsRegistration {
  * "chat-top-bar"; receives `{ workspaceId, workspaceLabel, currentPage,
  * presentation }`). On phones, `presentation` is "mobile": contributions
  * join the horizontally scrollable middle action strip between the fixed
- * Kandev link and menu button. Use the host `ui.Button` icon-button contract
- * there: a 32px box with a 16px SVG icon. Desktop contributions retain their
- * existing sizing.
+ * Kandev link and menu button. Ordinary `ui.Button` icon actions are
+ * normalized there to a 32px box with a 16px SVG icon. A rich status control
+ * with ordered text may opt out by setting `data-main-top-bar-rich` on its
+ * root; it must own a compact layout with a minimum 44px touch height and
+ * must not add a nested scroller. Desktop contributions retain their existing
+ * sizing.
  * "app-status-bar-left" / "app-status-bar-right" (receives
  * `AppStatusBarSlotProps` as `slotProps`), and
  * "plugin-settings" (inline UI on a plugin's own settings

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -822,9 +822,12 @@ interface PluginRegistry {
   // controls) and forwards `{ workspaceId, workspaceLabel, currentPage,
   // presentation }`, where presentation is "desktop" or "mobile". On a phone,
   // contributions join the horizontally scrollable middle action strip between
-  // the fixed Kandev link and menu button. Documented host ui.Button icon
-  // contributions are normalized to a 32px box with a 16px SVG icon on phones;
-  // desktop contribution sizing is unchanged. It is the app-wide,
+  // the fixed Kandev link and menu button. Ordinary host ui.Button icon
+  // contributions are normalized to a 32px box with a 16px SVG icon on phones.
+  // A rich status control with ordered text may set data-main-top-bar-rich on
+  // its root to opt out; it must own a compact layout with a minimum 44px touch
+  // height and must not add a nested scroller. Desktop contribution sizing is
+  // unchanged. It is the app-wide,
   // task-agnostic counterpart to "chat-top-bar", so it carries no task/session
   // ids.
   // "sidebar-workspace-actions" renders icon buttons after the built-in Quick
@@ -842,7 +845,8 @@ interface PluginRegistry {
   // as `slotProps`. It is owner-scoped: the host renders only the component
   // registered by the plugin currently being viewed, so your card appears on
   // your own settings page and never on another plugin's — no per-id gating
-  // needed in your component.
+  // needed in your component. Signed-in users can see this card; the separate
+  // schema-driven operator form and lifecycle controls remain administrator-only.
   registerComponent(
     slot: string,
     Component: React.ComponentType<{ slotProps?: unknown }>,

--- a/docs/plans/task-manager-host-monitor/plan.md
+++ b/docs/plans/task-manager-host-monitor/plan.md
@@ -1,0 +1,191 @@
+---
+created: 2026-09-05
+status: completed
+requirements:
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-002
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-003
+system_design:
+  - ../../specs/plugins/system-design/task-manager-host-monitor.md
+legacy_specs: []
+---
+
+# Implementation Plan: Task Manager Host Monitor
+
+## Overview
+
+Extend the independently released Task Manager plugin in three sequential
+increments. First add a lightweight, platform-aware summary contract and
+install-wide sampling configuration. Then add versioned personal preferences
+and the configurable top-bar composition. Finally make the browser and package
+checks self-contained, document the behavior, and prove the artifact against a
+disposable Kandev instance. This order keeps each UI state backed by a tested
+runtime contract before it is exposed.
+
+## Scope
+
+### In scope
+
+- Host and Kandev-task CPU sources with relative and backward-compatible
+  per-core presentation.
+- Host memory percentage/GB, disk percentage/threshold, CPU temperature, and
+  one-minute load.
+- Per-user metric enablement, order, unit, threshold, and progress-bar choices.
+- Install-wide ambient refresh interval and disk path.
+- Lightweight ambient polling separated from the expensive detailed task scan.
+- Desktop/mobile, accessibility, synchronization, lifecycle, documentation,
+  and packaged-artifact evidence.
+
+### Out of scope
+
+- Removing or modifying Kandev's built-in resource monitor.
+- A Kandev host/SDK/protocol change.
+- Remote executor metrics, alerts, retained time series, process control, or
+  resource limits.
+- Reordering the plugin contribution relative to other top-bar items.
+- Publishing a release or marketplace update.
+
+## Technical approach
+
+### Plugin backend and manifest
+
+- In `kdlbs/kandev-plugin-task-manager/manifest.yaml`, add the authenticated
+  `summary` webhook, `capabilities.user_state: true`, and required
+  `refresh_interval_seconds`/`disk_path` config fields.
+- Add a small configuration loader around `pluginsdk.Host.GetConfig`. Cache only
+  a successful normalized value; rely on the host's plugin restart after config
+  save to refresh it.
+- Add platform-specific host readers for aggregate CPU counters, physical or
+  cgroup memory capacity, filesystem capacity, CPU temperature, and one-minute
+  load. Keep raw parsing/calculation in common testable helpers and return
+  independent availability per metric.
+- Extend the current sampler with a CPU-only attributed summary that uses the
+  existing stable process keys, attribution cache, baseline rules, and mutex but
+  never calls PSS/RSS aggregation or title APIs.
+- Route `summary` separately from the existing `usage` response. Validate metric
+  IDs and CPU source, omit unrequested collectors, return partial metric errors,
+  and include the effective ambient interval and core count.
+- Implement the collector from operating-system interfaces rather than copying
+  the AGPL Kandev collector into the MIT plugin.
+
+### Personal settings and shared frontend state
+
+- Add a versioned monitor-preference model and deterministic normalization for
+  missing, malformed, duplicate, older, and newly introduced metric entries.
+- Persist the confirmed object with `host.storage` at instance/profile scope.
+  Use conditional writes, cross-client invalidation, a same-tab shared
+  controller, and generation fencing.
+- Register an owner-scoped `plugin-settings` card. Use host UI primitives and
+  the native Save/Discard contributor for enabled state, CPU mode, memory unit,
+  disk threshold, per-metric bars, and ordering.
+- Put a focusable information icon beside the Disk row. Its localized tooltip
+  explains the filesystem-capacity query, absence of file/directory scanning,
+  and that threshold visibility does not suspend sampling.
+- Implement pointer drag with explicit insertion feedback plus keyboard Move up
+  and Move down controls. Keep disabled metrics in the ordered list and keep
+  focus on the moved row.
+- Register translated new UI copy through the plugin translation contract.
+
+### Ambient top-bar monitor
+
+- Replace the fixed CPU-only chip with ordered metric segments derived from the
+  confirmed preference. Preserve one click target for the existing dialog and
+  the current desktop/mobile placement.
+- Use one completion-scheduled timeout rather than overlapping intervals. The
+  first request starts immediately, and later delays use the effective interval
+  returned by the backend.
+- Render CPU source/scale, memory unit, disk threshold, independent bar choices,
+  unavailable/stale detail, and sampled time. Define the missing progress-fill
+  CSS and test its computed width.
+- Do not mount a poller until preferences load; stop it when all metrics are
+  disabled. Keep detailed dialog polling independent and cancel it on unmount.
+
+### Verification and documentation
+
+- Extract pure UI model functions into an importable ES module and cover them
+  with Node tests. Make the existing Playwright harness resolve dependencies
+  from the plugin repository instead of developer-specific absolute paths.
+- Extend the harness host with `host.storage`, settings-save coordination,
+  translations, summary responses, and both top-bar presentations. Exercise
+  pointer/keyboard reorder, Save/Discard, threshold boundaries, CPU modes,
+  units, bars, errors, polling cadence, and containment.
+- Add UI checks to CI alongside existing Go tests and retain five-platform
+  packaging. Update README behavior, settings ownership, cost claims, platform
+  availability, and development commands.
+- Build `package-host`, inspect its entries/checksums, install it into a
+  disposable Kandev instance, and smoke-test settings persistence,
+  disable/re-enable cleanup, the top bar, and the dialog.
+
+## Tests
+
+- `server/hostmetrics_test.go` tests host/task CPU normalization, memory and
+  disk capacity math, requested-family selection, unsupported metrics, bounded
+  errors, invalid config, and cancellation. Platform-specific parser tests use
+  injected fixture files or pure syscall-result conversion helpers.
+- `server/sampler_test.go::TestSummarySkipsProcessMemoryAndTitles` proves the
+  ambient task CPU path never invokes PSS/RSS enrichment or the Task API while
+  retaining stable-key and stale-baseline behavior.
+- `server/plugin_test.go::TestSummaryWebhookReturnsPartialMetrics` and
+  `TestSummaryWebhookRejectsInvalidSelectors` cover the wire boundary and leave
+  the existing `usage` method/response tests unchanged.
+- `ui/monitor-model.test.mjs` covers versioned defaults, upgrade normalization,
+  three CPU modes, memory units, disk threshold equality, metric order,
+  per-metric bars, all-disabled behavior, and stale/unavailable view models.
+- `.harness/shoot.mjs` covers shared Save/Discard coordination, conditional
+  storage writes and conflict recovery, same-tab and cross-client updates,
+  timer rescheduling, cleanup, accessible reordering, disk-help hover/focus and
+  accessible naming, rendering, and dialog activation.
+
+## E2E tests
+
+- `.harness/shoot.mjs` mounts the packaged UI contract at wide, narrow, and
+  mobile widths. It saves personal settings, reorders metrics by pointer and
+  keyboard, reloads from storage, crosses the disk threshold, switches every
+  CPU mode, toggles bars and memory units, and confirms the dialog still opens.
+- `.harness/real-app.mjs` installs or targets the host-platform package in a
+  disposable Kandev instance. It verifies the owner-scoped settings card,
+  administrator config fields, restart recovery, top-bar containment, sampled
+  values, and disable/re-enable cleanup.
+
+## Work orders
+
+- [x] [Task 01: Add ambient summary sampling](task-01-ambient-summary-sampling.md)
+- [x] [Task 02: Build configurable monitor UI](task-02-configurable-monitor-ui.md)
+- [x] [Task 03: Prove the packaged monitor](task-03-packaged-monitor-verification.md)
+
+Dependency order: Task 01, then Task 02, then Task 03. The work orders share
+the manifest, UI bundle, harness, and package contract, so none is
+parallel-safe.
+
+## Verification results
+
+Completed on 2026-09-05. The plugin implementation, deterministic UI model
+tests, portable browser harness, cross-platform builds, and packaged archive
+checks passed in the plugin repository:
+
+- `make fmt`
+- `make vet`
+- `make test` (89 tests)
+- `make test-ui` (8 tests)
+- `make test-harness`
+- `make package`
+- `tar -tzf kandev-plugin-task-manager-0.1.1.tar.gz`
+- Darwin, Windows, and FreeBSD `go test -c` compilation checks
+
+## Risks
+
+- The Kandev monorepo is AGPL-3.0 and the plugin is MIT. Host collector behavior
+  can be used as an oracle, but implementation text must not be copied without
+  an explicit license decision.
+- Task CPU summaries still require a process-table scan and attribution. The
+  CPU-only path removes PSS/title/process-payload cost but is heavier than a
+  whole-host CPU counter read.
+- macOS aggregate host sampling can require cgo/Mach calls, while Windows and
+  macOS do not expose every temperature/load reading used on Linux. Partial
+  availability is a normal result, not an all-or-nothing failure.
+- `main-top-bar` treats one plugin component as opaque. Internal metric ordering
+  belongs to the plugin and does not replace Kandev's separate status-item
+  ordering behavior.
+- Multi-user browsers can still issue concurrent summary requests. The
+  install-wide interval bounds each client, and backend serialization prevents
+  corrupt deltas, but the plugin does not become a global push broadcaster.

--- a/docs/plans/task-manager-host-monitor/plan.md
+++ b/docs/plans/task-manager-host-monitor/plan.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-09-05
-status: completed
+status: in_progress
 requirements:
   - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
   - REQ-PLUGINS-TASK-MANAGER-MONITOR-002
@@ -39,7 +39,9 @@ runtime contract before it is exposed.
 ### Out of scope
 
 - Removing or modifying Kandev's built-in resource monitor.
-- A Kandev host/SDK/protocol change.
+- A new Kandev host API, database, WebSocket protocol, or first-party monitor
+  change. A small compatibility rule in the existing mobile top-bar wrapper is
+  in scope so rich status controls can preserve their required touch target.
 - Remote executor metrics, alerts, retained time series, process control, or
   resource limits.
 - Reordering the plugin contribution relative to other top-bar items.
@@ -151,7 +153,7 @@ runtime contract before it is exposed.
 
 - [x] [Task 01: Add ambient summary sampling](task-01-ambient-summary-sampling.md)
 - [x] [Task 02: Build configurable monitor UI](task-02-configurable-monitor-ui.md)
-- [x] [Task 03: Prove the packaged monitor](task-03-packaged-monitor-verification.md)
+- [ ] [Task 03: Prove the packaged monitor](task-03-packaged-monitor-verification.md)
 
 Dependency order: Task 01, then Task 02, then Task 03. The work orders share
 the manifest, UI bundle, harness, and package contract, so none is
@@ -159,9 +161,9 @@ parallel-safe.
 
 ## Verification results
 
-Completed on 2026-09-05. The plugin implementation, deterministic UI model
-tests, portable browser harness, cross-platform builds, and packaged archive
-checks passed in the plugin repository:
+Local verification completed on 2026-09-05. The plugin implementation,
+deterministic UI model tests, portable browser harness, cross-platform builds,
+and packaged archive checks passed in the plugin repository:
 
 - `make fmt`
 - `make vet`
@@ -171,6 +173,10 @@ checks passed in the plugin repository:
 - `make package`
 - `tar -tzf kandev-plugin-task-manager-0.1.1.tar.gz`
 - Darwin, Windows, and FreeBSD `go test -c` compilation checks
+
+The disposable real-app smoke test remains pending because this workspace has no
+`KANDEV_URL`. Task 03 and this plan stay in progress until that command is run
+against a disposable Kandev instance.
 
 ## Risks
 

--- a/docs/plans/task-manager-host-monitor/task-01-ambient-summary-sampling.md
+++ b/docs/plans/task-manager-host-monitor/task-01-ambient-summary-sampling.md
@@ -1,0 +1,108 @@
+---
+id: "01-ambient-summary-sampling"
+title: "Add ambient summary sampling"
+status: completed
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-003
+acceptance_criteria:
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.1
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.3
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.1
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.3
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.5
+system_design:
+  - ../../specs/plugins/system-design/task-manager-host-monitor.md
+---
+
+# Task 01: Add Ambient Summary Sampling
+
+## Summary
+
+Add the backend contract that the ambient monitor needs: normalized operator
+configuration, platform host readings, attributed CPU-only summaries, and a
+bounded partial-success webhook. Preserve the existing detailed usage response.
+
+## In scope
+
+- Manifest capability, summary webhook, refresh choices, and disk path.
+- Config loading and normalization through the injected Host.
+- Host CPU, memory, disk, temperature, and load collectors across declared
+  platforms.
+- Task CPU per-core and relative calculations without PSS or task-title reads.
+- Request validation, cancellation, serialization, partial errors, and tests.
+
+## Out of scope
+
+- Personal preference storage or UI.
+- Changing the detailed Task Manager dialog.
+- Copying Kandev's AGPL collector source into the MIT plugin.
+
+## Acceptance
+
+- A valid summary request returns only requested resource families, correct raw
+  values, effective interval/core metadata, and independent availability.
+- Relative CPU is clamped to 0%-100%; task per-core CPU retains values above
+  100%; the task summary never calls the expensive memory/title paths.
+- Invalid selectors/config fail safely, while a disk or platform collector
+  error leaves other metrics available and all existing usage tests green.
+
+## Verification
+
+```bash
+rtk go test ./server/...
+rtk go vet ./server/...
+rtk make package
+```
+
+Run from `kdlbs-kandev-plugin-task-manager`.
+
+## Files likely touched
+
+- `kdlbs/kandev-plugin-task-manager/manifest.yaml`
+- `kdlbs/kandev-plugin-task-manager/server/plugin.go`
+- `kdlbs/kandev-plugin-task-manager/server/plugin_test.go`
+- `kdlbs/kandev-plugin-task-manager/server/sampler.go`
+- `kdlbs/kandev-plugin-task-manager/server/sampler_test.go`
+- New `kdlbs/kandev-plugin-task-manager/server/hostmetrics*.go` and focused
+  platform/common tests.
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Cross-platform unit tests run only on their owning operating system; the
+  package build must still compile every manifest target.
+- Back-to-back dialog and summary requests share cumulative task CPU baselines
+  and must remain serialized without manufacturing short-interval spikes.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- Requirement sections `REQ-PLUGINS-TASK-MANAGER-MONITOR-001` and `003`.
+- System-design sections **Existing baseline**, **Operator configuration**,
+  **Summary contract**, **Metric semantics**, and **Collection flow**.
+- Existing `server/sampler_test.go` fake clock/scanner patterns.
+
+## Results
+
+Completed on 2026-09-05. The plugin now exposes the authenticated `summary`
+webhook, validates and caches install-wide configuration, samples host CPU,
+memory, disk, temperature, and load independently, and keeps task CPU
+sampling free of PSS/RSS and title enrichment. Platform readers compile for
+Linux, macOS, Windows, and unsupported targets.
+
+Verification: `go test ./server/...`, `go vet ./server/...`, five-platform
+`make package`, and Darwin/Windows/FreeBSD `go test -c` all passed.

--- a/docs/plans/task-manager-host-monitor/task-02-configurable-monitor-ui.md
+++ b/docs/plans/task-manager-host-monitor/task-02-configurable-monitor-ui.md
@@ -1,0 +1,136 @@
+---
+id: "02-configurable-monitor-ui"
+title: "Build configurable monitor UI"
+status: completed
+wave: 2
+depends_on:
+  - "01-ambient-summary-sampling"
+plan: "plan.md"
+requirements:
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-002
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-003
+acceptance_criteria:
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.1
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.3
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.5
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.1
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.3
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.5
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.6
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.7
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.3
+system_design:
+  - ../../specs/plugins/system-design/task-manager-host-monitor.md
+---
+
+# Task 02: Build Configurable Monitor UI
+
+## Summary
+
+Implement the personal preference model and owner-scoped settings card, then
+drive a responsive, ordered top-bar monitor from the summary contract. Keep one
+shared browser-generation controller so the settings page, top bar, and other
+signed-in clients converge without timer or stale-write leaks.
+
+## In scope
+
+- Versioned defaults, normalization, value derivation, and formatting helpers.
+- `host.storage` load/save/conflict/subscription behavior and shared
+  Save/Discard integration.
+- Metric enablement, CPU mode, memory unit, disk threshold, independent bars,
+  drag order, and keyboard move controls.
+- A keyboard-focusable Disk information icon whose localized tooltip explains
+  filesystem-capacity metadata, the absence of file/directory scanning, and
+  continued sampling while threshold visibility hides the reading.
+- Translation catalogs for all new settings, values, tooltips, errors, and
+  accessible names.
+- Completion-scheduled summary polling, stale/unavailable behavior, progress
+  fill styling, desktop/mobile containment, and dialog activation.
+- Deterministic unit and browser-harness coverage for the above behavior.
+
+## Out of scope
+
+- Schema-driven operator-config persistence, which Task 01 owns.
+- Changes to Kandev host components or built-in monitor state.
+- Changing detailed dialog sorting, task metrics, or process controls.
+
+## Acceptance
+
+- A new user sees the backward-compatible CPU-only layout; saved personal
+  settings round-trip, synchronize, discard, and conflict without cross-user or
+  stale-read overwrites.
+- Pointer and keyboard ordering, all CPU modes, memory units, threshold edges,
+  and per-metric bars render correctly in desktop and mobile top bars.
+- The Disk information tooltip opens on hover and keyboard focus, uses the same
+  explanatory copy in both cases, and exposes an accessible icon name and
+  tooltip relationship.
+- No setting or initial snapshot appears as a false zero; all-disabled state
+  creates no poller; unmount/destroy leaves no timers, requests, subscriptions,
+  modal, or injected style.
+
+## Verification
+
+```bash
+rtk go test ./server/...
+rtk make test-ui
+rtk make test-harness
+```
+
+Run from `kdlbs-kandev-plugin-task-manager`. This work order adds the
+`test-ui` and portable `test-harness` targets before using them.
+
+## Files likely touched
+
+- `kdlbs-kandev-plugin-task-manager/ui/bundle.js`
+- New `kdlbs-kandev-plugin-task-manager/ui/monitor-model.mjs`
+- New `kdlbs-kandev-plugin-task-manager/ui/monitor-model.test.mjs`
+- `kdlbs-kandev-plugin-task-manager/.harness/harness.js`
+- `kdlbs-kandev-plugin-task-manager/.harness/shoot.mjs`
+- `kdlbs-kandev-plugin-task-manager/.harness/index.html`
+- `kdlbs-kandev-plugin-task-manager/Makefile`
+- Optional pinned browser-test package metadata if the harness cannot consume
+  the sibling Kandev Playwright installation portably.
+
+## Dependencies
+
+- Task 01: the stable summary request/response and effective interval.
+
+## Risks
+
+- HTML drag events do not provide complete keyboard or touch support by
+  themselves. Explicit move controls are required even when pointer drag is
+  present.
+- Same-tab storage notifications are intentionally suppressed by the host, so
+  the controller must publish successful local saves directly.
+- The current bundle is a large hand-written module; extraction must preserve
+  relative asset loading in an installed package.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- All requirement acceptance criteria listed in frontmatter.
+- System-design sections **Personal preference model**, **Settings surface**,
+  **Top-bar rendering**, **Synchronization and lifecycle**, and **Failure and
+  recovery**.
+- Kandev's documented `plugin-settings`, `main-top-bar`, `host.storage`, and
+  `host.useSettingsSaveContributor` contracts.
+
+## Results
+
+Completed on 2026-09-05. The plugin now stores normalized per-user metric
+settings, contributes ordered CPU/memory/disk/temperature/load segments, uses
+the shared Save/Discard contract, supports pointer and keyboard ordering, and
+provides localized accessible disk help. Ambient polling is completion
+scheduled, stale-safe, and disabled when no reading is enabled.
+
+Verification: `make test-ui` and `make test-harness` passed, including desktop
+and mobile containment, settings persistence, disk-help focus, threshold
+behavior, and the all-disabled no-poller state.

--- a/docs/plans/task-manager-host-monitor/task-03-packaged-monitor-verification.md
+++ b/docs/plans/task-manager-host-monitor/task-03-packaged-monitor-verification.md
@@ -1,0 +1,118 @@
+---
+id: "03-packaged-monitor-verification"
+title: "Prove the packaged monitor"
+status: completed
+wave: 3
+depends_on:
+  - "01-ambient-summary-sampling"
+  - "02-configurable-monitor-ui"
+plan: "plan.md"
+requirements:
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-002
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-003
+acceptance_criteria:
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-001.5
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.5
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-002.7
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.2
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.3
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.4
+  - AC-PLUGINS-TASK-MANAGER-MONITOR-003.5
+system_design:
+  - ../../specs/plugins/system-design/task-manager-host-monitor.md
+---
+
+# Task 03: Prove the Packaged Monitor
+
+## Summary
+
+Make the complete feature a repeatable repository and artifact gate. Run the
+UI checks in CI, update public plugin documentation, inspect the host-platform
+package, and exercise the installed plugin in a disposable Kandev instance.
+
+## In scope
+
+- CI coverage for pure UI tests and the portable browser harness.
+- README updates for semantics, settings ownership, platform availability,
+  refresh cost, and development commands.
+- Five-platform build and host-platform archive inspection.
+- Disposable Kandev install, config-save restart, personal persistence,
+  top-bar/dialog, failure, and disable/re-enable smoke evidence.
+
+## Out of scope
+
+- Tagging, publishing, changelog release metadata, or marketplace mutation.
+- Removing the built-in monitor.
+- Treating unavailable temperature/load values as packaging failures on
+  platforms that do not expose them.
+
+## Acceptance
+
+- CI runs Go formatting/vet/tests plus deterministic UI and browser checks from
+  a clean checkout with pinned dependencies and no developer-specific paths.
+- The README accurately distinguishes host readings, task readings, personal
+  display settings, administrator sampling settings, and panel-versus-ambient
+  cost.
+- The installed host package preserves settings and cleanup across restart and
+  re-enable, contains every referenced UI asset and generated checksum, and
+  passes the documented desktop/mobile smoke flow.
+
+## Verification
+
+```bash
+rtk make fmt
+rtk make vet
+rtk make test
+rtk make test-ui
+rtk make test-harness
+rtk make package
+rtk tar -tzf kandev-plugin-task-manager-*.tar.gz
+```
+
+Run from `kdlbs-kandev-plugin-task-manager`, followed by the documented
+`.harness/real-app.mjs` command against a disposable Kandev instance.
+
+## Files likely touched
+
+- `kdlbs-kandev-plugin-task-manager/.github/workflows/ci.yml`
+- `kdlbs-kandev-plugin-task-manager/Makefile`
+- `kdlbs-kandev-plugin-task-manager/README.md`
+- `kdlbs-kandev-plugin-task-manager/.harness/real-app.mjs`
+- Pinned UI-test package metadata and lockfile introduced by Task 02.
+
+## Dependencies
+
+- Task 01: complete backend summary and cross-platform build.
+- Task 02: complete settings, rendering, and local harness flows.
+
+## Risks
+
+- A real-app smoke test needs a disposable instance and cannot uninstall from a
+  developer's primary Kandev data directory.
+- Same-version UI assets can be browser-cached during local iteration; the smoke
+  procedure must use a fresh document or a deliberately bumped development
+  version.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- System-design section **Verification strategy**.
+- Existing package/release workflow and `.harness/real-app.mjs` patterns.
+- Canonical Kandev plugin authoring artifact-verification procedure.
+
+## Results
+
+Completed on 2026-09-05. CI now installs pinned harness dependencies and
+Chromium, runs Go/UI/browser verification, and builds the package. The README
+documents host versus task readings, operator versus personal settings, and
+panel versus ambient cost. The package archive contains all five platform
+executables, the manifest, the UI bundle, and generated checksums.
+
+The real-app smoke command remains environment-dependent and must be run with
+`KANDEV_URL` set to a disposable Kandev instance.

--- a/docs/plans/task-manager-host-monitor/task-03-packaged-monitor-verification.md
+++ b/docs/plans/task-manager-host-monitor/task-03-packaged-monitor-verification.md
@@ -1,7 +1,7 @@
 ---
 id: "03-packaged-monitor-verification"
 title: "Prove the packaged monitor"
-status: completed
+status: in_progress
 wave: 3
 depends_on:
   - "01-ambient-summary-sampling"
@@ -108,11 +108,13 @@ Run from `kdlbs-kandev-plugin-task-manager`, followed by the documented
 
 ## Results
 
-Completed on 2026-09-05. CI now installs pinned harness dependencies and
-Chromium, runs Go/UI/browser verification, and builds the package. The README
-documents host versus task readings, operator versus personal settings, and
-panel versus ambient cost. The package archive contains all five platform
-executables, the manifest, the UI bundle, and generated checksums.
+Local verification completed on 2026-09-05. CI now installs pinned harness
+dependencies and Chromium, runs Go/UI/browser verification, and builds the
+package. The README documents host versus task readings, operator versus
+personal settings, and panel versus ambient cost. The package archive contains
+all five platform executables, the manifest, the UI bundle, and generated
+checksums.
 
-The real-app smoke command remains environment-dependent and must be run with
-`KANDEV_URL` set to a disposable Kandev instance.
+The real-app smoke command remains pending and must be run with `KANDEV_URL` set
+to a disposable Kandev instance. This work order remains in progress until that
+smoke result is recorded.

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -322,8 +322,10 @@ slice shapes in a released plugin.
 
 Users configure a plugin's declared shortcuts on that installed plugin's detail
 page at **Settings > Plugins > `<plugin>`**. These overrides are personal to
-the signed-in user. The plugin's schema-driven configuration and lifecycle
-controls remain install-wide and administrator-only.
+the signed-in user. A plugin-owned plugin-settings card on that page is also
+available to signed-in users and should store personal display preferences with
+host.storage. The plugin's schema-driven configuration and lifecycle controls
+remain install-wide and administrator-only.
 
 If a bundle registers a component at its exact plugin detail route, Kandev
 keeps that component and renders the host-owned shortcut card alongside it.
@@ -558,6 +560,11 @@ The `composer` capability provides `insertText`, `focus`, and asynchronous
 operation, otherwise `blocked` or `unavailable`.
 
 ## Backend contract
+
+The generic plugin settings form and backend validator support the manifest
+config_schema subset of required fields, primitive types, enum membership, and
+inclusive numeric minimum/maximum bounds. Use minimum and maximum for numeric
+operator settings that must accept a continuous bounded range.
 
 ### Plugin lifecycle surface
 
@@ -1837,9 +1844,11 @@ Because the bar is not scoped to a task, no task/session ids are provided. Like
 badges or icon buttons. On a phone, `presentation` is `"mobile"`; the
 contribution joins the horizontally scrollable middle strip between the fixed
 Kandev link and menu button. Use `host.ui.Button` for documented icon actions.
-The host normalizes those buttons to a 32px box and their SVG icons to 16px.
-Do not add a second horizontal scroll container. Desktop contributions keep
-their existing sizing.
+The host normalizes those ordinary icon buttons to a 32px box and their SVG
+icons to 16px. A rich status control with ordered text may set
+data-main-top-bar-rich on its root to opt out of that icon normalization; it
+must own a compact layout with a minimum 44px touch height. Do not add a second
+horizontal scroll container. Desktop contributions keep their existing sizing.
 
 ```js
 // inside initialize(registry, host):
@@ -1849,10 +1858,11 @@ registry.registerComponent("main-top-bar", makeAppBarStatus(host));
 ### Plugin settings page
 
 Register a `plugin-settings` component to render your own UI inline on your
-plugin's administration page (**Settings > Plugins > `<plugin>`**), at the top above
-the schema-driven settings form. Use it for package/runtime health or custom controls
-alongside that form. Service credentials, provider health, defaults, and saved watches
-belong in `registerIntegrationSettings(...)`. The host passes:
+plugin's settings page (**Settings > Plugins > `<plugin>`**), at the top above
+the schema-driven settings form. Signed-in users can see this owner-scoped card,
+so use it for personal display preferences or package/runtime health. Service
+credentials, provider health, defaults, and saved watches belong in
+`registerIntegrationSettings(...)`. The host passes:
 
 ```ts
 type PluginSettingsSlotProps = {

--- a/docs/specs/plugins/README.md
+++ b/docs/specs/plugins/README.md
@@ -39,6 +39,7 @@ plugin security boundaries.
 - [Plugin Shortcut Settings](requirements/plugin-shortcut-settings.md)
 - [Plugin System](requirements/plugins.md)
 - [Plugin Repository Task Creation](requirements/repository-provider-task-creation.md)
+- [Task Manager Host Monitor](requirements/task-manager-host-monitor.md)
 - [Voice Plugin Host Prerequisites](requirements/voice-extraction-host.md)
 - [Voice Mode Leaves Core](requirements/voice-extraction.md)
 
@@ -57,6 +58,7 @@ plugin security boundaries.
 - [Plugin System System Design Part 3](system-design/plugins-03.md)
 - [Plugin System System Design Part 4](system-design/plugins-04.md)
 - [Plugin Repository Task Creation](system-design/repository-provider-task-creation.md)
+- [Task Manager Host Monitor](system-design/task-manager-host-monitor.md)
 
 ## Migration record
 

--- a/docs/specs/plugins/requirements/task-manager-host-monitor.md
+++ b/docs/specs/plugins/requirements/task-manager-host-monitor.md
@@ -1,0 +1,158 @@
+---
+status: draft
+system: plugins
+created: 2026-09-05
+owners:
+  - kandev
+---
+
+# Task Manager Host Monitor Requirements
+
+## Overview
+
+The official Task Manager plugin already attributes CPU and memory to live
+Kandev task process trees. Its top-bar contribution shows only task-attributed
+CPU in the `top`/`htop` convention, where 100% is one logical core. Users need
+a configurable ambient host monitor without losing that task breakdown. The
+plugin system owns this contract because the independently released plugin
+owns the measurements, personal display state, and contributed UI; Kandev only
+supplies its existing plugin settings, storage, and top-bar contracts.
+
+## Terminology
+
+- **Host CPU:** CPU consumed across the machine, including processes that are
+  not attributed to Kandev tasks.
+- **Task CPU:** The sum of CPU consumed by processes attributed to Kandev tasks.
+- **Per-core CPU:** The `top`/`htop` scale where one fully occupied logical core
+  is 100% and a multi-core workload can exceed 100%.
+- **Relative CPU:** CPU as a share of total logical CPU capacity, clamped to the
+  inclusive range 0% through 100%.
+- **Ambient monitor:** The compact plugin contribution in the Home, Kanban, and
+  Tasks top bar. The Task Manager dialog remains the detailed task breakdown.
+
+## Requirements
+
+### REQ-PLUGINS-TASK-MANAGER-MONITOR-001: Configurable resource readings
+
+**Intent:** Let a user choose the resource values that answer their monitoring
+question while retaining the existing task-oriented CPU view.
+
+**User story:** As a Kandev user, I want to choose the CPU source and scale and
+add host memory and disk values, so that the top bar shows the resource pressure
+that matters to me.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-001.1:** When CPU is enabled, the user shall
+  be able to select host-relative CPU, task-relative CPU, or task per-core CPU.
+  Both relative modes shall remain between 0% and 100% inclusive, while task
+  per-core CPU may exceed 100% and shall retain the current task attribution
+  semantics.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-001.2:** When memory is enabled, the user
+  shall be able to show host memory used as either a percentage of available
+  host capacity or an absolute value in GB. The detail text shall expose used
+  and total bytes even when the compact value is absolute.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-001.3:** When disk is enabled, the ambient
+  monitor shall show usage for the operator-configured filesystem as a
+  percentage and identify that filesystem in inspectable detail.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-001.4:** The plugin shall also offer the
+  CPU-temperature and one-minute system-load readings available in Kandev's
+  built-in host monitor. A reading unsupported by the current platform shall be
+  shown as unavailable with inspectable error detail and shall not suppress
+  supported readings.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-001.5:** Top-bar display preferences shall
+  not change the Task Manager dialog's per-task and per-process CPU, memory,
+  sorting, filtering, history, or keyboard-shortcut behavior. Activating the
+  ambient monitor shall continue to open that dialog.
+
+### REQ-PLUGINS-TASK-MANAGER-MONITOR-002: Personal top-bar composition
+
+**Intent:** Give each user control over a compact monitor without making one
+user's layout the install-wide default for everyone else.
+
+**User story:** As a Kandev user, I want to choose, arrange, and simplify the
+top-bar readings, so that the monitor fits how I scan resource pressure.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.1:** Each supported reading shall have
+  an independent enabled state. Disabling every reading shall remove the
+  ambient contribution and stop its polling without disabling the plugin or
+  its keyboard shortcut.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.2:** The plugin settings page shall let
+  the user drag enabled and disabled readings into a preferred order. It shall
+  also provide keyboard-operable move controls, preserve focus after a move,
+  and render enabled readings in that order on desktop and mobile.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.3:** CPU, memory, and disk shall each
+  have an independent progress-bar preference. Turning off one bar shall keep
+  that reading's label or icon, formatted value, accessible name, and detail
+  available without changing another reading.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.4:** Disk shall support an optional
+  visibility threshold from 1% through 100%. When threshold visibility is on,
+  an available disk reading below the threshold shall be omitted; a reading at
+  or above the threshold, or an unavailable reading, shall remain visible.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.5:** The Disk settings row shall place
+  a keyboard-focusable information icon beside its label. Its hover and focus
+  tooltip shall explain that the plugin reads capacity metadata for the
+  filesystem containing the configured path, does not scan files or
+  directories, and continues sampling when a visibility threshold hides the
+  top-bar reading.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.6:** Personal display preferences shall
+  participate in Kandev's shared settings Save and Discard flow, survive page
+  reloads and plugin restarts, propagate to another signed-in client for the
+  same user, and remain isolated from other users.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.7:** A user without saved preferences
+  shall get the backward-compatible ambient layout: task per-core CPU enabled
+  first with its progress bar, and every newly added reading disabled. A newer
+  plugin version shall append new known readings without losing an existing
+  user's order.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-002.8:** Before personal settings or the
+  first resource snapshot load, the ambient monitor shall not present a zero as
+  a measured value. A failed settings read shall remain retryable and shall not
+  overwrite stored preferences; after a transient sampling failure, the last
+  successful reading may remain visible with stale or error detail.
+
+### REQ-PLUGINS-TASK-MANAGER-MONITOR-003: Install-wide sampling policy
+
+**Intent:** Let an operator bound background collection cost and choose the
+filesystem once for all users of the Kandev installation.
+
+**User story:** As a Kandev operator, I want one refresh and disk policy, so
+that users cannot create conflicting host collection settings and I can trade
+freshness for lower overhead.
+
+#### Acceptance criteria
+
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-003.1:** Plugin configuration shall offer
+  one install-wide ambient refresh interval from 1 through 300 seconds and one
+  install-wide disk path. Defaults shall be five seconds and `/`, matching the
+  built-in monitor's current collection defaults.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-003.2:** After an administrator saves valid
+  sampling configuration, the active plugin shall restart through the existing
+  plugin lifecycle and subsequent ambient snapshots shall report and use the
+  new interval and disk path without a Kandev restart.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-003.3:** Ambient requests shall collect only
+  enabled resource families and shall not perform proportional-set-size reads
+  or construct the detailed per-process response. Opening the Task Manager
+  dialog may use its existing faster interactive cadence and full task scan;
+  closing it shall release that additional polling.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-003.4:** An invalid or inaccessible disk
+  path, an unsupported platform reading, or one failed collector shall degrade
+  only the affected reading. The endpoint and remaining readings shall stay
+  usable, and errors shall be bounded and safe to display.
+- **AC-PLUGINS-TASK-MANAGER-MONITOR-003.5:** The feature shall use the existing
+  authenticated plugin webhook, `plugin-settings`, `main-top-bar`, and
+  `host.storage` contracts. It shall require no Kandev host API, database,
+  WebSocket protocol, or first-party monitor change.
+
+## Out of scope
+
+- Removing or changing Kandev's built-in resource monitor.
+- Showing execution-environment or remote-host metrics in the Task Manager
+  plugin.
+- Per-user refresh intervals or per-user disk paths.
+- Killing processes, setting resource limits, retaining metric history across
+  reloads, or generating alerts outside the top bar.
+- Reordering the Task Manager contribution relative to other Kandev or plugin
+  top-bar items; the preference orders only readings inside this plugin's
+  contribution.

--- a/docs/specs/plugins/system-design/task-manager-host-monitor.md
+++ b/docs/specs/plugins/system-design/task-manager-host-monitor.md
@@ -84,8 +84,10 @@ system-metrics subsystems until a later removal proposal.
   primitives.
 - The `main-top-bar` component derives the requested metric families from the
   confirmed preference, polls `summary` at the interval returned by the
-  backend, and renders one compact clickable contribution. It never starts a
-  timer when no reading is enabled.
+  backend, and renders one compact clickable contribution. It calls
+  `host.api.fetch("webhooks/summary", ...)`, which the host scopes to this
+  plugin's authenticated webhook route. It never starts a timer when no
+  reading is enabled.
 - The existing modal continues to poll `usage` only while mounted. It is not
   restyled or reinterpreted by ambient display preferences.
 
@@ -101,7 +103,8 @@ config_schema:
       type: integer
       title: Ambient refresh interval
       description: Seconds between Task Manager top-bar updates.
-      enum: [1, 2, 5, 10, 30, 60, 120, 300]
+      minimum: 1
+      maximum: 300
       default: 5
     disk_path:
       type: string
@@ -111,10 +114,12 @@ config_schema:
   required: [refresh_interval_seconds, disk_path]
 ```
 
-The enum keeps the generic schema form and backend validator aligned without a
-new minimum/maximum plugin-contract feature. `disk_path` must be non-empty and
-is never accepted from the summary request. Invalid runtime configuration
-returns a bounded configuration error instead of sampling an arbitrary fallback
+The generic schema form and backend validator enforce the inclusive
+1-to-300-second range through their shared numeric minimum/maximum subset.
+`disk_path` must be non-empty and is never accepted from the summary request.
+An invalid cached refresh interval returns a bounded configuration error. An
+invalid cached disk path makes only the disk metric unavailable; CPU, memory,
+temperature, and load requests continue without sampling an arbitrary fallback
 path. Config is install-wide and administrator-owned; the existing plugin save
 and restart lifecycle applies.
 
@@ -299,7 +304,10 @@ host's generic configuration form.
 The contribution is one button with ordered metric segments and one click target
 that opens Task Manager. Desktop uses a compact height consistent with the
 existing contribution. Mobile uses the host's horizontal action strip and a
-minimum 44 px touch height without adding an inner scroller.
+minimum 44 px touch height without adding an inner scroller. Because this is a
+rich status control rather than an icon action, it marks its root with
+`data-main-top-bar-rich`; the host preserves its dimensions while continuing
+to normalize unmarked icon buttons to 32 px.
 
 The frontend view model derives each bar's capacity percentage: CPU uses the
 summary's `relative_percent`, and memory and disk use their `percent` fields.
@@ -337,8 +345,10 @@ and authoritative storage read.
   a retryable status.
 - A single collector failure produces one unavailable metric and leaves the
   response, schedule, and other readings intact.
-- An invalid summary body returns 400. Invalid cached operator configuration
+- An invalid summary body returns 400. An invalid cached refresh interval
   returns a bounded 500/configuration error until an administrator corrects it.
+  An invalid cached disk path produces an unavailable disk metric while other
+  requested metrics remain usable.
 - A failed personal-settings read disables Save. A failed write keeps the draft
   dirty. A conflict never discards the local draft.
 - Unmount, plugin reload, disable, and uninstall fence late promise callbacks so

--- a/docs/specs/plugins/system-design/task-manager-host-monitor.md
+++ b/docs/specs/plugins/system-design/task-manager-host-monitor.md
@@ -1,0 +1,372 @@
+---
+status: draft
+system: plugins
+requirements:
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-001
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-002
+  - REQ-PLUGINS-TASK-MANAGER-MONITOR-003
+created: 2026-09-05
+owners:
+  - kandev
+---
+
+# Task Manager Host Monitor System Design
+
+## Purpose and boundaries
+
+The official `kdlbs/kandev-plugin-task-manager` repository owns this feature.
+It already ships a Go process sampler, an authenticated `usage` webhook, a
+native UI bundle, a `main-top-bar` contribution, and a Task Manager dialog.
+This design adds a lightweight ambient summary path and personal display
+settings while preserving the detailed task sampler.
+
+Kandev remains a generic host. The design consumes the existing manifest
+`config_schema`, `capabilities.user_state`, `host.storage`,
+`host.useSettingsSaveContributor`, `plugin-settings`, and `main-top-bar`
+contracts. No change to the Kandev monorepo's runtime or public plugin API is
+required. The built-in monitor remains independently owned by the UI and
+system-metrics subsystems until a later removal proposal.
+
+## Requirement mapping
+
+| Requirement | Design sections |
+| --- | --- |
+| `REQ-PLUGINS-TASK-MANAGER-MONITOR-001` | [Summary contract](#summary-contract), [Metric semantics](#metric-semantics), [Top-bar rendering](#top-bar-rendering) |
+| `REQ-PLUGINS-TASK-MANAGER-MONITOR-002` | [Personal preference model](#personal-preference-model), [Settings surface](#settings-surface), [Synchronization and lifecycle](#synchronization-and-lifecycle) |
+| `REQ-PLUGINS-TASK-MANAGER-MONITOR-003` | [Operator configuration](#operator-configuration), [Collection flow](#collection-flow), [Failure and recovery](#failure-and-recovery) |
+
+## Existing baseline
+
+- `server/sampler.go` computes per-process and per-task CPU as a delta of
+  cumulative CPU seconds. One core is 100%, and `snapshot.cpu_cores` exposes
+  the logical-core denominator.
+- `server/sampler.go` refreshes Linux PSS on a five-second TTL. PSS dominates
+  the sampling cost, so the ambient chip must not call the full `usage`
+  webhook.
+- `ui/bundle.js` currently polls `usage` every four seconds for the top-bar
+  chip and every 1.2 seconds while the dialog is open. It sums task CPU for the
+  chip. The `.ktm-fill` element currently has no matching stylesheet rule, so
+  progress-fill behavior needs explicit regression coverage rather than being
+  assumed from the existing track.
+- Kandev's built-in monitor reports whole-host CPU on a 0%-to-100% scale plus
+  host memory, disk, CPU temperature, and one-minute system load. Platform
+  collectors can report an individual metric as unavailable.
+
+## Components and responsibilities
+
+### Plugin backend
+
+- A new host-summary collector reads machine CPU, memory, filesystem, CPU
+  temperature, and one-minute load through platform-specific files. It returns
+  raw values and per-metric availability rather than presentation strings.
+- The existing task sampler gains a CPU-only summary operation. It reuses the
+  existing process identity and cumulative-CPU baseline under the plugin's
+  sampling mutex but skips `memoryBytes`, PSS, title annotation, process
+  serialization, and task history concerns.
+- `taskManagerPlugin.HandleWebhook` keeps `usage` backward compatible and adds
+  the authenticated `summary` key. It validates the bounded summary request,
+  loads cached operator configuration from `Host.GetConfig`, invokes only the
+  requested collectors, and returns partial success.
+- The plugin process caches successfully loaded configuration because a config
+  save restarts an active plugin. A Host-not-ready or transient config read is
+  retryable and never permanently freezes defaults through a one-shot failure.
+
+### Plugin frontend
+
+- A shared preference controller owns the confirmed value, draft value,
+  `updatedAt`, loading/error state, and subscribers for the current browser
+  generation. Top-bar and settings components consume the same controller, so
+  a successful same-tab save updates both even though `host.storage.subscribe`
+  suppresses the writer's own echo.
+- A `plugin-settings` component renders the personal display card and registers
+  one `host.useSettingsSaveContributor`. It uses host-owned Settings/Card,
+  Switch, Checkbox, Select, Input, Button, Tooltip, and accessible label
+  primitives.
+- The `main-top-bar` component derives the requested metric families from the
+  confirmed preference, polls `summary` at the interval returned by the
+  backend, and renders one compact clickable contribution. It never starts a
+  timer when no reading is enabled.
+- The existing modal continues to poll `usage` only while mounted. It is not
+  restyled or reinterpreted by ambient display preferences.
+
+## Operator configuration
+
+`manifest.yaml` adds two required schema properties:
+
+```yaml
+config_schema:
+  type: object
+  properties:
+    refresh_interval_seconds:
+      type: integer
+      title: Ambient refresh interval
+      description: Seconds between Task Manager top-bar updates.
+      enum: [1, 2, 5, 10, 30, 60, 120, 300]
+      default: 5
+    disk_path:
+      type: string
+      title: Disk path
+      description: Filesystem path measured by the disk reading.
+      default: /
+  required: [refresh_interval_seconds, disk_path]
+```
+
+The enum keeps the generic schema form and backend validator aligned without a
+new minimum/maximum plugin-contract feature. `disk_path` must be non-empty and
+is never accepted from the summary request. Invalid runtime configuration
+returns a bounded configuration error instead of sampling an arbitrary fallback
+path. Config is install-wide and administrator-owned; the existing plugin save
+and restart lifecycle applies.
+
+The manifest also declares `capabilities.user_state: true` and a second
+authenticated webhook key, `summary`. No new capability is required for
+operating-system reads because the plugin process already runs as trusted host
+code.
+
+## Personal preference model
+
+The frontend stores one JSON object at
+`("instance", "profile", "topbar-settings-v1")` through `host.storage`:
+
+```ts
+type TopbarSettingsV1 = {
+  version: 1;
+  metrics: Array<
+    | {
+        id: "cpu";
+        enabled: boolean;
+        mode: "host_relative" | "tasks_relative" | "tasks_per_core";
+        show_bar: boolean;
+      }
+    | {
+        id: "memory";
+        enabled: boolean;
+        unit: "percent" | "gb";
+        show_bar: boolean;
+      }
+    | {
+        id: "disk";
+        enabled: boolean;
+        show_bar: boolean;
+        visibility: "always" | "threshold";
+        threshold_percent: number;
+      }
+    | { id: "cpu_temperature"; enabled: boolean }
+    | { id: "system_load"; enabled: boolean }
+  >;
+};
+```
+
+Defaults are CPU first, enabled, `tasks_per_core`, with a bar. Memory, disk,
+temperature, and load follow disabled. Normalization removes duplicate known
+IDs, validates enum values and the disk threshold, preserves the user's known
+order, and appends newly introduced known IDs in default order. An absent,
+malformed, or unsupported version produces defaults in memory; it is not
+written until the user explicitly saves.
+
+Settings writes use `ifUnmodifiedSince`. On a conflict, the controller keeps
+the local draft, refetches the confirmed record and timestamp, and shows a
+retryable conflict rather than silently overwriting another client. Discard
+restores the last confirmed value.
+
+## Summary contract
+
+The UI calls the authenticated `summary` webhook with a small JSON request:
+
+```json
+{
+  "metric_ids": ["cpu", "memory", "disk"],
+  "cpu_source": "tasks"
+}
+```
+
+`metric_ids` is de-duplicated and restricted to `cpu`, `memory`, `disk`,
+`cpu_temperature`, and `system_load`. `cpu_source` is required only when CPU
+is requested and is either `host` or `tasks`. The request has no path, interval,
+unit, threshold, or arbitrary collector input.
+
+The response is presentation-neutral:
+
+```json
+{
+  "sampled_at": "2026-09-05T16:00:00Z",
+  "refresh_interval_seconds": 5,
+  "cpu_cores": 16,
+  "metrics": {
+    "cpu": {
+      "available": true,
+      "source": "tasks",
+      "core_percent": 273.0,
+      "relative_percent": 17.1
+    },
+    "memory": {
+      "available": true,
+      "used_bytes": 11682311045,
+      "total_bytes": 34359738368,
+      "percent": 34.0
+    },
+    "disk": {
+      "available": true,
+      "path": "/",
+      "used_bytes": 450971566080,
+      "total_bytes": 1000204886016,
+      "percent": 45.1
+    }
+  }
+}
+```
+
+Temperature adds `celsius`; system load adds `one_minute`. Every metric object
+has `available` and can carry a bounded `error`. Omitted metric IDs are not
+sampled and do not appear. HTTP 200 with partial metric errors distinguishes a
+collector failure from invalid input, invalid configuration, cancellation, or
+an unavailable plugin runtime.
+
+## Metric semantics
+
+- Host-relative CPU compares aggregate idle and total host CPU counters across
+  a sampling window. The result is clamped to 0%-100%.
+- Task per-core CPU sums the deltas for attributed Kandev processes. Task
+  relative CPU divides that sum by the logical-core count and clamps the result
+  to 0%-100%. A task-scoped summary uses the existing start-key protection,
+  counter regression clamp, identity cache, stale-baseline reset, and serialized
+  sampling window.
+- Host memory uses physical memory used and total. Linux honors a meaningful
+  cgroup limit when the plugin is itself container-constrained; otherwise it
+  uses machine memory. Absolute UI values use 1024-based units and the existing
+  `GB` product label for compatibility.
+- Disk reports the filesystem capacity containing the configured path. It uses
+  capacity available to the current user, matching the built-in monitor's
+  semantics.
+- Temperature and load use the current platform's available system interfaces.
+  Unsupported metrics remain explicit unavailable records.
+
+Platform collectors are implemented from operating-system interfaces and public
+documentation. Kandev's built-in collector is an acceptance oracle, not source
+to transplant: the monorepo is AGPL-3.0 while the plugin is MIT, so copied code
+would blur the plugin's license boundary.
+
+## Collection flow
+
+1. The top-bar component loads confirmed personal preferences. If no metric is
+   enabled, it renders `null` and performs no request.
+2. It immediately requests enabled metric IDs and the selected CPU source. The
+   server loads cached operator config and samples only those families.
+3. Host CPU and task CPU establish a short baseline when none is usable, then
+   take the second reading needed for a rate. Other metrics are instantaneous.
+4. The response supplies the effective refresh interval. The UI schedules one
+   next poll after the current request settles; it does not use overlapping
+   `setInterval` requests.
+5. Opening the dialog mounts its independent detailed `usage` consumer. Closing
+   the dialog cancels its request/timer and leaves only the ambient summary
+   cadence.
+
+One serialized backend sampling boundary protects cumulative CPU baselines.
+Cancellation releases waits. Requests never create an unbounded goroutine for a
+potentially blocking disk call.
+
+## Settings surface
+
+The owner-scoped `plugin-settings` card lists all five readings. Each row has a
+drag handle, enabled control, relevant formatting controls, and explicit Move up
+and Move down actions. Pointer drag uses a visible insertion target and commits
+only to draft state. Keyboard controls keep focus on the moved row. Disabled
+rows remain orderable so re-enabling returns them to their selected position.
+
+The Disk row places a keyboard-focusable information icon beside its label.
+Hovering the icon or focusing it shows the same tooltip: "Reports capacity for
+the filesystem containing the configured path. It reads filesystem metadata;
+it does not scan files or directories. The visibility threshold hides this
+reading from the top bar but does not stop sampling." The icon has the
+accessible name `About disk monitoring`, and the tooltip is associated with it
+for screen readers. This help belongs to the plugin-owned personal settings
+row; the administrator-owned disk-path field retains the manifest description
+rendered by Kandev's generic configuration form.
+
+The card explains that display choices are personal. The schema-driven fields
+below it remain the administrator-owned Sampling section. Personal changes use
+the page's shared Save/Discard bar and do not restart the plugin; install-wide
+schema changes use the existing plugin config contributor and restart behavior.
+
+All new strings in the native UI bundle use `registry.registerTranslations`
+and `host.i18n`. English is the fallback catalog; Portuguese and Kandev's
+Simplified and Traditional Chinese locales ship with the official plugin
+package. The install-wide schema labels remain manifest data rendered by the
+host's generic configuration form.
+
+## Top-bar rendering
+
+The contribution is one button with ordered metric segments and one click target
+that opens Task Manager. Desktop uses a compact height consistent with the
+existing contribution. Mobile uses the host's horizontal action strip and a
+minimum 44 px touch height without adding an inner scroller.
+
+The frontend view model derives each bar's capacity percentage: CPU uses the
+summary's `relative_percent`, and memory and disk use their `percent` fields.
+Widths are clamped independently from displayed values. A task per-core CPU
+value can display above 100% while its bar represents the task share of total
+machine capacity. Memory in GB retains a capacity bar when enabled.
+Temperature and load have no bar control. Every segment has an accessible
+name, a formatted value, and tooltip/detail text that names source, units,
+capacity, sampled time, and any error.
+
+Disk threshold filtering occurs after availability is known. Below-threshold
+disk is omitted without leaving spacing. An unavailable disk remains visible so
+configuration and collector failures are not mistaken for healthy low usage.
+
+## Synchronization and lifecycle
+
+`host.storage.subscribe` listens for the settings key in other tabs/clients and
+refetches it. Incoming changes replace confirmed state but do not erase a dirty
+local draft; the settings card reports that the saved value changed elsewhere.
+The shared controller publishes a successful same-tab save directly.
+
+`initialize` creates one generation-scoped controller and registers translations,
+settings, keybinding, and top-bar contributions. `destroy` aborts requests,
+unsubscribes storage listeners, clears scheduled timeouts, closes any modal
+handle, and removes the injected style. Re-enable starts from a fresh controller
+and authoritative storage read.
+
+## Failure and recovery
+
+- The top bar renders nothing before its first successful settings and summary
+  load, avoiding a false 0% value.
+- A transient summary failure keeps the last successful snapshot, marks its
+  details stale, and retries at the configured cadence. If no snapshot ever
+  succeeds, the compact contribution remains hidden and the settings card shows
+  a retryable status.
+- A single collector failure produces one unavailable metric and leaves the
+  response, schedule, and other readings intact.
+- An invalid summary body returns 400. Invalid cached operator configuration
+  returns a bounded 500/configuration error until an administrator corrects it.
+- A failed personal-settings read disables Save. A failed write keeps the draft
+  dirty. A conflict never discards the local draft.
+- Unmount, plugin reload, disable, and uninstall fence late promise callbacks so
+  they cannot recreate timers or mutate the next plugin generation.
+
+## Security and privacy
+
+- Both webhooks remain authenticated. The summary request is an allowlisted
+  selector and never accepts a filesystem path.
+- Disk path and cadence are administrator-owned config. Personal settings are
+  isolated by Kandev's authenticated `plugin_user_state` rows.
+- Responses contain aggregate machine readings and task-attributed totals, not
+  new process command lines beyond the existing detailed `usage` response.
+- Error strings are bounded and do not include environment blocks, credentials,
+  or arbitrary file contents.
+
+## Verification strategy
+
+Pure calculations, preference normalization, threshold rules, ordering, and
+formatting receive deterministic unit tests. Backend tests inject clocks,
+platform readers, and process tables. The browser harness exercises real React
+mounts, storage synchronization, Save/Discard, pointer and keyboard ordering,
+disk-help hover/focus behavior and accessible naming, poll rescheduling,
+responsive containment, and modal activation. Artifact tests inspect the
+packaged manifest, UI modules, platform executable, and generated checksums
+before a disposable Kandev smoke test.
+
+## Related decisions
+
+- [Resource Metrics Sampling](../../../decisions/0017-resource-metrics-sampling.md)
+- [Host-Provided Per-User Plugin Storage](../../../decisions/2026-08-01-per-user-plugin-storage.md)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3427/b550aac69299.html)
<!-- kandev-pr-walkthrough-end -->

## Summary

- add Kandev host validation for plugin numeric configuration bounds
- expose owner-scoped personal plugin settings independently from admin-only operator controls
- preserve rich status controls in the mobile top bar and document the plugin host contracts
- add requirements, system design, implementation plan, and packaged-monitor verification guidance

This PR contains the Kandev host contracts and runtime integration required by the companion [task-manager plugin PR #3](https://github.com/kdlbs/kandev-plugin-task-manager/pull/3). The host changes in this PR should land with or before the companion plugin implementation.

## Verification

- `go test ./internal/plugins/...`
- `go vet ./...`
- focused web Vitest tests
- web lint, typecheck, and Vite build
- `python3 scripts/lint-spec-files.py --all`

The full backend target also includes unrelated environment-sensitive home-config and launcher tests that require a different HOME/config setup. The disposable real-app smoke test remains pending because no `KANDEV_URL` instance is available.

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3427-bwo7.sprites.app |
| **Commit** | `b550aac` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->