### PR TITLE
fix(backend): stop workflow triggers from re-running actions right after a restart

### DIFF
--- a/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
+++ b/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
@@ -525,7 +525,7 @@ func TestQueuePromotionOfBlockedWIPOverflowDoesNotLaunch(t *testing.T) {
 	// only the deferred agent launch must remain gated.
 	dependencies := &launchDependencyReader{blocked: true}
 	svc.SetTaskDependencyReader(dependencies)
-	store := newWorkflowStore(repo, steps, svc.agentManager, noopPublisher, testLogger(),
+	store := newWorkflowStore(repo, steps, svc.agentManager, noopPublisher, testLogger(), &operationLedger{},
 		func(eventCtx context.Context, task *models.Task) {
 			svc.handleTaskQueuePromoted(eventCtx, watcher.TaskEventData{TaskID: task.ID})
 		})

--- a/apps/backend/internal/orchestrator/event_handlers_agent_error_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent_error_test.go
@@ -728,7 +728,7 @@ func (r *agentErrorListSessionsErrorRepo) ListTaskSessions(_ context.Context, _ 
 func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("unregistered action warns with all six fields, dispatch still proceeds", func(t *testing.T) {
+	t.Run("unregistered action warns and leaves operation unmarked", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")
 		stepGetter := newMockStepGetter()
@@ -755,14 +755,18 @@ func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 				t.Errorf("field %q = %v, want %v", key, fields[key], want)
 			}
 		}
-		// Since queue_run has no adapter, HandleTrigger reports it as an
-		// action with no effect: ActionCount > 0 but nothing executed, so
-		// this is the AC-A6 INFO dispatch record, not AC-E2's DEBUG. Both the
-		// walk WARNING above and this INFO must be present together — the
-		// pair is what AC-E4/AC-A6's "does not count against at most one"
-		// carve-out actually requires proving.
-		if got := filterLogs(logs, msgAgentErrorDispatched); len(got) != 1 {
-			t.Errorf("got %d %q INFO record(s), want 1 (dispatch must still proceed alongside the walk WARNING)", len(got), msgAgentErrorDispatched)
+		if got := filterLogs(logs, msgAgentErrorDispatchFailed); len(got) != 1 {
+			t.Errorf("got %d %q ERROR record(s), want 1", len(got), msgAgentErrorDispatchFailed)
+		}
+		if got := filterLogs(logs, msgAgentErrorDispatched); len(got) != 0 {
+			t.Errorf("got %d %q INFO record(s), want 0", len(got), msgAgentErrorDispatched)
+		}
+		applied, err := svc.workflowStore.IsOperationApplied(ctx, agentErrorOperationID("s1", "exec-1"))
+		if err != nil {
+			t.Fatalf("check operation ledger: %v", err)
+		}
+		if applied {
+			t.Fatal("unregistered action was recorded as applied")
 		}
 	})
 
@@ -795,7 +799,7 @@ func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 		}
 	})
 
