### PR TITLE
test(plugins): cover external priority persistence

### DIFF
--- a/apps/backend/cmd/plugin-fixture/fixture-package/manifest.yaml
+++ b/apps/backend/cmd/plugin-fixture/fixture-package/manifest.yaml
@@ -24,6 +24,7 @@ runtime:
 
 capabilities:
   events: ["task.created"]
+  api_read: ["tasks"]
   api_write: ["tasks"]
   state: true
   secrets: true
@@ -88,6 +89,9 @@ agent_tools:
       idempotent_hint: true
 
 webhooks:
+  - key: "priority"
+    description: "Exercises external Host priority persistence for integration tests"
+    method: "POST"
   - key: "test-hook"
     description: "Records inbound webhooks for e2e polling"
     method: "POST"

--- a/apps/backend/cmd/plugin-fixture/fixture_package_test.go
+++ b/apps/backend/cmd/plugin-fixture/fixture_package_test.go
@@ -27,6 +27,8 @@ func TestFixtureManifest_ParsesAndValidates(t *testing.T) {
 	require.Equal(t, "https://github.com/kdlbs/kandev-plugin-template", m.RepoURL)
 	require.Equal(t, "/ui/bundle.js", m.UI.Bundle)
 	require.True(t, m.HasEvent("task.created"))
+	require.Equal(t, []string{"tasks"}, m.Capabilities.APIRead)
+	require.Equal(t, []string{"tasks"}, m.Capabilities.APIWrite)
 	require.True(t, m.Capabilities.State)
 	require.True(t, m.Capabilities.UserState)
 	require.Equal(t, []string{"fixture-source-control"}, m.RepositoryProviders)
@@ -46,12 +48,14 @@ func TestFixtureManifest_ParsesAndValidates(t *testing.T) {
 	require.Len(t, m.AgentTools, 1)
 	require.Equal(t, "test_echo", m.AgentTools[0].Name)
 
-	require.Len(t, m.Webhooks, 2)
-	require.Equal(t, "test-hook", m.Webhooks[0].Key)
-	require.Equal(t, "POST", m.Webhooks[0].Method)
-	require.Equal(t, manifest.WebhookAccessAuthenticated, m.Webhooks[0].EffectiveAccess(m.APIVersion), "test-hook exercises the private (auth-gated) webhook path")
-	require.Equal(t, "public-hook", m.Webhooks[1].Key)
-	require.Equal(t, manifest.WebhookAccessPublic, m.Webhooks[1].EffectiveAccess(m.APIVersion), "public-hook exercises the anonymous auth-gate opt-in")
+	require.Len(t, m.Webhooks, 3)
+	require.Equal(t, "priority", m.Webhooks[0].Key)
+	require.Equal(t, manifest.WebhookAccessAuthenticated, m.Webhooks[0].EffectiveAccess(m.APIVersion), "priority exercises the private Host write path")
+	require.Equal(t, "test-hook", m.Webhooks[1].Key)
+	require.Equal(t, "POST", m.Webhooks[1].Method)
+	require.Equal(t, manifest.WebhookAccessAuthenticated, m.Webhooks[1].EffectiveAccess(m.APIVersion), "test-hook exercises the private (auth-gated) webhook path")
+	require.Equal(t, "public-hook", m.Webhooks[2].Key)
+	require.Equal(t, manifest.WebhookAccessPublic, m.Webhooks[2].EffectiveAccess(m.APIVersion), "public-hook exercises the anonymous auth-gate opt-in")
 }
 
 func TestFixtureManifest_DeclaresHostPlatformExecutable(t *testing.T) {

--- a/apps/backend/cmd/plugin-fixture/plugin.go
+++ b/apps/backend/cmd/plugin-fixture/plugin.go
@@ -173,11 +173,13 @@ func (p *fixturePlugin) HandleWebhook(ctx context.Context, req *pluginsdk.Webhoo
 // priorityProbeResult is deliberately limited to the Host contract values the
 // external-process integration test needs to observe after each write.
 type priorityProbeResult struct {
-	CreateHighReadback    string `json:"create_high_readback"`
-	CreateDefaultReadback string `json:"create_default_readback"`
-	UpdateHighReadback    string `json:"update_high_readback"`
-	InvalidCreateError    string `json:"invalid_create_error"`
-	InvalidUpdateError    string `json:"invalid_update_error"`
+	CreateHighReadback     string `json:"create_high_readback"`
+	CreateDefaultReadback  string `json:"create_default_readback"`
+	UpdateHighReadback     string `json:"update_high_readback"`
+	InvalidCreateError     string `json:"invalid_create_error"`
+	InvalidCreateTaskCount int    `json:"invalid_create_task_count"`
+	InvalidUpdateError     string `json:"invalid_update_error"`
+	InvalidUpdateReadback  string `json:"invalid_update_readback"`
 }
 
 // priorityProbe performs Create and Update writes through the injected Host,
@@ -227,8 +229,22 @@ func (p *fixturePlugin) priorityProbe(ctx context.Context) (*pluginsdk.WebhookRe
 	}); err != nil {
 		result.InvalidCreateError = err.Error()
 	}
+	tasks, _, err := host.Tasks().List(ctx, pluginsdk.TaskFilter{WorkspaceIDs: []string{createdHigh.WorkspaceID}}, pluginsdk.Page{})
+	if err != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
+	}
+	for _, task := range tasks {
+		if task.Title == "invalid priority" {
+			result.InvalidCreateTaskCount++
+		}
+	}
 	if _, err := host.Tasks().Update(ctx, pluginsdk.UpdateTaskInput{ID: createdDefault.ID, Priority: &invalid}); err != nil {
 		result.InvalidUpdateError = err.Error()
+	}
+	if readback, readErr := host.Tasks().Get(ctx, createdDefault.ID); readErr != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(readErr.Error())}, nil
+	} else {
+		result.InvalidUpdateReadback = readback.Priority
 	}
 	body, err := json.Marshal(result)
 	if err != nil {

--- a/apps/backend/cmd/plugin-fixture/plugin.go
+++ b/apps/backend/cmd/plugin-fixture/plugin.go
@@ -191,7 +191,7 @@ func (p *fixturePlugin) priorityProbe(ctx context.Context) (*pluginsdk.WebhookRe
 	}
 	result := priorityProbeResult{}
 	createdHigh, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
-		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "priority high", Priority: "high",
+		Title: "priority high", Priority: "high",
 	})
 	if err != nil {
 		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
@@ -202,7 +202,7 @@ func (p *fixturePlugin) priorityProbe(ctx context.Context) (*pluginsdk.WebhookRe
 		result.CreateHighReadback = readback.Priority
 	}
 	createdDefault, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
-		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "priority default",
+		Title: "priority default",
 	})
 	if err != nil {
 		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
@@ -223,7 +223,7 @@ func (p *fixturePlugin) priorityProbe(ctx context.Context) (*pluginsdk.WebhookRe
 	}
 	invalid := "invalid"
 	if _, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
-		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "invalid priority", Priority: invalid,
+		Title: "invalid priority", Priority: invalid,
 	}); err != nil {
 		result.InvalidCreateError = err.Error()
 	}

