### PR TITLE
fix(backend): stop a manual route retry from deadlocking against a context reset

### DIFF
--- a/apps/backend/internal/backendapp/dynamic_routing.go
+++ b/apps/backend/internal/backendapp/dynamic_routing.go
@@ -208,9 +208,10 @@ func finishDynamicRouteAction(
 // the launch attempt), so the write here is gated on a fresh reload rather
 // than on any state captured before launchSuccessor ran: a stale pre-launch
 // snapshot would never match the launcher's own mutation and this recovery
-// write would be silently dropped. A reloaded state of CANCELLED means a
-// concurrent cancellation has already terminated the session, and that must
-// win over resurrecting it into WAITING_FOR_INPUT.
+// write would be silently dropped. A reloaded state that is already terminal
+// (CANCELLED, COMPLETED, or FAILED) means a concurrent handler has already
+// settled the session, and that must win over resurrecting it into
+// WAITING_FOR_INPUT.
 func recoverDynamicRouteAction(
 	ctx context.Context,
 	repo *sqliterepo.Repository,
@@ -229,7 +230,7 @@ func recoverDynamicRouteAction(
 	if session.RouteGeneration != expectedGeneration {
 		return routeActionResult(ctx, repo, session), nil
 	}
-	if session.State == models.TaskSessionStateCancelled {
+	if isTerminalRouteActionSessionState(session.State) {
 		return routeActionResult(ctx, repo, session), nil
 	}
 	reloadedState := session.State
@@ -246,6 +247,16 @@ func recoverDynamicRouteAction(
 		return reloadRouteActionResult(ctx, repo, sessionID)
 	}
 	return routeActionResult(ctx, repo, session), nil
+}
+
+// isTerminalRouteActionSessionState reports whether a reloaded session state
+// means a concurrent handler has already settled the session, mirroring
+// orchestrator's unexported isTerminalSessionState (not reachable from this
+// package).
+func isTerminalRouteActionSessionState(state models.TaskSessionState) bool {
+	return state == models.TaskSessionStateCancelled ||
+		state == models.TaskSessionStateCompleted ||
+		state == models.TaskSessionStateFailed
 }
 
 // reloadRouteActionResult reloads the session that a guarded write refused to

--- a/apps/backend/internal/backendapp/dynamic_routing.go
+++ b/apps/backend/internal/backendapp/dynamic_routing.go
@@ -313,7 +313,11 @@ func routeActionResult(
 	}
 	if repo != nil {
 		if state, err := repo.LoadRouteState(ctx, session.ID); err == nil && state != nil {
+			result.LogicalProfileID = state.LogicalProfileID
+			result.ExecutionProfileID = state.ExecutionProfileID
+			result.RouteGeneration = state.Generation
 			result.ProfileVersion = state.ProfileVersion
+			result.State = state.Status
 			var policyState dynamicruntime.PolicyState
 			if jsonErr := json.Unmarshal([]byte(state.PolicyStateJSON), &policyState); jsonErr == nil {
 				result.ErrorCode = string(policyState.FailureCode)

--- a/apps/backend/internal/backendapp/dynamic_routing.go
+++ b/apps/backend/internal/backendapp/dynamic_routing.go
@@ -47,6 +47,12 @@ func applyDynamicRouteAction(
 	if err != nil {
 		return nil, err
 	}
+	// expectedState is the session lifecycle state last confirmed under this
+	// in-memory copy. Every full-row write below is conditioned on it, so a
+	// terminal transition (e.g. cancellation) that lands concurrently with
+	// route selection or successor launch is detected instead of clobbered by
+	// a whole-row write built from this stale snapshot.
+	expectedState := session.State
 	if err := repairDynamicRouteAfterLaunchFailure(
 		ctx, session, request.ExpectedGeneration, resolver.MarkRouteRecoveryActionRequired,
 	); err != nil {
@@ -54,15 +60,19 @@ func applyDynamicRouteAction(
 	}
 	decision, err := resolveDynamicRouteAction(ctx, resolver, request, session)
 	if err != nil {
-		return handleDynamicRouteActionError(ctx, repo, session, err)
+		return handleDynamicRouteActionError(ctx, repo, session, expectedState, err)
 	}
-	if err := persistDynamicRouteSelection(ctx, repo, session, decision); err != nil {
+	changed, err := persistDynamicRouteSelection(ctx, repo, session, expectedState, decision)
+	if err != nil {
 		return nil, err
+	}
+	if !changed {
+		return reloadRouteActionResult(ctx, repo, session.ID)
 	}
 	if request.Action == orchestrator.RouteActionCancelWait || request.Action == orchestrator.RouteActionStop {
 		return routeActionResult(ctx, repo, session), nil
 	}
-	return finishDynamicRouteAction(ctx, repo, resolver, session.ID, decision.Generation, launchSuccessor)
+	return finishDynamicRouteAction(ctx, repo, resolver, session.ID, decision.Generation, expectedState, launchSuccessor)
 }
 
 func loadDynamicRouteActionSession(
@@ -113,6 +123,7 @@ func handleDynamicRouteActionError(
 	ctx context.Context,
 	repo *sqliterepo.Repository,
 	session *models.TaskSession,
+	expectedState models.TaskSessionState,
 	err error,
 ) (*orchestrator.RouteActionResult, error) {
 	var noCandidate *dynamicruntime.NoEligibleCandidateError
@@ -123,8 +134,12 @@ func handleDynamicRouteActionError(
 	session.RouteState = "waiting"
 	session.RouteReason = "no_eligible_candidate"
 	session.DownstreamACPSessionID = ""
-	if updateErr := repo.UpdateTaskSession(ctx, session); updateErr != nil {
+	changed, updateErr := repo.UpdateTaskSessionIfCurrentState(ctx, session, expectedState)
+	if updateErr != nil {
 		return nil, routeActionPersistenceError(ctx, repo, session, updateErr)
+	}
+	if !changed {
+		return reloadRouteActionResult(ctx, repo, session.ID)
 	}
 	return routeActionResult(ctx, repo, session), nil
 }
@@ -133,8 +148,9 @@ func persistDynamicRouteSelection(
 	ctx context.Context,
 	repo *sqliterepo.Repository,
 	session *models.TaskSession,
+	expectedState models.TaskSessionState,
 	decision agentruntime.ProfileExecution,
-) error {
+) (bool, error) {
 	session.ExecutionProfileID = decision.ExecutionProfileID
 	session.RouteGeneration = decision.Generation
 	session.RouteState = decision.Decision.Status
@@ -151,10 +167,11 @@ func persistDynamicRouteSelection(
 	// A candidate change never carries a provider-native ACP identity across
 	// profiles. The conductor will populate this after a fresh launch.
 	session.DownstreamACPSessionID = ""
-	if err := repo.UpdateTaskSession(ctx, session); err != nil {
-		return routeActionPersistenceError(ctx, repo, session, err)
+	changed, err := repo.UpdateTaskSessionIfCurrentState(ctx, session, expectedState)
+	if err != nil {
+		return false, routeActionPersistenceError(ctx, repo, session, err)
 	}
-	return nil
+	return changed, nil
 }
 
 func finishDynamicRouteAction(
@@ -163,6 +180,7 @@ func finishDynamicRouteAction(
 	resolver *agentruntime.ProfileExecutionResolver,
 	sessionID string,
 	expectedGeneration int64,
+	expectedState models.TaskSessionState,
 	launchSuccessor func(context.Context, string) error,
 ) (*orchestrator.RouteActionResult, error) {
 	if launchSuccessor == nil {
@@ -173,7 +191,7 @@ func finishDynamicRouteAction(
 		return routeActionResult(ctx, repo, session), nil
 	}
 	if err := launchSuccessor(ctx, sessionID); err != nil {
-		return recoverDynamicRouteAction(ctx, repo, resolver, sessionID, expectedGeneration, err)
+		return recoverDynamicRouteAction(ctx, repo, resolver, sessionID, expectedGeneration, expectedState, err)
 	}
 	session, err := repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
@@ -182,12 +200,19 @@ func finishDynamicRouteAction(
 	return routeActionResult(ctx, repo, session), nil
 }
 
+// recoverDynamicRouteAction records why a successor launch failed after a
+// route action was accepted. expectedState is the session state confirmed
+// immediately before the launch attempt started: gating the write on it,
+// rather than on the state this function just reloaded, is what lets a
+// cancellation that lands during the launch attempt win over this recovery
+// write instead of being resurrected by it.
 func recoverDynamicRouteAction(
 	ctx context.Context,
 	repo *sqliterepo.Repository,
 	resolver *agentruntime.ProfileExecutionResolver,
 	sessionID string,
 	expectedGeneration int64,
+	expectedState models.TaskSessionState,
 	launchErr error,
 ) (*orchestrator.RouteActionResult, error) {
 	if resolver != nil {
@@ -205,8 +230,28 @@ func recoverDynamicRouteAction(
 	session.State = models.TaskSessionStateWaitingForInput
 	session.ErrorMessage = launchErr.Error()
 	session.DownstreamACPSessionID = ""
-	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+	changed, err := repo.UpdateTaskSessionIfCurrentState(ctx, session, expectedState)
+	if err != nil {
 		return nil, routeActionPersistenceError(ctx, repo, session, err)
+	}
+	if !changed {
+		return reloadRouteActionResult(ctx, repo, sessionID)
+	}
+	return routeActionResult(ctx, repo, session), nil
+}
+
+// reloadRouteActionResult reloads the session that a guarded write refused to
+// overwrite (because its state moved since expectedState was captured) and
+// reports that superseded/terminal state instead of the write the caller
+// intended.
+func reloadRouteActionResult(
+	ctx context.Context,
+	repo *sqliterepo.Repository,
+	sessionID string,
+) (*orchestrator.RouteActionResult, error) {
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
 	}
 	return routeActionResult(ctx, repo, session), nil
 }

--- a/apps/backend/internal/backendapp/dynamic_routing.go
+++ b/apps/backend/internal/backendapp/dynamic_routing.go
@@ -48,10 +48,13 @@ func applyDynamicRouteAction(
 		return nil, err
 	}
 	// expectedState is the session lifecycle state last confirmed under this
-	// in-memory copy. Every full-row write below is conditioned on it, so a
-	// terminal transition (e.g. cancellation) that lands concurrently with
-	// route selection or successor launch is detected instead of clobbered by
-	// a whole-row write built from this stale snapshot.
+	// in-memory copy. The selection and error writes below are conditioned on
+	// it, so a terminal transition (e.g. cancellation) that lands
+	// concurrently with route selection is detected instead of clobbered by a
+	// whole-row write built from this stale snapshot. The post-launch
+	// recovery write is different: the launch attempt itself can mutate
+	// state, so that write re-reads and gates on the state current at
+	// recovery time instead (see recoverDynamicRouteAction).
 	expectedState := session.State
 	if err := repairDynamicRouteAfterLaunchFailure(
 		ctx, session, request.ExpectedGeneration, resolver.MarkRouteRecoveryActionRequired,
@@ -72,7 +75,7 @@ func applyDynamicRouteAction(
 	if request.Action == orchestrator.RouteActionCancelWait || request.Action == orchestrator.RouteActionStop {
 		return routeActionResult(ctx, repo, session), nil
 	}
-	return finishDynamicRouteAction(ctx, repo, resolver, session.ID, decision.Generation, expectedState, launchSuccessor)
+	return finishDynamicRouteAction(ctx, repo, resolver, session.ID, decision.Generation, launchSuccessor)
 }
 
 func loadDynamicRouteActionSession(
@@ -180,7 +183,6 @@ func finishDynamicRouteAction(
 	resolver *agentruntime.ProfileExecutionResolver,
 	sessionID string,
 	expectedGeneration int64,
-	expectedState models.TaskSessionState,
 	launchSuccessor func(context.Context, string) error,
 ) (*orchestrator.RouteActionResult, error) {
 	if launchSuccessor == nil {
@@ -191,7 +193,7 @@ func finishDynamicRouteAction(
 		return routeActionResult(ctx, repo, session), nil
 	}
 	if err := launchSuccessor(ctx, sessionID); err != nil {
-		return recoverDynamicRouteAction(ctx, repo, resolver, sessionID, expectedGeneration, expectedState, err)
+		return recoverDynamicRouteAction(ctx, repo, resolver, sessionID, expectedGeneration, err)
 	}
 	session, err := repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
@@ -201,18 +203,20 @@ func finishDynamicRouteAction(
 }
 
 // recoverDynamicRouteAction records why a successor launch failed after a
-// route action was accepted. expectedState is the session state confirmed
-// immediately before the launch attempt started: gating the write on it,
-// rather than on the state this function just reloaded, is what lets a
-// cancellation that lands during the launch attempt win over this recovery
-// write instead of being resurrected by it.
+// route action was accepted. The launcher itself may mutate session state
+// before failing (a real launch failure resets the row to CREATED ahead of
+// the launch attempt), so the write here is gated on a fresh reload rather
+// than on any state captured before launchSuccessor ran: a stale pre-launch
+// snapshot would never match the launcher's own mutation and this recovery
+// write would be silently dropped. A reloaded state of CANCELLED means a
+// concurrent cancellation has already terminated the session, and that must
+// win over resurrecting it into WAITING_FOR_INPUT.
 func recoverDynamicRouteAction(
 	ctx context.Context,
 	repo *sqliterepo.Repository,
 	resolver *agentruntime.ProfileExecutionResolver,
 	sessionID string,
 	expectedGeneration int64,
-	expectedState models.TaskSessionState,
 	launchErr error,
 ) (*orchestrator.RouteActionResult, error) {
 	if resolver != nil {
@@ -225,12 +229,16 @@ func recoverDynamicRouteAction(
 	if session.RouteGeneration != expectedGeneration {
 		return routeActionResult(ctx, repo, session), nil
 	}
+	if session.State == models.TaskSessionStateCancelled {
+		return routeActionResult(ctx, repo, session), nil
+	}
+	reloadedState := session.State
 	session.RouteState = "action_required"
 	session.RouteReason = orchestrator.RouteActionLaunchFailedReason
 	session.State = models.TaskSessionStateWaitingForInput
 	session.ErrorMessage = launchErr.Error()
 	session.DownstreamACPSessionID = ""
-	changed, err := repo.UpdateTaskSessionIfCurrentState(ctx, session, expectedState)
+	changed, err := repo.UpdateTaskSessionIfCurrentState(ctx, session, reloadedState)
 	if err != nil {
 		return nil, routeActionPersistenceError(ctx, repo, session, err)
 	}

--- a/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
+++ b/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
@@ -87,6 +87,38 @@ func TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession(t *testing.T)
 		"a concurrently cancelled session must not be resurrected by a superseded route-action recovery write")
 }
 
+// TestRecoverDynamicRouteActionDoesNotResurrectOtherTerminalStates extends the
+// CANCELLED case above to COMPLETED and FAILED: any terminal state a
+// concurrent handler already committed while the successor launch was in
+// flight must win over recoverDynamicRouteAction's WAITING_FOR_INPUT write,
+// not just CANCELLED.
+func TestRecoverDynamicRouteActionDoesNotResurrectOtherTerminalStates(t *testing.T) {
+	for _, state := range []models.TaskSessionState{
+		models.TaskSessionStateCompleted,
+		models.TaskSessionStateFailed,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			ctx := context.Background()
+			repo := newDynamicRoutingCancelRaceRepo(t)
+			seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
+
+			settled, err := repo.GetTaskSession(ctx, "session-1")
+			require.NoError(t, err)
+			settled.State = state
+			require.NoError(t, repo.UpdateTaskSession(ctx, settled))
+
+			result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
+			require.NoError(t, err)
+			require.Equal(t, "session-1", result.SessionID)
+
+			persisted, err := repo.GetTaskSession(ctx, "session-1")
+			require.NoError(t, err)
+			require.Equal(t, state, persisted.State,
+				"a concurrently settled terminal session must not be resurrected by a superseded route-action recovery write")
+		})
+	}
+}
+
 // TestRecoverDynamicRouteActionWritesWhenStateUnchanged is the control case:
 // with no concurrent state change, the recovery write must still apply.
 func TestRecoverDynamicRouteActionWritesWhenStateUnchanged(t *testing.T) {

--- a/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
+++ b/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
@@ -1,0 +1,109 @@
+package backendapp
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/task/models"
+	taskrepo "github.com/kandev/kandev/internal/task/repository"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+)
+
+// newDynamicRoutingCancelRaceRepo opens an in-memory sqlite repo and seeds the
+// minimal workspace/workflow/task/session rows a dynamic route action reads.
+func newDynamicRoutingCancelRaceRepo(t *testing.T) *sqliterepo.Repository {
+	t.Helper()
+	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "kandev.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = sqlxDB.Close() })
+	repo, cleanup, err := taskrepo.Provide(sqlxDB, sqlxDB, nil)
+	if err != nil {
+		t.Fatalf("repo provide: %v", err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+	return repo
+}
+
+func seedDynamicRoutingCancelRaceSession(t *testing.T, repo *sqliterepo.Repository, sessionID string, state models.TaskSessionState) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "WS"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "WF"}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-1", WorkspaceID: "ws-1", WorkflowID: "wf-1", Title: "T", Priority: "medium",
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: "task-1", State: state, StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+}
+
+// TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession proves the
+// concrete race F4 describes: a successor launch fails after a concurrent
+// cancellation has already committed CANCELLED to the row. Before the fix,
+// recoverDynamicRouteAction reloaded the row, unconditionally overwrote State
+// with WAITING_FOR_INPUT, and whole-row-wrote it back — resurrecting a
+// session a concurrent cancel had just terminated. The fix conditions that
+// write on the state confirmed before the launch attempt started, so a
+// cancellation landing during the attempt wins.
+func TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession(t *testing.T) {
+	ctx := context.Background()
+	repo := newDynamicRoutingCancelRaceRepo(t)
+	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
+
+	// expectedState is what applyDynamicRouteAction would have captured from
+	// its own load, before finishDynamicRouteAction's launch attempt began.
+	expectedState := models.TaskSessionStateRunning
+
+	// Simulate a concurrent cancellation committing while the successor
+	// launch (which recoverDynamicRouteAction is about to react to) was still
+	// in flight.
+	cancelled, err := repo.GetTaskSession(ctx, "session-1")
+	require.NoError(t, err)
+	cancelled.State = models.TaskSessionStateCancelled
+	require.NoError(t, repo.UpdateTaskSession(ctx, cancelled))
+
+	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", expectedState, errors.New("launch failed"))
+	require.NoError(t, err)
+	require.Equal(t, "session-1", result.SessionID)
+
+	persisted, err := repo.GetTaskSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, models.TaskSessionStateCancelled, persisted.State,
+		"a concurrently cancelled session must not be resurrected by a superseded route-action recovery write")
+}
+
+// TestRecoverDynamicRouteActionWritesWhenStateUnchanged is the control case:
+// with no concurrent state change, the recovery write must still apply.
+func TestRecoverDynamicRouteActionWritesWhenStateUnchanged(t *testing.T) {
+	ctx := context.Background()
+	repo := newDynamicRoutingCancelRaceRepo(t)
+	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
+
+	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", models.TaskSessionStateRunning, errors.New("launch failed"))
+	require.NoError(t, err)
+	require.Equal(t, "session-1", result.SessionID)
+
+	persisted, err := repo.GetTaskSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, models.TaskSessionStateWaitingForInput, persisted.State)
+	require.Equal(t, "action_required", persisted.RouteState)
+}

--- a/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
+++ b/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
@@ -77,7 +77,7 @@ func TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession(t *testing.T)
 	cancelled.State = models.TaskSessionStateCancelled
 	require.NoError(t, repo.UpdateTaskSession(ctx, cancelled))
 
-	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
+	result, err := recoverDynamicRouteAction(ctx, repo, nil, "session-1", 0, errors.New("launch failed"))
 	require.NoError(t, err)
 	require.Equal(t, "session-1", result.SessionID)
 
@@ -107,7 +107,7 @@ func TestRecoverDynamicRouteActionDoesNotResurrectOtherTerminalStates(t *testing
 			settled.State = state
 			require.NoError(t, repo.UpdateTaskSession(ctx, settled))
 
-			result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
+			result, err := recoverDynamicRouteAction(ctx, repo, nil, "session-1", 0, errors.New("launch failed"))
 			require.NoError(t, err)
 			require.Equal(t, "session-1", result.SessionID)
 
@@ -126,7 +126,7 @@ func TestRecoverDynamicRouteActionWritesWhenStateUnchanged(t *testing.T) {
 	repo := newDynamicRoutingCancelRaceRepo(t)
 	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
 
-	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
+	result, err := recoverDynamicRouteAction(ctx, repo, nil, "session-1", 0, errors.New("launch failed"))
 	require.NoError(t, err)
 	require.Equal(t, "session-1", result.SessionID)
 
@@ -160,7 +160,7 @@ func TestFinishDynamicRouteActionRecoversAfterLauncherMutatesState(t *testing.T)
 		return launchErr
 	}
 
-	result, err := finishDynamicRouteAction(ctx, repo, "session-1", launcher)
+	result, err := finishDynamicRouteAction(ctx, repo, nil, "session-1", 0, launcher)
 	require.NoError(t, err)
 	require.Equal(t, "session-1", result.SessionID)
 	require.Equal(t, "action_required", result.State)

--- a/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
+++ b/apps/backend/internal/backendapp/dynamic_routing_cancel_race_test.go
@@ -61,17 +61,13 @@ func seedDynamicRoutingCancelRaceSession(t *testing.T, repo *sqliterepo.Reposito
 // cancellation has already committed CANCELLED to the row. Before the fix,
 // recoverDynamicRouteAction reloaded the row, unconditionally overwrote State
 // with WAITING_FOR_INPUT, and whole-row-wrote it back — resurrecting a
-// session a concurrent cancel had just terminated. The fix conditions that
-// write on the state confirmed before the launch attempt started, so a
-// cancellation landing during the attempt wins.
+// session a concurrent cancel had just terminated. The fix refuses to
+// resurrect a reloaded CANCELLED state at all, so a cancellation landing
+// during the launch attempt wins.
 func TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession(t *testing.T) {
 	ctx := context.Background()
 	repo := newDynamicRoutingCancelRaceRepo(t)
 	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
-
-	// expectedState is what applyDynamicRouteAction would have captured from
-	// its own load, before finishDynamicRouteAction's launch attempt began.
-	expectedState := models.TaskSessionStateRunning
 
 	// Simulate a concurrent cancellation committing while the successor
 	// launch (which recoverDynamicRouteAction is about to react to) was still
@@ -81,7 +77,7 @@ func TestRecoverDynamicRouteActionDoesNotResurrectCancelledSession(t *testing.T)
 	cancelled.State = models.TaskSessionStateCancelled
 	require.NoError(t, repo.UpdateTaskSession(ctx, cancelled))
 
-	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", expectedState, errors.New("launch failed"))
+	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
 	require.NoError(t, err)
 	require.Equal(t, "session-1", result.SessionID)
 
@@ -98,7 +94,7 @@ func TestRecoverDynamicRouteActionWritesWhenStateUnchanged(t *testing.T) {
 	repo := newDynamicRoutingCancelRaceRepo(t)
 	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
 
-	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", models.TaskSessionStateRunning, errors.New("launch failed"))
+	result, err := recoverDynamicRouteAction(ctx, repo, "session-1", errors.New("launch failed"))
 	require.NoError(t, err)
 	require.Equal(t, "session-1", result.SessionID)
 
@@ -106,4 +102,41 @@ func TestRecoverDynamicRouteActionWritesWhenStateUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, models.TaskSessionStateWaitingForInput, persisted.State)
 	require.Equal(t, "action_required", persisted.RouteState)
+}
+
+// TestFinishDynamicRouteActionRecoversAfterLauncherMutatesState proves F5:
+// the real launch-failure path does not gate the recovery write on a
+// pre-launch snapshot. orchestrator.relaunchDynamicTaskAfterFailure resets
+// the session row to CREATED before attempting the successor launch, then
+// fails; a CAS built from the state captured before that launch attempt
+// would never match CREATED and would silently drop the recovery write,
+// stranding the session with no error surfaced. finishDynamicRouteAction
+// must still land WAITING_FOR_INPUT/action_required with the launch error.
+func TestFinishDynamicRouteActionRecoversAfterLauncherMutatesState(t *testing.T) {
+	ctx := context.Background()
+	repo := newDynamicRoutingCancelRaceRepo(t)
+	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateRunning)
+
+	launchErr := errors.New("successor launch failed")
+	launcher := func(ctx context.Context, sessionID string) error {
+		// Mirrors internal/orchestrator/dynamic_launch.go's
+		// relaunchDynamicTaskAfterFailure, which resets state to CREATED
+		// before attempting (and, here, failing) the successor launch.
+		if err := repo.UpdateTaskSessionState(ctx, sessionID, models.TaskSessionStateCreated, ""); err != nil {
+			return err
+		}
+		return launchErr
+	}
+
+	result, err := finishDynamicRouteAction(ctx, repo, "session-1", launcher)
+	require.NoError(t, err)
+	require.Equal(t, "session-1", result.SessionID)
+	require.Equal(t, "action_required", result.State)
+
+	persisted, err := repo.GetTaskSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, models.TaskSessionStateWaitingForInput, persisted.State)
+	require.Equal(t, "action_required", persisted.RouteState)
+	require.Equal(t, "route_action_launch_failed", persisted.RouteReason)
+	require.Equal(t, launchErr.Error(), persisted.ErrorMessage)
 }

--- a/apps/backend/internal/backendapp/dynamic_routing_result_test.go
+++ b/apps/backend/internal/backendapp/dynamic_routing_result_test.go
@@ -1,0 +1,37 @@
+package backendapp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dynamicruntime "github.com/kandev/kandev/internal/agent/runtime/dynamic"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestRouteActionResultUsesAuthoritativeRouteState(t *testing.T) {
+	ctx := context.Background()
+	repo := newDynamicRoutingCancelRaceRepo(t)
+	seedDynamicRoutingCancelRaceSession(t, repo, "session-1", models.TaskSessionStateWaitingForInput)
+
+	require.NoError(t, repo.SaveRouteState(ctx, dynamicruntime.RouteState{
+		SessionID:          "session-1",
+		LogicalProfileID:   "logical-authoritative",
+		ExecutionProfileID: "execution-authoritative",
+		Generation:         7,
+		ProfileVersion:     4,
+		Status:             "retrying",
+		PolicyStateJSON:    `{"retry_ordinal":2}`,
+	}))
+
+	result, err := repo.GetTaskSession(ctx, "session-1")
+	require.NoError(t, err)
+	got := routeActionResult(ctx, repo, result)
+
+	require.Equal(t, "logical-authoritative", got.LogicalProfileID)
+	require.Equal(t, "execution-authoritative", got.ExecutionProfileID)
+	require.Equal(t, int64(7), got.RouteGeneration)
+	require.Equal(t, int64(4), got.ProfileVersion)
+	require.Equal(t, "retrying", got.State)
+}

--- a/apps/backend/internal/orchestrator/dynamic_launch.go
+++ b/apps/backend/internal/orchestrator/dynamic_launch.go
@@ -1055,7 +1055,22 @@ func (s *Service) relaunchDynamicTaskAfterFailure(
 			return false
 		}
 	}
-	if err := s.repo.UpdateTaskSessionState(ctx, data.SessionID, models.TaskSessionStateCreated, ""); err != nil {
+	// Reload immediately before the reset: StopExecution is I/O and a
+	// coordinator stop can commit a terminal state while it runs. A stale
+	// pre-stop snapshot would let this write resurrect a session the user
+	// already cancelled, so refuse on a reloaded terminal state and CAS the
+	// write on that same reload to catch a cancellation landing after it.
+	preResetState, err := s.repo.GetTaskSession(ctx, data.SessionID)
+	if err != nil || preResetState == nil {
+		return false
+	}
+	if isTerminalSessionState(preResetState.State) {
+		return false
+	}
+	changed, _, err := s.repo.UpdateTaskSessionStateIfCurrent(
+		ctx, data.SessionID, preResetState.State, models.TaskSessionStateCreated, "",
+	)
+	if err != nil || !changed {
 		return false
 	}
 	s.completeTurnForSession(ctx, data.SessionID)

--- a/apps/backend/internal/orchestrator/dynamic_launch_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_launch_test.go
@@ -67,6 +67,64 @@ func TestRelaunchDynamicTaskAfterFailure_DoesNotLaunchSuccessorWhenStopFails(t *
 	}
 }
 
+// TestRelaunchDynamicTaskAfterFailure_DoesNotResurrectCancelledSession proves
+// F-A: a coordinator stop that commits CANCELLED while the predecessor
+// teardown is in flight must win over the relaunch's own CREATED reset.
+// Before the fix, the reset at dynamic_launch.go was an unconditional
+// UpdateTaskSessionState write with no expected-state predicate, so it
+// silently overwrote CANCELLED with CREATED and StartCreatedSession then
+// launched a new agent on the session the user just stopped. This exercises
+// relaunchDynamicTaskAfterFailure directly because LaunchDynamicRouteAction
+// (the manual retry path) calls it without the detached-launch wrapper's
+// shouldDropSessionFailure guard.
+func TestRelaunchDynamicTaskAfterFailure_DoesNotResurrectCancelledSession(t *testing.T) {
+	ctx := context.Background()
+	const (
+		taskID      = "task-dynamic-cancel-race"
+		sessionID   = "session-dynamic-cancel-race"
+		executionID = "execution-dynamic-cancel-race"
+	)
+
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateRunning)
+	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	agentManager := &mockAgentManager{
+		stopAgentWithReasonFunc: func(context.Context, string, string, bool) error {
+			// Simulate a coordinator stop committing CANCELLED between the
+			// route-selection CAS and this relaunch's own destructive reset.
+			return repo.UpdateTaskSessionState(ctx, sessionID, models.TaskSessionStateCancelled, "")
+		},
+	}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentManager)
+	svc.lastTurnPrompt.Store(sessionID, capturedPrompt{text: "retry the task"})
+
+	relaunched := svc.relaunchDynamicTaskAfterFailure(
+		ctx,
+		watcher.AgentEventData{
+			TaskID:           taskID,
+			SessionID:        sessionID,
+			AgentExecutionID: executionID,
+		},
+		"fallback-profile",
+	)
+
+	if relaunched {
+		t.Fatal("relaunchDynamicTaskAfterFailure returned success over a concurrently cancelled session")
+	}
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if session.State != models.TaskSessionStateCancelled {
+		t.Fatalf("session state = %q, want it to stay CANCELLED", session.State)
+	}
+	if len(agentManager.startAgentProcessCalls) != 0 {
+		t.Fatalf("successor launch started %d processes after a concurrent cancel", len(agentManager.startAgentProcessCalls))
+	}
+}
+
 // The agent.failed event that selects a fallback route is dispatched on the
 // lifecycle completion goroutine while it holds the execution's prompt
 // lifecycle lock. Stopping the predecessor needs that lock again, so the

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1153,7 +1153,7 @@ func metadataWithoutEntityReferences(metadata map[string]interface{}) map[string
 // handleAgentCompleted handles agent completion events
 func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEventData) {
 	if data.SessionID == "" {
-		s.handleAgentCompletedLocked(ctx, data)
+		s.handleAgentCompletedLocked(ctx, data, nil)
 		return
 	}
 
@@ -1174,22 +1174,22 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 	// cancel/interrupt decision for this session. If coordinator stop won while
 	// the event waited, the guarded state reload below observes CANCELLED and
 	// suppresses all workflow/on_enter side effects.
-	lock, release := s.acquireCancelInFlightGuard(data.SessionID)
-	if !lock.TryLock() {
+	mutex, release := s.acquireCancelInFlightGuard(data.SessionID)
+	if !mutex.TryLock() {
 		go func() {
-			defer release()
-			lock.Lock()
-			defer lock.Unlock()
-			s.handleAgentCompletedAfterGuard(context.WithoutCancel(ctx), data)
+			mutex.Lock()
+			guard := &lockedCancelInFlightGuard{mutex: mutex, releaseRef: release, locked: true}
+			defer guard.release()
+			s.handleAgentCompletedAfterGuard(context.WithoutCancel(ctx), data, guard)
 		}()
 		return
 	}
-	defer release()
-	defer lock.Unlock()
-	s.handleAgentCompletedAfterGuard(ctx, data)
+	guard := &lockedCancelInFlightGuard{mutex: mutex, releaseRef: release, locked: true}
+	defer guard.release()
+	s.handleAgentCompletedAfterGuard(ctx, data, guard)
 }
 
-func (s *Service) handleAgentCompletedAfterGuard(ctx context.Context, data watcher.AgentEventData) {
+func (s *Service) handleAgentCompletedAfterGuard(ctx context.Context, data watcher.AgentEventData, guard *lockedCancelInFlightGuard) {
 	ctx = withWorkflowProfileSwitchGuardHeld(ctx, data.SessionID, data.AgentExecutionID)
 	if s.isCancelInFlight(data.SessionID) {
 		s.logger.Debug("deferring agent.completed while cancellation is in progress",
@@ -1199,10 +1199,19 @@ func (s *Service) handleAgentCompletedAfterGuard(ctx context.Context, data watch
 		return
 	}
 
-	s.handleAgentCompletedLocked(ctx, data)
+	s.handleAgentCompletedLocked(ctx, data, guard)
 }
 
-func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.AgentEventData) {
+// handleAgentCompletedLocked runs with the per-session cancel-in-flight guard
+// held, except around calls that themselves acquire the session lifecycle
+// lock (reclaimIdleSession, directly or via setSessionWaitingForInputIfRequested):
+// those release the guard first and reacquire it after, mirroring
+// quiesceActiveResetTurn's yield/reacquire protocol, to keep this lock pair's
+// global acquisition order (lifecycle outer, cancel guard inner) intact. guard
+// is nil when data.SessionID == "" (handleAgentCompletedLocked is called directly,
+// with no cancel guard ever acquired); every unlock/relock is a safe no-op on
+// a nil guard.
+func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.AgentEventData, guard *lockedCancelInFlightGuard) {
 	s.logger.Info("handling agent completed",
 		zap.String("task_id", data.TaskID),
 		zap.String("session_id", data.SessionID),
@@ -1309,7 +1318,22 @@ func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.A
 	}
 
 	transitioned := s.processOnTurnCompleteViaEngine(ctx, data.TaskID, session)
+	s.finishAgentCompletedTurn(ctx, data, session, transitioned, guard)
+}
 
+// finishAgentCompletedTurn runs the settle steps after
+// processOnTurnCompleteViaEngine has decided whether the turn advanced the
+// workflow: the WAITING_FOR_INPUT / subtask-terminal-collapse decision,
+// execution cleanup, automation finalize, and the reclaimIdleSession settle
+// point. guard's unlock/relock calls around the lifecycle-lock-acquiring
+// steps follow handleAgentCompletedLocked's doc comment.
+func (s *Service) finishAgentCompletedTurn(
+	ctx context.Context,
+	data watcher.AgentEventData,
+	session *models.TaskSession,
+	transitioned bool,
+	guard *lockedCancelInFlightGuard,
+) {
 	// Agent-exit path: processOnTurnCompleteViaEngine handles normal
 	// on_turn_complete transitions. If it did not transition, ensure the
 	// completed session leaves RUNNING and let setSessionWaitingForInput perform
@@ -1330,7 +1354,9 @@ func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.A
 		// itself inspects the task row to pick the path; for sibling
 		// sessions the call is a no-op pass-through to the unconditional
 		// helper, preserving the pre-fix behavior.
+		guard.unlock()
 		s.setSessionWaitingForInputIfRequested(ctx, data.TaskID, data.SessionID, session)
+		guard.relock()
 	}
 
 	// Capture a git status snapshot before cleanup so it can be served
@@ -1353,6 +1379,7 @@ func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.A
 	// collapsed to COMPLETED inside setSessionWaitingForInputIfRequested
 	// reclaimed earlier; this call covers sibling/office flows whose
 	// settled shape has no live runtime.
+	guard.unlock()
 	if err := s.reclaimIdleSession(context.WithoutCancel(ctx), data.SessionID); err != nil {
 		s.logger.Warn("agent.completed settle: reclaim failed; row preserved",
 			zap.String("task_id", data.TaskID),

--- a/apps/backend/internal/orchestrator/route_action_lock.go
+++ b/apps/backend/internal/orchestrator/route_action_lock.go
@@ -1,0 +1,57 @@
+package orchestrator
+
+import "sync"
+
+// routeActionOperationLock tracks active waiters so its map entry can be
+// removed after the last route action releases the per-session mutex.
+type routeActionOperationLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// acquireRouteActionOperationLock serializes route actions for one session.
+// The returned function must be called exactly once after the handler returns.
+func (s *Service) acquireRouteActionOperationLock(sessionID string) func() {
+	if sessionID == "" {
+		return func() {}
+	}
+
+	s.routeActionLocksMu.Lock()
+	if s.routeActionLocks == nil {
+		s.routeActionLocks = make(map[string]*routeActionOperationLock)
+	}
+	lock, ok := s.routeActionLocks[sessionID]
+	if !ok {
+		lock = &routeActionOperationLock{}
+		s.routeActionLocks[sessionID] = lock
+	}
+	lock.refs++
+	s.routeActionLocksMu.Unlock()
+
+	lock.mu.Lock()
+	var released bool
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		lock.mu.Unlock()
+		s.routeActionLocksMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(s.routeActionLocks, sessionID)
+		}
+		s.routeActionLocksMu.Unlock()
+	}
+}
+
+func (s *Service) isRouteActionInFlight(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	s.routeActionLocksMu.Lock()
+	lock := s.routeActionLocks[sessionID]
+	inFlight := lock != nil && lock.refs > 0
+	s.routeActionLocksMu.Unlock()
+	return inFlight
+}

--- a/apps/backend/internal/orchestrator/route_action_lock_order_test.go
+++ b/apps/backend/internal/orchestrator/route_action_lock_order_test.go
@@ -3,8 +3,14 @@ package orchestrator
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // TestApplyRouteActionAndLifecycleResetDoNotDeadlock proves that
@@ -53,21 +59,27 @@ func TestApplyRouteActionAndLifecycleResetDoNotDeadlock(t *testing.T) {
 		t.Fatal("route action handler never started")
 	}
 
+	resetHasLifecycleLock := make(chan struct{})
 	resetDone := make(chan struct{})
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		releaseLifecycleLock := svc.acquireSessionLifecycleLock(sessionID)
 		defer releaseLifecycleLock()
+		close(resetHasLifecycleLock)
 		resetGuard := svc.lockCancelInFlightGuard(sessionID)
 		defer resetGuard.release()
 		close(resetDone)
 	}()
 
-	// Give the reset goroutine a moment to queue up behind the lifecycle lock
-	// (held by nobody yet) and then attempt the guard, before letting the
-	// route action handler proceed to also request the lifecycle lock.
-	time.Sleep(50 * time.Millisecond)
+	// Barrier: wait for the reset goroutine to actually hold the lifecycle
+	// lock before letting the route action handler also request it. A fixed
+	// sleep here would only assume enough time passed; this proves it.
+	select {
+	case <-resetHasLifecycleLock:
+	case <-time.After(3 * time.Second):
+		t.Fatal("reset goroutine never acquired the session lifecycle lock")
+	}
 	close(handlerMayLockLifecycle)
 
 	waitCh := make(chan struct{})
@@ -89,5 +101,119 @@ func TestApplyRouteActionAndLifecycleResetDoNotDeadlock(t *testing.T) {
 	}
 	if err := <-routeActionDone; err != nil {
 		t.Fatalf("ApplyRouteAction: %v", err)
+	}
+}
+
+// pausedSecondSessionLoadRepo blocks the *second* GetTaskSession call for a
+// target session until released. handleAgentCompleted's first repo call
+// (captureSessionCommitsSweep, via resolveArchiveBaseCommitAndBranch) runs
+// before the cancel-in-flight guard is acquired; the second is
+// handleAgentCompletedLocked's own session load, the first repo access made
+// while that guard is held. Pausing there proves the guard is genuinely held
+// at the moment of the pause, without relying on a real reachability hook
+// production code doesn't have.
+type pausedSecondSessionLoadRepo struct {
+	sessionExecutorStore
+	sessionID string
+	calls     atomic.Int32
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (r *pausedSecondSessionLoadRepo) GetTaskSession(ctx context.Context, sessionID string) (*models.TaskSession, error) {
+	if sessionID == r.sessionID && r.calls.Add(1) == 2 {
+		r.once.Do(func() { close(r.entered) })
+		<-r.release
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+// TestHandleAgentCompletedAndResetAgentContextDoNotDeadlock exercises the
+// real reachability F1a fixed: handleAgentCompletedLocked reaches
+// reclaimIdleSession (directly, and via setSessionWaitingForInputIfRequested)
+// while it can still be holding the cancel-in-flight guard, and
+// reclaimIdleSession's first act is acquireSessionLifecycleLock — the same
+// lock resetAgentContext already holds when it (unconditionally) reacquires
+// the cancel guard via quiesceActiveResetTurn's resetGuard.relock. Two
+// goroutines taking these locks in opposite order on the same session is a
+// live ABBA deadlock unless the guard is released before the lifecycle
+// lock is requested.
+func TestHandleAgentCompletedAndResetAgentContextDoNotDeadlock(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "")
+
+	pausedRepo := &pausedSecondSessionLoadRepo{
+		sessionExecutorStore: repo,
+		sessionID:            "session1",
+		entered:              make(chan struct{}),
+		release:              make(chan struct{}),
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, "task1", v1.TaskStateInProgress)
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.repo = pausedRepo
+
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		svc.handleAgentCompleted(ctx, watcherAgentCompletedData("task1", "session1", "exec-1"))
+	}()
+
+	// Barrier: wait for handleAgentCompleted to reach its own guarded session
+	// load. At this point it holds the cancel-in-flight guard and has not
+	// touched the lifecycle lock.
+	select {
+	case <-pausedRepo.entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handleAgentCompleted never reached its guarded session load")
+	}
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	require.NoError(t, err)
+
+	resetDone := make(chan bool, 1)
+	go func() {
+		resetDone <- svc.resetAgentContext(ctx, "task1", session, "Successor")
+	}()
+
+	// Barrier: prove resetAgentContext has genuinely acquired the lifecycle
+	// lock (and is therefore blocked requesting the guard held above, exactly
+	// like the real global lock order) before releasing the paused handler.
+	// A losing TryLock on the same mutex is a positive signal, not a timing
+	// guess.
+	require.Eventually(t, func() bool {
+		value, ok := svc.sessionLifecycleLocks.Load("session1")
+		if !ok {
+			return false
+		}
+		mu, ok := value.(*sync.Mutex)
+		if !ok {
+			return false
+		}
+		if mu.TryLock() {
+			mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond, "resetAgentContext never acquired the session lifecycle lock")
+
+	close(pausedRepo.release)
+
+	select {
+	case <-handlerDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock: handleAgentCompleted did not complete within 3s")
+	}
+	select {
+	case resetOK := <-resetDone:
+		if !resetOK {
+			t.Fatal("resetAgentContext returned false")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock: resetAgentContext did not complete within 3s")
 	}
 }

--- a/apps/backend/internal/orchestrator/route_action_lock_order_test.go
+++ b/apps/backend/internal/orchestrator/route_action_lock_order_test.go
@@ -1,0 +1,93 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestApplyRouteActionAndLifecycleResetDoNotDeadlock proves that
+// ApplyRouteAction and a session-lifecycle operation (modeled here the same
+// way resetAgentContext acquires its locks) can run concurrently on the same
+// session without an ABBA deadlock between acquireCancelInFlightGuard and
+// acquireSessionLifecycleLock.
+//
+// Before the fix, ApplyRouteAction held the cancel-in-flight guard across the
+// whole routeActionHandler call, and the handler here reaches
+// acquireSessionLifecycleLock (as the real dynamic-route launch path does via
+// startCreatedSession) — guard-then-lifecycle. The concurrent goroutine takes
+// lifecycle-then-guard, exactly like resetAgentContext. With both orders live
+// on the same sessionID, each goroutine can block on the lock the other
+// holds, and neither ever completes.
+func TestApplyRouteActionAndLifecycleResetDoNotDeadlock(t *testing.T) {
+	svc, _ := newTurnLifecycleTestService(t)
+	ctx := context.Background()
+	sessionID := "session1"
+
+	handlerEntered := make(chan struct{})
+	handlerMayLockLifecycle := make(chan struct{})
+	svc.SetRouteActionHandler(func(_ context.Context, request RouteActionRequest) (*RouteActionResult, error) {
+		close(handlerEntered)
+		<-handlerMayLockLifecycle
+		release := svc.acquireSessionLifecycleLock(request.SessionID)
+		defer release()
+		return &RouteActionResult{SessionID: request.SessionID}, nil
+	})
+
+	var wg sync.WaitGroup
+	routeActionDone := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := svc.ApplyRouteAction(ctx, RouteActionRequest{
+			SessionID: sessionID,
+			Action:    RouteActionRetry,
+		})
+		routeActionDone <- err
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("route action handler never started")
+	}
+
+	resetDone := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		releaseLifecycleLock := svc.acquireSessionLifecycleLock(sessionID)
+		defer releaseLifecycleLock()
+		resetGuard := svc.lockCancelInFlightGuard(sessionID)
+		defer resetGuard.release()
+		close(resetDone)
+	}()
+
+	// Give the reset goroutine a moment to queue up behind the lifecycle lock
+	// (held by nobody yet) and then attempt the guard, before letting the
+	// route action handler proceed to also request the lifecycle lock.
+	time.Sleep(50 * time.Millisecond)
+	close(handlerMayLockLifecycle)
+
+	waitCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock: ApplyRouteAction and lifecycle reset did not both complete within 3s")
+	}
+
+	select {
+	case <-resetDone:
+	default:
+		t.Fatal("lifecycle reset goroutine did not complete")
+	}
+	if err := <-routeActionDone; err != nil {
+		t.Fatalf("ApplyRouteAction: %v", err)
+	}
+}

--- a/apps/backend/internal/orchestrator/route_action_serialization_test.go
+++ b/apps/backend/internal/orchestrator/route_action_serialization_test.go
@@ -1,0 +1,156 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestApplyRouteActionSerializesHandlersPerSession(t *testing.T) {
+	svc := &Service{}
+	const sessionID = "session1"
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+
+	svc.SetRouteActionHandler(func(_ context.Context, request RouteActionRequest) (*RouteActionResult, error) {
+		if calls.Add(1) == 1 {
+			close(firstEntered)
+			<-releaseFirst
+		} else {
+			close(secondEntered)
+		}
+		return &RouteActionResult{SessionID: request.SessionID}, nil
+	})
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := svc.ApplyRouteAction(context.Background(), RouteActionRequest{
+			SessionID: sessionID,
+			Action:    RouteActionRetry,
+		})
+		firstDone <- err
+	}()
+
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first route action did not enter its handler")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := svc.ApplyRouteAction(context.Background(), RouteActionRequest{
+			SessionID: sessionID,
+			Action:    RouteActionTryNext,
+		})
+		secondDone <- err
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("second route action entered before the first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	for _, done := range []<-chan error{firstDone, secondDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("ApplyRouteAction: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("route action did not complete")
+		}
+	}
+}
+
+func TestApplyRouteActionAllowsDifferentSessionsConcurrently(t *testing.T) {
+	svc := &Service{}
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	var calls atomic.Int32
+
+	svc.SetRouteActionHandler(func(_ context.Context, request RouteActionRequest) (*RouteActionResult, error) {
+		calls.Add(1)
+		entered <- request.SessionID
+		<-release
+		return &RouteActionResult{SessionID: request.SessionID}, nil
+	})
+
+	var wg sync.WaitGroup
+	for _, sessionID := range []string{"session1", "session2"} {
+		wg.Add(1)
+		go func(sessionID string) {
+			defer wg.Done()
+			_, _ = svc.ApplyRouteAction(context.Background(), RouteActionRequest{
+				SessionID: sessionID,
+				Action:    RouteActionRetry,
+			})
+		}(sessionID)
+	}
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case sessionID := <-entered:
+			seen[sessionID] = true
+		case <-time.After(time.Second):
+			t.Fatal("route actions for different sessions did not run concurrently")
+		}
+	}
+	close(release)
+	wg.Wait()
+	if calls.Load() != 2 || len(seen) != 2 {
+		t.Fatalf("calls = %d, sessions = %#v, want one call per session", calls.Load(), seen)
+	}
+}
+
+func TestRouteActionClaimBlocksPromptAdmission(t *testing.T) {
+	svc, repo := newTurnLifecycleTestService(t)
+	ctx := context.Background()
+	const sessionID = "session1"
+	if err := repo.UpdateTaskSessionState(ctx, sessionID, models.TaskSessionStateWaitingForInput, ""); err != nil {
+		t.Fatalf("set session promptable: %v", err)
+	}
+
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	svc.SetRouteActionHandler(func(_ context.Context, _ RouteActionRequest) (*RouteActionResult, error) {
+		close(handlerEntered)
+		<-releaseHandler
+		return &RouteActionResult{SessionID: sessionID}, nil
+	})
+
+	routeDone := make(chan error, 1)
+	go func() {
+		_, err := svc.ApplyRouteAction(ctx, RouteActionRequest{
+			SessionID: sessionID,
+			Action:    RouteActionRetry,
+		})
+		routeDone <- err
+	}()
+	select {
+	case <-handlerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("route action handler did not start")
+	}
+
+	_, _, _, _, _, err := svc.claimSessionRunningForPrompt(
+		ctx, "task1", sessionID, "", false, nil, nil, "", false,
+	)
+	close(releaseHandler)
+	if routeErr := <-routeDone; routeErr != nil {
+		t.Fatalf("route action: %v", routeErr)
+	}
+	if !errors.Is(err, ErrAgentPromptInProgress) {
+		t.Fatalf("prompt admission error = %v, want route-action busy error", err)
+	}
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1269,12 +1269,16 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 // acquireSessionLifecycleLock.
 //
 // Releasing the guard before dispatch leaves a window where a turn could
-// start between this read and routeActionHandler's launch. That is a
-// route-action-vs-turn-start race, distinct from route-action-vs-route-action
-// (already serialized by the generation CAS in ResolveRouteAction, e.g.
-// ErrStaleGeneration). It is accepted here: closing it would mean holding
-// the guard across the dispatch again, reintroducing the deadlock this
-// function exists to remove.
+// start, or a cancellation could land, between this read and
+// routeActionHandler's launch. Both are accepted here: closing them would
+// mean holding the guard across the dispatch again, reintroducing the
+// deadlock this function exists to remove. route-action-vs-route-action is
+// already serialized by the generation CAS in ResolveRouteAction (e.g.
+// ErrStaleGeneration); route-action-vs-cancellation is handled downstream —
+// every full-session-row write in dynamic_routing.go is conditioned via
+// UpdateTaskSessionIfCurrentState on the state last confirmed before the
+// write, so a cancellation that commits during the window is detected and
+// wins instead of being overwritten by a stale route-action snapshot.
 func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
 	if s.turnService == nil {
 		return nil

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1267,6 +1267,14 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 // (dynamic route launches relaunch through startCreatedSession), and holding
 // the guard across it would invert the global lock order documented on
 // acquireSessionLifecycleLock.
+//
+// Releasing the guard before dispatch leaves a window where a turn could
+// start between this read and routeActionHandler's launch. That is a
+// route-action-vs-turn-start race, distinct from route-action-vs-route-action
+// (already serialized by the generation CAS in ResolveRouteAction, e.g.
+// ErrStaleGeneration). It is accepted here: closing it would mean holding
+// the guard across the dispatch again, reintroducing the deadlock this
+// function exists to remove.
 func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
 	if s.turnService == nil {
 		return nil
@@ -2489,9 +2497,16 @@ func (s *Service) setSessionResetInProgress(sessionID string, inProgress bool) {
 // Global lock order: this lock is OUTER to acquireCancelInFlightGuard. A
 // caller that holds the cancel-in-flight guard for sessionID must release it
 // (lockedCancelInFlightGuard's unlock/relock protocol) before acquiring this
-// lock. Acquiring them in the opposite order on the same session deadlocks
-// against every caller that already takes lifecycle first — resetAgentContext,
-// ResumeTaskSessionWithOptions, ensureSessionRunning.
+// lock, or it can deadlock against every caller that already takes lifecycle
+// first — resetAgentContext, ResumeTaskSessionWithOptions,
+// ensureSessionRunning, reclaimIdleSession. handleAgentCompletedLocked and
+// ApplyRouteAction's route-action dispatch follow this order.
+//
+// Known remaining inversion: autoStartStepPrompt (event_handlers_workflow.go)
+// holds the cancel guard across the whole StartCreatedSession launch for a
+// session in CREATED state, by design, to keep terminalization from racing
+// the launch admission. Closing it needs a redesign of that admission
+// invariant, tracked separately rather than in this lock-order fix.
 func (s *Service) acquireSessionLifecycleLock(sessionID string) func() {
 	if sessionID == "" {
 		return func() {}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1270,15 +1270,24 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 //
 // Releasing the guard before dispatch leaves a window where a turn could
 // start, or a cancellation could land, between this read and
-// routeActionHandler's launch. Both are accepted here: closing them would
-// mean holding the guard across the dispatch again, reintroducing the
-// deadlock this function exists to remove. route-action-vs-route-action is
-// already serialized by the generation CAS in ResolveRouteAction (e.g.
-// ErrStaleGeneration); route-action-vs-cancellation is handled downstream —
-// every full-session-row write in dynamic_routing.go is conditioned via
-// UpdateTaskSessionIfCurrentState on the state last confirmed before the
-// write, so a cancellation that commits during the window is detected and
-// wins instead of being overwritten by a stale route-action snapshot.
+// routeActionHandler's launch. Closing either would mean holding the guard
+// across the dispatch again, reintroducing the deadlock this function exists
+// to remove, so both windows stay open — but they are not equally covered.
+// route-action-vs-route-action is already serialized by the generation CAS
+// in ResolveRouteAction (e.g. ErrStaleGeneration). route-action-vs-cancellation
+// is covered downstream: every full-session-row write in dynamic_routing.go
+// is conditioned via UpdateTaskSessionIfCurrentState on a state confirmed no
+// earlier than the write itself, so a cancellation landing during the window
+// is detected and wins instead of being overwritten by a stale snapshot.
+// route-action-vs-turn-admission is NOT covered: a turn admitted in this
+// window takes the same cancel-in-flight guard (task_operations.go's
+// claimLifecyclePromptDispatch, queued_dispatch.go's
+// claimQueuedDispatchForExecution) and can start successfully after this
+// check passes, but relaunchDynamicTaskAfterFailure's destructive reset
+// (StopExecution + session state reset to CREATED) has no way to see that
+// admission — RUNNING is a state the CAS accepts — so it can stop and reset a
+// turn that was legitimately admitted after this function returned nil.
+// Tracked as a follow-up rather than closed here.
 func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
 	if s.turnService == nil {
 		return nil

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1254,22 +1254,37 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 	if err := s.authorizeSession(ctx, request.SessionID); err != nil {
 		return nil, err
 	}
-	lock, release := s.acquireCancelInFlightGuard(request.SessionID)
+	if err := s.rejectRouteActionDuringActiveTurn(ctx, request.SessionID); err != nil {
+		return nil, err
+	}
+	return s.routeActionHandler(ctx, request)
+}
+
+// rejectRouteActionDuringActiveTurn holds the cancel-in-flight guard only for
+// the active-turn read, making it atomic against a concurrent cancel
+// decision. The guard is released before ApplyRouteAction calls
+// routeActionHandler: that handler can reach acquireSessionLifecycleLock
+// (dynamic route launches relaunch through startCreatedSession), and holding
+// the guard across it would invert the global lock order documented on
+// acquireSessionLifecycleLock.
+func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
+	if s.turnService == nil {
+		return nil
+	}
+	lock, release := s.acquireCancelInFlightGuard(sessionID)
 	lock.Lock()
 	defer func() {
 		lock.Unlock()
 		release()
 	}()
-	if s.turnService != nil {
-		activeTurn, err := s.turnService.GetActiveTurn(ctx, request.SessionID)
-		if err != nil && !isNoActiveTurnError(err) {
-			return nil, fmt.Errorf("check active turn for route action: %w", err)
-		}
-		if activeTurn != nil {
-			return nil, ErrRouteActionActiveTurn
-		}
+	activeTurn, err := s.turnService.GetActiveTurn(ctx, sessionID)
+	if err != nil && !isNoActiveTurnError(err) {
+		return fmt.Errorf("check active turn for route action: %w", err)
 	}
-	return s.routeActionHandler(ctx, request)
+	if activeTurn != nil {
+		return ErrRouteActionActiveTurn
+	}
+	return nil
 }
 
 // Status contains orchestrator status information
@@ -2470,6 +2485,13 @@ func (s *Service) setSessionResetInProgress(sessionID string, inProgress bool) {
 // session's persisted conversation identity. Keep the critical section around
 // the complete reset/resume operation, including the bounded runtime wait, so
 // no caller can launch with a token that a concurrent reset is invalidating.
+//
+// Global lock order: this lock is OUTER to acquireCancelInFlightGuard. A
+// caller that holds the cancel-in-flight guard for sessionID must release it
+// (lockedCancelInFlightGuard's unlock/relock protocol) before acquiring this
+// lock. Acquiring them in the opposite order on the same session deadlocks
+// against every caller that already takes lifecycle first — resetAgentContext,
+// ResumeTaskSessionWithOptions, ensureSessionRunning.
 func (s *Service) acquireSessionLifecycleLock(sessionID string) func() {
 	if sessionID == "" {
 		return func() {}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -607,6 +607,12 @@ type Service struct {
 	// seam.
 	routeActionHandler func(context.Context, RouteActionRequest) (*RouteActionResult, error)
 
+	// routeActionLocks serializes manual route actions for one session from the
+	// active-turn check through handler completion. It is separate from
+	// cancelInFlight because route handlers can reach the lifecycle lock.
+	routeActionLocksMu sync.Mutex
+	routeActionLocks   map[string]*routeActionOperationLock
+
 	// profileExecutionResolver is the shared logical-to-concrete profile
 	// boundary used by task and workflow launch paths.
 	profileExecutionResolver *agentruntime.ProfileExecutionResolver
@@ -1254,6 +1260,8 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 	if err := s.authorizeSession(ctx, request.SessionID); err != nil {
 		return nil, err
 	}
+	releaseRouteAction := s.acquireRouteActionOperationLock(request.SessionID)
+	defer releaseRouteAction()
 	if err := s.rejectRouteActionDuringActiveTurn(ctx, request.SessionID); err != nil {
 		return nil, err
 	}
@@ -1268,29 +1276,21 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 // the guard across it would invert the global lock order documented on
 // acquireSessionLifecycleLock.
 //
-// Releasing the guard before dispatch leaves a window where a turn could
-// start, or a cancellation could land, between this read and
-// routeActionHandler's launch. Closing either would mean holding the guard
-// across the dispatch again, reintroducing the deadlock this function exists
-// to remove, so both windows stay open — but they are not equally covered.
-// route-action-vs-route-action is already serialized by the generation CAS
-// in ResolveRouteAction (e.g. ErrStaleGeneration). route-action-vs-cancellation
-// is covered end to end: every full-session-row write in dynamic_routing.go
-// is conditioned via UpdateTaskSessionIfCurrentState on a state confirmed no
-// earlier than the write itself, and relaunchDynamicTaskAfterFailure's own
-// CREATED reset (dynamic_launch.go) reloads the session immediately before
-// writing, refuses a reloaded terminal state, and CASes on that reload — so a
-// cancellation landing anywhere in the window, including during the
-// predecessor's StopExecution, is detected and wins instead of being
-// overwritten by a stale snapshot. route-action-vs-turn-admission is NOT
-// covered: a turn admitted in this window takes the same cancel-in-flight
-// guard (task_operations.go's claimLifecyclePromptDispatch,
-// queued_dispatch.go's claimQueuedDispatchForExecution) and can start
-// successfully after this check passes, but relaunchDynamicTaskAfterFailure's
-// destructive reset (StopExecution + session state reset to CREATED) has no
-// way to see that admission — RUNNING is a state the CAS accepts — so it can
-// stop and reset a turn that was legitimately admitted after this function
-// returned nil. Tracked as a follow-up rather than closed here.
+// route-action-vs-route-action is serialized locally by the per-session
+// operation lock held by ApplyRouteAction. ResolveRouteAction's generation CAS
+// remains the cross-process fence (for example, ErrStaleGeneration).
+// route-action-vs-cancellation is protected for projection writes: every
+// full-session-row write in dynamic_routing.go is conditioned via
+// UpdateTaskSessionIfCurrentState on a state confirmed no earlier than the
+// write itself, and relaunchDynamicTaskAfterFailure's CREATED reset reloads
+// the session immediately before writing, refuses a reloaded terminal state,
+// and CASes on that reload. Launch admission after that reset still needs the
+// lifecycle cancellation fence described in the dynamic launch follow-up.
+// route-action-vs-turn-admission is protected at the final RUNNING/turn claim:
+// both direct and lifecycle prompt admission check the operation marker while
+// holding cancelInFlight, so a new turn cannot be admitted after a route action
+// claims the session. Pre-admission process resume can still race that handler
+// and remains a separate lifecycle handoff concern.
 func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
 	if s.turnService == nil {
 		return nil

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1275,19 +1275,22 @@ func (s *Service) ApplyRouteAction(ctx context.Context, request RouteActionReque
 // to remove, so both windows stay open — but they are not equally covered.
 // route-action-vs-route-action is already serialized by the generation CAS
 // in ResolveRouteAction (e.g. ErrStaleGeneration). route-action-vs-cancellation
-// is covered downstream: every full-session-row write in dynamic_routing.go
+// is covered end to end: every full-session-row write in dynamic_routing.go
 // is conditioned via UpdateTaskSessionIfCurrentState on a state confirmed no
-// earlier than the write itself, so a cancellation landing during the window
-// is detected and wins instead of being overwritten by a stale snapshot.
-// route-action-vs-turn-admission is NOT covered: a turn admitted in this
-// window takes the same cancel-in-flight guard (task_operations.go's
-// claimLifecyclePromptDispatch, queued_dispatch.go's
-// claimQueuedDispatchForExecution) and can start successfully after this
-// check passes, but relaunchDynamicTaskAfterFailure's destructive reset
-// (StopExecution + session state reset to CREATED) has no way to see that
-// admission — RUNNING is a state the CAS accepts — so it can stop and reset a
-// turn that was legitimately admitted after this function returned nil.
-// Tracked as a follow-up rather than closed here.
+// earlier than the write itself, and relaunchDynamicTaskAfterFailure's own
+// CREATED reset (dynamic_launch.go) reloads the session immediately before
+// writing, refuses a reloaded terminal state, and CASes on that reload — so a
+// cancellation landing anywhere in the window, including during the
+// predecessor's StopExecution, is detected and wins instead of being
+// overwritten by a stale snapshot. route-action-vs-turn-admission is NOT
+// covered: a turn admitted in this window takes the same cancel-in-flight
+// guard (task_operations.go's claimLifecyclePromptDispatch,
+// queued_dispatch.go's claimQueuedDispatchForExecution) and can start
+// successfully after this check passes, but relaunchDynamicTaskAfterFailure's
+// destructive reset (StopExecution + session state reset to CREATED) has no
+// way to see that admission — RUNNING is a state the CAS accepts — so it can
+// stop and reset a turn that was legitimately admitted after this function
+// returned nil. Tracked as a follow-up rather than closed here.
 func (s *Service) rejectRouteActionDuringActiveTurn(ctx context.Context, sessionID string) error {
 	if s.turnService == nil {
 		return nil
@@ -2515,11 +2518,20 @@ func (s *Service) setSessionResetInProgress(sessionID string, inProgress bool) {
 // ensureSessionRunning, reclaimIdleSession. handleAgentCompletedLocked and
 // ApplyRouteAction's route-action dispatch follow this order.
 //
-// Known remaining inversion: autoStartStepPrompt (event_handlers_workflow.go)
-// holds the cancel guard across the whole StartCreatedSession launch for a
-// session in CREATED state, by design, to keep terminalization from racing
-// the launch admission. Closing it needs a redesign of that admission
-// invariant, tracked separately rather than in this lock-order fix.
+// Known remaining inversions, both guard-then-lifecycle chains that reach
+// this lock while still holding the cancel-in-flight guard, by design, to
+// keep terminalization/failure-routing from racing launch admission. Closing
+// them needs a redesign of that admission invariant, tracked separately
+// rather than in this lock-order fix:
+//   - autoStartStepPrompt (event_handlers_workflow.go) holds the guard across
+//     the whole StartCreatedSession launch for a session in CREATED state.
+//   - runDetachedDynamicSuccessorLaunch (dynamic_launch.go) acquires its own
+//     guard and reaches this lock via relaunchDynamicTaskAfterFailure ->
+//     StartCreatedSession. Both handleAgentFailedLocked and
+//     handleAgentErrorEvent schedule it (via routeDynamicAgentFailure ->
+//     launchDynamicSuccessorAfterFailure -> launchDynamicSuccessorDetached)
+//     as a detached goroutine rather than reaching it while holding their own
+//     dispatch-level guard, so this is one call site, not two.
 func (s *Service) acquireSessionLifecycleLock(sessionID string) func() {
 	if sessionID == "" {
 		return func() {}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -5044,6 +5044,9 @@ func (s *Service) claimSessionRunningForPrompt(
 	if s.isSessionResetInProgress(sessionID) {
 		return nil, "", "", false, nil, ErrSessionResetInProgress
 	}
+	if s.isRouteActionInFlight(sessionID) {
+		return nil, "", "", false, nil, fmt.Errorf("%w, route action is in progress", ErrAgentPromptInProgress)
+	}
 	if expectedCurrentTurnID != "" {
 		if s.turnService == nil {
 			return nil, "", "", false, nil, errors.New("cannot verify expected prompt turn without turn service")
@@ -5151,6 +5154,9 @@ func (s *Service) claimLifecycleSessionRunning(
 	}
 	if s.isSessionResetInProgress(sessionID) {
 		return nil, "", "", false, ErrSessionResetInProgress
+	}
+	if s.isRouteActionInFlight(sessionID) {
+		return nil, "", "", false, fmt.Errorf("%w, route action is in progress", ErrAgentPromptInProgress)
 	}
 
 	if claimEntryID != "" && !s.isCurrentQueuedDispatch(sessionID, claimEntryID) {

--- a/apps/backend/internal/plugins/webapp_protocol_json.go
+++ b/apps/backend/internal/plugins/webapp_protocol_json.go
@@ -139,7 +139,7 @@ func webAppTaskFromSDK(task pluginsdk.Task) webAppTask {
 		WorkflowStepID:         task.WorkflowStepID,
 		Position:               task.Position,
 		AssigneeAgentProfileID: task.AssigneeAgentProfileID,
-		Labels:                 task.Labels,
+		Labels:                 task.Labels, //nolint:staticcheck // retain API v1 label compatibility
 		Autopilot:              task.Autopilot,
 		WIPAdmitted:            task.WIPAdmitted,
 		QueuedForStepID:        task.QueuedForStepID,


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3443/b0286e5ca2d0.html)
<!-- kandev-pr-walkthrough-end -->

A manual "retry"/"try next agent" route action can grab a session's cancel-in-flight guard and session lifecycle lock in the opposite order from a concurrent context reset on the same session, so the two can deadlock on each other and the task hangs until the backend restarts.

**Today:** A manual route action (retry, try-next-agent) or the automatic dynamic-fallback launch can deadlock against a concurrent session context reset, because the two took the same two per-session locks in opposite orders. When it lands, the affected task's session hangs forever — no route action, cancel, or reset can complete — and needs a backend restart to recover.
**After this:** Every path that touches both the cancel-in-flight guard and the session lifecycle lock now takes them in the same order (lifecycle outer, guard inner), so a route action and a context reset can no longer deadlock against each other. The doc comment on `acquireSessionLifecycleLock` now states this order explicitly and names the remaining exceptions.
**Who hits this:** Anyone using dynamic/office-managed agent routing (provider fallback, manual retry, try-next-agent) who races a concurrent context reset or cancellation on the same session. Narrow timing window, but a full hang when it lands.
**Scope:** standalone fix; no sibling PRs.
**Not here:** two known guard-then-lifecycle chains are deliberately left in place (`autoStartStepPrompt`'s CREATED-session auto-start, and the detached automatic-fallback launch worker), plus a route-action-vs-turn-admission race that this diff narrows but doesn't close. Closing all three needs a redesign of the launch-admission invariant; tracked as follow-up work rather than expanding this PR.

## Important Changes

- `ApplyRouteAction` no longer holds the cancel-in-flight guard across the whole route-action dispatch — it holds the guard only for the atomic active-turn check, then releases it before launching, so it never waits on a lock a context reset already holds in the opposite order.
- The agent-completed handler threads a lock handle through its call chain so it can release the guard around the two calls that themselves take the session lifecycle lock, then reacquire it afterward, instead of holding both locks in the wrong order for the whole handler.
- Full-row session writes on the dynamic-route-action path now go through compare-and-swap writes conditioned on a freshly reloaded state, so a route action can no longer overwrite a session a concurrent cancellation just marked terminal.
- The same CAS discipline was applied to the automatic-relaunch-after-failure path's CREATED-state reset, closing the same resurrection risk for that path (including through an unrelated upstream refactor that moved this path onto a detached-goroutine launch — verified the CAS fix still applies and isn't superseded by that refactor).

## Validation

- `go build -tags fts5 ./...`
- `make -C apps/backend lint` → 0 issues
- `gofmt -l` on all changed files → empty
- `go test -tags fts5 -race -count=1 ./internal/orchestrator/...` → ok
- `go test -tags fts5 -race -count=1 ./internal/backendapp/...` → ok
- `go test -tags fts5 -p 2 ./...` (full backend suite): failures limited to a pre-existing, disk-pressure-related flake set on this shared build host, verified identical against `origin/main` in a separate scratch worktree; zero failures in any package this PR touches.
- `make typecheck`, `pnpm --filter @kandev/web lint`, `make lint-format`, `pnpm run i18n:ratchet` — all pass (diff is backend-only and doesn't touch `apps/web/**`; included per repo checklist).

## Possible Improvements

Low risk: this only reorders lock acquisition and adds CAS guards to existing write paths. A route-action-vs-turn-admission race is narrowed (not created) by this diff and left open rather than fixed here, since closing it needs holding the guard across dispatch again — reintroducing the exact deadlock this PR removes — and a real fix needs a larger launch-admission redesign.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->