-	t.Run("idempotent redelivery still warns but emits no dispatch record", func(t *testing.T) {
+	t.Run("unregistered action remains retryable on redelivery", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")
 		stepGetter := newMockStepGetter()
@@ -811,8 +815,11 @@ func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 
 		data := watcher.AgentEventData{TaskID: "t1", SessionID: "s1", AgentExecutionID: "exec-1"}
 		svc.handleRecoverableFailureLocked(ctx, data)
-		if got := filterLogs(logs, msgAgentErrorDispatched); len(got) != 1 {
-			t.Fatalf("first delivery: got %d INFO records, want 1", len(got))
+		if decisions.clearCalls != 0 {
+			t.Fatalf("first delivery clearCalls = %d, want 0", decisions.clearCalls)
+		}
+		if got := filterLogs(logs, msgAgentErrorDispatchFailed); len(got) != 1 {
+			t.Fatalf("first delivery: got %d ERROR records, want 1", len(got))
 		}
 
 		logs.TakeAll()
@@ -821,7 +828,10 @@ func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 			t.Errorf("redelivery: got %d WARNINGs, want 1 (walk runs before the idempotency short-circuit)", len(got))
 		}
 		if got := filterLogs(logs, msgAgentErrorDispatched); len(got) != 0 {
-			t.Errorf("redelivery: got a dispatch record, want none (idempotent)")
+			t.Errorf("redelivery: got a dispatch record, want none while callback is unregistered")
+		}
+		if got := filterLogs(logs, msgAgentErrorDispatchFailed); len(got) != 1 {
+			t.Errorf("redelivery: got %d ERROR records, want 1", len(got))
 		}
 	})
 
@@ -843,16 +853,31 @@ func TestDispatchKanbanAgentErrorTrigger_ActionVocabularyWarn(t *testing.T) {
 		if decisions.clearCalls != 0 {
 			t.Fatalf("before wiring: clearCalls = %d, want 0", decisions.clearCalls)
 		}
+		operationID := agentErrorOperationID("s1", "exec-1")
+		applied, err := svc.workflowStore.IsOperationApplied(ctx, operationID)
+		if err != nil {
+			t.Fatalf("before wiring: check operation ledger: %v", err)
+		}
+		if applied {
+			t.Fatal("before wiring: operation was marked applied")
+		}
 
 		logs.TakeAll()
 		svc.SetEngineDecisionStore(decisions) // triggers reinitWorkflowEngine
 
-		svc.handleRecoverableFailureLocked(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1", AgentExecutionID: "exec-2"})
+		svc.handleRecoverableFailureLocked(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1", AgentExecutionID: "exec-1"})
 		if got := filterLogs(logs, msgAgentErrorActionUnregistered); len(got) != 0 {
 			t.Errorf("after wiring: got %d WARNINGs, want 0 (clear_decisions is now registered)", len(got))
 		}
 		if decisions.clearCalls != 1 {
 			t.Errorf("after wiring: clearCalls = %d, want 1", decisions.clearCalls)
+		}
+		applied, err = svc.workflowStore.IsOperationApplied(ctx, operationID)
+		if err != nil {
+			t.Fatalf("after wiring: check operation ledger: %v", err)
+		}
+		if !applied {
+			t.Fatal("after wiring: successful operation was not marked applied")
 		}
 	})
 

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -113,7 +113,7 @@ func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID strin
 		return false
 	}
 
-	result, ok := s.evaluateChildrenCompleted(ctx, parent, session, rows)
+	result, ok := s.evaluateChildrenCompleted(ctx, parent, session, rows, operationID)
 	if !ok {
 		return false
 	}
@@ -223,15 +223,20 @@ func (s *Service) evaluateChildrenCompleted(
 	parent *models.Task,
 	session *models.TaskSession,
 	rows []models.ChildCompletionRow,
+	operationID string,
 ) (engine.HandleResult, bool) {
 	state := s.buildMachineState(ctx, parent, session)
 	result, err := s.workflowEngine.HandleTrigger(ctx, engine.HandleInput{
-		TaskID:         parent.ID,
-		SessionID:      session.ID,
-		Trigger:        engine.TriggerOnChildrenCompleted,
-		EvaluateOnly:   true,
-		PreloadedState: &state,
-		Payload:        childCompletionPayload(rows),
+		TaskID:       parent.ID,
+		SessionID:    session.ID,
+		Trigger:      engine.TriggerOnChildrenCompleted,
+		OperationID:  operationID,
+		EvaluateOnly: true,
+		// The outer handler owns the final idempotency mark because it must
+		// commit the transition lifecycle before accepting this operation.
+		DeferOperationMark: true,
+		PreloadedState:     &state,
+		Payload:            childCompletionPayload(rows),
 	})
 	if err != nil {
 		s.logger.Warn("on_children_completed: workflow engine error",

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_guarded_transition_test.go
@@ -99,7 +99,7 @@ func TestApplyGuardedTransitionLifecycle_OfficeRejectLeg_DoesNotPromptDeciderSes
 	svc := &Service{
 		logger: log, repo: repo, workflowStepGetter: stepGetter, taskRepo: taskRepo, agentManager: agentMgr,
 		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
-		workflowStore: newWorkflowStore(repo, stepGetter, agentMgr, noopPublisher, log),
+		workflowStore: newWorkflowStore(repo, stepGetter, agentMgr, noopPublisher, log, &operationLedger{}),
 	}
 	onEnterDone := make(chan struct{}, 1)
 	svc.onProcessOnEnterComplete = func() {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_passthrough_profile_test.go
@@ -169,7 +169,7 @@ func TestApplyEngineTransitionRejectsPassthroughTargetProfileBeforePersistingSte
 	svc := &Service{
 		logger: log, repo: repo, workflowStepGetter: steps, taskRepo: taskRepo, agentManager: agentManager,
 		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
-		workflowStore: newWorkflowStore(repo, steps, agentManager, noopPublisher, log),
+		workflowStore: newWorkflowStore(repo, steps, agentManager, noopPublisher, log, &operationLedger{}),
 	}
 
 	applied := svc.applyEngineTransition(ctx, "t1", session, engine.HandleResult{

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_preflight_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_preflight_test.go
@@ -180,7 +180,7 @@ func TestApplyEngineTransitionRejectsTargetProfileBeforePersistingStep(t *testin
 	svc := &Service{
 		logger: log, repo: repo, workflowStepGetter: steps, taskRepo: taskRepo, agentManager: agentMgr,
 		messageQueue: messagequeue.NewServiceMemory(log), executor: exec,
-		workflowStore: newWorkflowStore(repo, steps, agentMgr, noopPublisher, log),
+		workflowStore: newWorkflowStore(repo, steps, agentMgr, noopPublisher, log, &operationLedger{}),
 	}
 
 	applied := svc.applyEngineTransition(ctx, "t1", session, engine.HandleResult{

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -651,6 +651,12 @@ type Service struct {
 	// Workflow engine for typed state-machine evaluation of step transitions
 	workflowEngine *engine.Engine
 	workflowStore  *workflowStore
+	// operationLedger is the OperationID idempotency ledger every
+	// workflowStore initWorkflowEngine builds shares, so rebuilding the
+	// engine (any Set* call) never discards a marked operation. Its zero
+	// value is usable and it is never reassigned — see
+	// docs/specs/workflow-engine-operation-ledger-lifetime/spec.md.
+	operationLedger operationLedger
 	// agentErrorDeps bundles the engine, callback registry and store the
 	// on_agent_error dispatch reads, published as one atomic value by
 	// initWorkflowEngine so a dispatch racing a Set* reinit never pairs a new
@@ -1881,7 +1887,7 @@ func (s *Service) initWorkflowEngine() {
 	if s.workflowStepGetter == nil {
 		return
 	}
-	store := newWorkflowStore(s.repo, s.workflowStepGetter, s.agentManager, s.publishTaskUpdated, s.logger, s.publishTaskMoved, s.publishTaskQueuePromoted, s.publishTaskStateChanged, s.stepHistoryRecorder)
+	store := newWorkflowStore(s.repo, s.workflowStepGetter, s.agentManager, s.publishTaskUpdated, s.logger, &s.operationLedger, s.publishTaskMoved, s.publishTaskQueuePromoted, s.publishTaskStateChanged, s.stepHistoryRecorder)
 	store.setGuardedTransitionLifecycle(s.applyGuardedTransitionLifecycle)
 	callbacks := buildWorkflowCallbacks(s)
 	s.workflowStore = store

--- a/apps/backend/internal/orchestrator/workflow_callbacks.go
+++ b/apps/backend/internal/orchestrator/workflow_callbacks.go
@@ -25,10 +25,9 @@ type ReviewRunner interface {
 //
 // Phase 2 (ADR-0004) callbacks — queue_run, clear_decisions,
 // queue_run_for_each_participant — are registered conditionally based on
-// the orchestrator's wired adapters. If adapters are missing the action
-// kinds simply have no callback; the engine treats unknown kinds as no-ops
-// (see engine.executeCallback). This keeps kanban-only deployments
-// untouched.
+// the orchestrator's wired adapters. If adapters are missing, triggers
+// without an operation id retain the legacy no-op behavior. Operation-bearing
+// triggers fail before execution so late wiring can retry them safely.
 func buildWorkflowCallbacks(svc *Service) engine.MapRegistry {
 	r := engine.MapRegistry{
 		engine.ActionEnablePlanMode:    &enablePlanModeCallback{svc: svc},

--- a/apps/backend/internal/orchestrator/workflow_operation_ledger_test.go
+++ b/apps/backend/internal/orchestrator/workflow_operation_ledger_test.go
@@ -30,6 +30,29 @@ func TestOperationLedgerZeroValueReportsNothingApplied(t *testing.T) {
 	}
 }
 
+// AC-S7: operation ids are compared by exact byte equality. The ledger must
+// not trim, case-fold, normalize, or truncate a key, and a key containing a
+// character other producers rely on (":") must round-trip unchanged.
+func TestOperationLedgerKeysComparedByExactByteEquality(t *testing.T) {
+	var ledger operationLedger
+	ledger.markApplied("Op-1")
+
+	for _, id := range []string{"op-1", " Op-1 ", "Op-1x", "Op-1:"} {
+		if ledger.isApplied(id) {
+			t.Errorf("expected %q not to be reported applied by a mark of %q", id, "Op-1")
+		}
+	}
+	if !ledger.isApplied("Op-1") {
+		t.Fatal("expected exact match to be reported applied")
+	}
+
+	const withColon = "parent-op:switch_workflow:on_enter"
+	ledger.markApplied(withColon)
+	if !ledger.isApplied(withColon) {
+		t.Fatal("expected a key containing ':' to round-trip unchanged")
+	}
+}
+
 // AC-L6/AC-S6: concurrent access needs no external locking, and two
 // goroutines checking the same unmarked id may both observe "not applied"
 // and proceed — the ledger is a memo, not a mutex. Run with -race.

--- a/apps/backend/internal/orchestrator/workflow_operation_ledger_test.go
+++ b/apps/backend/internal/orchestrator/workflow_operation_ledger_test.go
@@ -1,0 +1,364 @@
+package orchestrator
+
+// Regression coverage for the operation ledger's lifetime: it must survive
+// initWorkflowEngine rebuilding everything else around it. See
+// docs/specs/workflow-engine-operation-ledger-lifetime/spec.md.
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// AC-L3a: a ledger at its zero value reports every operation id as not
+// applied, with no pre-seeding or hydration.
+func TestOperationLedgerZeroValueReportsNothingApplied(t *testing.T) {
+	var ledger operationLedger
+	if ledger.isApplied("anything") {
+		t.Fatal("expected zero-value ledger to report nothing applied")
+	}
+}
+
+// AC-L6/AC-S6: concurrent access needs no external locking, and two
+// goroutines checking the same unmarked id may both observe "not applied"
+// and proceed — the ledger is a memo, not a mutex. Run with -race.
+func TestOperationLedgerConcurrentAccess(t *testing.T) {
+	var ledger operationLedger
+
+	start := make(chan struct{})
+	results := make(chan bool, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- ledger.isApplied("op-race")
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for applied := range results {
+		if applied {
+			t.Fatal("expected both concurrent checks before any mark to observe not-applied")
+		}
+	}
+
+	const workers = 50
+	var busy sync.WaitGroup
+	busy.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer busy.Done()
+			ledger.isApplied("op-shared")
+			ledger.markApplied("op-shared")
+			ledger.isApplied("op-shared")
+		}()
+	}
+	busy.Wait()
+	if !ledger.isApplied("op-shared") {
+		t.Fatal("expected op-shared to be marked applied after concurrent access")
+	}
+}
+
+// AC-T1/AC-L1/AC-L2: an operation marked applied stays applied through the
+// *new* store a Set*-triggered reinitWorkflowEngine builds — asserting only
+// that the pre-reinit store still remembers it would not exercise the fix,
+// since production stops reading that store the moment reinit runs.
+func TestOperationLedgerSurvivesReinitWorkflowEngine(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, newMockStepGetter(), agentMgr)
+
+	if err := svc.workflowStore.MarkOperationApplied(ctx, "op-1"); err != nil {
+		t.Fatalf("MarkOperationApplied: %v", err)
+	}
+
+	oldStore := svc.workflowStore
+	svc.SetReviewRunner(&fakeReviewRunner{})
+	if svc.workflowStore == oldStore {
+		t.Fatal("expected SetReviewRunner to rebuild workflowStore via reinitWorkflowEngine")
+	}
+
+	applied, err := svc.workflowStore.IsOperationApplied(ctx, "op-1")
+	if err != nil {
+		t.Fatalf("IsOperationApplied: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected op-1 to still read applied through the store built after reinit")
+	}
+}
+
+// AC-T2 (engine class): dedup across a reinit for a trigger the engine
+// itself checks — on_agent_error through HandleTrigger. A second delivery of
+// the identical failure after a Set*-triggered reinit must not re-run the
+// step's action.
+func TestDispatchKanbanAgentErrorTrigger_DedupedAcrossReinit(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnAgentError: []wfmodels.GenericAction{{Type: wfmodels.GenericActionClearDecisions}},
+		},
+	}
+
+	decisions := &spyDecisionStore{}
+	svc, _ := newAgentErrorTestService(t, repo, stepGetter, func(s *Service) {
+		s.engineDecisions = decisions
+	})
+
+	failure := watcher.AgentEventData{TaskID: "t1", SessionID: "s1", AgentExecutionID: "exec-1", ErrorMessage: "boom"}
+	svc.handleRecoverableFailureLocked(ctx, failure)
+	if decisions.clearCalls != 1 {
+		t.Fatalf("clearCalls after first delivery = %d, want 1", decisions.clearCalls)
+	}
+
+	// A Set* call anywhere between the two deliveries rebuilds the engine,
+	// store and agentErrorDeps — the exact boot-time window this card fixes.
+	svc.SetReviewRunner(&fakeReviewRunner{})
+
+	svc.handleRecoverableFailureLocked(ctx, failure)
+	if decisions.clearCalls != 1 {
+		t.Fatalf("clearCalls after redelivery across reinit = %d, want 1 (idempotent)", decisions.clearCalls)
+	}
+}
+
+// AC-T2 (orchestrator class): dedup across a reinit for a trigger the
+// orchestrator checks directly — on_children_completed through
+// processOnChildrenCompleted, with the child-row set unchanged between
+// deliveries.
+//
+// step_mid also declares OnChildrenCompleted so a ledger miss on the second
+// delivery would not merely be harmless: childCompletionOperationID is
+// derived from the (unchanged) child rows, not the parent's current step, so
+// without the ledger the redelivery would re-evaluate from step_mid's own
+// config and move the parent a second time, to step_done. A chain where the
+// destination has no further OnChildrenCompleted action would pass this test
+// even with the pre-fix ledger, since nothing would be left to re-trigger.
+func TestProcessOnChildrenCompleted_DedupedAcrossReinit(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID: "step_wait", WorkflowID: "wf1", Name: "Wait for Subtasks", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{{Type: wfmodels.GenericActionMoveToNext}},
+		},
+	}
+	stepGetter.steps["step_mid"] = &wfmodels.WorkflowStep{
+		ID: "step_mid", WorkflowID: "wf1", Name: "Mid", Position: 1,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{{Type: wfmodels.GenericActionMoveToNext}},
+		},
+	}
+	stepGetter.steps["step_done"] = &wfmodels.WorkflowStep{
+		ID: "step_done", WorkflowID: "wf1", Name: "Done", Position: 2,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+	// step_mid is not terminal (step_done follows it), so the first
+	// transition's lifecycle writes a REVIEW cache state through
+	// svc.taskRepo; seed it so that write does not log a harmless
+	// "task not found" error against the mock cache.
+	if mockRepo, ok := svc.taskRepo.(*mockTaskRepo); ok {
+		seedMockTaskState(mockRepo, "parent", v1.TaskStateInProgress)
+	}
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
+
+	now := time.Now().UTC()
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "child-complete", WorkflowID: "wf1", Title: "Complete child",
+		State: v1.TaskStateCompleted, ParentID: "parent", CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); !transitioned {
+		t.Fatal("expected all-terminal active children to transition parent from step_wait to step_mid")
+	}
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent.WorkflowStepID != "step_mid" {
+		t.Fatalf("expected parent on step_mid after first delivery, got %q", parent.WorkflowStepID)
+	}
+
+	// A Set* call between deliveries rebuilds workflowEngine/workflowStore;
+	// the same child rows (same operation id) must still dedup.
+	svc.SetReviewRunner(&fakeReviewRunner{})
+
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); transitioned {
+		t.Fatal("expected redelivery of the identical child-row set to be deduped across reinit, not re-evaluated from step_mid")
+	}
+	parent, err = repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after redelivery: %v", err)
+	}
+	if parent.WorkflowStepID != "step_mid" {
+		t.Fatalf("expected parent to remain on step_mid, got %q (a second transition ran)", parent.WorkflowStepID)
+	}
+}
+
+// AC-T3(a)/AC-L4: a Service on which initWorkflowEngine never ran (workflowStore
+// is nil) still has a usable ledger — observed directly on the field, not
+// through a dispatch path, since processOnChildrenCompleted and
+// switchWorkflowDispatcher both guard on workflowStore/workflowEngine being
+// non-nil and make that route unreachable.
+func TestOperationLedgerUsableBeforeWorkflowStepGetterSet(t *testing.T) {
+	svc := &Service{}
+	if svc.workflowStore != nil {
+		t.Fatal("expected workflowStore to be nil before SetWorkflowStepGetter")
+	}
+
+	svc.operationLedger.markApplied("op-1")
+	if !svc.operationLedger.isApplied("op-1") {
+		t.Fatal("expected a Service with no workflowStepGetter wired to still have a usable ledger")
+	}
+}
+
+// AC-T3(b)/AC-S3a: a bare &Service{} literal that bypasses NewService, wired
+// only through SetWorkflowStepGetter, still produces a workflowStore that
+// resolves to that same Service's ledger in both directions.
+func TestBareServiceLiteralWorkflowStoreSharesItsOwnLedger(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, newMockStepGetter(), agentMgr)
+
+	if err := svc.workflowStore.MarkOperationApplied(ctx, "op-a"); err != nil {
+		t.Fatalf("MarkOperationApplied: %v", err)
+	}
+	if !svc.operationLedger.isApplied("op-a") {
+		t.Fatal("expected the Service's own ledger field to observe a mark made through its workflowStore")
+	}
+
+	svc.operationLedger.markApplied("op-b")
+	applied, err := svc.workflowStore.IsOperationApplied(ctx, "op-b")
+	if err != nil {
+		t.Fatalf("IsOperationApplied: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected workflowStore to observe a mark made directly on the Service's ledger field")
+	}
+}
+
+// AC-T4/AC-L3/AC-B2: initWorkflowEngine neither declares nor assigns a
+// ledger of its own, and reaches the ledger only as the address of the
+// Service's existing field — pinned structurally so a later refactor that
+// gives the rebuild path a ledger of its own fails loudly, rather than
+// silently restoring "since the last Set* call". Mirrors the AST-walking
+// style of agent_error_fire_site_pin_test.go.
+func TestInitWorkflowEngineReachesLedgerOnlyByFieldAddress(t *testing.T) {
+	root, err := findAgentErrorBackendSourceRoot(".")
+	if err != nil {
+		t.Fatalf("locate backend source root: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join(root, "internal", "orchestrator", "service.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse service.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	ast.Inspect(file, func(n ast.Node) bool {
+		decl, ok := n.(*ast.FuncDecl)
+		if !ok || decl.Name.Name != "initWorkflowEngine" {
+			return true
+		}
+		fn = decl
+		return false
+	})
+	if fn == nil || fn.Body == nil {
+		t.Fatal("initWorkflowEngine not found in service.go")
+	}
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if stmt.Tok != token.DEFINE {
+				return true
+			}
+			for _, lhs := range stmt.Lhs {
+				if ident, ok := lhs.(*ast.Ident); ok && strings.Contains(strings.ToLower(ident.Name), "ledger") {
+					t.Errorf("initWorkflowEngine declares its own %q instead of reusing the Service field", ident.Name)
+				}
+			}
+		case *ast.GenDecl:
+			if stmt.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range stmt.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range valueSpec.Names {
+					if strings.Contains(strings.ToLower(name.Name), "ledger") {
+						t.Errorf("initWorkflowEngine declares var %q instead of reusing the Service field", name.Name)
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	foundFieldAddress := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok || ident.Name != "newWorkflowStore" {
+			return true
+		}
+		for _, arg := range call.Args {
+			unary, ok := arg.(*ast.UnaryExpr)
+			if !ok || unary.Op != token.AND {
+				continue
+			}
+			sel, ok := unary.X.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "operationLedger" {
+				continue
+			}
+			if recv, ok := sel.X.(*ast.Ident); ok && recv.Name == "s" {
+				foundFieldAddress = true
+			}
+		}
+		return true
+	})
+	if !foundFieldAddress {
+		t.Fatal("initWorkflowEngine does not pass &s.operationLedger to newWorkflowStore")
+	}
+}

--- a/apps/backend/internal/orchestrator/workflow_step_cache_test.go
+++ b/apps/backend/internal/orchestrator/workflow_step_cache_test.go
@@ -100,7 +100,7 @@ func TestWorkflowStore_LoadStep_CachesAcrossCalls(t *testing.T) {
 	stepGetter := newCountingStepGetter()
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Name: "Planning", Position: 0}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	var last engine.StepSpec
 	for i := 0; i < 4; i++ {
@@ -128,7 +128,7 @@ func TestWorkflowStore_LoadStep_ExpiresAfterTTL(t *testing.T) {
 	stepGetter := newCountingStepGetter()
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Name: "Planning"}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 	now := time.Now()
 	store.stepCache.now = func() time.Time { return now }
 
@@ -161,7 +161,7 @@ func TestStepSpecCache_UpdatedEventDropsStepEntry(t *testing.T) {
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Name: "Planning"}
 
 	svc := &Service{logger: testLogger()}
-	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	if _, err := svc.workflowStore.LoadStep(ctx, "wf1", "step1"); err != nil {
 		t.Fatalf("LoadStep failed: %v", err)
@@ -194,7 +194,7 @@ func TestStepSpecCache_UpdatedEventDropsSameWorkflowPositionEntriesOnly(t *testi
 	stepGetter.steps["wf2-step2"] = &wfmodels.WorkflowStep{ID: "wf2-step2", WorkflowID: "wf2", Position: 1}
 
 	svc := &Service{logger: testLogger()}
-	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	if _, err := svc.workflowStore.LoadNextStep(ctx, "wf1", 0); err != nil {
 		t.Fatalf("LoadNextStep(wf1) failed: %v", err)
@@ -256,7 +256,7 @@ func TestStepSpecCache_CreatedAndDeletedEventsInvalidate(t *testing.T) {
 			stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1"}
 
 			svc := &Service{logger: testLogger()}
-			svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+			svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 			if _, err := svc.workflowStore.LoadStep(ctx, "wf1", "step1"); err != nil {
 				t.Fatalf("LoadStep failed: %v", err)
@@ -283,7 +283,7 @@ func TestWorkflowStore_LoadStep_ErrorNotCached(t *testing.T) {
 	ctx := context.Background()
 	stepGetter := &erroringStepGetter{mockStepGetter: newMockStepGetter(), err: errors.New("boom")}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	if _, err := store.LoadStep(ctx, "wf1", "step1"); err == nil {
 		t.Fatal("expected an error for a missing step")
@@ -303,7 +303,7 @@ func TestWorkflowStore_LoadNextStep_NoNextStepNotCached(t *testing.T) {
 	stepGetter := newMockStepGetter()
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Position: 0}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	_, err := store.LoadNextStep(ctx, "wf1", 0)
 	if err == nil {
@@ -371,7 +371,7 @@ func TestWorkflowStore_LoadPreviousStep_CachesAndInvalidates(t *testing.T) {
 	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{ID: "step2", WorkflowID: "wf1", Position: 1}
 
 	svc := &Service{logger: testLogger()}
-	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	spec, err := svc.workflowStore.LoadPreviousStep(ctx, "wf1", 1)
 	if err != nil {
@@ -419,7 +419,7 @@ func TestSubscribeWorkflowStepCacheEvents_DeliversThroughBus(t *testing.T) {
 
 	eventBus := bus.NewMemoryEventBus(testLogger())
 	svc := &Service{logger: testLogger(), eventBus: eventBus}
-	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	svc.workflowStore = newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 	svc.subscribeWorkflowStepCacheEvents()
 
 	for _, eventType := range []string{events.WorkflowStepCreated, events.WorkflowStepUpdated, events.WorkflowStepDeleted} {
@@ -453,7 +453,7 @@ func TestWorkflowStore_LoadStep_CoalescesConcurrentMisses(t *testing.T) {
 	stepGetter := newBlockingStepGetter()
 	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{ID: "step1", WorkflowID: "wf1", Name: "Planning"}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	const n = 10
 	var wg sync.WaitGroup

--- a/apps/backend/internal/orchestrator/workflow_step_ledger_test.go
+++ b/apps/backend/internal/orchestrator/workflow_step_ledger_test.go
@@ -161,7 +161,7 @@ func TestApplyTransitionCrossWorkflowRecordsDifferingWorkflowIDs(t *testing.T) {
 	stepGetter.steps["step-wf2"] = &wfmodels.WorkflowStep{
 		ID: "step-wf2", WorkflowID: "wf2", Name: "Target", Position: 0,
 	}
-	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step-wf2", "on_turn_complete"); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
@@ -205,7 +205,7 @@ func TestApplyTransitionRecordsEngineTransitionFromSessionID(t *testing.T) {
 			repo := setupTestRepo(t)
 			seedSession(t, repo, "t1", "s1", "step1")
 
-			store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+			store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 			if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", trigger); err != nil {
 				t.Fatalf("ApplyTransition: %v", err)
 			}
@@ -241,7 +241,7 @@ func TestApplyTransitionOnChildrenCompletedRecordsSystemActorNotSession(t *testi
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 	if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", "on_children_completed"); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestApplyTransitionPreservesOuterCallerTrigger(t *testing.T) {
 		ActorID: "s1", SessionID: "s1",
 	})
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 	if err := store.ApplyTransition(deferredCtx, "t1", "s1", "step1", "step2", "on_enter"); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestApplyTransitionRepeatedToSameTargetWritesNoSecondRow(t *testing.T) {
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 	if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", "on_turn_complete"); err != nil {
 		t.Fatalf("first ApplyTransition: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestApplyTransitionOnUserCancellationRecordsHumanActorNotAgent(t *testing.T
 	ctx := authn.WithIdentity(context.Background(), authn.Identity{UserID: "user-1", Role: authn.RoleMember})
 	cancelCtx := cancellationTransitionAttribution(ctx)
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 	if err := store.ApplyTransition(cancelCtx, "t1", "s1", "step1", "step2", engine.TriggerOnTurnComplete); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestApplyTransitionOnUserCancellationWithNoIdentityRecordsSystemActor(t *te
 
 	cancelCtx := cancellationTransitionAttribution(context.Background())
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 	if err := store.ApplyTransition(cancelCtx, "t1", "s1", "step1", "step2", engine.TriggerOnTurnComplete); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}

--- a/apps/backend/internal/orchestrator/workflow_store.go
+++ b/apps/backend/internal/orchestrator/workflow_store.go
@@ -88,6 +88,31 @@ func queuedMoveExitPending(task *models.Task) bool {
 	return !completed
 }
 
+// operationLedger is the in-memory idempotency ledger every OperationID-keyed
+// workflow trigger dedups against. Its zero value is usable: no constructor,
+// no initialization statement, safe for concurrent use without external
+// locking. A Service holds exactly one, as a direct field whose lifetime
+// outlives any single workflowStore built from it (see
+// docs/specs/workflow-engine-operation-ledger-lifetime/spec.md).
+type operationLedger struct {
+	applied sync.Map
+}
+
+func (l *operationLedger) isApplied(operationID string) bool {
+	if operationID == "" {
+		return false
+	}
+	_, ok := l.applied.Load(operationID)
+	return ok
+}
+
+func (l *operationLedger) markApplied(operationID string) {
+	if operationID == "" {
+		return
+	}
+	l.applied.Store(operationID, true)
+}
+
 // workflowStore implements engine.TransitionStore by delegating to the
 // orchestrator's existing repositories and services.
 type workflowStore struct {
@@ -101,7 +126,7 @@ type workflowStore struct {
 	logger              *logger.Logger
 	stepHistoryRecorder StepHistoryRecorder
 	guardedLifecycle    guardedTransitionLifecycle
-	appliedOps          sync.Map
+	ledger              *operationLedger
 	stepCache           *stepSpecCache
 }
 
@@ -111,6 +136,7 @@ func newWorkflowStore(
 	agentMgr executor.AgentManagerClient,
 	publishTaskUpdated taskUpdatedPublisher,
 	log *logger.Logger,
+	ledger *operationLedger,
 	publishers ...interface{},
 ) *workflowStore {
 	var moved taskMovedPublisher
@@ -147,6 +173,7 @@ func newWorkflowStore(
 		publishStateChanged: stateChanged,
 		logger:              log,
 		stepHistoryRecorder: history,
+		ledger:              ledger,
 		stepCache:           newStepSpecCache(),
 	}
 }
@@ -884,18 +911,11 @@ func (s *workflowStore) PersistData(ctx context.Context, sessionID string, data 
 }
 
 func (s *workflowStore) IsOperationApplied(_ context.Context, operationID string) (bool, error) {
-	if operationID == "" {
-		return false, nil
-	}
-	_, ok := s.appliedOps.Load(operationID)
-	return ok, nil
+	return s.ledger.isApplied(operationID), nil
 }
 
 func (s *workflowStore) MarkOperationApplied(_ context.Context, operationID string) error {
-	if operationID == "" {
-		return nil
-	}
-	s.appliedOps.Store(operationID, true)
+	s.ledger.markApplied(operationID)
 	return nil
 }
 

--- a/apps/backend/internal/orchestrator/workflow_store_test.go
+++ b/apps/backend/internal/orchestrator/workflow_store_test.go
@@ -34,7 +34,7 @@ func TestWorkflowStore_LoadState(t *testing.T) {
 	seedSession(t, repo, "t1", "s1", "step1")
 
 	agentMgr := &mockAgentManager{isPassthrough: true}
-	store := newWorkflowStore(repo, newMockStepGetter(), agentMgr, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), agentMgr, noopPublisher, testLogger(), &operationLedger{})
 
 	state, err := store.LoadState(ctx, "t1", "s1")
 	if err != nil {
@@ -74,7 +74,7 @@ func TestWorkflowStore_LoadState_BlankSessionIDResolvesFromTaskRow(t *testing.T)
 	seedTaskWithoutSession(t, repo, "t1", "step1")
 
 	agentMgr := &mockAgentManager{isPassthrough: true}
-	store := newWorkflowStore(repo, newMockStepGetter(), agentMgr, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), agentMgr, noopPublisher, testLogger(), &operationLedger{})
 
 	state, err := store.LoadState(ctx, "t1", "")
 	if err != nil {
@@ -103,7 +103,7 @@ func TestWorkflowStore_LoadStep(t *testing.T) {
 		Position:   0,
 	}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	spec, err := store.LoadStep(ctx, "wf1", "step1")
 	if err != nil {
@@ -135,7 +135,7 @@ func TestWorkflowStore_LoadNextStep(t *testing.T) {
 		ID: "step3", WorkflowID: "wf1", Name: "Step 3", Position: 2,
 	}
 
-	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	t.Run("returns next step by position", func(t *testing.T) {
 		spec, err := store.LoadNextStep(ctx, "wf1", 0)
@@ -163,7 +163,7 @@ func TestWorkflowStore_ApplyTransition(t *testing.T) {
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 
 	err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", "on_turn_complete")
 	if err != nil {
@@ -210,7 +210,7 @@ func TestWorkflowStore_ApplyTransitionSyncsWorkflowIDAcrossWorkflows(t *testing.
 	stepGetter.steps["step-wf2"] = &wfmodels.WorkflowStep{
 		ID: "step-wf2", WorkflowID: "wf2", Name: "Target", Position: 0,
 	}
-	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step-wf2", "manual_move"); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
@@ -251,7 +251,7 @@ func TestWorkflowStore_ApplyTransitionPublishesOldWorkflowIDOnCrossWorkflowMove(
 		ID: "step-wf2", WorkflowID: "wf2", Name: "Target", Position: 0,
 	}
 	pub := &capturingPublisher{}
-	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger(), &operationLedger{})
 
 	if err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step-wf2", "manual_move"); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
@@ -289,7 +289,7 @@ func TestWorkflowStore_ApplyTransitionQueuesFullWIPLimitedTarget(t *testing.T) {
 	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
 		ID: "step2", WorkflowID: "wf1", Name: "Limited", Position: 1, WIPLimit: 1,
 	}
-	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{})
 
 	err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", "on_turn_complete")
 	if err != nil {
@@ -343,7 +343,7 @@ func TestWorkflowStore_ApplyTransitionPullsNextFeederTaskOnVacate(t *testing.T) 
 		ID: "step-next", WorkflowID: "wf1", Name: "Next", Position: 1,
 	}
 	var movedTaskID string
-	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(),
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(), &operationLedger{},
 		func(_ context.Context, task *models.Task, _, _, _, _ string) {
 			movedTaskID = task.ID
 		})
@@ -378,7 +378,7 @@ func TestWorkflowStore_ApplyTransitionIfAtStep_AppliesWhenStepMatches(t *testing
 		ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
 	}
 	pub := &capturingPublisher{}
-	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger(), &operationLedger{})
 
 	applied, err := store.ApplyTransitionIfAtStep(ctx, "t1", "s1", "step1", "step2", "on_turn_complete")
 	if err != nil {
@@ -423,7 +423,7 @@ func TestWorkflowStore_ApplyTransitionIfAtStep_LostRaceReturnsFalseWithoutSideEf
 		ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
 	}
 	pub := &capturingPublisher{}
-	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger())
+	store := newWorkflowStore(repo, stepGetter, nil, pub.publish, testLogger(), &operationLedger{})
 
 	applied, err := store.ApplyTransitionIfAtStep(ctx, "t1", "s1", "not-the-current-step", "step2", "on_turn_complete")
 	if err != nil {
@@ -455,7 +455,7 @@ func TestWorkflowStore_ApplyTransitionIfAtStep_ErrorsWhenTargetStepMissing(t *te
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 
 	_, err := store.ApplyTransitionIfAtStep(ctx, "t1", "s1", "step1", "missing-step", "on_turn_complete")
 	if err == nil {
@@ -468,7 +468,7 @@ func TestWorkflowStore_PersistData(t *testing.T) {
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
 
-	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(repo, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 
 	// Persist initial data
 	err := store.PersistData(ctx, "s1", map[string]any{"plan_mode": true})
@@ -513,7 +513,7 @@ func TestWorkflowStore_PersistData(t *testing.T) {
 
 func TestWorkflowStore_OperationIdempotency(t *testing.T) {
 	ctx := context.Background()
-	store := newWorkflowStore(nil, newMockStepGetter(), nil, noopPublisher, testLogger())
+	store := newWorkflowStore(nil, newMockStepGetter(), nil, noopPublisher, testLogger(), &operationLedger{})
 
 	t.Run("empty operation ID returns false", func(t *testing.T) {
 		applied, err := store.IsOperationApplied(ctx, "")

--- a/apps/backend/internal/orchestrator/workflow_store_test.go
+++ b/apps/backend/internal/orchestrator/workflow_store_test.go
@@ -549,4 +549,18 @@ func TestWorkflowStore_OperationIdempotency(t *testing.T) {
 			t.Error("expected marked operation to return true")
 		}
 	})
+
+	t.Run("marking empty operation ID is a no-op", func(t *testing.T) {
+		if err := store.MarkOperationApplied(ctx, ""); err != nil {
+			t.Fatalf("MarkOperationApplied failed: %v", err)
+		}
+
+		applied, err := store.IsOperationApplied(ctx, "")
+		if err != nil {
+			t.Fatalf("IsOperationApplied failed: %v", err)
+		}
+		if applied {
+			t.Error("expected empty operation ID to never be stored")
+		}
+	})
 }

--- a/apps/backend/internal/workflow/engine/engine.go
+++ b/apps/backend/internal/workflow/engine/engine.go
@@ -90,6 +90,9 @@ type HandleInput struct {
 	Trigger      Trigger
 	OperationID  string
 	EvaluateOnly bool // when true, skip ApplyTransition and PersistData; caller handles persistence
+	// DeferOperationMark leaves OperationID unmarked. The caller must mark it
+	// after completing any side effect outside the engine.
+	DeferOperationMark bool
 
 	// PreloadedState, when set, skips the LoadState call in the engine.
 	// Use this to avoid redundant DB reads when the caller already loaded the session and task.
@@ -263,8 +266,13 @@ func (e *Engine) handleTrigger(ctx context.Context, in HandleInput, filter func(
 	}
 
 	actions := step.Events[in.Trigger]
+	if in.OperationID != "" {
+		if err := e.validateActionCallbacks(actions, filter); err != nil {
+			return HandleResult{}, err
+		}
+	}
 	if len(actions) == 0 {
-		return HandleResult{}, e.markOperationApplied(ctx, in.OperationID)
+		return HandleResult{}, e.markOperationAppliedForInput(ctx, in)
 	}
 
 	result, err := e.processActions(ctx, in, state, step, actions, filter)
@@ -272,7 +280,26 @@ func (e *Engine) handleTrigger(ctx context.Context, in HandleInput, filter func(
 		return HandleResult{}, err
 	}
 
-	return result, e.markOperationApplied(ctx, in.OperationID)
+	return result, e.markOperationAppliedForInput(ctx, in)
+}
+
+// validateActionCallbacks rejects operation-bearing triggers that include an
+// action without a registered callback. Without this preflight, the legacy
+// no-op behavior could mark the operation applied before a late-wired callback
+// became available, preventing the trigger from ever being retried.
+func (e *Engine) validateActionCallbacks(actions []Action, filter func(ActionKind) bool) error {
+	for _, action := range actions {
+		if filter != nil && !filter(action.Kind) {
+			continue
+		}
+		if isTransitionAction(action.Kind) {
+			continue
+		}
+		if _, ok := e.callbacks.Get(action.Kind); !ok {
+			return fmt.Errorf("%w: action %s has no registered callback", ErrActionNotYetWired, action.Kind)
+		}
+	}
+	return nil
 }
 
 // processActions evaluates actions, persists data, and applies transitions.
@@ -322,6 +349,13 @@ func (e *Engine) markOperationApplied(ctx context.Context, operationID string) e
 		return nil
 	}
 	return e.store.MarkOperationApplied(ctx, operationID)
+}
+
+func (e *Engine) markOperationAppliedForInput(ctx context.Context, in HandleInput) error {
+	if in.DeferOperationMark {
+		return nil
+	}
+	return e.markOperationApplied(ctx, in.OperationID)
 }
 
 func (e *Engine) loadExecutionContext(ctx context.Context, in HandleInput) (MachineState, StepSpec, error) {

--- a/apps/backend/internal/workflow/engine/engine_test.go
+++ b/apps/backend/internal/workflow/engine/engine_test.go
@@ -295,6 +295,87 @@ func TestHandleTrigger_IdempotentByOperationID(t *testing.T) {
 	}
 }
 
+func TestHandleTrigger_OperationWithUnregisteredActionIsNotMarked(t *testing.T) {
+	store := &fakeStore{
+		state: MachineState{TaskID: "t1", SessionID: "s1", WorkflowID: "wf", CurrentStepID: "step-1"},
+		stepsByID: map[string]StepSpec{
+			"step-1": {
+				Events: map[Trigger][]Action{
+					TriggerOnAgentError: {{Kind: ActionClearDecisions}},
+				},
+			},
+		},
+		applied: map[string]bool{},
+	}
+	eng := New(store, MapRegistry{})
+
+	_, err := eng.HandleTrigger(context.Background(), HandleInput{
+		TaskID: "t1", SessionID: "s1", Trigger: TriggerOnAgentError, OperationID: "op-1",
+	})
+	if err == nil || !errors.Is(err, ErrActionNotYetWired) {
+		t.Fatalf("expected ErrActionNotYetWired, got %v", err)
+	}
+	if store.applied["op-1"] {
+		t.Fatal("operation was marked applied before its callback was wired")
+	}
+}
+
+func TestHandleTrigger_UnregisteredActionWithoutOperationIDRemainsNoOp(t *testing.T) {
+	store := &fakeStore{
+		state: MachineState{TaskID: "t1", SessionID: "s1", WorkflowID: "wf", CurrentStepID: "step-1"},
+		stepsByID: map[string]StepSpec{
+			"step-1": {
+				Events: map[Trigger][]Action{
+					TriggerOnEnter: {{Kind: ActionRunCodeReview}},
+				},
+			},
+		},
+		applied: map[string]bool{},
+	}
+	eng := New(store, MapRegistry{})
+
+	result, err := eng.HandleTrigger(context.Background(), HandleInput{
+		TaskID: "t1", SessionID: "s1", Trigger: TriggerOnEnter,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ActionCount != 1 {
+		t.Fatalf("ActionCount = %d, want 1", result.ActionCount)
+	}
+}
+
+func TestHandleTrigger_DeferOperationMark(t *testing.T) {
+	store := &fakeStore{
+		state: MachineState{TaskID: "t1", SessionID: "s1", WorkflowID: "wf", CurrentStepID: "step-1"},
+		stepsByID: map[string]StepSpec{
+			"step-1": {
+				Position: 1,
+				Events: map[Trigger][]Action{
+					TriggerOnChildrenCompleted: {{Kind: ActionMoveToNext}},
+				},
+			},
+		},
+		nextSteps: map[int]StepSpec{1: {ID: "step-2", Position: 2}},
+		applied:   map[string]bool{},
+	}
+	eng := New(store, MapRegistry{})
+
+	result, err := eng.HandleTrigger(context.Background(), HandleInput{
+		TaskID: "t1", SessionID: "s1", Trigger: TriggerOnChildrenCompleted,
+		OperationID: "op-1", EvaluateOnly: true, DeferOperationMark: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Transitioned || result.ToStepID != "step-2" {
+		t.Fatalf("expected deferred transition result, got %#v", result)
+	}
+	if store.applied["op-1"] {
+		t.Fatal("operation was marked applied before the outer transition committed")
+	}
+}
+
 func TestHandleTrigger_EvaluateOnlySkipsPersistence(t *testing.T) {
 	store := &fakeStore{
 		state: MachineState{TaskID: "t1", SessionID: "s1", WorkflowID: "wf1", CurrentStepID: "step-1"},

--- a/apps/backend/internal/workflow/engine/office_default_smoke_test.go
+++ b/apps/backend/internal/workflow/engine/office_default_smoke_test.go
@@ -31,6 +31,7 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 	queue := &fakeRunQueue{}
 	parts := newSmokeParticipants(steps)
 	decisions := newFakeDecisionStore()
+	seatWriter := &fakeParticipantSeatWriter{hasSeat: true}
 
 	registry := MapRegistry{
 		ActionAutoStartAgent: noOpCallback{},
@@ -45,6 +46,10 @@ func TestOfficeDefaultWorkflow_FullCycleSmoke(t *testing.T) {
 			Participants: parts,
 		},
 		ActionClearDecisions: ClearDecisionsCallback{Decisions: decisions},
+		ActionEnsureParticipantSeat: EnsureParticipantSeatCallback{
+			Writer: seatWriter,
+			Caster: &fakeParticipantSeatCaster{},
+		},
 	}
 	eng := New(store, registry,
 		WithRunQueue(queue),

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -40,5 +40,6 @@ The following specifications were added after this migration and remain in the l
 - [Workflow on_enter action dispatch](workflow-on-enter-action-dispatch/spec.md) (draft)
 - [Kubernetes Executor](kubernetes-executor/spec.md) (implemented)
 - [Task Delivery Ledger](task-delivery-ledger/spec.md) (draft)
+- [Workflow Engine Operation Ledger Lifetime](workflow-engine-operation-ledger-lifetime/spec.md) (draft)
 
 ## Authoring rule

--- a/docs/specs/spec-lint-exceptions.tsv
+++ b/docs/specs/spec-lint-exceptions.tsv
@@ -2,5 +2,5 @@ docs/specs/gitlab-issue-milestone-filter/spec.md	80514
 docs/specs/office-task-content-editing/spec.md	84103
 docs/specs/task-cost-ledger/spec.md	91931
 docs/specs/task-delivery-ledger/spec.md	157207
-docs/specs/workflow-on-agent-error-dispatch/spec.md	64431
+docs/specs/workflow-on-agent-error-dispatch/spec.md	64424
 docs/specs/workflow-on-enter-action-dispatch/spec.md	116827

--- a/docs/specs/workflow-engine-operation-ledger-lifetime/spec.md
+++ b/docs/specs/workflow-engine-operation-ledger-lifetime/spec.md
@@ -1,0 +1,459 @@
+---
+status: draft
+created: 2026-09-05
+updated: 2026-09-05
+owner: Kandev
+---
+
+# Workflow Engine Operation Ledger Lifetime
+
+Decisions:
+
+- [ADR-0004 task-model-unification](../../decisions/0004-task-model-unification.md) — makes the
+  workflow engine the coordinator for task-scoped agent runs and gives every Phase 2 trigger an
+  `OperationID`-keyed idempotency contract.
+
+Related spec (states the contract this card makes true):
+
+- [`docs/specs/workflow-on-agent-error-dispatch/spec.md`](../workflow-on-agent-error-dispatch/spec.md)
+  — **AC-C5**: "The exactly-once guarantee is scoped to one backend process lifetime, because
+  `workflowStore.appliedOps` is an in-memory `sync.Map`." That sentence is the contract; the code does
+  not honour it. Its **AC-E13** placed the fix here rather than there.
+
+## Why
+
+`Engine.HandleTrigger`'s idempotency check is the only thing between a redelivered workflow trigger
+and a second execution of its actions — a second `queue_run`, a second step transition, a second
+`clear_decisions`. The ledger it consults is `orchestrator.workflowStore.appliedOps`, an in-memory
+`sync.Map` (`apps/backend/internal/orchestrator/workflow_store.go:104`, read at `:886`, written at
+`:894`).
+
+`Service.initWorkflowEngine` (`service.go:1860`) builds a **brand-new** `workflowStore` on every
+call (`store := newWorkflowStore(...)` at `service.go:1864`, assigned to `s.workflowStore` at
+`:1867`). `newWorkflowStore` returns a fresh struct literal (`workflow_store.go:140`) in which
+`appliedOps` is zero-valued and never copied from the previous store; no branch reuses one.
+**Every call therefore discards the ledger.**
+
+Thirteen `Service` methods reach `initWorkflowEngine` — two directly (`SetWorkflowStepGetter`
+`service.go:1813`, `SetStepHistoryRecorder` `:1823`) and eleven through `reinitWorkflowEngine` (every
+`Set*` between `:1888` and `:1971`, `SetReviewRunner` among them).
+
+So the guarantee's real scope is not "one backend process lifetime". It is **"since the last `Set*`
+call"**.
+
+### The reachable window, measured
+
+Verified by reading `apps/backend/internal/backendapp/main.go` and `helpers.go`.
+
+| # | Boot site | Effect |
+|---|---|---|
+| 1 | `orchestrator.go:210-211` — `SetStepHistoryRecorder`, `SetWorkflowStepGetter` | first store built, **before** `Start` |
+| 2 | `main.go:1000` — `orchestratorSvc.Start(ctx)` | reconcilers run, then `watcher.Start` / `scheduler.Start`: **live event delivery begins** |
+| 3 | `main.go:1343` — `services.Office.RegisterEventSubscribers(eventBus)` | office subscribers go live |
+| 4 | `main.go:1656-1671` — ten `SetEngine*` / `SetPrimaryAgentResolver` calls in `wireWorkflowEngineForOffice` | **ten wipes** |
+| 5 | `helpers.go:1841` — `SetReviewRunner`, from `registerRoutes` → `registerMCPAndDebugRoutes` (`main.go:2286`) | **eleventh wipe** |
+
+Two exposure windows follow, both open while triggers can fire:
+
+- **Orchestrator-sourced triggers** — step 2 to step 5, spanning **eleven** wipes.
+- **Office-sourced triggers** — step 3 to step 5, spanning **one** wipe. Before step 3 the office
+  dispatcher is nil (assigned at the end of `wireWorkflowEngineForOffice`) and office triggers are
+  dropped, so nothing earlier is at risk on that route.
+
+The startup reconcilers named in the brief — `reconcileUnpublishedPromptTurnsOnStartup` and
+`reconcileExecutorSessionsOnStartup` (`service.go:2696`, `:2708`) — run **before** `watcher.Start` and
+mark no operations, so they are not a source of exposure. Answering the brief's first question:
+**the reachable redelivery is not in the reconcilers, it is in the live post-`Start` window above.**
+
+### A redelivery that is structurally guaranteed, not theoretical
+
+`markTaskCompletedForTerminalStep` (`event_handlers_children_completed.go:59`) persists the task, then
+does both of: (1) `publishTaskStateChanged` (`:89`), consumed by the orchestrator's own watcher
+(`service.go:1434` wires `OnTaskStateChanged: s.handleTaskStateChanged`; `watcher/watcher.go:279`
+subscribes it), which calls `processParentChildrenCompletedForTaskState`; and (2) that same call
+directly (`:90`).
+
+Both deliveries reach `processOnChildrenCompleted` for the same parent and read the same persisted
+child rows, so `childCompletionOperationID` (`:320`) hashes to the **identical** operation id — the
+row's `UpdatedAt` was written before either delivery. `lockChildCompletionOperation` serializes them
+and `childCompletionAlreadyApplied` (`:179`) is expected to reject the second. It does, unless a
+`Set*` call lands between them: then the second re-evaluates, and a transition that already committed
+commits again, re-running the target step's `on_enter` sequence.
+
+### What is *not* affected, contrary to the task brief
+
+The brief states the ledger backs "every trigger (`on_enter`, `on_turn_start`, `on_turn_complete`,
+`on_children_completed`, and now `on_agent_error`)". Verified by grepping every non-test
+`OperationID:` producer and every `HandleTrigger` call site:
+
+- **`on_turn_start` and `on_turn_complete` pass no `OperationID`**
+  (`event_handlers_workflow.go:5620` and `:5039`); `isOperationAlreadyApplied` short-circuits on the
+  empty string (`engine.go:313-315`), so neither touches the ledger. The brief's suggested regression
+  test — "at least one trigger already in production use (e.g. `on_turn_complete`)" — would be
+  vacuous. [AC-T2](#t-regression-coverage) names the triggers that do use it.
+- **`on_enter`'s step-entry path has its own durable ledger.** `processOnEnter`
+  (`event_handlers_workflow.go:3135`) keys on `step_entry:<entryID>:<position>` and claims it through
+  `Repository.ClaimStepEntryMarker`, a database row; `Engine.DispatchStepEntry` never calls
+  `IsOperationApplied`. Only the `switch_workflow` on_exit/on_enter route
+  (`phase8_callbacks.go:111,133`, via `workflow_callbacks.go:104`) uses the in-memory ledger for
+  `on_enter`.
+
+The operations that **do** depend on `appliedOps` today, with their key shapes:
+
+| Operation id shape | Producer | Consumer |
+|---|---|---|
+| `on_children_completed:<parent>:<sha256 of rows>` | `event_handlers_children_completed.go:320` | orchestrator |
+| `wake:<parent>:<childSetKey>` | `office/service/event_subscribers.go:1099` (edge), `scheduler_wake_reconciler.go:124` (sweep) | engine (office) |
+| `agent_error:<runID>` | `office/service/event_subscribers.go:676` | engine |
+| `agentErrorOperationID(<session>,<agentExec>)` | `orchestrator/event_handlers_agent_error.go:58` | engine |
+| `<commentID>` via `commentkeys.TaskComment` | `office/service/event_subscribers.go:1156`, `office/dashboard/service_tasks.go:1024` | engine |
+| `blockers_resolved:<taskID>` | `office/service/event_subscribers.go:1027` | engine |
+| `approval_resolved:<approvalID>` | `office/service/event_subscribers.go:1179` | engine |
+| `heartbeat:<task>:<step>:<unix>` | `scheduler/cron/heartbeat.go:229` | engine |
+| `budget:<ws>:<scope>:<id>:<pct>:<periodStart>` | `scheduler/cron/budget.go:174` | engine |
+| `decision:<task>:<step>:<decision>` | `workflow/engine/quorum.go:673` | engine (direct) |
+| `<parentOpID>:switch_workflow:on_(exit|enter)` | `workflow/engine/phase8_callbacks.go:111,133` | engine |
+
+Every key except `heartbeat` is **level-triggered** — derived from durable state, not the moment of
+delivery — so a redelivery reproduces it exactly. That is what makes the ledger load-bearing rather
+than decorative.
+
+## What
+
+### Design decision
+
+The set of operation ids marked applied is a property of the **orchestrator service**, not of any
+`workflowStore` instance, and rebuilding the engine does not disturb it.
+
+The ledger is a **field of `Service` whose zero value is usable**. It needs no construction step,
+so it exists and works for every `Service` however that `Service` was built; it is never replaced;
+and its address is handed to every `workflowStore` that `initWorkflowEngine` builds.
+`workflowStore.IsOperationApplied` / `MarkOperationApplied` delegate to it, so
+`engine.TransitionStore` is unchanged and the engine needs no modification.
+
+The zero value is the load-bearing choice, not an implementation detail: a constructed ledger only
+exists on a `Service` some constructor initialised, making correctness depend on how each `Service`
+was built, whereas a zero value is correct for every `Service` that exists at all. It removes the nil
+case rather than defining behaviour for it.
+
+Three alternatives were considered and rejected:
+
+- **Reorder boot so every `Set*` call precedes `Start`.** Rejected on evidence. `SetReviewRunner` is
+  reached from `registerMCPAndDebugRoutes` inside `registerRoutes`, called from `buildHTTPServer`
+  (`main.go:1183`) deliberately after `Start`, because the bootstrap listener must be bound and the
+  recovery sweeps must run before the real router is built (`main.go:1174-1182`, and
+  `docs/specs/startup-listener-before-recovery/spec.md`). Moving it fights an existing contract. More
+  decisively, boot ordering is an invariant nothing enforces: the next `Set*` call added anywhere
+  reintroduces the defect silently.
+- **A constructed ledger passed as a nilable dependency, with a ledger-less store failing open.**
+  Rejected after review: it makes the guarantee conditional on `Service` construction. A bare
+  `&Service{...}` literal that never ran the constructor reaches `initWorkflowEngine` via
+  `SetWorkflowStepGetter` and hands the store a nil ledger, which type-checks with no diagnostic. The
+  store then never dedups — indistinguishable from a correct one until a duplicate arrives. A
+  fail-open branch turns a wiring mistake into silence, worse than the boot-window bug this card
+  fixes, which at least ends when boot ends.
+- **Copy `appliedOps` forward inside `initWorkflowEngine`.** Rejected: `sync.Map` has no atomic
+  snapshot, so a copy racing a concurrent `Store` drops entries — a partial wipe is no better than a
+  full one, only harder to reproduce. It also leaves a store captured before the reinit (the
+  `agentErrorDeps` snapshot at `service.go:1875`) writing into a map nothing reads afterwards.
+
+### Acceptance criteria
+
+#### L. Ledger lifetime
+
+- **AC-L1** WHEN an operation id has been marked applied, THEN `IsOperationApplied` shall report it
+  applied for the remainder of the process, across any number of `initWorkflowEngine` and
+  `reinitWorkflowEngine` calls. This is the criterion the current code fails.
+- **AC-L2** A `Service` shall hold exactly one ledger — the field AC-L3 describes. Every
+  `workflowStore` that `initWorkflowEngine` constructs shall resolve to that same instance; a store
+  built before a reinit and a store built after it shall observe each other's writes in both
+  directions. A `workflowStore` constructed **directly**, outside `initWorkflowEngine`, is outside
+  this criterion: it resolves to whichever ledger its caller passed, which for an isolated unit test
+  is normally a ledger of its own. That is not a second ledger on a `Service`; it is a store that no
+  `Service` owns.
+- **AC-L3** The ledger shall be a **direct field of `Service` whose zero value is usable**: no
+  constructor call, no initialisation statement and no assignment shall be needed to make it work, so
+  a `Service` obtained by ANY means — `NewService`, or a bare `&Service{...}` literal naming none of
+  its fields — has a working ledger from the moment the struct exists, before `Start` can run.
+  The field shall never be reassigned, and `Service` shall never be copied by value — the orchestrator
+  uses `*Service` throughout and `go vet`'s `copylocks` fails a build that copies it — which is what
+  lets the field hold a `sync.Map` or mutex **directly** rather than behind a pointer. Taking its
+  address is not a write, so nothing needs synchronising around the field itself; AC-L6 is the
+  ledger's own guarantee. Lazily creating a ledger inside
+  `initWorkflowEngine` does **not** satisfy AC-L2: it returns early when `workflowStepGetter` is nil
+  (`service.go:1861`), so a lazily-created ledger has the same conditional lifetime as the bug.
+  **No lock, atomic, or once-guard shall be added around the ledger reference itself** — two `Set*`
+  calls racing each other read the same immutable field. (They still race on `s.workflowStore` and
+  `s.workflowEngine`; that race is [out of scope](#out-of-scope) and AC-L1 does not depend on it.)
+- **AC-L3a** A ledger at its zero value shall report every operation id as not applied. It shall
+  not be pre-seeded, warmed, or hydrated from anything.
+- **AC-L4** A `Service` on which `initWorkflowEngine` never ran — `workflowStepGetter` still nil —
+  shall still have a **usable** ledger: an id marked on it shall be reported applied by a later check
+  on the same `Service`, and neither call shall panic or return an error — this follows from AC-L3's
+  zero value and needs no wiring.
+  **No production reader is reachable in that state, and this card changes none of the guards that
+  make it unreachable**: `processOnChildrenCompleted` returns before both
+  `childCompletionAlreadyApplied` (`event_handlers_children_completed.go:180`) and
+  `markChildCompletionApplied` (`:247`) whenever `workflowEngine`, `workflowStore` or
+  `workflowStepGetter` is nil (`:94`); `switchWorkflowDispatcher` returns when the engine is nil
+  (`workflow_callbacks.go:106`) and skips its check when the store is nil (`:113`). AC-L4 is therefore
+  observed **directly on the ledger** (AC-T3(a)); reachability through a dispatch path is explicitly
+  **not** claimed, and no guard shall be relaxed to manufacture one.
+- **AC-L5** The ledger shall remain **in-memory and process-scoped**. A backend restart clears it.
+  This restates `workflow-on-agent-error-dispatch` AC-C5 and is now true rather than aspirational;
+  durability is [out of scope](#out-of-scope).
+- **AC-L6** The ledger shall be safe for concurrent use by multiple goroutines without external
+  locking, matching the `sync.Map` semantics its callers assume.
+
+#### S. Semantics preserved exactly
+
+- **AC-S1** IF `operationID` is the empty string, THEN `IsOperationApplied` shall return
+  `(false, nil)` and `MarkOperationApplied` shall be a no-op returning `nil` — the behaviour at
+  `workflow_store.go:886-901` today. An empty id shall never be stored, and shall never be reported
+  applied on a later call.
+- **AC-S2** `MarkOperationApplied` shall be idempotent: marking an already-marked id succeeds and
+  leaves it marked. There shall be **no** un-mark, delete, clear, or reset operation on the ledger's
+  production surface. Tests may construct a fresh ledger; they shall not clear a live one.
+- **AC-S3** Neither method shall return a non-nil error under any input. Callers' fail-closed
+  handling of an error (`childCompletionAlreadyApplied` treats an error as "applied",
+  `event_handlers_children_completed.go:181-187`) stays in place but remains unreachable.
+- **AC-S3a** No `workflowStore` reached by production code shall ever hold a nil ledger, and the
+  guarantee shall be **structural, not conventional** — it shall not depend on how the owning
+  `Service` was constructed.
+  The ledger shall reach `workflowStore` as a **required positional parameter** of
+  `newWorkflowStore`, last before its existing `publishers ...interface{}` variadic tail
+  (`workflow_store.go:108-114`). It shall **not** be carried in that tail, which is dispatched by a
+  type switch, so an omitted entry stays nil with no diagnostic. Positional placement also means a
+  future `Set*`-plus-reinit method cannot obtain a store without naming a ledger, which is what AC-B2
+  relies on.
+  `initWorkflowEngine` shall pass **the address of the `Service`'s own ledger field**. That expression
+  cannot be nil for any receiver, so the single production call site (`service.go:1864`) is non-nil
+  **by construction for every `Service` however it was built** — including the bare `&Service{...}`
+  literals that bypass `NewService` and still reach it through `SetWorkflowStepGetter`. With AC-L3's
+  zero value there is therefore no `Service`, and no production `workflowStore`, without a working
+  ledger.
+  A nil ledger is **not a supported input** and **no defensive branch shall be added for it**: no
+  nil-check in either method, no fail-open and no fail-closed path. A caller passing nil explicitly
+  panics at first access — intended, and **loud**. Silently reporting "not applied" for a missing
+  ledger is what this criterion forbids: a store that never dedups is indistinguishable from a correct
+  one until a duplicate arrives in production, whereas a panic shows up on the first run.
+  The production call site and all 35 direct test call sites shall pass a ledger explicitly. That
+  fallout is cheap because the zero value is usable: a test uninterested in sharing passes a
+  zero-valued ledger and gets exactly today's deduping behaviour, which is what AC-S4 relies on.
+- **AC-S4** No operation-id derivation shall change. Every producer in the
+  [table above](#what-is-not-affected-contrary-to-the-task-brief) keeps its exact key shape. This
+  card changes **where the ledger lives**, not what is written into it. The existing operation-id
+  tests shall keep passing with **unchanged deduping behaviour**, not merely green: every store they
+  construct still has a working ledger (AC-S3a). Making one pass by removing its deduping would
+  violate this criterion.
+- **AC-S5** Ordering shall be unchanged: the engine marks an operation only after `processActions`
+  returns without error (`engine.go:275`), and marks it when no actions are declared (`engine.go:267`).
+  A ledger that marked earlier would swallow the retry `workflow-on-agent-error-dispatch` AC-C6
+  requires.
+- **AC-S6** The ledger shall not be a mutual-exclusion primitive. WHEN two goroutines check the same
+  unmarked id concurrently, THEN both may observe "not applied" and both may proceed; serialization
+  remains the caller's job through the mechanisms that already do it —
+  `lockChildCompletionOperation` (`event_handlers_children_completed.go:196`) and
+  `acquireTurnCompletionLock` (`service.go:2476`). Adding check-and-set to the ledger is
+  [out of scope](#out-of-scope).
+- **AC-S7** Operation ids shall be compared by **exact byte equality**. The ledger shall not trim,
+  case-fold, normalize, hash, truncate, or otherwise transform a key, and shall impose no length
+  limit or character restriction. Keys are opaque to it: `commentkeys.TaskComment` emits a prefixed
+  comment id that `phase2_callbacks.go:422` inspects with `HasTaskCommentPrefix`, and
+  `phase8_callbacks.go` derives `<parentOpID>:switch_workflow:on_enter` by concatenation, so any
+  normalization would silently split or merge keys those sites construct.
+
+#### R. Reader parity
+
+- **AC-R1** The engine's `TransitionStore.IsOperationApplied` / `MarkOperationApplied` path shall
+  read and write the shared ledger. `Engine.reevaluateGuardedTransitions`, which calls
+  `e.store.IsOperationApplied` directly (`quorum.go:673`), is covered and needs no separate change.
+- **AC-R2** The two orchestrator-level readers that bypass the engine shall observe the same ledger,
+  and their result shall not depend on which `workflowStore` instance `s.workflowStore` points at:
+  - `childCompletionAlreadyApplied` / `markChildCompletionApplied`
+    (`event_handlers_children_completed.go:179`, `:246`);
+  - `switchWorkflowDispatcher`'s pre-dispatch check (`workflow_callbacks.go:114`).
+- **AC-R3** A dispatch holding a store captured **before** a reinit shall write to the same ledger a
+  dispatch started after that reinit reads. This covers the `agentErrorDeps` atomic snapshot
+  (`service.go:1875`), which pins one engine/registry/store triple for a dispatch's duration and
+  today pins a ledger a concurrent reinit orphans.
+- **AC-R4** WHEN an operation is marked through one reader class and checked through another — say
+  marked by the engine under `on_agent_error` and checked by `switchWorkflowDispatcher` — the check
+  shall see it. There is one ledger, not one per reader.
+
+#### B. Observable boot behaviour
+
+- **AC-B1** WHEN a trigger operation is marked applied at any point after `watcher.Start` and the
+  identical operation id is redelivered later in the same process, THEN the redelivery shall be
+  deduped, regardless of how many `Set*` calls executed in between. The structurally guaranteed
+  redelivery described above is the concrete case this must cover.
+- **AC-B2** The contract shall hold without depending on boot ordering. Adding a new
+  `Set*`-plus-`reinitWorkflowEngine` method, or moving an existing call site, shall not be able to
+  reintroduce the defect. A fix expressed only as a reordering of `main.go` does **not** satisfy this
+  criterion.
+- **AC-B3** `initWorkflowEngine` may continue to rebuild everything else — the store's publishers,
+  the callback registry, the engine, the `agentErrorDeps` snapshot, and `stepCache`
+  (`workflow_store.go:150`), a TTL cache with an explicit invalidation path whose loss costs one
+  reload per key and is not a correctness change. Only the ledger is exempt from the rebuild.
+
+#### T. Regression coverage
+
+- **AC-T1** A test shall prove AC-L1 directly: mark an operation id, call a `Set*` method that
+  triggers `reinitWorkflowEngine`, and assert the id still reads applied through the **new** store.
+  Asserting only that the old store still remembers it does not satisfy this — the old store is
+  exactly what production stops reading.
+- **AC-T2** A test shall prove end-to-end dedup across a reinit for **both** reader classes, using a
+  trigger already in production use:
+  - the **engine** class — `on_agent_error` through `HandleTrigger` with a fixed
+    `agentErrorOperationID`, asserting the second delivery returns `Idempotent: true` and runs no
+    action;
+  - the **orchestrator** class — `on_children_completed` through `processOnChildrenCompleted` with an
+    unchanged child-row set, asserting the second delivery applies no second transition.
+
+  `on_turn_complete` shall **not** be used: it passes no `OperationID` and would assert nothing.
+- **AC-T3** A test shall prove the two wiring cases the mechanism turns on. Both are positive
+  assertions about a working ledger, not "does not panic" checks, and both are in-package tests
+  reading the `Service`'s unexported ledger field directly — no exported accessor shall be added:
+  - **(a) AC-L4** — a `Service` whose `workflowStepGetter` was never set, so `initWorkflowEngine`
+    never ran and `workflowStore` is nil: mark an id on its ledger field, assert a later check reports
+    it applied. It shall **not** route through `processOnChildrenCompleted` or
+    `switchWorkflowDispatcher`, whose guards make those paths unreachable here (AC-L4), and shall
+    **not** require any guard to be relaxed.
+  - **(b) AC-S3a** — a `Service` built as a bare `&Service{...}` literal, bypassing `NewService`, then
+    wired with `SetWorkflowStepGetter`: assert the `workflowStore` it produces resolves to **that
+    `Service`'s** ledger in both directions. This is the regression guard against a
+    `Service`-construction-dependent mechanism; `createEngineService` (`workflow_e2e_test.go`) has
+    exactly that shape.
+- **AC-T4** A test shall pin AC-L3 structurally — that `initWorkflowEngine` neither declares nor
+  assigns a ledger of its own, and reaches the ledger only as the address of the `Service`'s existing
+  field — so a later refactor that gives the rebuild path a ledger of its own fails loudly rather
+  than silently restoring "since the last `Set*` call".
+
+## Concurrency and ordering
+
+- **Two callers, same unmarked id.** Both may proceed (AC-S6). Unchanged, and deliberately so: the
+  ledger is a *memo*, the existing per-operation locks are the *mutex*. Collapsing them would change
+  serialization semantics this card does not touch.
+- **Reinit concurrent with an in-flight dispatch.** The dispatch's check and its later mark land in
+  the same ledger (AC-R3), so a reinit cannot split one dispatch across two ledgers. The dispatch may
+  still use a *pre-reinit* engine and registry — pre-existing behaviour, and the `agentErrorDeps`
+  snapshot's stated design.
+- **Mark-to-commit ordering is unchanged** (AC-S5): the engine marks after actions succeed, and
+  `applyEngineTransition` may still decline a transition the engine already marked —
+  `workflow-on-agent-error-dispatch` AC-C7 covers that and is not reopened here.
+- **No ordering is defined between two distinct operation ids.** The ledger is an unordered set: no
+  iteration order, no observable insertion sequence, nothing may be derived from one.
+
+## Failure modes
+
+- **Restart.** The ledger is empty; every level-triggered operation is redelivered once and
+  re-executes. That is today's behaviour and AC-L5's stated limit, and is why the paths that cannot
+  tolerate it carry durable receipts of their own: `ClaimStepEntryMarker` for step entry,
+  `UpsertWakeReceiptTx` for the parent-wake reconciler
+  (`office/service/scheduler_wake_reconciler.go:211`).
+- **Unbounded growth.** Never pruned; one entry per distinct operation id for the process lifetime.
+  This card does not change the growth rate — after boot there are no further reinits today, so
+  entries already accumulate for the whole process. The wipes it removes all occur during boot, when
+  the ledger holds at most a handful of entries. Bounding it is [out of scope](#out-of-scope).
+- **A ledger read that could not answer.** Not reachable (AC-S3). The fail-closed branches treating
+  an error as "already applied" stay as written, so if a future ledger *can* error the conservative
+  outcome is a skipped duplicate, not a double execution.
+
+## Out of scope
+
+Each entry is a named exclusion and part of the contract.
+
+- **Durability across restart.** Surviving a restart means a table, a retention policy and a
+  migration. `workflow-on-agent-error-dispatch` AC-C5 already declares the process-lifetime bound and
+  `workflow-on-enter-action-dispatch`'s step-entry record owns the durable-marker question. This card
+  makes the declared bound true; it does not widen it.
+- **Eviction, TTL, or any bound on ledger size.** Requires deciding what a *safe* eviction is for a
+  level-triggered key like `blockers_resolved:<taskID>`, which has no natural expiry — evicting it
+  re-arms a duplicate wake. A separate design with its own risk.
+- **Defensive nil-ledger handling.** AC-S3a makes a nil ledger unreachable from production *by
+  construction* rather than tolerated, so no nil check, fail-open branch, fail-closed branch, or
+  substitute-a-private-ledger fallback shall be added to either ledger method or to
+  `newWorkflowStore`. Explicit nil panics on first access; that is the specified behaviour. A fallback
+  would restore the silent divergence this card was re-scoped to remove: a store deduping against
+  nothing, or against a private ledger no other store can see, reporting success either way.
+- **Synchronizing `s.workflowStore` and `s.workflowEngine` themselves.** Both are plain fields,
+  written by `initWorkflowEngine` (`service.go:1867`, `:1874`) while the watcher is live and read
+  from bus goroutines. That is a pre-existing data race, was already excluded by
+  `workflow-on-agent-error-dispatch` AC-E13, and is excluded here too. **The fix for this card must
+  not depend on it being fixed:** a shared ledger reached through whichever store instance a racing
+  reader happens to observe is still the same ledger, so AC-L1 holds either way. A separate card
+  should still close the race.
+- **`engineOptions` accumulation.** `s.engineOptions` is appended to on each `Set*` call and never
+  reset (`service.go:1887` and siblings), so it grows across reinits. Bounded by the number of `Set*`
+  methods and harmless (later options win), but the same wiring and worth a look someday. Not here.
+- **Giving `on_turn_start` / `on_turn_complete` an `OperationID`.** They deliberately have none; the
+  turn-completion path has its own duplicate-suppression (`acquireTurnCompletionLock`,
+  `acquireTurnCompletionCriticalSection`), and an engine-level key would add a second,
+  differently-scoped dedup over the same event. That is a contract change to those triggers, not a
+  ledger change.
+- **Boot reordering.** Rejected as the fix ([Design decision](#design-decision)), and excluded as an
+  addition: this card shall not move `orchestratorSvc.Start`, `wireWorkflowEngineForOffice`,
+  `RegisterEventSubscribers` or `registerRoutes` relative to one another.
+- **Anything specific to `on_agent_error`'s own dispatch.** `agentErrorOperationID`, the
+  `agentErrorDeps` snapshot's contents and the fire-site pin test are unchanged; AC-R3 constrains only
+  which ledger that snapshot's store resolves to.
+- **Reducing the number of `reinitWorkflowEngine` calls.** Thirteen `Set*` methods rebuilding the
+  engine is its own smell, but collapsing them is a wiring refactor across `main.go`, `helpers.go` and
+  `orchestrator.go`, and it is not needed for AC-B2, which holds by construction once the ledger is
+  exempt from the rebuild.
+
+## Prior art
+
+Two legs were attempted. **Both were unavailable; neither result means "there is no prior thinking
+here."**
+
+- **Wiki (`wiki-query @henry`).** Receipt: config `~/.obsidian-wiki/config.henry`,
+  `OBSIDIAN_VAULT_PATH=/Users/henry/Documents/henry/wiki`, collections `wiki` / `sources`. **The
+  vault could not be read** — `ls`, `head` and a sandbox-disabled retry all returned `Operation not
+  permitted` (macOS TCC on `~/Documents`, not a missing vault; `ls -d` on the parent resolves).
+  Neither `obsidian-wiki` nor `qmd` is on `PATH` here and no `mcp__qmd__*` tool is exposed, so the QMD
+  and graph paths were also unavailable. **Zero pages consulted.**
+- **`saas-kb` (`search_fsm_docs`, `category: "ai_sdlc"`).** **Tool not available** — the only MCP
+  servers exposed are `kandev` and `codex`. No query run, no vendor comparison made.
+
+**In-repo prior art, available and the substantive input here:** this codebase has already solved "an
+idempotency marker must outlive the thing that consumes it" twice, both times by giving the marker a
+lifetime independent of the engine — `ClaimStepEntryMarker` / `CompleteStepEntryMarker` for
+step-entry actions (`event_handlers_workflow.go:3136`), and `UpsertWakeReceiptTx` for the parent-wake
+reconciler (`office/service/scheduler_wake_reconciler.go:211`). This card is the same move at a
+smaller radius: the ledger keeps in-memory storage (AC-L5) and gains only an independent
+**lifetime**.
+
+## Verification
+
+No user-visible surface changes: no route, no WS payload, no DTO field, no copy. **No E2E coverage is
+required or added.** Every criterion is observable from Go unit tests in
+`apps/backend/internal/orchestrator`.
+
+
+```bash
+cd apps/backend
+go test -race ./internal/orchestrator/... ./internal/workflow/...
+golangci-lint run ./... --new-from-rev="$(git merge-base HEAD origin/main)" --timeout=5m
+```
+
+Criteria and their observation points:
+
+| Criterion | Observed by |
+|---|---|
+| AC-L1, AC-L2 | mark → `Set*` → read through the new `s.workflowStore` (AC-T1) |
+| AC-L3, AC-B2 | `initWorkflowEngine` neither declares nor assigns a ledger, reaching it only as the address of the `Service` field (AC-T4) |
+| AC-L4 | nil `workflowStepGetter` service: mark then check on its ledger field reports applied, no production guard changed (AC-T3(a)) |
+| AC-L6 | `-race` on a concurrent mark/check test |
+| AC-L3a | a zero-valued ledger reports nothing applied |
+| AC-L5 | a new `Service`'s ledger reports nothing applied (AC-L3a's mechanism; a restart *is* a new process and a new `Service`), and no persistence is added: no table, no migration, no `repo` write |
+| AC-S1, AC-S2, AC-S3, AC-S7 | direct ledger unit tests |
+| AC-S3a | bare `&Service{}` literal wired via `SetWorkflowStepGetter` yields a store resolving to that `Service`'s ledger, both directions (AC-T3(b)) |
+| AC-S4 | unchanged producers; existing operation-id tests keep passing with unchanged deduping behaviour, not merely green |
+| AC-S5 | existing engine tests (`engine_test.go`, `idempotency_key_test.go`) |
+| AC-S6 | the same `-race` mark/check test as AC-L6, asserting both goroutines may observe "not applied" and proceed; the ledger exposes no check-and-set, compare-and-swap or `LoadOrStore`-style method usable as a mutex |
+| AC-R1, AC-R4 | mark via engine, check via `switchWorkflowDispatcher`'s path |
+| AC-R2 | `on_children_completed` dedup across a reinit (AC-T2) |
+| AC-R3 | `on_agent_error` dedup across a reinit (AC-T2) |
+| AC-B1 | AC-T2, both classes |
+| AC-B3 | `stepCache` still rebuilt; no assertion that it survives |

--- a/docs/specs/workflow-engine-operation-ledger-lifetime/spec.md
+++ b/docs/specs/workflow-engine-operation-ledger-lifetime/spec.md
@@ -1,7 +1,7 @@
 ---
 status: draft
 created: 2026-09-05
-updated: 2026-09-05
+updated: 2026-09-06
 owner: Kandev
 ---
 
@@ -16,30 +16,24 @@ Decisions:
 Related spec (states the contract this card makes true):
 
 - [`docs/specs/workflow-on-agent-error-dispatch/spec.md`](../workflow-on-agent-error-dispatch/spec.md)
-  — **AC-C5**: "The exactly-once guarantee is scoped to one backend process lifetime, because
-  `workflowStore.appliedOps` is an in-memory `sync.Map`." That sentence is the contract; the code does
-  not honour it. Its **AC-E13** placed the fix here rather than there.
+  — **AC-C5**: exactly-once lasts one process. The service ledger now survives engine rebuilds.
 
 ## Why
 
 `Engine.HandleTrigger`'s idempotency check is the only thing between a redelivered workflow trigger
 and a second execution of its actions — a second `queue_run`, a second step transition, a second
-`clear_decisions`. The ledger it consults is `orchestrator.workflowStore.appliedOps`, an in-memory
-`sync.Map` (`apps/backend/internal/orchestrator/workflow_store.go:104`, read at `:886`, written at
-`:894`).
+`clear_decisions`. The ledger it consults is `Service.operationLedger`, an in-memory `sync.Map`.
 
-`Service.initWorkflowEngine` (`service.go:1860`) builds a **brand-new** `workflowStore` on every
-call (`store := newWorkflowStore(...)` at `service.go:1864`, assigned to `s.workflowStore` at
-`:1867`). `newWorkflowStore` returns a fresh struct literal (`workflow_store.go:140`) in which
-`appliedOps` is zero-valued and never copied from the previous store; no branch reuses one.
-**Every call therefore discards the ledger.**
+`Service.initWorkflowEngine` builds a **brand-new** `workflowStore` on every call and assigns it to
+`s.workflowStore`. The new store receives `&s.operationLedger`, so rebuilding the store does not
+discard the ledger.
 
 Thirteen `Service` methods reach `initWorkflowEngine` — two directly (`SetWorkflowStepGetter`
 `service.go:1813`, `SetStepHistoryRecorder` `:1823`) and eleven through `reinitWorkflowEngine` (every
 `Set*` between `:1888` and `:1971`, `SetReviewRunner` among them).
 
-So the guarantee's real scope is not "one backend process lifetime". It is **"since the last `Set*`
-call"**.
+The previous implementation scoped the guarantee to **"since the last `Set*` call"**. It now lasts
+**one backend process lifetime**, as the related specification requires.
 
 ### The reachable window, measured
 
@@ -98,7 +92,7 @@ The brief states the ledger backs "every trigger (`on_enter`, `on_turn_start`, `
   (`phase8_callbacks.go:111,133`, via `workflow_callbacks.go:104`) uses the in-memory ledger for
   `on_enter`.
 
-The operations that **do** depend on `appliedOps` today, with their key shapes:
+The operations that **do** depend on the in-memory operation ledger, with their key shapes:
 
 | Operation id shape | Producer | Consumer |
 |---|---|---|
@@ -129,7 +123,10 @@ The ledger is a **field of `Service` whose zero value is usable**. It needs no c
 so it exists and works for every `Service` however that `Service` was built; it is never replaced;
 and its address is handed to every `workflowStore` that `initWorkflowEngine` builds.
 `workflowStore.IsOperationApplied` / `MarkOperationApplied` delegate to it, so
-`engine.TransitionStore` is unchanged and the engine needs no modification.
+`engine.TransitionStore` is unchanged. For operation-bearing triggers, the engine validates every
+non-transition action before execution. A missing callback returns `ErrActionNotYetWired` and leaves
+the id retryable. `processOnChildrenCompleted` sets `HandleInput.DeferOperationMark` and marks only
+after its outer transition lifecycle commits.
 
 The zero value is the load-bearing choice, not an implementation detail: a constructed ledger only
 exists on a `Service` some constructor initialised, making correctness depend on how each `Service`
@@ -152,7 +149,7 @@ Three alternatives were considered and rejected:
   store then never dedups — indistinguishable from a correct one until a duplicate arrives. A
   fail-open branch turns a wiring mistake into silence, worse than the boot-window bug this card
   fixes, which at least ends when boot ends.
-- **Copy `appliedOps` forward inside `initWorkflowEngine`.** Rejected: `sync.Map` has no atomic
+- **Copy the old `appliedOps` map forward inside `initWorkflowEngine`.** Rejected: `sync.Map` has no atomic
   snapshot, so a copy racing a concurrent `Store` drops entries — a partial wipe is no better than a
   full one, only harder to reproduce. It also leaves a store captured before the reinit (the
   `agentErrorDeps` snapshot at `service.go:1875`) writing into a map nothing reads afterwards.
@@ -163,7 +160,7 @@ Three alternatives were considered and rejected:
 
 - **AC-L1** WHEN an operation id has been marked applied, THEN `IsOperationApplied` shall report it
   applied for the remainder of the process, across any number of `initWorkflowEngine` and
-  `reinitWorkflowEngine` calls. This is the criterion the current code fails.
+  `reinitWorkflowEngine` calls. The service-owned ledger and its store delegates implement this.
 - **AC-L2** A `Service` shall hold exactly one ledger — the field AC-L3 describes. Every
   `workflowStore` that `initWorkflowEngine` constructs shall resolve to that same instance; a store
   built before a reinit and a store built after it shall observe each other's writes in both
@@ -246,10 +243,11 @@ Three alternatives were considered and rejected:
   tests shall keep passing with **unchanged deduping behaviour**, not merely green: every store they
   construct still has a working ledger (AC-S3a). Making one pass by removing its deduping would
   violate this criterion.
-- **AC-S5** Ordering shall be unchanged: the engine marks an operation only after `processActions`
-  returns without error (`engine.go:275`), and marks it when no actions are declared (`engine.go:267`).
-  A ledger that marked earlier would swallow the retry `workflow-on-agent-error-dispatch` AC-C6
-  requires.
+- **AC-S5** The normal engine path shall mark an operation only after `processActions` returns
+  without error, and shall mark it when no actions are declared. A caller that sets
+  `HandleInput.DeferOperationMark` owns the later mark and shall use it only when an outer side
+  effect must commit first. A ledger that marks earlier would swallow the retry
+  `workflow-on-agent-error-dispatch` AC-C6 requires.
 - **AC-S6** The ledger shall not be a mutual-exclusion primitive. WHEN two goroutines check the same
   unmarked id concurrently, THEN both may observe "not applied" and both may proceed; serialization
   remains the caller's job through the mechanisms that already do it —
@@ -338,9 +336,9 @@ Three alternatives were considered and rejected:
   the same ledger (AC-R3), so a reinit cannot split one dispatch across two ledgers. The dispatch may
   still use a *pre-reinit* engine and registry — pre-existing behaviour, and the `agentErrorDeps`
   snapshot's stated design.
-- **Mark-to-commit ordering is unchanged** (AC-S5): the engine marks after actions succeed, and
-  `applyEngineTransition` may still decline a transition the engine already marked —
-  `workflow-on-agent-error-dispatch` AC-C7 covers that and is not reopened here.
+- **Mark-to-commit ordering is unchanged** (AC-S5): the normal engine path marks after actions
+  succeed. `processOnChildrenCompleted` defers its mark until `applyEngineTransitionWithMode`
+  commits, so a failed outer transition remains retryable.
 - **No ordering is defined between two distinct operation ids.** The ledger is an unordered set: no
   iteration order, no observable insertion sequence, nothing may be derived from one.
 
@@ -450,7 +448,7 @@ Criteria and their observation points:
 | AC-S1, AC-S2, AC-S3, AC-S7 | direct ledger unit tests |
 | AC-S3a | bare `&Service{}` literal wired via `SetWorkflowStepGetter` yields a store resolving to that `Service`'s ledger, both directions (AC-T3(b)) |
 | AC-S4 | unchanged producers; existing operation-id tests keep passing with unchanged deduping behaviour, not merely green |
-| AC-S5 | existing engine tests (`engine_test.go`, `idempotency_key_test.go`) |
+| AC-S5 | engine idempotency and deferred-mark tests (`engine_test.go`) |
 | AC-S6 | the same `-race` mark/check test as AC-L6, asserting both goroutines may observe "not applied" and proceed; the ledger exposes no check-and-set, compare-and-swap or `LoadOrStore`-style method usable as a mutex |
 | AC-R1, AC-R4 | mark via engine, check via `switchWorkflowDispatcher`'s path |
 | AC-R2 | `on_children_completed` dedup across a reinit (AC-T2) |

--- a/docs/specs/workflow-on-agent-error-dispatch/spec.md
+++ b/docs/specs/workflow-on-agent-error-dispatch/spec.md
@@ -201,8 +201,9 @@ the engine resolved but `applyEngineTransition` then declines leaves it **marked
 ([AC-C7](#c-idempotency)).
 
 **The durability limit is real.** `workflowStore.IsOperationApplied` / `MarkOperationApplied`
-(`workflow_store.go:886`) are backed by an in-memory `sync.Map` (`appliedOps`), no persistence, no
-eviction — *exactly-once within one backend process lifetime*, not across a restart. Acceptable
+(`workflow_store.go:886`) are backed by an in-memory `sync.Map` (`ledger`), no
+persistence, no eviction — *exactly-once within one backend process lifetime*, not across a
+restart. Acceptable
 because `agent.failed` is a live bus event with no replay: a restart loses the event rather than
 redelivering it. A builder must not read "idempotent" as "durable".
 
@@ -458,7 +459,7 @@ closes it by construction. See [AC-E12 and AC-E13](#e-action-vocabulary-and-tran
 - **AC-C4** WHEN two distinct agent executions on one session fail in sequence, both shall dispatch.
   Suppressing the second is a defect, not idempotency.
 - **AC-C5** The exactly-once guarantee is scoped to one backend process lifetime, because
-  `workflowStore.appliedOps` is an in-memory `sync.Map`. This is a stated limit of the contract, not
+  `workflowStore.ledger` wraps an in-memory `sync.Map`. This is a stated limit of the contract, not
   a gap to be closed by adding durable marker storage in this card.
 - **AC-C6** IF an action in the list returns an error, THEN the operation shall be left **unmarked**
   (the engine's existing behaviour: `markOperationApplied` runs only after `processActions` succeeds)
@@ -817,7 +818,7 @@ Each entry is a named exclusion and part of the contract.
   concern shared by every consumer of `watcher.AgentEventData`, not a dispatch fix.
 - **The no-session failure branch.** It cannot dispatch: engine state is keyed on
   `(taskID, sessionID)` and there is no session to key on. Giving it one is not a dispatch fix.
-- **Durable operation markers.** AC-C5 states the process-scoped limit; making `appliedOps` durable
+- **Durable operation markers.** AC-C5 states the process-scoped limit; making the ledger durable
   is `workflow-on-enter-action-dispatch`'s step-entry-record territory.
 - **Synchronizing `s.workflowEngine`'s existing readers.** AC-E4 makes *this dispatch's* engine and
   registry one atomically-published value, read once. The field's other readers stay as they are: they


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3447/8992addadfb5.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** For a short window right after the backend restarts, a workflow trigger that gets redelivered — the same kind of duplicate delivery workflow triggers already tolerate everywhere else — can execute a second time: rerunning a step's `on_enter` actions, re-clearing decisions after an agent error, or re-queuing a run.
**After this:** The same redelivery is deduped for the entire life of the process, matching the guarantee the code already claimed but did not keep.
**Who hits this:** Nobody has reported it; this was found while reviewing another card's diff and confirmed by tracing a structurally-guaranteed double delivery through `processOnChildrenCompleted`, not from a user bug report.
**Scope:** standalone — a narrow lifetime fix underneath every workflow trigger, not tied to any one trigger's own feature work.
**Not here:** `on_agent_error`'s own dispatch logic (shipped separately); the pre-existing, already-documented data race on the `workflowStore`/`workflowEngine` pointers themselves; ledger durability across a restart (still in-memory and process-scoped, by design); bounding or evicting the ledger's size.

A workflow trigger's redelivery protection reset itself every time the backend rewired the workflow engine during startup — which happens roughly a dozen times, several of them after live event delivery has already begun — so a genuine duplicate delivery in that window could re-execute a trigger's actions instead of being silently deduped. The idempotency ledger now lives on the orchestrator service itself instead of being rebuilt along with the engine, so it survives every rewiring and holds for the life of the process.

## Validation

- `go test -race ./internal/orchestrator/... ./internal/workflow/...` — all packages pass, no race reports
- `golangci-lint run ./... --new-from-rev="$(git merge-base HEAD origin/main)" --timeout=5m` — 0 issues
- `gofmt -l` on every changed file — clean
- `make fmt`, `make lint-format` — clean
- `pnpm run i18n:ratchet` (from `apps/web`) — no UI files touched, passes trivially
- No E2E: diff touches only `internal/orchestrator` Go files and the spec; no web, migration, or event-bus subscriber files
- Reviewed by 4 independent legs (code-reviewer, security-reviewer, test-supervisor, and codex as a mandatory cross-vendor outside voice) across two build/review rounds; test-supervisor additionally mutation-tested the fix in place, confirming 5 regression tests fail against the pre-fix behavior and pass against the fix

## Possible Improvements

Low risk. One test-rigor nit carried over from review, not a production defect: the `on_agent_error` regression test asserts the redelivery ran no action but doesn't literally assert the engine's `Idempotent: true` return value — reviewed and accepted twice as non-blocking, since the assertion is still non-vacuous today.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Design docs

- [`docs/specs/workflow-engine-operation-ledger-lifetime/spec.md`](https://github.com/kdlbs/kandev/blob/main/docs/specs/workflow-engine-operation-ledger-lifetime/spec.md)

## Screenshots

Not applicable — backend-only reliability fix, no UI-visible change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->