--- a/apps/backend/cmd/plugin-fixture/plugin.go
+++ b/apps/backend/cmd/plugin-fixture/plugin.go
@@ -28,6 +28,7 @@ const (
 	// (CreateTask + CreateComment). Gated on this key so unrelated webhook
 	// deliveries don't attempt writes.
 	writeProbeWebhookKey        = "write"
+	priorityProbeWebhookKey     = "priority"
 	fixtureReferenceSource      = "fixture-pull-requests"
 	fixturePullRequestID        = "pull-request-42"
 	revokedPullRequestID        = "pull-request-revoked"
@@ -163,7 +164,77 @@ func (p *fixturePlugin) HandleWebhook(ctx context.Context, req *pluginsdk.Webhoo
 	if req.WebhookKey == writeProbeWebhookKey {
 		p.snapshotWriteProbeBestEffort(ctx)
 	}
+	if req.WebhookKey == priorityProbeWebhookKey {
+		return p.priorityProbe(ctx)
+	}
 	return &pluginsdk.WebhookResponse{Status: 200, Body: []byte("ok")}, nil
+}
+
+// priorityProbeResult is deliberately limited to the Host contract values the
+// external-process integration test needs to observe after each write.
+type priorityProbeResult struct {
+	CreateHighReadback    string `json:"create_high_readback"`
+	CreateDefaultReadback string `json:"create_default_readback"`
+	UpdateHighReadback    string `json:"update_high_readback"`
+	InvalidCreateError    string `json:"invalid_create_error"`
+	InvalidUpdateError    string `json:"invalid_update_error"`
+}
+
+// priorityProbe performs Create and Update writes through the injected Host,
+// then immediately reads each persisted task back through Host.Tasks().Get.
+// It is an integration-only fixture hook: production plugins choose their own
+// webhook behavior.
+func (p *fixturePlugin) priorityProbe(ctx context.Context) (*pluginsdk.WebhookResponse, error) {
+	host := p.Host()
+	if host == nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte("no host")}, nil
+	}
+	result := priorityProbeResult{}
+	createdHigh, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
+		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "priority high", Priority: "high",
+	})
+	if err != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
+	}
+	if readback, readErr := host.Tasks().Get(ctx, createdHigh.ID); readErr != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(readErr.Error())}, nil
+	} else {
+		result.CreateHighReadback = readback.Priority
+	}
+	createdDefault, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
+		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "priority default",
+	})
+	if err != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
+	}
+	if readback, readErr := host.Tasks().Get(ctx, createdDefault.ID); readErr != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(readErr.Error())}, nil
+	} else {
+		result.CreateDefaultReadback = readback.Priority
+	}
+	high := "high"
+	if _, err := host.Tasks().Update(ctx, pluginsdk.UpdateTaskInput{ID: createdDefault.ID, Priority: &high}); err != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(err.Error())}, nil
+	}
+	if readback, readErr := host.Tasks().Get(ctx, createdDefault.ID); readErr != nil {
+		return &pluginsdk.WebhookResponse{Status: 500, Body: []byte(readErr.Error())}, nil
+	} else {
+		result.UpdateHighReadback = readback.Priority
+	}
+	invalid := "invalid"
+	if _, err := host.Tasks().Create(ctx, pluginsdk.CreateTaskInput{
+		WorkspaceID: "ws-probe", WorkflowID: "wf-probe", Title: "invalid priority", Priority: invalid,
+	}); err != nil {
+		result.InvalidCreateError = err.Error()
+	}
+	if _, err := host.Tasks().Update(ctx, pluginsdk.UpdateTaskInput{ID: createdDefault.ID, Priority: &invalid}); err != nil {
+		result.InvalidUpdateError = err.Error()
+	}
+	body, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	return &pluginsdk.WebhookResponse{Status: 200, Body: body}, nil
 }
 
 // HandleAction provides fixture-only authenticated actions. The response is

