### PR TITLE
feat: add DeepSeek API Balance to plugin registry

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -56,6 +56,9 @@ plugins:
   - id: kandev-plugin-youtrack
     repo: ahmedbally/kandev-plugin-youtrack
     categories: [integrations]
+  - id: kandev-plugin-deepseek-balance
+    repo: Fclem/kandev-plugin-deepseek-balance
+    categories: [analytics]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3452/fdbbab1991df.html)
<!-- kandev-pr-walkthrough-end -->

## Summary
- add `kandev-plugin-deepseek-balance` to the official plugin registry
- point the entry at `Fclem/kandev-plugin-deepseek-balance`
- classify it under `analytics`

The plugin is published as GitHub Release v0.1.1 with the required package tarball and `checksums.txt` asset. The registry entry id matches the manifest id and release package prefix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->