### PR TITLE
perf(web): isolate kanban task update renders

### DIFF
--- a/apps/web/components/kanban-card-menu-items.tsx
+++ b/apps/web/components/kanban-card-menu-items.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
+import { useShallow } from "zustand/react/shallow";
 import {
   IconArchive,
   IconArrowRight,
@@ -45,6 +46,7 @@ import { buildEditMenuEntry } from "./kanban-card-edit-submenu";
 import { buildPrimaryPluginEntries } from "./plugins/task-menu-actions";
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
+import type { WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 
 type ItemEntry = {
   kind: "item";
@@ -485,14 +487,21 @@ export function useKanbanCardMoveTargets(
   steps?: WorkflowStep[],
 ): KanbanCardMoveTargets {
   const workflows = useAppStore((state) => state.workflows.items);
-  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
-
-  const currentWorkflowId = useMemo(() => {
-    for (const [workflowId, snapshot] of Object.entries(snapshots)) {
+  const currentWorkflowId = useAppStore((state) => {
+    for (const [workflowId, snapshot] of Object.entries(state.kanbanMulti.snapshots)) {
       if (snapshot.tasks.some((task) => task.id === taskId)) return workflowId;
     }
     return null;
-  }, [snapshots, taskId]);
+  });
+  const snapshotStepsByWorkflowId = useAppStore(
+    useShallow((state): Record<string, WorkflowSnapshotData["steps"]> => {
+      const result: Record<string, WorkflowSnapshotData["steps"]> = {};
+      for (const [workflowId, snapshot] of Object.entries(state.kanbanMulti.snapshots)) {
+        result[workflowId] = snapshot.steps;
+      }
+      return result;
+    }),
+  );
 
   const workflowItems = useMemo<TaskMoveWorkflow[]>(() => {
     const current = workflows.find((workflow) => workflow.id === currentWorkflowId);
@@ -503,8 +512,8 @@ export function useKanbanCardMoveTargets(
 
   const stepsByWorkflowId = useMemo<Record<string, TaskMoveStep[]>>(() => {
     const result: Record<string, TaskMoveStep[]> = {};
-    for (const [workflowId, snapshot] of Object.entries(snapshots)) {
-      result[workflowId] = snapshot.steps
+    for (const [workflowId, snapshotSteps] of Object.entries(snapshotStepsByWorkflowId)) {
+      result[workflowId] = snapshotSteps
         .slice()
         .sort((a, b) => a.position - b.position)
         .map((step) => ({
@@ -523,7 +532,7 @@ export function useKanbanCardMoveTargets(
       }));
     }
     return result;
-  }, [snapshots, currentWorkflowId, steps]);
+  }, [snapshotStepsByWorkflowId, currentWorkflowId, steps]);
 
   return { currentWorkflowId, workflowItems, stepsByWorkflowId };
 }

--- a/apps/web/components/kanban-card.render-stability.test.tsx
+++ b/apps/web/components/kanban-card.render-stability.test.tsx
@@ -1,0 +1,102 @@
+import { act, cleanup, render } from "@testing-library/react";
+import type { StoreApi } from "zustand";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppState } from "@/lib/state/store";
+
+const shellRenderCounts = vi.hoisted(() => new Map<string, number>());
+
+vi.mock("@/components/kanban-card-content", () => ({
+  KanbanCardShell: ({ task }: { task: { id: string } }) => {
+    shellRenderCounts.set(task.id, (shellRenderCounts.get(task.id) ?? 0) + 1);
+    return <div data-testid={`card-shell-${task.id}`} />;
+  },
+}));
+
+import { KanbanCard } from "./kanban-card";
+import { StateProvider, useAppStoreApi } from "./state-provider";
+import { ToastProvider } from "./toast-provider";
+import { defaultState } from "@/lib/state/default-state";
+import type { KanbanState } from "@/lib/state/slices/kanban/types";
+
+const WORKSPACE_ID = "workspace-1";
+const WORKFLOW_A = "workflow-a";
+const WORKFLOW_B = "workflow-b";
+const STEP_A = { id: "step-a", title: "Todo", color: "bg-blue-500", position: 0 };
+const STEP_B = { id: "step-b", title: "Todo", color: "bg-blue-500", position: 0 };
+const TASK_A: KanbanState["tasks"][number] = {
+  id: "task-a",
+  workflowId: WORKFLOW_A,
+  title: "Task A",
+  workflowStepId: STEP_A.id,
+  position: 0,
+};
+const TASK_B: KanbanState["tasks"][number] = {
+  id: "task-b",
+  workflowId: WORKFLOW_B,
+  title: "Task B",
+  workflowStepId: STEP_B.id,
+  position: 0,
+};
+
+function StoreCapture({ holder }: { holder: { current: StoreApi<AppState> | null } }) {
+  holder.current = useAppStoreApi();
+  return null;
+}
+
+beforeEach(() => shellRenderCounts.clear());
+afterEach(cleanup);
+
+describe("KanbanCard render isolation", () => {
+  it("does not rerender when a task in another workflow updates", () => {
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    render(
+      <ToastProvider>
+        <StateProvider
+          initialState={{
+            workspaces: { ...defaultState.workspaces, activeId: WORKSPACE_ID },
+            workflows: {
+              activeId: null,
+              items: [
+                { id: WORKFLOW_A, workspaceId: WORKSPACE_ID, name: "Workflow A" },
+                { id: WORKFLOW_B, workspaceId: WORKSPACE_ID, name: "Workflow B" },
+              ],
+            },
+            kanbanMulti: {
+              isLoading: false,
+              snapshots: {
+                [WORKFLOW_A]: {
+                  workflowId: WORKFLOW_A,
+                  workflowName: "Workflow A",
+                  steps: [STEP_A],
+                  tasks: [TASK_A],
+                },
+                [WORKFLOW_B]: {
+                  workflowId: WORKFLOW_B,
+                  workflowName: "Workflow B",
+                  steps: [STEP_B],
+                  tasks: [TASK_B],
+                },
+              },
+            },
+          }}
+        >
+          <StoreCapture holder={holder} />
+          <KanbanCard
+            task={TASK_A}
+            workspaceId={WORKSPACE_ID}
+            steps={[STEP_A]}
+            externalLinkAvailability={{ jira: false, linear: false, sentry: false }}
+          />
+        </StateProvider>
+      </ToastProvider>,
+    );
+
+    const store = holder.current;
+    if (!store) throw new Error("Store was not captured");
+    act(() => {
+      store.getState().updateMultiTask(WORKFLOW_B, { ...TASK_B, title: "Updated Task B" });
+    });
+
+    expect(shellRenderCounts.get(TASK_A.id)).toBe(1);
+  });
+});

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { Task, type KanbanPresentation } from "./kanban-card";
 import { Badge } from "@kandev/ui/badge";
@@ -84,7 +84,59 @@ function ColumnHeader({ step, tasks }: { step: WorkflowStep; tasks: Task[] }) {
   );
 }
 
-export function KanbanColumn({
+function taskItemsEqual(previous: Task[], next: Task[]): boolean {
+  return previous.length === next.length && previous.every((task, index) => task === next[index]);
+}
+
+function externalLinkAvailabilityEqual(
+  previous: KanbanExternalLinkAvailability,
+  next: KanbanExternalLinkAvailability,
+): boolean {
+  return (
+    previous.gitlab === next.gitlab &&
+    previous.jira === next.jira &&
+    previous.linear === next.linear &&
+    previous.sentry === next.sentry
+  );
+}
+
+function columnCallbacksEqual(previous: KanbanColumnProps, next: KanbanColumnProps): boolean {
+  return (
+    previous.onPreviewTask === next.onPreviewTask &&
+    previous.onOpenTask === next.onOpenTask &&
+    previous.onEditTask === next.onEditTask &&
+    previous.onDeleteTask === next.onDeleteTask &&
+    previous.onArchiveTask === next.onArchiveTask &&
+    previous.onMoveTask === next.onMoveTask &&
+    previous.onToggleSelect === next.onToggleSelect &&
+    previous.onSelectRange === next.onSelectRange
+  );
+}
+
+function columnDisplayPropsEqual(previous: KanbanColumnProps, next: KanbanColumnProps): boolean {
+  return (
+    previous.presentation === next.presentation &&
+    previous.steps === next.steps &&
+    previous.showMaximizeButton === next.showMaximizeButton &&
+    previous.deletingTaskId === next.deletingTaskId &&
+    previous.archivingTaskId === next.archivingTaskId &&
+    previous.hideHeader === next.hideHeader &&
+    previous.selectedIds === next.selectedIds &&
+    previous.isMultiSelectMode === next.isMultiSelectMode
+  );
+}
+
+function kanbanColumnPropsEqual(previous: KanbanColumnProps, next: KanbanColumnProps): boolean {
+  return (
+    previous.step === next.step &&
+    taskItemsEqual(previous.tasks, next.tasks) &&
+    columnCallbacksEqual(previous, next) &&
+    columnDisplayPropsEqual(previous, next) &&
+    externalLinkAvailabilityEqual(previous.externalLinkAvailability, next.externalLinkAvailability)
+  );
+}
+
+export const KanbanColumn = memo(function KanbanColumn({
   step,
   tasks,
   presentation = "desktop",
@@ -161,4 +213,4 @@ export function KanbanColumn({
       />
     </div>
   );
-}
+}, kanbanColumnPropsEqual);

--- a/apps/web/components/kanban/swimlane-container.render-stability.test.tsx
+++ b/apps/web/components/kanban/swimlane-container.render-stability.test.tsx
@@ -1,0 +1,234 @@
+import { act, cleanup, render } from "@testing-library/react";
+import type { StoreApi } from "zustand";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppState } from "@/lib/state/store";
+
+const renderCounts = vi.hoisted(() => ({
+  lanes: new Map<string, number>(),
+  cards: new Map<string, number>(),
+  stepLists: new Map<string, Array<{ steps: unknown; moveTargetSteps: unknown }>>(),
+}));
+const stableCallbacks = vi.hoisted(() => ({
+  isCollapsed: () => false,
+  toggleCollapse: vi.fn(),
+  onToggleStepVisibility: vi.fn(),
+  onToggleAutoHideEmpty: vi.fn(),
+  onWorkflowChange: vi.fn(),
+}));
+const responsive = vi.hoisted(() => ({ isMobile: false, isTablet: false }));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => responsive,
+}));
+
+vi.mock("@/hooks/use-kanban-display-settings", () => ({
+  useKanbanDisplaySettings: () => ({
+    onToggleStepVisibility: stableCallbacks.onToggleStepVisibility,
+    onToggleAutoHideEmpty: stableCallbacks.onToggleAutoHideEmpty,
+  }),
+}));
+
+vi.mock("@/hooks/domains/kanban/use-swimlane-collapse", () => ({
+  useSwimlaneCollapse: () => ({
+    isCollapsed: stableCallbacks.isCollapsed,
+    toggleCollapse: stableCallbacks.toggleCollapse,
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({ reorderWorkflows: vi.fn() }));
+
+vi.mock("@/lib/kanban/view-registry", () => {
+  const CountedView = ({
+    workflowId,
+    steps,
+    moveTargetSteps,
+    tasks,
+  }: {
+    workflowId: string;
+    steps: unknown;
+    moveTargetSteps: unknown;
+    tasks: Array<{ id: string }>;
+  }) => {
+    renderCounts.lanes.set(workflowId, (renderCounts.lanes.get(workflowId) ?? 0) + 1);
+    const stepLists = renderCounts.stepLists.get(workflowId) ?? [];
+    stepLists.push({ steps, moveTargetSteps });
+    renderCounts.stepLists.set(workflowId, stepLists);
+    for (const task of tasks) {
+      renderCounts.cards.set(task.id, (renderCounts.cards.get(task.id) ?? 0) + 1);
+    }
+    return <div data-testid={`workflow-${workflowId}`} />;
+  };
+  const view = {
+    id: "kanban",
+    component: CountedView,
+  };
+  return { getEffectiveView: () => view };
+});
+
+import { StateProvider, useAppStoreApi } from "@/components/state-provider";
+import { defaultState } from "@/lib/state/default-state";
+import { SwimlaneContainer } from "./swimlane-container";
+
+const WORKSPACE_ID = "workspace-1";
+const WORKFLOW_A = "workflow-a";
+const WORKFLOW_B = "workflow-b";
+const STORE_CAPTURE_ERROR = "Store was not captured";
+const UPDATED_TASK_TITLE = "Updated task";
+
+function task(id: string, workflowId: string, workflowStepId: string) {
+  return {
+    id,
+    workflowId,
+    workflowStepId,
+    title: id,
+    position: 0,
+  };
+}
+
+function snapshot(workflowId: string, taskId: string) {
+  return {
+    workflowId,
+    workflowName: workflowId,
+    steps: [{ id: `${workflowId}-step`, title: "Todo", color: "bg-blue-500", position: 0 }],
+    tasks: [task(taskId, workflowId, `${workflowId}-step`)],
+  };
+}
+
+function StoreCapture({ holder }: { holder: { current: StoreApi<AppState> | null } }) {
+  holder.current = useAppStoreApi();
+  return null;
+}
+
+function renderSwimlanes(
+  holder: { current: StoreApi<AppState> | null },
+  matchesPluginTaskFilters?: (taskId: string) => boolean,
+) {
+  return render(
+    <StateProvider
+      initialState={{
+        workspaces: { ...defaultState.workspaces, activeId: WORKSPACE_ID },
+        workflows: {
+          activeId: null,
+          items: [
+            { id: WORKFLOW_A, workspaceId: WORKSPACE_ID, name: "Workflow A" },
+            { id: WORKFLOW_B, workspaceId: WORKSPACE_ID, name: "Workflow B" },
+          ],
+        },
+        kanbanMulti: {
+          isLoading: false,
+          snapshots: {
+            [WORKFLOW_A]: snapshot(WORKFLOW_A, "task-a"),
+            [WORKFLOW_B]: snapshot(WORKFLOW_B, "task-b"),
+          },
+        },
+        repositories: { ...defaultState.repositories, itemsByWorkspaceId: {} },
+        userSettings: {
+          ...defaultState.userSettings,
+          hiddenWorkflowStepIds: {},
+          workflowIdsWithAutoHideEmptySteps: [],
+        },
+      }}
+    >
+      <StoreCapture holder={holder} />
+      <SwimlaneContainer
+        viewMode="graph2"
+        workflowFilter={null}
+        onPreviewTask={vi.fn()}
+        onOpenTask={vi.fn()}
+        onEditTask={vi.fn()}
+        onDeleteTask={vi.fn()}
+        onWorkflowChange={stableCallbacks.onWorkflowChange}
+        matchesPluginTaskFilters={matchesPluginTaskFilters}
+      />
+    </StateProvider>,
+  );
+}
+
+beforeEach(() => {
+  renderCounts.lanes.clear();
+  renderCounts.cards.clear();
+  renderCounts.stepLists.clear();
+  responsive.isMobile = false;
+  responsive.isTablet = false;
+});
+
+afterEach(cleanup);
+
+describe("SwimlaneContainer render isolation", () => {
+  it("does not rerender an unaffected workflow lane or card after another workflow task updates", () => {
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    renderSwimlanes(holder);
+
+    const store = holder.current;
+    if (!store) throw new Error(STORE_CAPTURE_ERROR);
+    const currentTask = store.getState().kanbanMulti.snapshots[WORKFLOW_A].tasks[0];
+
+    act(() => {
+      store.getState().updateMultiTask(WORKFLOW_A, { ...currentTask, title: UPDATED_TASK_TITLE });
+    });
+
+    expect({
+      affectedLane: renderCounts.lanes.get(WORKFLOW_A),
+      affectedCard: renderCounts.cards.get("task-a"),
+      unaffectedLane: renderCounts.lanes.get(WORKFLOW_B),
+      unaffectedCard: renderCounts.cards.get("task-b"),
+    }).toEqual({ affectedLane: 2, affectedCard: 2, unaffectedLane: 1, unaffectedCard: 1 });
+  });
+
+  it("does not rerender the focused mobile workflow when another workflow task updates", () => {
+    responsive.isMobile = true;
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    renderSwimlanes(holder);
+
+    const store = holder.current;
+    if (!store) throw new Error(STORE_CAPTURE_ERROR);
+    const currentTask = store.getState().kanbanMulti.snapshots[WORKFLOW_B].tasks[0];
+
+    act(() => {
+      store.getState().updateMultiTask(WORKFLOW_B, { ...currentTask, title: UPDATED_TASK_TITLE });
+    });
+
+    expect({
+      focusedLane: renderCounts.lanes.get(WORKFLOW_A),
+      focusedCard: renderCounts.cards.get("task-a"),
+    }).toEqual({ focusedLane: 1, focusedCard: 1 });
+  });
+
+  it("does not recompute another workflow's task projection", () => {
+    const matchesPluginTaskFilters = vi.fn((taskId: string) => taskId.length > 0);
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    renderSwimlanes(holder, matchesPluginTaskFilters);
+
+    const unaffectedCallsBefore = matchesPluginTaskFilters.mock.calls.filter(
+      ([taskId]) => taskId === "task-b",
+    ).length;
+    const store = holder.current;
+    if (!store) throw new Error(STORE_CAPTURE_ERROR);
+    const currentTask = store.getState().kanbanMulti.snapshots[WORKFLOW_A].tasks[0];
+
+    act(() => {
+      store.getState().updateMultiTask(WORKFLOW_A, { ...currentTask, title: UPDATED_TASK_TITLE });
+    });
+
+    expect(
+      matchesPluginTaskFilters.mock.calls.filter(([taskId]) => taskId === "task-b").length,
+    ).toBe(unaffectedCallsBefore);
+  });
+
+  it("preserves step-list identities for a task-only update", () => {
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    renderSwimlanes(holder);
+
+    const store = holder.current;
+    if (!store) throw new Error(STORE_CAPTURE_ERROR);
+    const currentTask = store.getState().kanbanMulti.snapshots[WORKFLOW_A].tasks[0];
+
+    act(() => {
+      store.getState().updateMultiTask(WORKFLOW_A, { ...currentTask, title: UPDATED_TASK_TITLE });
+    });
+
+    const [initial, updated] = renderCounts.stepLists.get(WORKFLOW_A) ?? [];
+    expect(updated?.steps).toBe(initial?.steps);
+    expect(updated?.moveTargetSteps).toBe(initial?.moveTargetSteps);
+  });
+});

--- a/apps/web/components/kanban/swimlane-container.render-stability.test.tsx
+++ b/apps/web/components/kanban/swimlane-container.render-stability.test.tsx
@@ -231,4 +231,39 @@ describe("SwimlaneContainer render isolation", () => {
     expect(updated?.steps).toBe(initial?.steps);
     expect(updated?.moveTargetSteps).toBe(initial?.moveTargetSteps);
   });
+
+  it("evicts a cached projection when its workflow leaves the snapshot map", () => {
+    const matchesPluginTaskFilters = vi.fn((taskId: string) => taskId.length > 0);
+    const holder: { current: StoreApi<AppState> | null } = { current: null };
+    renderSwimlanes(holder, matchesPluginTaskFilters);
+
+    const store = holder.current;
+    if (!store) throw new Error(STORE_CAPTURE_ERROR);
+    const snapshotB = store.getState().kanbanMulti.snapshots[WORKFLOW_B];
+    const callsBeforeRemoval = matchesPluginTaskFilters.mock.calls.filter(
+      ([taskId]) => taskId === "task-b",
+    ).length;
+
+    act(() => {
+      store.setState((state) => ({
+        kanbanMulti: {
+          ...state.kanbanMulti,
+          snapshots: { [WORKFLOW_A]: state.kanbanMulti.snapshots[WORKFLOW_A] },
+        },
+      }));
+    });
+    act(() => {
+      store.setState((state) => ({
+        kanbanMulti: {
+          ...state.kanbanMulti,
+          snapshots: { ...state.kanbanMulti.snapshots, [WORKFLOW_B]: snapshotB },
+        },
+      }));
+    });
+
+    const callsAfterRestore = matchesPluginTaskFilters.mock.calls.filter(
+      ([taskId]) => taskId === "task-b",
+    ).length;
+    expect(callsAfterRestore - callsBeforeRemoval).toBe(4);
+  });
 });

--- a/apps/web/components/kanban/swimlane-container.tsx
+++ b/apps/web/components/kanban/swimlane-container.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ComponentType, type HTMLAttributes, useCallback, useEffect, useMemo } from "react";
+import {
+  memo,
+  type ComponentType,
+  type HTMLAttributes,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
 import {
   DndContext,
   closestCenter,
@@ -19,13 +26,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "@/components/state-provider";
 import { useSwimlaneCollapse } from "@/hooks/domains/kanban/use-swimlane-collapse";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
-import { mapSelectedRepositoryIds } from "@/lib/kanban/filters";
-import { projectWorkflowTasks } from "@/lib/kanban/task-projections";
-import {
-  selectMobileNavigatorWorkflows,
-  selectWorkflowSwimlanes,
-  selectVisibleWorkflows,
-} from "@/lib/kanban/workflow-swimlanes";
+import { selectVisibleWorkflows } from "@/lib/kanban/workflow-swimlanes";
 import { reorderWorkflows } from "@/lib/api";
 import { SwimlaneSection } from "./swimlane-section";
 import { ColumnsMenu } from "./columns-menu";
@@ -39,9 +40,14 @@ import {
 } from "@/lib/kanban/view-registry";
 import type { Task } from "@/components/kanban-card";
 import type { MoveTaskError } from "@/hooks/use-drag-and-drop";
-import type { Repository } from "@/lib/types/http";
 import type { WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 import { t } from "@/lib/i18n";
+import {
+  useStableStringSet,
+  useStableWorkflowList,
+  useSwimlaneRenderData,
+  useWorkflowSwimlaneData,
+} from "@/hooks/domains/kanban/use-swimlane-render-data";
 
 export type SwimlaneContainerProps = {
   viewMode: string;
@@ -98,19 +104,20 @@ function renderEmptyState(emptyMessage: string) {
   );
 }
 
-/** Stable identity so an unhidden workflow does not remount its menu each render. */
-const EMPTY_HIDDEN_IDS: string[] = [];
+const EMPTY_SELECTED_REPOSITORY_IDS: string[] = [];
+const EMPTY_WORKFLOW_STEPS: WorkflowSnapshotData["steps"] = [];
+const WORKFLOW_POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 8 } };
 
 type WorkflowItemProps = {
   wf: { id: string; name: string };
-  snapshot: WorkflowSnapshotData;
-  tasks: Task[];
-  occupancyTasks: Task[];
+  repoFilter: Set<string>;
+  searchQuery: string;
+  matchesPluginTaskFilters?: (taskId: string) => boolean;
   ViewComponent: ComponentType<ViewContentProps>;
   hideHeader: boolean;
   isSortable: boolean;
   isCollapsed: boolean;
-  onToggleCollapse: () => void;
+  toggleCollapse: (workflowId: string) => void;
   onPreviewTask: (task: Task) => void;
   onOpenTask: (task: Task) => void;
   onEditTask: (task: Task) => void;
@@ -131,11 +138,12 @@ type WorkflowItemProps = {
   onToggleAutoHideEmpty: (workflowId: string) => void;
 };
 
-function SortableWorkflowItem({
+const SortableWorkflowItem = memo(function SortableWorkflowItem({
   wf,
   hideHeader,
   isSortable,
   fillHeight,
+  toggleCollapse,
   ...rest
 }: WorkflowItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -147,7 +155,11 @@ function SortableWorkflowItem({
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
-  const dragHandleProps = isSortable && !hideHeader ? { ...attributes, ...listeners } : undefined;
+  const dragHandleProps = useMemo(
+    () => (isSortable && !hideHeader ? { ...attributes, ...listeners } : undefined),
+    [attributes, hideHeader, isSortable, listeners],
+  );
+  const onToggleCollapse = useCallback(() => toggleCollapse(wf.id), [toggleCollapse, wf.id]);
   return (
     <div
       ref={setNodeRef}
@@ -159,17 +171,23 @@ function SortableWorkflowItem({
         hideHeader={hideHeader}
         fillHeight={fillHeight}
         dragHandleProps={dragHandleProps}
+        onToggleCollapse={onToggleCollapse}
         {...rest}
       />
     </div>
   );
-}
+});
 
-function WorkflowItemContent({
+type WorkflowItemContentProps = Omit<WorkflowItemProps, "isSortable" | "toggleCollapse"> & {
+  dragHandleProps?: HTMLAttributes<HTMLDivElement>;
+  onToggleCollapse: () => void;
+};
+
+const WorkflowItemContent = memo(function WorkflowItemContent({
   wf,
-  snapshot,
-  tasks,
-  occupancyTasks,
+  repoFilter,
+  searchQuery,
+  matchesPluginTaskFilters,
   ViewComponent,
   hideHeader,
   isCollapsed,
@@ -180,36 +198,18 @@ function WorkflowItemContent({
   onToggleStepVisibility,
   onToggleAutoHideEmpty,
   ...viewProps
-}: Omit<WorkflowItemProps, "isSortable"> & { dragHandleProps?: HTMLAttributes<HTMLDivElement> }) {
-  const hiddenWorkflowStepIds = useAppStore((state) => state.userSettings.hiddenWorkflowStepIds);
-  const workflowIdsWithAutoHideEmptySteps = useAppStore(
-    (state) => state.userSettings.workflowIdsWithAutoHideEmptySteps,
+}: WorkflowItemContentProps) {
+  const { snapshot, tasks, occupancyTasks, hiddenStepIds, hiddenSet, autoHideEmpty } =
+    useWorkflowSwimlaneData(wf.id, repoFilter, searchQuery, matchesPluginTaskFilters);
+  const snapshotSteps = snapshot?.steps ?? EMPTY_WORKFLOW_STEPS;
+  const derivedAutoHiddenSet = useMemo(
+    () => deriveAutoHiddenStepIds(snapshotSteps, occupancyTasks, autoHideEmpty, hiddenStepIds),
+    [autoHideEmpty, hiddenStepIds, occupancyTasks, snapshotSteps],
   );
-  const hiddenSet = useMemo(() => {
-    const ids = hiddenWorkflowStepIds[wf.id];
-    if (!ids || ids.length === 0) return new Set<string>();
-    const liveStepIds = new Set(snapshot.steps.map((s) => s.id));
-    return new Set(ids.filter((id) => liveStepIds.has(id)));
-  }, [hiddenWorkflowStepIds, wf.id, snapshot.steps]);
-  const autoHiddenSet = useMemo(
-    () =>
-      deriveAutoHiddenStepIds(
-        snapshot.steps,
-        occupancyTasks,
-        workflowIdsWithAutoHideEmptySteps.includes(wf.id),
-        hiddenWorkflowStepIds[wf.id] ?? EMPTY_HIDDEN_IDS,
-      ),
-    [
-      snapshot.steps,
-      occupancyTasks,
-      workflowIdsWithAutoHideEmptySteps,
-      wf.id,
-      hiddenWorkflowStepIds,
-    ],
-  );
+  const autoHiddenSet = useStableStringSet(derivedAutoHiddenSet);
   const moveTargetSteps = useMemo(
-    () => sortWorkflowStepsByPosition(snapshot.steps).filter((step) => !hiddenSet.has(step.id)),
-    [snapshot.steps, hiddenSet],
+    () => sortWorkflowStepsByPosition(snapshotSteps).filter((step) => !hiddenSet.has(step.id)),
+    [hiddenSet, snapshotSteps],
   );
   const steps = useMemo(
     () => moveTargetSteps.filter((step) => !autoHiddenSet.has(step.id)),
@@ -224,6 +224,8 @@ function WorkflowItemContent({
       {...viewProps}
     />
   );
+
+  if (!snapshot) return null;
 
   if (hideHeader) {
     return <div className={fillHeight ? "h-full min-h-0" : undefined}>{content}</div>;
@@ -244,10 +246,10 @@ function WorkflowItemContent({
         <ColumnsMenu
           workflowId={wf.id}
           workflowName={wf.name}
-          steps={snapshot.steps}
-          hiddenStepIds={hiddenWorkflowStepIds[wf.id] ?? EMPTY_HIDDEN_IDS}
+          steps={snapshotSteps}
+          hiddenStepIds={hiddenStepIds}
           onToggle={onToggleStepVisibility}
-          autoHideEmpty={workflowIdsWithAutoHideEmptySteps.includes(wf.id)}
+          autoHideEmpty={autoHideEmpty}
           onToggleAutoHide={onToggleAutoHideEmpty}
         />
       }
@@ -255,7 +257,7 @@ function WorkflowItemContent({
       {content}
     </SwimlaneSection>
   );
-}
+});
 
 function useWorkflowReorder(
   orderedWorkflows: { id: string; name: string }[],
@@ -264,7 +266,7 @@ function useWorkflowReorder(
   const reorderWorkflowItems = useAppStore((state) => state.reorderWorkflowItems);
   const workflows = useAppStore((state) => state.workflows.items);
   const workspaceId = workflows[0]?.workspaceId;
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const sensors = useSensors(useSensor(PointerSensor, WORKFLOW_POINTER_SENSOR_OPTIONS));
   const canSort = !workflowFilter && orderedWorkflows.length > 1;
 
   const handleDragEnd = useCallback(
@@ -287,103 +289,6 @@ function useWorkflowReorder(
   );
 
   return { sensors, canSort, handleDragEnd };
-}
-
-function useSwimlaneData(
-  workflowFilter: string | null | undefined,
-  selectedRepositoryIds: string[],
-  searchQuery: string,
-  matchesPluginTaskFilters?: (taskId: string) => boolean,
-) {
-  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
-  const isLoading = useAppStore((state) => state.kanbanMulti.isLoading);
-  const workflows = useAppStore((state) => state.workflows.items);
-  const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
-  const hiddenWorkflowStepIds = useAppStore((state) => state.userSettings.hiddenWorkflowStepIds);
-  const workflowIdsWithAutoHideEmptySteps = useAppStore(
-    (state) => state.userSettings.workflowIdsWithAutoHideEmptySteps,
-  );
-
-  const repositories = useMemo(
-    () => Object.values(repositoriesByWorkspace).flat() as Repository[],
-    [repositoriesByWorkspace],
-  );
-  const repoFilter = useMemo(
-    () => mapSelectedRepositoryIds(repositories, selectedRepositoryIds),
-    [repositories, selectedRepositoryIds],
-  );
-  const allOrderedWorkflows = useMemo(
-    () => selectWorkflowSwimlanes(null, workflows, snapshots),
-    [workflows, snapshots],
-  );
-  const orderedWorkflows = useMemo(
-    () => selectWorkflowSwimlanes(workflowFilter, workflows, snapshots),
-    [workflowFilter, workflows, snapshots],
-  );
-
-  const getTaskProjection = useMemo(() => {
-    const cache = new Map<string, ReturnType<typeof projectWorkflowTasks>>();
-    return (wfId: string) => {
-      const cached = cache.get(wfId);
-      if (cached) return cached;
-      const hidden = hiddenWorkflowStepIds[wfId];
-      const hiddenSet = hidden && hidden.length > 0 ? new Set(hidden) : undefined;
-      const projection = projectWorkflowTasks(snapshots, wfId, repoFilter, {
-        searchQuery,
-        matchesPluginTaskFilters,
-        hiddenStepIds: hiddenSet,
-      });
-      cache.set(wfId, projection);
-      return projection;
-    };
-  }, [snapshots, repoFilter, searchQuery, matchesPluginTaskFilters, hiddenWorkflowStepIds]);
-  const getFilteredTasks = useCallback(
-    (wfId: string) => getTaskProjection(wfId).visibleTasks,
-    [getTaskProjection],
-  );
-  const getOccupancyTasks = useCallback(
-    (wfId: string) => getTaskProjection(wfId).occupancyTasks,
-    [getTaskProjection],
-  );
-
-  const hasLiveHiddenSteps = useCallback(
-    (workflowId: string) => {
-      const hidden = hiddenWorkflowStepIds[workflowId];
-      if (workflowIdsWithAutoHideEmptySteps.includes(workflowId)) return true;
-      if (!hidden || hidden.length === 0) return false;
-      const liveStepIds = new Set((snapshots[workflowId]?.steps ?? []).map((step) => step.id));
-      return hidden.some((id) => liveStepIds.has(id));
-    },
-    [hiddenWorkflowStepIds, workflowIdsWithAutoHideEmptySteps, snapshots],
-  );
-
-  // The mobile board navigator is the only workflow switcher on the mobile
-  // kanban page (the display menu hides its workflow select there), so hidden
-  // workflows with tasks or live hidden columns are included alongside the
-  // visible ones. The selector returns the filtered tasks with each entry so
-  // `getFilteredTasks` runs once per workflow and the task count reuses that
-  // result.
-  const workflowOptions = useMemo(
-    () =>
-      selectMobileNavigatorWorkflows(
-        allOrderedWorkflows,
-        workflows,
-        getFilteredTasks,
-        hasLiveHiddenSteps,
-      ).map(({ workflow, tasks }) => ({ ...workflow, taskCount: tasks.length })),
-    [allOrderedWorkflows, workflows, getFilteredTasks, hasLiveHiddenSteps],
-  );
-
-  return {
-    snapshots,
-    isLoading,
-    orderedWorkflows,
-    allOrderedWorkflows,
-    workflowOptions,
-    getFilteredTasks,
-    getOccupancyTasks,
-    hasLiveHiddenSteps,
-  };
 }
 
 function getRenderedWorkflows(
@@ -412,9 +317,9 @@ function shouldHideHeaders(
 
 type WorkflowItemsProps = {
   workflows: { id: string; name: string }[];
-  snapshots: Record<string, WorkflowSnapshotData>;
-  getFilteredTasks: (workflowId: string) => Task[];
-  getOccupancyTasks: (workflowId: string) => Task[];
+  repoFilter: Set<string>;
+  searchQuery: string;
+  matchesPluginTaskFilters?: (taskId: string) => boolean;
   ViewComponent: ComponentType<ViewContentProps>;
   hideHeaders: boolean;
   fillHeight: boolean;
@@ -430,9 +335,9 @@ type WorkflowItemsProps = {
 
 function WorkflowItems({
   workflows,
-  snapshots,
-  getFilteredTasks,
-  getOccupancyTasks,
+  repoFilter,
+  searchQuery,
+  matchesPluginTaskFilters,
   ViewComponent,
   hideHeaders,
   fillHeight,
@@ -446,22 +351,20 @@ function WorkflowItems({
   mobileWorkflowNavigation,
 }: WorkflowItemsProps) {
   return workflows.map((workflow, index) => {
-    const snapshot = snapshots[workflow.id];
-    if (!snapshot) return null;
     const collapsed = isCollapsed(workflow.id);
     return (
       <SortableWorkflowItem
         key={isMobileKanban ? "mobile-active-workflow" : workflow.id}
         wf={workflow}
-        snapshot={snapshot}
-        tasks={getFilteredTasks(workflow.id)}
-        occupancyTasks={getOccupancyTasks(workflow.id)}
+        repoFilter={repoFilter}
+        searchQuery={searchQuery}
+        matchesPluginTaskFilters={matchesPluginTaskFilters}
         ViewComponent={ViewComponent}
         hideHeader={hideHeaders}
         fillHeight={fillHeight && !collapsed}
         isSortable={canSortWorkflows && !isMobileKanban}
         isCollapsed={collapsed}
-        onToggleCollapse={() => toggleCollapse(workflow.id)}
+        toggleCollapse={toggleCollapse}
         onPreviewTask={containerProps.onPreviewTask}
         onOpenTask={containerProps.onOpenTask}
         onEditTask={containerProps.onEditTask}
@@ -498,8 +401,28 @@ function usePublishMobileFocus(focusedWorkflowId: string | null) {
   }, [focusedWorkflowId, setMobileKanbanFocusedWorkflow]);
 }
 
+function useMobileWorkflowNavigation(
+  isMobileKanban: boolean,
+  focusedWorkflowId: string | null,
+  workflowOptions: MobileWorkflowNavigation["workflows"],
+  onWorkflowChange: SwimlaneContainerProps["onWorkflowChange"],
+) {
+  return useMemo(
+    () =>
+      isMobileKanban && focusedWorkflowId && onWorkflowChange
+        ? { activeWorkflowId: focusedWorkflowId, workflows: workflowOptions, onWorkflowChange }
+        : undefined,
+    [focusedWorkflowId, isMobileKanban, onWorkflowChange, workflowOptions],
+  );
+}
+
 export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
-  const { viewMode, workflowFilter, searchQuery, selectedRepositoryIds = [] } = containerProps;
+  const {
+    viewMode,
+    workflowFilter,
+    searchQuery,
+    selectedRepositoryIds = EMPTY_SELECTED_REPOSITORY_IDS,
+  } = containerProps;
   const { isMobile } = useResponsiveBreakpoint();
   const { onToggleStepVisibility, onToggleAutoHideEmpty } = useKanbanDisplaySettings();
   const { isCollapsed, toggleCollapse } = useSwimlaneCollapse();
@@ -509,9 +432,9 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
     orderedWorkflows,
     workflowOptions,
     getFilteredTasks,
-    getOccupancyTasks,
     hasLiveHiddenSteps,
-  } = useSwimlaneData(
+    repoFilter,
+  } = useSwimlaneRenderData(
     workflowFilter,
     selectedRepositoryIds,
     searchQuery ?? "",
@@ -525,28 +448,30 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
 
   const view = getEffectiveView(viewMode, isMobile);
   const isMobileKanban = isMobile && view.id === "kanban";
-  const visibleWorkflows = selectVisibleWorkflows({
-    workflowFilter,
-    orderedWorkflows,
-    hasTasks: (workflowId) => getFilteredTasks(workflowId).length > 0,
-    hasLiveHiddenSteps,
-    showEmptyBoard: isMobileKanban,
-  });
+  const visibleWorkflows = useStableWorkflowList(
+    selectVisibleWorkflows({
+      workflowFilter,
+      orderedWorkflows,
+      hasTasks: (workflowId) => getFilteredTasks(workflowId).length > 0,
+      hasLiveHiddenSteps,
+      showEmptyBoard: isMobileKanban,
+    }),
+  );
   const focusedWorkflowId = visibleWorkflows[0]?.id ?? null;
   usePublishMobileFocus(isMobileKanban ? focusedWorkflowId : null);
-  const renderedWorkflows = getRenderedWorkflows(
+  const renderedWorkflows = useStableWorkflowList(
+    getRenderedWorkflows(isMobileKanban, focusedWorkflowId, visibleWorkflows),
+  );
+  const sortableWorkflowIds = useMemo(
+    () => renderedWorkflows.map((workflow) => workflow.id),
+    [renderedWorkflows],
+  );
+  const mobileWorkflowNavigation = useMobileWorkflowNavigation(
     isMobileKanban,
     focusedWorkflowId,
-    visibleWorkflows,
+    workflowOptions,
+    containerProps.onWorkflowChange,
   );
-  const mobileWorkflowNavigation =
-    isMobileKanban && focusedWorkflowId && containerProps.onWorkflowChange
-      ? {
-          activeWorkflowId: focusedWorkflowId,
-          workflows: workflowOptions,
-          onWorkflowChange: containerProps.onWorkflowChange,
-        }
-      : undefined;
 
   const emptyMessage = getEmptyMessage({
     isLoading,
@@ -557,7 +482,6 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
   });
   if (emptyMessage) return renderEmptyState(emptyMessage);
 
-  const ViewComponent = view.component;
   const hideHeaders = shouldHideHeaders(
     isMobile,
     isMobileKanban,
@@ -572,17 +496,14 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
       collisionDetection={closestCenter}
       onDragEnd={handleWorkflowDragEnd}
     >
-      <SortableContext
-        items={renderedWorkflows.map((workflow) => workflow.id)}
-        strategy={verticalListSortingStrategy}
-      >
+      <SortableContext items={sortableWorkflowIds} strategy={verticalListSortingStrategy}>
         <div className={containerClass} data-testid="swimlane-container">
           <WorkflowItems
             workflows={renderedWorkflows}
-            snapshots={snapshots}
-            getFilteredTasks={getFilteredTasks}
-            getOccupancyTasks={getOccupancyTasks}
-            ViewComponent={ViewComponent}
+            repoFilter={repoFilter}
+            searchQuery={searchQuery ?? ""}
+            matchesPluginTaskFilters={containerProps.matchesPluginTaskFilters}
+            ViewComponent={view.component}
             hideHeaders={hideHeaders}
             onToggleStepVisibility={onToggleStepVisibility}
             onToggleAutoHideEmpty={onToggleAutoHideEmpty}

--- a/apps/web/components/kanban/swimlane-kanban-content.render-stability.test.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.render-stability.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const columnRenderCounts = vi.hoisted(() => new Map<string, number>());
+const responsive = vi.hoisted(() => ({ isMobile: false, isTablet: false }));
+const externalLinkAvailability = vi.hoisted(() => ({
+  gitlab: false,
+  jira: false,
+  linear: false,
+  sentry: false,
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => responsive,
+}));
+
+vi.mock("embla-carousel-react", () => ({
+  default: () => [vi.fn(), null],
+}));
+
+vi.mock("@/components/kanban-external-link-availability", () => ({
+  useKanbanExternalLinkAvailability: () => externalLinkAvailability,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  PointerSensor: function PointerSensor() {},
+  TouchSensor: function TouchSensor() {},
+  useSensor: () => ({}),
+  useSensors: (...sensors: unknown[]) => sensors,
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+vi.mock("./kanban-drag-surface", () => ({
+  KanbanDragSurface: ({ layoutContent }: { layoutContent: React.ReactNode }) => layoutContent,
+}));
+
+vi.mock("./virtualized-column-task-list", () => ({
+  VirtualizedColumnTaskList: ({ step }: { step: { id: string } }) => {
+    columnRenderCounts.set(step.id, (columnRenderCounts.get(step.id) ?? 0) + 1);
+    return <div data-testid={`task-list-${step.id}`} />;
+  },
+}));
+
+import { StateProvider } from "@/components/state-provider";
+import type { Task } from "@/components/kanban-card";
+import type { WorkflowStep } from "@/components/kanban-column";
+import { defaultState } from "@/lib/state/default-state";
+import { SwimlaneKanbanContent } from "./swimlane-kanban-content";
+
+const WORKFLOW_ID = "workflow-1";
+const STEPS: WorkflowStep[] = [
+  { id: "step-a", title: "Step A", color: "bg-blue-500" },
+  { id: "step-b", title: "Step B", color: "bg-green-500" },
+];
+const TASK_A: Task = {
+  id: "task-a",
+  title: "Task A",
+  workflowStepId: "step-a",
+  position: 0,
+};
+const TASK_B: Task = {
+  id: "task-b",
+  title: "Task B",
+  workflowStepId: "step-b",
+  position: 0,
+};
+const HANDLERS = {
+  onPreviewTask: vi.fn(),
+  onOpenTask: vi.fn(),
+  onEditTask: vi.fn(),
+  onDeleteTask: vi.fn(),
+};
+
+function Content({ tasks }: { tasks: Task[] }) {
+  return (
+    <StateProvider
+      initialState={{
+        workspaces: { ...defaultState.workspaces, activeId: "workspace-1" },
+        repositories: { ...defaultState.repositories, itemsByWorkspaceId: {} },
+        mobileKanban: {
+          ...defaultState.mobileKanban,
+          activeStepIdByWorkflowId: { [WORKFLOW_ID]: STEPS[0].id },
+        },
+      }}
+    >
+      <SwimlaneKanbanContent
+        workflowId={WORKFLOW_ID}
+        steps={STEPS}
+        moveTargetSteps={STEPS}
+        tasks={tasks}
+        {...HANDLERS}
+      />
+    </StateProvider>
+  );
+}
+
+beforeEach(() => {
+  columnRenderCounts.clear();
+  responsive.isMobile = false;
+  responsive.isTablet = false;
+});
+afterEach(cleanup);
+
+describe("SwimlaneKanbanContent column render isolation", () => {
+  it("does not rerender an unaffected column after a task in another column updates", () => {
+    const view = render(<Content tasks={[TASK_A, TASK_B]} />);
+
+    view.rerender(<Content tasks={[{ ...TASK_A, title: "Updated Task A" }, TASK_B]} />);
+
+    expect({
+      affectedColumn: columnRenderCounts.get("step-a"),
+      unaffectedColumn: columnRenderCounts.get("step-b"),
+    }).toEqual({ affectedColumn: 2, unaffectedColumn: 1 });
+  });
+
+  it("keeps the same isolation in the mobile swipeable-column composition", () => {
+    responsive.isMobile = true;
+    const view = render(<Content tasks={[TASK_A, TASK_B]} />);
+
+    view.rerender(<Content tasks={[{ ...TASK_A, title: "Updated Task A" }, TASK_B]} />);
+
+    expect({
+      affectedColumn: columnRenderCounts.get("step-a"),
+      unaffectedColumn: columnRenderCounts.get("step-b"),
+    }).toEqual({ affectedColumn: 2, unaffectedColumn: 1 });
+  });
+});

--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DragEndEvent,
   DragStartEvent,
@@ -50,6 +50,9 @@ import { useKanbanExternalLinkAvailability } from "@/components/kanban-external-
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
 
+const TASK_POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 8 } };
+const TASK_TOUCH_SENSOR_OPTIONS = { activationConstraint: { delay: 250, tolerance: 5 } };
+
 export type SwimlaneKanbanContentProps = {
   workflowId: string;
   steps: WorkflowStep[];
@@ -81,12 +84,12 @@ function useSwimlaneKanbanDnd({ tasks, workflowId, onMoveError }: SwimlaneKanban
   const store = useAppStoreApi();
   const { moveTaskById } = useTaskActions();
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 250, tolerance: 5 },
-    }),
+    useSensor(PointerSensor, TASK_POINTER_SENSOR_OPTIONS),
+    useSensor(TouchSensor, TASK_TOUCH_SENSOR_OPTIONS),
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -101,7 +104,7 @@ function useSwimlaneKanbanDnd({ tasks, workflowId, onMoveError }: SwimlaneKanban
 
       const taskId = active.id as string;
       const targetStepId = over.id as string;
-      const task = tasks.find((t) => t.id === taskId);
+      const task = tasksRef.current.find((candidate) => candidate.id === taskId);
       if (!task || task.workflowStepId === targetStepId || isOrphanMoveTarget(targetStepId)) return;
 
       const state = store.getState();
@@ -138,7 +141,7 @@ function useSwimlaneKanbanDnd({ tasks, workflowId, onMoveError }: SwimlaneKanban
         onMoveError?.({ message, taskId, sessionId: task.primarySessionId ?? null });
       }
     },
-    [tasks, workflowId, store, moveTaskById, onMoveError],
+    [workflowId, store, moveTaskById, onMoveError],
   );
 
   const handleDragCancel = useCallback(() => {

--- a/apps/web/components/kanban/swipeable-columns.tsx
+++ b/apps/web/components/kanban/swipeable-columns.tsx
@@ -107,7 +107,7 @@ export function SwipeableColumns({
     (stepId: string) => {
       return tasks
         .filter((task) => task.workflowStepId === stepId)
-        .map((task) => ({ ...task, position: task.position ?? 0 }))
+        .map((task) => (task.position == null ? { ...task, position: 0 } : task))
         .sort(compareTasksByCreatedDesc);
     },
     [tasks],

--- a/apps/web/components/kanban/virtualized-column-task-list.render-stability.test.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.render-stability.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cardRenderCounts = vi.hoisted(() => new Map<string, number>());
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 100,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index * 100 })),
+    measureElement: vi.fn(),
+  }),
+}));
+
+vi.mock("../kanban-card", () => ({
+  KanbanCard: ({ task }: { task: { id: string } }) => {
+    cardRenderCounts.set(task.id, (cardRenderCounts.get(task.id) ?? 0) + 1);
+    return <div data-testid={`card-${task.id}`} />;
+  },
+  resolveTaskRepositoryChips: () => [],
+}));
+
+import type { Task } from "../kanban-card";
+import type { WorkflowStep } from "../kanban-column";
+import type { Repository } from "@/lib/types/http";
+import { VirtualizedColumnTaskList } from "./virtualized-column-task-list";
+
+const STEP: WorkflowStep = { id: "step-1", title: "Todo", color: "bg-blue-500" };
+const STEPS = [STEP];
+const TASK_A: Task = {
+  id: "task-a",
+  title: "Task A",
+  workflowStepId: STEP.id,
+  position: 0,
+};
+const TASK_B: Task = {
+  id: "task-b",
+  title: "Task B",
+  workflowStepId: STEP.id,
+  position: 1,
+};
+const HANDLERS = {
+  onPreviewTask: vi.fn(),
+  onOpenTask: vi.fn(),
+  onEditTask: vi.fn(),
+  onDeleteTask: vi.fn(),
+};
+const EXTERNAL_LINK_AVAILABILITY = { jira: false, linear: false, sentry: false };
+const REPOSITORIES: Repository[] = [];
+
+function TaskList({ tasks }: { tasks: Task[] }) {
+  return (
+    <VirtualizedColumnTaskList
+      orderedTasks={tasks}
+      queuedStartIndex={tasks.length}
+      queuedCount={0}
+      step={STEP}
+      steps={STEPS}
+      presentation="desktop"
+      workspaceId="workspace-1"
+      repositories={REPOSITORIES}
+      externalLinkAvailability={{ ...EXTERNAL_LINK_AVAILABILITY }}
+      {...HANDLERS}
+    />
+  );
+}
+
+beforeEach(() => cardRenderCounts.clear());
+afterEach(cleanup);
+
+describe("VirtualizedColumnTaskList card render isolation", () => {
+  it("does not rerender an unchanged card after a sibling task updates", () => {
+    const view = render(<TaskList tasks={[TASK_A, TASK_B]} />);
+
+    view.rerender(<TaskList tasks={[{ ...TASK_A, title: "Updated Task A" }, TASK_B]} />);
+
+    expect({
+      affectedCard: cardRenderCounts.get(TASK_A.id),
+      unaffectedCard: cardRenderCounts.get(TASK_B.id),
+    }).toEqual({ affectedCard: 2, unaffectedCard: 1 });
+  });
+});

--- a/apps/web/components/kanban/virtualized-column-task-list.render-stability.test.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.render-stability.test.tsx
@@ -48,7 +48,15 @@ const HANDLERS = {
 const EXTERNAL_LINK_AVAILABILITY = { jira: false, linear: false, sentry: false };
 const REPOSITORIES: Repository[] = [];
 
-function TaskList({ tasks }: { tasks: Task[] }) {
+function TaskList({
+  tasks,
+  deletingTaskId,
+  archivingTaskId,
+}: {
+  tasks: Task[];
+  deletingTaskId?: string;
+  archivingTaskId?: string;
+}) {
   return (
     <VirtualizedColumnTaskList
       orderedTasks={tasks}
@@ -60,6 +68,8 @@ function TaskList({ tasks }: { tasks: Task[] }) {
       workspaceId="workspace-1"
       repositories={REPOSITORIES}
       externalLinkAvailability={{ ...EXTERNAL_LINK_AVAILABILITY }}
+      deletingTaskId={deletingTaskId}
+      archivingTaskId={archivingTaskId}
       {...HANDLERS}
     />
   );
@@ -79,4 +89,24 @@ describe("VirtualizedColumnTaskList card render isolation", () => {
       unaffectedCard: cardRenderCounts.get(TASK_B.id),
     }).toEqual({ affectedCard: 2, unaffectedCard: 1 });
   });
+
+  it.each(["deletingTaskId", "archivingTaskId"] as const)(
+    "does not rerender sibling cards when %s targets another card",
+    (busyProp) => {
+      const view = render(<TaskList tasks={[TASK_A, TASK_B]} />);
+
+      view.rerender(
+        <TaskList
+          tasks={[TASK_A, TASK_B]}
+          deletingTaskId={busyProp === "deletingTaskId" ? TASK_A.id : undefined}
+          archivingTaskId={busyProp === "archivingTaskId" ? TASK_A.id : undefined}
+        />,
+      );
+
+      expect({
+        affectedCard: cardRenderCounts.get(TASK_A.id),
+        unaffectedCard: cardRenderCounts.get(TASK_B.id),
+      }).toEqual({ affectedCard: 2, unaffectedCard: 1 });
+    },
+  );
 });

--- a/apps/web/components/kanban/virtualized-column-task-list.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.tsx
@@ -40,10 +40,12 @@ type VirtualizedColumnTaskListProps = {
 
 type VirtualizedKanbanCardProps = Omit<
   VirtualizedColumnTaskListProps,
-  "orderedTasks" | "queuedStartIndex" | "queuedCount"
+  "orderedTasks" | "queuedStartIndex" | "queuedCount" | "deletingTaskId" | "archivingTaskId"
 > & {
   task: Task;
   columnTaskIds: string[];
+  isDeleting: boolean;
+  isArchiving: boolean;
 };
 
 const VirtualizedKanbanCard = memo(function VirtualizedKanbanCard({
@@ -56,8 +58,8 @@ const VirtualizedKanbanCard = memo(function VirtualizedKanbanCard({
   repositories,
   externalLinkAvailability,
   showMaximizeButton,
-  deletingTaskId,
-  archivingTaskId,
+  isDeleting,
+  isArchiving,
   selectedIds,
   onPreviewTask,
   onOpenTask,
@@ -94,8 +96,8 @@ const VirtualizedKanbanCard = memo(function VirtualizedKanbanCard({
       onMove={onMoveTask}
       steps={steps}
       showMaximizeButton={showMaximizeButton}
-      isDeleting={deletingTaskId === task.id}
-      isArchiving={archivingTaskId === task.id}
+      isDeleting={isDeleting}
+      isArchiving={isArchiving}
       isSelected={selectedIds?.has(task.id)}
       selectedIds={selectedIds}
       onToggleSelect={onToggleSelect}
@@ -204,8 +206,8 @@ export function VirtualizedColumnTaskList({
                 repositories={repositories}
                 externalLinkAvailability={stableExternalLinkAvailability}
                 showMaximizeButton={showMaximizeButton}
-                deletingTaskId={deletingTaskId}
-                archivingTaskId={archivingTaskId}
+                isDeleting={deletingTaskId === task.id}
+                isArchiving={archivingTaskId === task.id}
                 selectedIds={selectedIds}
                 onPreviewTask={onPreviewTask}
                 onOpenTask={onOpenTask}

--- a/apps/web/components/kanban/virtualized-column-task-list.tsx
+++ b/apps/web/components/kanban/virtualized-column-task-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { memo, useCallback, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useTranslation } from "react-i18next";
 import {
@@ -38,6 +38,97 @@ type VirtualizedColumnTaskListProps = {
   isMultiSelectMode?: boolean;
 };
 
+type VirtualizedKanbanCardProps = Omit<
+  VirtualizedColumnTaskListProps,
+  "orderedTasks" | "queuedStartIndex" | "queuedCount"
+> & {
+  task: Task;
+  columnTaskIds: string[];
+};
+
+const VirtualizedKanbanCard = memo(function VirtualizedKanbanCard({
+  task,
+  columnTaskIds,
+  step,
+  steps,
+  presentation,
+  workspaceId,
+  repositories,
+  externalLinkAvailability,
+  showMaximizeButton,
+  deletingTaskId,
+  archivingTaskId,
+  selectedIds,
+  onPreviewTask,
+  onOpenTask,
+  onEditTask,
+  onDeleteTask,
+  onArchiveTask,
+  onMoveTask,
+  onToggleSelect,
+  onSelectRange,
+  isMultiSelectMode,
+}: VirtualizedKanbanCardProps) {
+  const displayTask = useMemo(() => queuedTaskWithTitle(task, steps, step), [step, steps, task]);
+  const repositoryChips = useMemo(
+    () => resolveTaskRepositoryChips(task, repositories),
+    [repositories, task],
+  );
+  const handleRangeSelect = useCallback(
+    (taskId: string) => onSelectRange?.(taskId, columnTaskIds),
+    [columnTaskIds, onSelectRange],
+  );
+
+  return (
+    <KanbanCard
+      task={displayTask}
+      workspaceId={workspaceId}
+      presentation={presentation}
+      externalLinkAvailability={externalLinkAvailability}
+      repositoryChips={repositoryChips}
+      onClick={onPreviewTask}
+      onOpenFullPage={onOpenTask}
+      onEdit={onEditTask}
+      onDelete={onDeleteTask}
+      onArchive={onArchiveTask}
+      onMove={onMoveTask}
+      steps={steps}
+      showMaximizeButton={showMaximizeButton}
+      isDeleting={deletingTaskId === task.id}
+      isArchiving={archivingTaskId === task.id}
+      isSelected={selectedIds?.has(task.id)}
+      selectedIds={selectedIds}
+      onToggleSelect={onToggleSelect}
+      onRangeSelect={onSelectRange ? handleRangeSelect : undefined}
+      isMultiSelectMode={isMultiSelectMode}
+    />
+  );
+});
+
+function useStableTaskIds(tasks: Task[]): string[] {
+  const previousRef = useRef<string[]>([]);
+  const next = tasks.map((task) => task.id);
+  const previous = previousRef.current;
+  const isUnchanged =
+    previous.length === next.length && previous.every((taskId, index) => taskId === next[index]);
+  if (!isUnchanged) previousRef.current = next;
+  return isUnchanged ? previous : next;
+}
+
+function useStableExternalLinkAvailability(
+  availability: KanbanExternalLinkAvailability,
+): KanbanExternalLinkAvailability {
+  const previousRef = useRef(availability);
+  const previous = previousRef.current;
+  const isUnchanged =
+    previous.gitlab === availability.gitlab &&
+    previous.jira === availability.jira &&
+    previous.linear === availability.linear &&
+    previous.sentry === availability.sentry;
+  if (!isUnchanged) previousRef.current = availability;
+  return isUnchanged ? previous : availability;
+}
+
 export function VirtualizedColumnTaskList({
   orderedTasks,
   queuedStartIndex,
@@ -64,7 +155,9 @@ export function VirtualizedColumnTaskList({
 }: VirtualizedColumnTaskListProps) {
   const { t } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const columnTaskIds = useMemo(() => orderedTasks.map((task) => task.id), [orderedTasks]);
+  const columnTaskIds = useStableTaskIds(orderedTasks);
+  const stableExternalLinkAvailability =
+    useStableExternalLinkAvailability(externalLinkAvailability);
   const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
     count: orderedTasks.length,
     getScrollElement: () => scrollRef.current,
@@ -101,28 +194,27 @@ export function VirtualizedColumnTaskList({
                   <span className="tabular-nums">{queuedCount}</span>
                 </div>
               )}
-              <KanbanCard
-                task={queuedTaskWithTitle(task, steps, step)}
-                workspaceId={workspaceId}
-                presentation={presentation}
-                externalLinkAvailability={externalLinkAvailability}
-                repositoryChips={resolveTaskRepositoryChips(task, repositories)}
-                onClick={onPreviewTask}
-                onOpenFullPage={onOpenTask}
-                onEdit={onEditTask}
-                onDelete={onDeleteTask}
-                onArchive={onArchiveTask}
-                onMove={onMoveTask}
+              <VirtualizedKanbanCard
+                task={task}
+                columnTaskIds={columnTaskIds}
+                step={step}
                 steps={steps}
+                presentation={presentation}
+                workspaceId={workspaceId}
+                repositories={repositories}
+                externalLinkAvailability={stableExternalLinkAvailability}
                 showMaximizeButton={showMaximizeButton}
-                isDeleting={deletingTaskId === task.id}
-                isArchiving={archivingTaskId === task.id}
-                isSelected={selectedIds?.has(task.id)}
+                deletingTaskId={deletingTaskId}
+                archivingTaskId={archivingTaskId}
                 selectedIds={selectedIds}
+                onPreviewTask={onPreviewTask}
+                onOpenTask={onOpenTask}
+                onEditTask={onEditTask}
+                onDeleteTask={onDeleteTask}
+                onArchiveTask={onArchiveTask}
+                onMoveTask={onMoveTask}
                 onToggleSelect={onToggleSelect}
-                onRangeSelect={
-                  onSelectRange ? (taskId) => onSelectRange(taskId, columnTaskIds) : undefined
-                }
+                onSelectRange={onSelectRange}
                 isMultiSelectMode={isMultiSelectMode}
               />
             </div>

--- a/apps/web/hooks/domains/kanban/use-swimlane-render-data.ts
+++ b/apps/web/hooks/domains/kanban/use-swimlane-render-data.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import type { Task } from "@/components/kanban-card";
 import { mapSelectedRepositoryIds } from "@/lib/kanban/filters";
@@ -37,11 +37,18 @@ export function useStableWorkflowList<T extends { id: string }>(workflows: T[]):
   return useStableList(workflows, Object.is);
 }
 
+function stringSetsEqual(previous: Set<string>, value: Set<string>): boolean {
+  if (previous.size !== value.size) return false;
+  for (const item of previous) {
+    if (!value.has(item)) return false;
+  }
+  return true;
+}
+
 export function useStableStringSet(value: Set<string>): Set<string> {
   const previousRef = useRef(value);
   const previous = previousRef.current;
-  const isUnchanged =
-    previous.size === value.size && Array.from(previous).every((item) => value.has(item));
+  const isUnchanged = stringSetsEqual(previous, value);
   if (!isUnchanged) previousRef.current = value;
   return isUnchanged ? previous : value;
 }
@@ -56,6 +63,26 @@ function useStableWorkflowOptions(
       previous.name === next.name &&
       previous.taskCount === next.taskCount,
   );
+}
+
+function useOrderedWorkflowLists(
+  workflowFilter: string | null | undefined,
+  workflows: Parameters<typeof selectWorkflowSwimlanes>[1],
+  snapshots: Record<string, unknown>,
+) {
+  const allOrderedWorkflows = useStableWorkflowList(
+    useMemo(() => selectWorkflowSwimlanes(null, workflows, snapshots), [workflows, snapshots]),
+  );
+  const orderedWorkflows = useStableWorkflowList(
+    useMemo(
+      () =>
+        workflowFilter
+          ? selectWorkflowSwimlanes(workflowFilter, workflows, snapshots)
+          : allOrderedWorkflows,
+      [allOrderedWorkflows, workflowFilter, workflows, snapshots],
+    ),
+  );
+  return { allOrderedWorkflows, orderedWorkflows };
 }
 
 export function useSwimlaneRenderData(
@@ -81,17 +108,18 @@ export function useSwimlaneRenderData(
     () => mapSelectedRepositoryIds(repositories, selectedRepositoryIds),
     [repositories, selectedRepositoryIds],
   );
-  const allOrderedWorkflows = useStableWorkflowList(
-    useMemo(() => selectWorkflowSwimlanes(null, workflows, snapshots), [workflows, snapshots]),
-  );
-  const orderedWorkflows = useStableWorkflowList(
-    useMemo(
-      () => selectWorkflowSwimlanes(workflowFilter, workflows, snapshots),
-      [workflowFilter, workflows, snapshots],
-    ),
+  const { allOrderedWorkflows, orderedWorkflows } = useOrderedWorkflowLists(
+    workflowFilter,
+    workflows,
+    snapshots,
   );
 
   const projectionCacheRef = useRef(new Map<string, TaskProjectionCacheEntry>());
+  useEffect(() => {
+    for (const workflowId of projectionCacheRef.current.keys()) {
+      if (!(workflowId in snapshots)) projectionCacheRef.current.delete(workflowId);
+    }
+  }, [snapshots]);
   const getFilteredTasks = useCallback(
     (workflowId: string) => {
       const snapshot = snapshots[workflowId];

--- a/apps/web/hooks/domains/kanban/use-swimlane-render-data.ts
+++ b/apps/web/hooks/domains/kanban/use-swimlane-render-data.ts
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useMemo, useRef } from "react";
+import { useAppStore } from "@/components/state-provider";
+import type { Task } from "@/components/kanban-card";
+import { mapSelectedRepositoryIds } from "@/lib/kanban/filters";
+import { projectWorkflowTasks } from "@/lib/kanban/task-projections";
+import {
+  selectMobileNavigatorWorkflows,
+  selectWorkflowSwimlanes,
+} from "@/lib/kanban/workflow-swimlanes";
+import type { WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
+import type { Repository } from "@/lib/types/http";
+
+export const EMPTY_HIDDEN_STEP_IDS: string[] = [];
+
+type TaskProjectionCacheEntry = {
+  snapshot: WorkflowSnapshotData | undefined;
+  hiddenStepIds: string[] | undefined;
+  repoFilter: Set<string>;
+  searchQuery: string;
+  matchesPluginTaskFilters: ((taskId: string) => boolean) | undefined;
+  visibleTasks: Task[];
+};
+
+function useStableList<T>(items: T[], itemEqual: (previous: T, next: T) => boolean): T[] {
+  const previousRef = useRef(items);
+  const previous = previousRef.current;
+  const isUnchanged =
+    previous.length === items.length &&
+    previous.every((previousItem, index) => itemEqual(previousItem, items[index]));
+  if (!isUnchanged) previousRef.current = items;
+  return isUnchanged ? previous : items;
+}
+
+export function useStableWorkflowList<T extends { id: string }>(workflows: T[]): T[] {
+  return useStableList(workflows, Object.is);
+}
+
+export function useStableStringSet(value: Set<string>): Set<string> {
+  const previousRef = useRef(value);
+  const previous = previousRef.current;
+  const isUnchanged =
+    previous.size === value.size && Array.from(previous).every((item) => value.has(item));
+  if (!isUnchanged) previousRef.current = value;
+  return isUnchanged ? previous : value;
+}
+
+function useStableWorkflowOptions(
+  options: Array<{ id: string; name: string; taskCount: number }>,
+): Array<{ id: string; name: string; taskCount: number }> {
+  return useStableList(
+    options,
+    (previous, next) =>
+      previous.id === next.id &&
+      previous.name === next.name &&
+      previous.taskCount === next.taskCount,
+  );
+}
+
+export function useSwimlaneRenderData(
+  workflowFilter: string | null | undefined,
+  selectedRepositoryIds: string[],
+  searchQuery: string,
+  matchesPluginTaskFilters?: (taskId: string) => boolean,
+) {
+  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
+  const isLoading = useAppStore((state) => state.kanbanMulti.isLoading);
+  const workflows = useAppStore((state) => state.workflows.items);
+  const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
+  const hiddenWorkflowStepIds = useAppStore((state) => state.userSettings.hiddenWorkflowStepIds);
+  const workflowIdsWithAutoHideEmptySteps = useAppStore(
+    (state) => state.userSettings.workflowIdsWithAutoHideEmptySteps,
+  );
+
+  const repositories = useMemo(
+    () => Object.values(repositoriesByWorkspace).flat() as Repository[],
+    [repositoriesByWorkspace],
+  );
+  const repoFilter = useMemo(
+    () => mapSelectedRepositoryIds(repositories, selectedRepositoryIds),
+    [repositories, selectedRepositoryIds],
+  );
+  const allOrderedWorkflows = useStableWorkflowList(
+    useMemo(() => selectWorkflowSwimlanes(null, workflows, snapshots), [workflows, snapshots]),
+  );
+  const orderedWorkflows = useStableWorkflowList(
+    useMemo(
+      () => selectWorkflowSwimlanes(workflowFilter, workflows, snapshots),
+      [workflowFilter, workflows, snapshots],
+    ),
+  );
+
+  const projectionCacheRef = useRef(new Map<string, TaskProjectionCacheEntry>());
+  const getFilteredTasks = useCallback(
+    (workflowId: string) => {
+      const snapshot = snapshots[workflowId];
+      const hiddenStepIds = hiddenWorkflowStepIds[workflowId];
+      const cached = projectionCacheRef.current.get(workflowId);
+      if (
+        cached?.snapshot === snapshot &&
+        cached.hiddenStepIds === hiddenStepIds &&
+        cached.repoFilter === repoFilter &&
+        cached.searchQuery === searchQuery &&
+        cached.matchesPluginTaskFilters === matchesPluginTaskFilters
+      ) {
+        return cached.visibleTasks;
+      }
+      const visibleTasks = projectWorkflowTasks(snapshots, workflowId, repoFilter, {
+        searchQuery,
+        matchesPluginTaskFilters,
+        hiddenStepIds: hiddenStepIds?.length ? new Set(hiddenStepIds) : undefined,
+      }).visibleTasks;
+      projectionCacheRef.current.set(workflowId, {
+        snapshot,
+        hiddenStepIds,
+        repoFilter,
+        searchQuery,
+        matchesPluginTaskFilters,
+        visibleTasks,
+      });
+      return visibleTasks;
+    },
+    [hiddenWorkflowStepIds, matchesPluginTaskFilters, repoFilter, searchQuery, snapshots],
+  );
+
+  const hasLiveHiddenSteps = useCallback(
+    (workflowId: string) => {
+      const hidden = hiddenWorkflowStepIds[workflowId];
+      if (workflowIdsWithAutoHideEmptySteps.includes(workflowId)) return true;
+      if (!hidden?.length) return false;
+      const liveStepIds = new Set((snapshots[workflowId]?.steps ?? []).map((step) => step.id));
+      return hidden.some((id) => liveStepIds.has(id));
+    },
+    [hiddenWorkflowStepIds, snapshots, workflowIdsWithAutoHideEmptySteps],
+  );
+
+  const workflowOptions = useStableWorkflowOptions(
+    useMemo(
+      () =>
+        selectMobileNavigatorWorkflows(
+          allOrderedWorkflows,
+          workflows,
+          getFilteredTasks,
+          hasLiveHiddenSteps,
+        ).map(({ workflow, tasks }) => ({
+          id: workflow.id,
+          name: workflow.name,
+          taskCount: tasks.length,
+        })),
+      [allOrderedWorkflows, getFilteredTasks, hasLiveHiddenSteps, workflows],
+    ),
+  );
+
+  return {
+    snapshots,
+    isLoading,
+    orderedWorkflows,
+    workflowOptions,
+    getFilteredTasks,
+    hasLiveHiddenSteps,
+    repoFilter,
+  };
+}
+
+export function useWorkflowSwimlaneData(
+  workflowId: string,
+  repoFilter: Set<string>,
+  searchQuery: string,
+  matchesPluginTaskFilters?: (taskId: string) => boolean,
+): {
+  snapshot: WorkflowSnapshotData | undefined;
+  tasks: Task[];
+  occupancyTasks: Task[];
+  hiddenStepIds: string[];
+  hiddenSet: Set<string>;
+  autoHideEmpty: boolean;
+} {
+  const snapshot = useAppStore((state) => state.kanbanMulti.snapshots[workflowId]);
+  const hiddenStepIds = useAppStore(
+    (state) => state.userSettings.hiddenWorkflowStepIds[workflowId] ?? EMPTY_HIDDEN_STEP_IDS,
+  );
+  const autoHideEmpty = useAppStore((state) =>
+    state.userSettings.workflowIdsWithAutoHideEmptySteps.includes(workflowId),
+  );
+  const derivedHiddenSet = useMemo(() => {
+    if (!snapshot || hiddenStepIds.length === 0) return new Set<string>();
+    const liveStepIds = new Set(snapshot.steps.map((step) => step.id));
+    return new Set(hiddenStepIds.filter((id) => liveStepIds.has(id)));
+  }, [hiddenStepIds, snapshot]);
+  const hiddenSet = useStableStringSet(derivedHiddenSet);
+  const projection = useMemo(() => {
+    if (!snapshot) return { visibleTasks: [], occupancyTasks: [] };
+    return projectWorkflowTasks({ [workflowId]: snapshot }, workflowId, repoFilter, {
+      searchQuery,
+      matchesPluginTaskFilters,
+      hiddenStepIds: hiddenSet,
+    });
+  }, [hiddenSet, matchesPluginTaskFilters, repoFilter, searchQuery, snapshot, workflowId]);
+
+  return {
+    snapshot,
+    tasks: projection.visibleTasks,
+    occupancyTasks: projection.occupancyTasks,
+    hiddenStepIds,
+    hiddenSet,
+    autoHideEmpty,
+  };
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3436/56a90cee849d.html)
<!-- kandev-pr-walkthrough-end -->

Task updates caused the kanban board to recompute and rerender unrelated workflows, columns, and cards. Per-workflow subscriptions, structural memoization, and stable drag/mobile props now contain updates to the affected render path.

## Important Changes

- Cache task projections by workflow and subscribe each lane only to its own snapshot and display settings.
- Preserve column and card identities through memo boundaries while keeping drag-and-drop, filtering, grouping, and virtualization behavior intact.
- Narrow card move-menu subscriptions from the full snapshot map to workflow membership and shallow-stable step metadata.

## Validation

- Focused Vitest suite covering the four render-stability files plus existing swimlane, menu, card-store, adaptive-layout, drag-surface, and workflow-selection tests: 10 files and 63 tests passed.
- The four new render-stability files pass independently: 8 tests passed.
- `cd apps/web && pnpm run typecheck`
- Targeted ESLint with `--max-warnings 0` across all changed and new TypeScript files.
- `git diff --check`
- Pre-commit and commit-msg hooks passed, including changed-file web lint, Prettier, i18n guard, architecture lint, and Conventional Commits validation.
- Desktop/mobile screenshots are not applicable: no markup, layout, copy, touch target, or interaction behavior changed. A phone-mode render regression covers the mobile composition.
- Public docs are unaffected because this is an internal rendering-performance change with no user-facing contract change.

## Possible Improvements

Low risk: browser-profiler measurements could supplement the deterministic render-count regressions for exceptionally large boards.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->