--- a/apps/backend/internal/plugins/host_write_external_process_test.go
+++ b/apps/backend/internal/plugins/host_write_external_process_test.go
@@ -33,17 +33,19 @@ import (
 // backendapp adapter has its own field-mapping unit coverage; this fixture
 // proves the external process reaches the real task service and SQLite store.
 type externalProcessTaskWriter struct {
-	svc              *taskservice.Service
-	workspaceID      string
-	workflowID       string
-	createPriorities []string
-	updatePriorities []string
+	svc                *taskservice.Service
+	createWorkspaceIDs []string
+	createWorkflowIDs  []string
+	createPriorities   []string
+	updatePriorities   []string
 }
 
 func (w *externalProcessTaskWriter) CreateTask(ctx context.Context, in TaskCreateInput) (*taskmodels.Task, error) {
+	w.createWorkspaceIDs = append(w.createWorkspaceIDs, in.WorkspaceID)
+	w.createWorkflowIDs = append(w.createWorkflowIDs, in.WorkflowID)
 	w.createPriorities = append(w.createPriorities, in.Priority)
 	result, err := w.svc.CreateTask(ctx, &taskservice.CreateTaskRequest{
-		WorkspaceID: w.workspaceID, WorkflowID: w.workflowID, WorkflowStepID: in.WorkflowStepID,
+		WorkspaceID: in.WorkspaceID, WorkflowID: in.WorkflowID, WorkflowStepID: in.WorkflowStepID,
 		Title: in.Title, Description: in.Description, ParentID: in.ParentID, Metadata: in.Metadata,
 		PlanMode: in.PlanMode, Priority: in.Priority, StartAgent: in.StartAgent,
 	})
@@ -100,12 +102,13 @@ func TestPluginHost_ExternalProcessPersistsPriorityThroughTaskService(t *testing
 	require.NoError(t, err)
 	require.NotEmpty(t, workflows)
 
-	writer := &externalProcessTaskWriter{svc: taskSvc, workspaceID: workspaces[0].ID, workflowID: workflows[0].ID}
+	writer := &externalProcessTaskWriter{svc: taskSvc}
 	host := &pluginHost{
 		pluginID:     "priority-probe",
 		capabilities: manifest.Capabilities{APIRead: []string{"tasks"}, APIWrite: []string{"tasks"}},
 		taskData:     taskSvc,
 		taskWriter:   writer,
+		workflows:    taskSvc,
 	}
 
 	bin := buildExternalPriorityProbe(t)
@@ -144,6 +147,8 @@ func TestPluginHost_ExternalProcessPersistsPriorityThroughTaskService(t *testing
 	require.Equal(t, "high", probe.UpdateHighReadback)
 	require.NotEmpty(t, probe.InvalidCreateError)
 	require.NotEmpty(t, probe.InvalidUpdateError)
+	require.Equal(t, []string{workspaces[0].ID, workspaces[0].ID}, writer.createWorkspaceIDs)
+	require.Equal(t, []string{workflows[0].ID, workflows[0].ID}, writer.createWorkflowIDs)
 	require.Equal(t, []string{"high", ""}, writer.createPriorities)
 	require.Equal(t, []string{"high"}, writer.updatePriorities)
 }

--- a/apps/backend/internal/plugins/host_write_external_process_test.go
+++ b/apps/backend/internal/plugins/host_write_external_process_test.go
@@ -70,11 +70,13 @@ func (w *externalProcessTaskWriter) MoveTask(context.Context, TaskMoveInput) (*T
 }
 
 type externalPriorityProbeResult struct {
-	CreateHighReadback    string `json:"create_high_readback"`
-	CreateDefaultReadback string `json:"create_default_readback"`
-	UpdateHighReadback    string `json:"update_high_readback"`
-	InvalidCreateError    string `json:"invalid_create_error"`
-	InvalidUpdateError    string `json:"invalid_update_error"`
+	CreateHighReadback     string `json:"create_high_readback"`
+	CreateDefaultReadback  string `json:"create_default_readback"`
+	UpdateHighReadback     string `json:"update_high_readback"`
+	InvalidCreateError     string `json:"invalid_create_error"`
+	InvalidCreateTaskCount int    `json:"invalid_create_task_count"`
+	InvalidUpdateError     string `json:"invalid_update_error"`
+	InvalidUpdateReadback  string `json:"invalid_update_readback"`
 }
 
 // TestPluginPriorityWirePayload pins the exact protobuf representation compiled
@@ -146,7 +148,9 @@ func TestPluginHost_ExternalProcessPersistsPriorityThroughTaskService(t *testing
 	require.Equal(t, "medium", probe.CreateDefaultReadback)
 	require.Equal(t, "high", probe.UpdateHighReadback)
 	require.NotEmpty(t, probe.InvalidCreateError)
+	require.Zero(t, probe.InvalidCreateTaskCount)
 	require.NotEmpty(t, probe.InvalidUpdateError)
+	require.Equal(t, "high", probe.InvalidUpdateReadback)
 	require.Equal(t, []string{workspaces[0].ID, workspaces[0].ID}, writer.createWorkspaceIDs)
 	require.Equal(t, []string{workflows[0].ID, workflows[0].ID}, writer.createWorkflowIDs)
 	require.Equal(t, []string{"high", ""}, writer.createPriorities)

--- a/apps/backend/internal/plugins/host_write_external_process_test.go
+++ b/apps/backend/internal/plugins/host_write_external_process_test.go
@@ -1,0 +1,181 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/plugins/manifest"
+	pluginruntime "github.com/kandev/kandev/internal/plugins/runtime"
+	"github.com/kandev/kandev/internal/plugins/store"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+	taskrepo "github.com/kandev/kandev/internal/task/repository"
+	taskservice "github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/pkg/pluginsdk"
+	pluginv1 "github.com/kandev/kandev/proto/kandev/plugin/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// externalProcessTaskWriter is intentionally shaped like backendapp's adapter:
+// the Host package cannot import backendapp without an import cycle. The
+// backendapp adapter has its own field-mapping unit coverage; this fixture
+// proves the external process reaches the real task service and SQLite store.
+type externalProcessTaskWriter struct {
+	svc              *taskservice.Service
+	workspaceID      string
+	workflowID       string
+	createPriorities []string
+	updatePriorities []string
+}
+
+func (w *externalProcessTaskWriter) CreateTask(ctx context.Context, in TaskCreateInput) (*taskmodels.Task, error) {
+	w.createPriorities = append(w.createPriorities, in.Priority)
+	result, err := w.svc.CreateTask(ctx, &taskservice.CreateTaskRequest{
+		WorkspaceID: w.workspaceID, WorkflowID: w.workflowID, WorkflowStepID: in.WorkflowStepID,
+		Title: in.Title, Description: in.Description, ParentID: in.ParentID, Metadata: in.Metadata,
+		PlanMode: in.PlanMode, Priority: in.Priority, StartAgent: in.StartAgent,
+	})
+	return result.Task, err
+}
+
+func (w *externalProcessTaskWriter) UpdateTask(ctx context.Context, in TaskUpdateInput) (*taskmodels.Task, error) {
+	if in.Priority != nil {
+		w.updatePriorities = append(w.updatePriorities, *in.Priority)
+	}
+	return w.svc.UpdateTask(ctx, in.ID, &taskservice.UpdateTaskRequest{
+		Title: in.Title, Description: in.Description, Priority: in.Priority,
+	})
+}
+
+func (w *externalProcessTaskWriter) DeleteTask(ctx context.Context, id string) error {
+	return w.svc.DeleteTask(ctx, id)
+}
+
+func (w *externalProcessTaskWriter) MoveTask(context.Context, TaskMoveInput) (*TaskMoveResult, error) {
+	return nil, nil
+}
+
+type externalPriorityProbeResult struct {
+	CreateHighReadback    string `json:"create_high_readback"`
+	CreateDefaultReadback string `json:"create_default_readback"`
+	UpdateHighReadback    string `json:"update_high_readback"`
+	InvalidCreateError    string `json:"invalid_create_error"`
+	InvalidUpdateError    string `json:"invalid_update_error"`
+}
+
+// TestPluginPriorityWirePayload pins the exact protobuf representation compiled
+// into the external fixture: CreateTaskRequest.priority is field 11 (0x5a),
+// and optional UpdateTaskRequest.priority is field 6 (0x32).
+func TestPluginPriorityWirePayload(t *testing.T) {
+	high := "high"
+	createPayload, err := proto.Marshal(&pluginv1.CreateTaskRequest{Priority: high})
+	require.NoError(t, err)
+	require.True(t, bytes.Contains(createPayload, []byte{0x5a, 0x04, 'h', 'i', 'g', 'h'}))
+	updatePayload, err := proto.Marshal(&pluginv1.UpdateTaskRequest{Priority: &high})
+	require.NoError(t, err)
+	require.True(t, bytes.Contains(updatePayload, []byte{0x32, 0x04, 'h', 'i', 'g', 'h'}))
+}
+
+func TestPluginHost_ExternalProcessPersistsPriorityThroughTaskService(t *testing.T) {
+	ctx := context.Background()
+	taskSvc, closeDB := newExternalProcessTaskService(t)
+	t.Cleanup(closeDB)
+
+	workspaces, err := taskSvc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, workspaces)
+	workflows, err := taskSvc.ListWorkflows(ctx, workspaces[0].ID, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, workflows)
+
+	writer := &externalProcessTaskWriter{svc: taskSvc, workspaceID: workspaces[0].ID, workflowID: workflows[0].ID}
+	host := &pluginHost{
+		pluginID:     "priority-probe",
+		capabilities: manifest.Capabilities{APIRead: []string{"tasks"}, APIWrite: []string{"tasks"}},
+		taskData:     taskSvc,
+		taskWriter:   writer,
+	}
+
+	bin := buildExternalPriorityProbe(t)
+	installPath := t.TempDir()
+	platform := goruntime.GOOS + "-" + goruntime.GOARCH
+	relative := filepath.Join("server", "plugin-"+platform)
+	destination := filepath.Join(installPath, relative)
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o755))
+	contents, err := os.ReadFile(bin)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(destination, contents, 0o755))
+
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	require.NoError(t, err)
+	runtime := pluginruntime.NewManager(t.TempDir(), nil, log)
+	t.Cleanup(runtime.StopAll)
+	record := &store.Record{Manifest: manifest.Manifest{
+		ID: "priority-probe", APIVersion: 1, Version: "1.0.0",
+		Runtime: manifest.Runtime{Type: "binary", Executables: map[string]string{platform: relative}},
+	}, InstallPath: installPath}
+	require.NoError(t, runtime.Start(ctx, record, func(string) pluginsdk.Host { return host }))
+	remote, ok := runtime.Get(record.ID)
+	require.True(t, ok)
+	var response *pluginsdk.WebhookResponse
+	require.Eventually(t, func() bool {
+		var callErr error
+		response, callErr = remote.HandleWebhook(ctx, &pluginsdk.WebhookRequest{WebhookKey: "priority"})
+		return callErr == nil && string(response.Body) != "no host"
+	}, 5*time.Second, 20*time.Millisecond, "the plugin must receive its Host before the priority probe")
+	require.Equalf(t, int32(200), response.Status, "external plugin response: %s", response.Body)
+
+	var probe externalPriorityProbeResult
+	require.NoError(t, json.Unmarshal(response.Body, &probe), "plugin response must expose immediate Host readback")
+	require.Equal(t, "high", probe.CreateHighReadback)
+	require.Equal(t, "medium", probe.CreateDefaultReadback)
+	require.Equal(t, "high", probe.UpdateHighReadback)
+	require.NotEmpty(t, probe.InvalidCreateError)
+	require.NotEmpty(t, probe.InvalidUpdateError)
+	require.Equal(t, []string{"high", ""}, writer.createPriorities)
+	require.Equal(t, []string{"high"}, writer.updatePriorities)
+}
+
+func buildExternalPriorityProbe(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "plugin-fixture")
+	command := exec.Command("go", "build", "-o", bin, "../../cmd/plugin-fixture")
+	command.Dir = "."
+	output, err := command.CombinedOutput()
+	require.NoErrorf(t, err, "build external plugin fixture: %s", output)
+	return bin
+}
+
+func newExternalProcessTaskService(t *testing.T) (*taskservice.Service, func()) {
+	t.Helper()
+	connection, err := db.OpenSQLite(filepath.Join(t.TempDir(), "priority-probe.db"))
+	require.NoError(t, err)
+	database := sqlx.NewDb(connection, "sqlite3")
+	repository, cleanup, err := taskrepo.Provide(database, database, nil)
+	require.NoError(t, err)
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	require.NoError(t, err)
+	service := taskservice.NewService(taskservice.Repos{
+		Workspaces: repository, Tasks: repository, TaskRepos: repository, Workflows: repository,
+		Messages: repository, Turns: repository, Sessions: repository, GitSnapshots: repository,
+		RepoEntities: repository, RepositorySets: repository, Executors: repository, Environments: repository,
+		TaskEnvironments: repository, Reviews: repository, StatusSummaries: repository,
+	}, bus.NewMemoryEventBus(log), log, taskservice.RepositoryDiscoveryConfig{})
+	service.SetWorkspaceBootstrapper(repository)
+	return service, func() {
+		_ = cleanup()
+		_ = database.Close()
+	}
+}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3468/c2b16b5e51a1.html)
<!-- kandev-pr-walkthrough-end -->

Adds an external-process regression that protects plugin task-priority persistence through the Host, service, and SQLite boundaries. The packaged fixture now declares the Host read capability required for immediate readback.

## Important Changes

- Builds an SDK fixture as a real plugin subprocess and verifies high, default, update, and invalid priority behavior against persisted task data.
- Pins the Create and optional Update protobuf priority field encodings.

## Validation

- `go test -race -run 'TestPluginHost_ExternalProcessPersistsPriorityThroughTaskService|TestPluginPriorityWirePayload' -v ./internal/plugins`
- `go test ./cmd/plugin-fixture ./internal/plugins`
- `go vet ./cmd/plugin-fixture ./internal/plugins`
- `go build ./cmd/plugin-fixture`

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3468-bwo7.sprites.app |
| **Commit** | `973a9d6` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->