### PR TITLE
fix(web): hide inactive repository providers

### DIFF
--- a/apps/web/components/task-create-dialog-repo-chips.test.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.test.tsx
@@ -23,6 +23,17 @@ vi.mock("@/hooks/domains/workspace/use-repository-branch-policies", () => ({
   useRepositoryBranchPolicies: () => ({ policies: mockPolicies.value }),
 }));
 
+vi.mock("@/hooks/domains/integrations/use-remote-repositories", () => ({
+  useRemoteRepositories: () => ({
+    repos: [],
+    availableProviders: [],
+    loading: false,
+    unavailable: false,
+    error: null,
+    search: () => undefined,
+  }),
+}));
+
 // The Remote-mode branch of RepoChipsRow renders RemoteRepoChipsRow, which
 // in turn renders RemoteRepoChip — a heavy popover with its own GitHub
 // hook. Stub the chip here so tests for this row stay focused on the

--- a/apps/web/components/task/sidebar-filter/use-repository-rule-catalog.test.tsx
+++ b/apps/web/components/task/sidebar-filter/use-repository-rule-catalog.test.tsx
@@ -1,8 +1,13 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { StateProvider } from "@/components/state-provider";
 
 const mocks = vi.hoisted(() => ({
   fetchAccessibleRepos: vi.fn(),
+  fetchGitHubStatus: vi.fn(),
+  fetchGitLabStatus: vi.fn(),
+  getAzureDevOpsConfig: vi.fn(),
   listUserProjects: vi.fn(),
   listAzureDevOpsProjects: vi.fn(),
   listAzureDevOpsRepositories: vi.fn(),
@@ -10,11 +15,14 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/api/domains/github-api", () => ({
   fetchAccessibleRepos: mocks.fetchAccessibleRepos,
+  fetchGitHubStatus: mocks.fetchGitHubStatus,
 }));
 vi.mock("@/lib/api/domains/gitlab-api", () => ({
+  fetchGitLabStatus: mocks.fetchGitLabStatus,
   listUserProjects: mocks.listUserProjects,
 }));
 vi.mock("@/lib/api/domains/azure-devops-api", () => ({
+  getAzureDevOpsConfig: mocks.getAzureDevOpsConfig,
   listAzureDevOpsProjects: mocks.listAzureDevOpsProjects,
   listAzureDevOpsRepositories: mocks.listAzureDevOpsRepositories,
 }));
@@ -33,6 +41,10 @@ import { useRepositoryRuleCatalog } from "./use-repository-rule-catalog";
 
 const WORKSPACE_ID = "workspace-1";
 const PLUGIN_ID = "catalog-bitbucket-provider";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <StateProvider>{children}</StateProvider>
+);
 
 afterEach(() => {
   cleanup();
@@ -60,10 +72,16 @@ describe("useRepositoryRuleCatalog", () => {
       ],
     });
     mocks.fetchAccessibleRepos.mockRejectedValue(new Error("GitHub not configured"));
+    mocks.fetchGitHubStatus.mockResolvedValue({
+      authenticated: false,
+      token_configured: false,
+    });
+    mocks.fetchGitLabStatus.mockResolvedValue(null);
+    mocks.getAzureDevOpsConfig.mockResolvedValue(null);
     mocks.listUserProjects.mockRejectedValue(new Error("GitLab not configured"));
     mocks.listAzureDevOpsProjects.mockRejectedValue(new Error("Azure DevOps not configured"));
 
-    const { result } = renderHook(() => useRepositoryRuleCatalog(WORKSPACE_ID, true));
+    const { result } = renderHook(() => useRepositoryRuleCatalog(WORKSPACE_ID, true), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     act(() => result.current.setQuery("bitbucket.org"));

--- a/apps/web/e2e/tests/task/create-task-remote-repo.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-remote-repo.spec.ts
@@ -568,6 +568,44 @@ test.describe("Task creation from Remote tab (chip picker)", () => {
     );
   });
 
+  test("unconfigured provider stays silent in the remote picker", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    await apiClient.mockGitHubSetWorkspaceConnection(seedData.workspaceId, {
+      source: "legacy_shared",
+      status: "active",
+    });
+    await seedAccessibleRepos(apiClient);
+    let gitLabProjectRequests = 0;
+    await testPage.route("**/api/v1/gitlab/projects?*", async (route) => {
+      gitLabProjectRequests += 1;
+      await route.continue();
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await openCreateDialog(testPage, kanban);
+    await clickRemoteMode(testPage);
+    await testPage.getByTestId("remote-repo-chip-trigger").first().click();
+
+    await expect(
+      testPage.getByTestId("remote-repo-option").filter({ hasText: "mock-user/alpha" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByTestId("remote-repo-provider-tabs")).toHaveCount(0);
+    await expect(testPage.getByText(/Could not load repositories/i)).toHaveCount(0);
+    expect(gitLabProjectRequests).toBe(0);
+    await prCapture.screenshot("remote-repository-picker-desktop", {
+      caption: "Desktop remote picker with an unconfigured provider hidden",
+    });
+
+    await testPage.getByTestId("remote-repo-option").filter({ hasText: "mock-user/alpha" }).click();
+    await expect(testPage.getByTestId("remote-repo-chip-trigger").first()).toContainText(
+      "mock-user/alpha",
+    );
+  });
+
   test("switches between configured repository providers with bottom tabs", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/task/mobile-create-task-remote-repo.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-remote-repo.spec.ts
@@ -307,4 +307,51 @@ test.describe("Create task Remote repo picker on mobile", () => {
       "mock-user/duplicate",
     );
   });
+
+  test("keeps an unconfigured provider out of the touch picker", async ({
+    apiClient,
+    seedData,
+    testPage,
+    prCapture,
+  }) => {
+    await apiClient.mockGitHubSetWorkspaceConnection(seedData.workspaceId, {
+      source: "legacy_shared",
+      status: "active",
+    });
+    await apiClient.mockGitHubAddRepos("mock-user", [
+      {
+        full_name: "mock-user/phone-alpha",
+        owner: "mock-user",
+        name: "phone-alpha",
+        private: false,
+      },
+    ]);
+    let gitLabProjectRequests = 0;
+    await testPage.route("**/api/v1/gitlab/projects?*", async (route) => {
+      gitLabProjectRequests += 1;
+      await route.continue();
+    });
+
+    await openRemotePicker(testPage);
+
+    await expect(
+      testPage.getByTestId("remote-repo-option").filter({ hasText: "mock-user/phone-alpha" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByTestId("remote-repo-provider-tabs")).toHaveCount(0);
+    await expect(testPage.getByText(/Could not load repositories/i)).toHaveCount(0);
+    await expect(testPage.getByTestId("remote-repo-input")).toBeVisible();
+    expect(gitLabProjectRequests).toBe(0);
+    await prCapture.screenshot("remote-repository-picker-mobile", {
+      caption: "Mobile remote picker with an unconfigured provider hidden",
+    });
+
+    await testPage
+      .getByTestId("remote-repo-option")
+      .filter({ hasText: "mock-user/phone-alpha" })
+      .tap();
+    await expect(testPage.getByTestId("remote-repo-chip-trigger").first()).toContainText(
+      "mock-user/phone-alpha",
+    );
+    await expectNoDocumentHorizontalOverflow(testPage);
+  });
 });

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AzureDevOpsPullRequest } from "@/lib/types/azure-devops";
 import { invalidateIntegrationAvailability } from "@/lib/integrations/integration-availability-events";
+import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 
 const apiMocks = vi.hoisted(() => ({
   config: vi.fn(),
@@ -28,10 +29,12 @@ const WORKSPACE_A = "workspace-a";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
     resolve = next;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 const pullRequest = {
@@ -46,7 +49,7 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-describe("Azure DevOps browse hooks", () => {
+describe("Azure DevOps connection hook", () => {
   it("clears connection data while switching workspaces", async () => {
     const nextWorkspace = deferred<{ hasSecret: boolean; organizationUrl: string }>();
     apiMocks.config
@@ -83,6 +86,70 @@ describe("Azure DevOps browse hooks", () => {
     await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(2));
   });
 
+  it("keeps a connected state usable during the scheduled background refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      const refresh = deferred<{ hasSecret: boolean; lastOk: boolean }>();
+      apiMocks.config
+        .mockResolvedValueOnce({ hasSecret: true, lastOk: true })
+        .mockReturnValueOnce(refresh.promise);
+      const { result } = renderHook(() => useAzureDevOpsConnection(WORKSPACE_A));
+
+      await vi.waitFor(() => expect(result.current.data?.hasSecret).toBe(true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(INTEGRATION_STATUS_REFRESH_MS);
+      });
+
+      expect(apiMocks.config).toHaveBeenCalledTimes(2);
+      expect(result.current.data?.hasSecret).toBe(true);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.refreshing).toBe(true);
+
+      await act(async () => {
+        refresh.resolve({ hasSecret: true, lastOk: true });
+        await refresh.promise;
+      });
+      expect(result.current.refreshing).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves a connected state during and after a failed background refresh", async () => {
+    const refresh = deferred<{ hasSecret: boolean; lastOk: boolean }>();
+    apiMocks.config
+      .mockResolvedValueOnce({ hasSecret: true, lastOk: true })
+      .mockReturnValueOnce(refresh.promise);
+    const { result } = renderHook(() => useAzureDevOpsConnection(WORKSPACE_A));
+
+    await waitFor(() => expect(result.current.data?.hasSecret).toBe(true));
+    act(() => invalidateIntegrationAvailability());
+    await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(2));
+
+    expect(result.current.data?.hasSecret).toBe(true);
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => refresh.reject(new Error("Azure temporarily unavailable")));
+    await waitFor(() => expect(result.current.error).toContain("temporarily unavailable"));
+    expect(result.current.data?.hasSecret).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("removes eligibility when a background refresh confirms no connection", async () => {
+    apiMocks.config
+      .mockResolvedValueOnce({ hasSecret: true, lastOk: true })
+      .mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useAzureDevOpsConnection(WORKSPACE_A));
+
+    await waitFor(() => expect(result.current.data?.hasSecret).toBe(true));
+    act(() => invalidateIntegrationAvailability());
+
+    await waitFor(() => expect(result.current.data).toBeNull());
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe("Azure DevOps browse hooks", () => {
   it("ignores a work-item response from the previous workspace", async () => {
     const stale = deferred<{ items: Array<{ id: number }> }>();
     apiMocks.workItems.mockReturnValueOnce(stale.promise);

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AzureDevOpsPullRequest } from "@/lib/types/azure-devops";
+import { invalidateIntegrationAvailability } from "@/lib/integrations/integration-availability-events";
 
 const apiMocks = vi.hoisted(() => ({
   config: vi.fn(),
@@ -68,6 +69,16 @@ describe("Azure DevOps browse hooks", () => {
 
     await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(1));
     act(() => result.current.refresh());
+
+    await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(2));
+  });
+
+  it("reloads connection data when integration availability is invalidated", async () => {
+    apiMocks.config.mockResolvedValue({ hasSecret: true, lastOk: true });
+    renderHook(() => useAzureDevOpsConnection(WORKSPACE_A));
+
+    await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(1));
+    act(() => invalidateIntegrationAvailability());
 
     await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(2));
   });

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.test.tsx
@@ -62,6 +62,16 @@ describe("Azure DevOps browse hooks", () => {
     expect(result.current.data).toBeNull();
   });
 
+  it("reloads connection data on refresh", async () => {
+    apiMocks.config.mockResolvedValue({ hasSecret: true, lastOk: true });
+    const { result } = renderHook(() => useAzureDevOpsConnection(WORKSPACE_A));
+
+    await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(1));
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(apiMocks.config).toHaveBeenCalledTimes(2));
+  });
+
   it("ignores a work-item response from the previous workspace", async () => {
     const stale = deferred<{ items: Array<{ id: number }> }>();
     apiMocks.workItems.mockReturnValueOnce(stale.promise);

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
@@ -25,6 +25,7 @@ type AsyncResult<T> = {
 
 type AzureDevOpsConnectionState = AsyncResult<AzureDevOpsConfig | null> & {
   workspaceId?: string;
+  refreshing: boolean;
 };
 
 function useOperationGeneration(scope?: string) {
@@ -42,22 +43,39 @@ export function useAzureDevOpsConnection(workspaceId?: string) {
     data: null,
     loading: true,
     error: null,
+    refreshing: false,
   });
   useEffect(() => {
     let cancelled = false;
     let requestId = 0;
     const load = async () => {
       const currentRequestId = ++requestId;
-      setState({ workspaceId, data: null, loading: Boolean(workspaceId), error: null });
+      setState((previous) => {
+        const sameWorkspace = previous.workspaceId === workspaceId;
+        const backgroundRefresh = sameWorkspace && !previous.loading;
+        return {
+          workspaceId,
+          data: sameWorkspace ? previous.data : null,
+          loading: Boolean(workspaceId) && !backgroundRefresh,
+          error: null,
+          refreshing: Boolean(workspaceId) && backgroundRefresh,
+        };
+      });
       if (!workspaceId) return;
       try {
         const data = await getAzureDevOpsConfig(workspaceId, { cache: "no-store" });
         if (!cancelled && currentRequestId === requestId) {
-          setState({ workspaceId, data, loading: false, error: null });
+          setState({ workspaceId, data, loading: false, error: null, refreshing: false });
         }
       } catch (err) {
         if (!cancelled && currentRequestId === requestId) {
-          setState({ workspaceId, data: null, loading: false, error: String(err) });
+          setState((previous) => ({
+            workspaceId,
+            data: previous.workspaceId === workspaceId ? previous.data : null,
+            loading: false,
+            error: String(err),
+            refreshing: false,
+          }));
         }
       }
     };
@@ -79,7 +97,7 @@ export function useAzureDevOpsConnection(workspaceId?: string) {
   const scopedState =
     state.workspaceId === workspaceId
       ? state
-      : { workspaceId, data: null, loading: Boolean(workspaceId), error: null };
+      : { workspaceId, data: null, loading: Boolean(workspaceId), error: null, refreshing: false };
   return { ...scopedState, refresh };
 }
 

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
@@ -14,11 +14,17 @@ import type {
   AzureDevOpsPullRequestFeedback,
   AzureDevOpsWorkItem,
 } from "@/lib/types/azure-devops";
+import { subscribeIntegrationAvailability } from "@/lib/integrations/integration-availability-events";
+import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 
 type AsyncResult<T> = {
   data: T;
   loading: boolean;
   error: string | null;
+};
+
+type AzureDevOpsConnectionState = AsyncResult<AzureDevOpsConfig | null> & {
+  workspaceId?: string;
 };
 
 function useOperationGeneration(scope?: string) {
@@ -31,31 +37,50 @@ function useOperationGeneration(scope?: string) {
 
 export function useAzureDevOpsConnection(workspaceId?: string) {
   const [refreshVersion, setRefreshVersion] = useState(0);
-  const [state, setState] = useState<AsyncResult<AzureDevOpsConfig | null>>({
+  const [state, setState] = useState<AzureDevOpsConnectionState>({
+    workspaceId,
     data: null,
     loading: true,
     error: null,
   });
   useEffect(() => {
-    if (!workspaceId) {
-      setState({ data: null, loading: false, error: null });
-      return;
-    }
     let cancelled = false;
-    setState({ data: null, loading: true, error: null });
-    getAzureDevOpsConfig(workspaceId, { cache: "no-store" })
-      .then((data) => {
-        if (!cancelled) setState({ data, loading: false, error: null });
-      })
-      .catch((err) => {
-        if (!cancelled) setState({ data: null, loading: false, error: String(err) });
-      });
+    let requestId = 0;
+    const load = async () => {
+      const currentRequestId = ++requestId;
+      setState({ workspaceId, data: null, loading: Boolean(workspaceId), error: null });
+      if (!workspaceId) return;
+      try {
+        const data = await getAzureDevOpsConfig(workspaceId, { cache: "no-store" });
+        if (!cancelled && currentRequestId === requestId) {
+          setState({ workspaceId, data, loading: false, error: null });
+        }
+      } catch (err) {
+        if (!cancelled && currentRequestId === requestId) {
+          setState({ workspaceId, data: null, loading: false, error: String(err) });
+        }
+      }
+    };
+    void load();
+    if (!workspaceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const interval = setInterval(() => void load(), INTEGRATION_STATUS_REFRESH_MS);
+    const unsubscribe = subscribeIntegrationAvailability(() => void load());
     return () => {
       cancelled = true;
+      clearInterval(interval);
+      unsubscribe();
     };
   }, [refreshVersion, workspaceId]);
   const refresh = useCallback(() => setRefreshVersion((version) => version + 1), []);
-  return { ...state, refresh };
+  const scopedState =
+    state.workspaceId === workspaceId
+      ? state
+      : { workspaceId, data: null, loading: Boolean(workspaceId), error: null };
+  return { ...scopedState, refresh };
 }
 
 export function useAzureDevOpsWorkItemSearch(workspaceId?: string) {

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-browse.ts
@@ -30,6 +30,7 @@ function useOperationGeneration(scope?: string) {
 }
 
 export function useAzureDevOpsConnection(workspaceId?: string) {
+  const [refreshVersion, setRefreshVersion] = useState(0);
   const [state, setState] = useState<AsyncResult<AzureDevOpsConfig | null>>({
     data: null,
     loading: true,
@@ -52,8 +53,9 @@ export function useAzureDevOpsConnection(workspaceId?: string) {
     return () => {
       cancelled = true;
     };
-  }, [workspaceId]);
-  return state;
+  }, [refreshVersion, workspaceId]);
+  const refresh = useCallback(() => setRefreshVersion((version) => version + 1), []);
+  return { ...state, refresh };
 }
 
 export function useAzureDevOpsWorkItemSearch(workspaceId?: string) {

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
@@ -10,12 +10,10 @@ const workspaceB = "workspace-b";
 const gitLabAHost = "https://gitlab-a.example";
 
 let activeWorkspaceId: string | null = workspaceA;
-let cachedStatus = {
-  workspaceId: workspaceA as string | null,
-  data: null as { host: string } | null,
-  loading: false,
-  loadedAt: null as number | null,
-};
+let cachedStatuses: Record<
+  string,
+  { data: { host: string } | null; loading: boolean; loadedAt: number | null }
+> = {};
 
 vi.mock("@/lib/api/domains/gitlab-api", () => ({
   fetchGitLabStatus: (...args: unknown[]) => fetchGitLabStatusMock(...args),
@@ -25,16 +23,17 @@ vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       workspaces: { activeId: activeWorkspaceId },
-      gitlabStatus: cachedStatus,
+      gitlabStatus: { byWorkspaceId: cachedStatuses },
       setGitLabStatus: setStatus,
       setGitLabStatusLoading: setStatusLoading,
+      resetGitLabStatus: vi.fn(),
     }),
 }));
 
 describe("useGitLabStatus", () => {
   beforeEach(() => {
     activeWorkspaceId = workspaceA;
-    cachedStatus = { workspaceId: workspaceA, data: null, loading: false, loadedAt: null };
+    cachedStatuses = {};
     fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
     setStatus.mockReset();
     setStatusLoading.mockReset();
@@ -141,11 +140,8 @@ describe("useGitLabStatus", () => {
 describe("useGitLabStatus workspace ownership", () => {
   it("hides workspace A's cached status on the first render for workspace B", () => {
     activeWorkspaceId = workspaceA;
-    cachedStatus = {
-      workspaceId: workspaceA,
-      data: { host: gitLabAHost },
-      loading: false,
-      loadedAt: 1,
+    cachedStatuses = {
+      [workspaceA]: { data: { host: gitLabAHost }, loading: false, loadedAt: 1 },
     };
     fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
     setStatus.mockReset();
@@ -163,7 +159,7 @@ describe("useGitLabStatus workspace ownership", () => {
 describe("useGitLabStatus requested workspace", () => {
   beforeEach(() => {
     activeWorkspaceId = workspaceA;
-    cachedStatus = { workspaceId: workspaceA, data: null, loading: false, loadedAt: null };
+    cachedStatuses = {};
     fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
     setStatus.mockReset();
     setStatusLoading.mockReset();
@@ -178,6 +174,20 @@ describe("useGitLabStatus requested workspace", () => {
         workspaceId: workspaceB,
       }),
     );
+    expect(setStatus).toHaveBeenCalledWith(workspaceB, null);
+  });
+
+  it("keeps simultaneous workspace status requests isolated", async () => {
+    const { rerender: rerenderA } = renderHook(() => useGitLabStatus(workspaceA));
+    const { rerender: rerenderB } = renderHook(() => useGitLabStatus(workspaceB));
+
+    await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(2));
+    rerenderA();
+    rerenderB();
+
+    expect(setStatus).not.toHaveBeenCalledWith(null, null);
+    expect(setStatusLoading).not.toHaveBeenCalledWith(null, false);
+    expect(setStatus).toHaveBeenCalledWith(workspaceA, null);
     expect(setStatus).toHaveBeenCalledWith(workspaceB, null);
   });
 });

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
@@ -1,10 +1,11 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useGitLabStatus } from "./use-gitlab-status";
 
 const fetchGitLabStatusMock = vi.fn();
 const setStatus = vi.fn();
 const setStatusLoading = vi.fn();
+const resetStatus = vi.fn();
 const workspaceA = "workspace-a";
 const workspaceB = "workspace-b";
 const gitLabAHost = "https://gitlab-a.example";
@@ -14,6 +15,18 @@ let cachedStatuses: Record<
   string,
   { data: { host: string } | null; loading: boolean; loadedAt: number | null }
 > = {};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function statusEntry(workspaceId: string) {
+  return (cachedStatuses[workspaceId] ??= { data: null, loading: false, loadedAt: null });
+}
 
 vi.mock("@/lib/api/domains/gitlab-api", () => ({
   fetchGitLabStatus: (...args: unknown[]) => fetchGitLabStatusMock(...args),
@@ -26,19 +39,31 @@ vi.mock("@/components/state-provider", () => ({
       gitlabStatus: { byWorkspaceId: cachedStatuses },
       setGitLabStatus: setStatus,
       setGitLabStatusLoading: setStatusLoading,
-      resetGitLabStatus: vi.fn(),
+      resetGitLabStatus: resetStatus,
     }),
 }));
 
-describe("useGitLabStatus", () => {
-  beforeEach(() => {
-    activeWorkspaceId = workspaceA;
-    cachedStatuses = {};
-    fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
-    setStatus.mockReset();
-    setStatusLoading.mockReset();
+beforeEach(() => {
+  activeWorkspaceId = workspaceA;
+  cachedStatuses = {};
+  fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
+  setStatus.mockReset();
+  setStatusLoading.mockReset();
+  resetStatus.mockReset();
+  setStatus.mockImplementation((workspaceId: string, status: { host: string } | null) => {
+    const entry = statusEntry(workspaceId);
+    entry.data = status;
+    entry.loadedAt = Date.now();
   });
+  setStatusLoading.mockImplementation((workspaceId: string, loading: boolean) => {
+    statusEntry(workspaceId).loading = loading;
+  });
+  resetStatus.mockImplementation((workspaceId: string) => {
+    cachedStatuses[workspaceId] = { data: null, loading: false, loadedAt: null };
+  });
+});
 
+describe("useGitLabStatus", () => {
   it("refetches status when the active workspace changes", async () => {
     const { rerender } = renderHook(() => useGitLabStatus());
 
@@ -59,7 +84,9 @@ describe("useGitLabStatus", () => {
       }),
     );
   });
+});
 
+describe("useGitLabStatus stale workspace responses", () => {
   it("clears the previous status and ignores a stale workspace response", async () => {
     let resolveA: (value: { host: string }) => void = () => undefined;
     let resolveB: (value: { host: string }) => void = () => undefined;
@@ -76,7 +103,7 @@ describe("useGitLabStatus", () => {
     activeWorkspaceId = workspaceB;
     rerender();
     await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(2));
-    expect(setStatus).toHaveBeenLastCalledWith(workspaceB, null);
+    expect(resetStatus).toHaveBeenCalledWith(workspaceB);
 
     resolveA({ host: "https://stale.example" });
     await Promise.resolve();
@@ -144,8 +171,9 @@ describe("useGitLabStatus workspace ownership", () => {
       [workspaceA]: { data: { host: gitLabAHost }, loading: false, loadedAt: 1 },
     };
     fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
-    setStatus.mockReset();
-    setStatusLoading.mockReset();
+    setStatus.mockClear();
+    setStatusLoading.mockClear();
+    resetStatus.mockClear();
     const { result, rerender } = renderHook(() => useGitLabStatus());
     expect(result.current.status).toEqual({ host: gitLabAHost });
 
@@ -161,8 +189,9 @@ describe("useGitLabStatus requested workspace", () => {
     activeWorkspaceId = workspaceA;
     cachedStatuses = {};
     fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
-    setStatus.mockReset();
-    setStatusLoading.mockReset();
+    setStatus.mockClear();
+    setStatusLoading.mockClear();
+    resetStatus.mockClear();
   });
 
   it("uses the requested workspace instead of the active workspace", async () => {
@@ -174,7 +203,7 @@ describe("useGitLabStatus requested workspace", () => {
         workspaceId: workspaceB,
       }),
     );
-    expect(setStatus).toHaveBeenCalledWith(workspaceB, null);
+    expect(resetStatus).toHaveBeenCalledWith(workspaceB);
   });
 
   it("keeps simultaneous workspace status requests isolated", async () => {
@@ -187,7 +216,85 @@ describe("useGitLabStatus requested workspace", () => {
 
     expect(setStatus).not.toHaveBeenCalledWith(null, null);
     expect(setStatusLoading).not.toHaveBeenCalledWith(null, false);
-    expect(setStatus).toHaveBeenCalledWith(workspaceA, null);
-    expect(setStatus).toHaveBeenCalledWith(workspaceB, null);
+    expect(resetStatus).toHaveBeenCalledWith(workspaceA);
+    expect(resetStatus).toHaveBeenCalledWith(workspaceB);
+  });
+});
+
+describe("useGitLabStatus shared request ownership", () => {
+  beforeEach(() => {
+    activeWorkspaceId = workspaceA;
+    cachedStatuses = {
+      [workspaceA]: { data: { host: gitLabAHost }, loading: false, loadedAt: 1 },
+    };
+    fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
+    setStatus.mockClear();
+    setStatusLoading.mockClear();
+    resetStatus.mockClear();
+  });
+
+  it("completes a refresh after the consumer that started it unmounts", async () => {
+    const initial = renderHook(() => useGitLabStatus());
+    await waitFor(() => expect(cachedStatuses[workspaceA]?.data).toEqual({ host: gitLabAHost }));
+    const refreshResponse = deferred<{ host: string }>();
+    fetchGitLabStatusMock.mockReset().mockReturnValue(refreshResponse.promise);
+
+    const repositoryConsumer = renderHook(() => useGitLabStatus(workspaceA));
+    expect(cachedStatuses[workspaceA]).toEqual({
+      data: { host: gitLabAHost },
+      loading: false,
+      loadedAt: 1,
+    });
+
+    act(() => {
+      void repositoryConsumer.result.current.refresh();
+    });
+    await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(1));
+
+    repositoryConsumer.unmount();
+    await act(async () => {
+      refreshResponse.resolve({ host: "https://gitlab-refreshed.example" });
+      await refreshResponse.promise;
+    });
+
+    expect(cachedStatuses[workspaceA]).toMatchObject({
+      data: { host: "https://gitlab-refreshed.example" },
+      loading: false,
+    });
+    initial.unmount();
+  });
+
+  it("lets the latest same-workspace refresh win", async () => {
+    const firstResponse = deferred<{ host: string }>();
+    const secondResponse = deferred<{ host: string }>();
+    fetchGitLabStatusMock.mockResolvedValue({ host: gitLabAHost });
+    const { result, unmount } = renderHook(() => useGitLabStatus(workspaceA));
+    await waitFor(() => expect(cachedStatuses[workspaceA]?.data).toEqual({ host: gitLabAHost }));
+    fetchGitLabStatusMock
+      .mockReset()
+      .mockReturnValueOnce(firstResponse.promise)
+      .mockReturnValueOnce(secondResponse.promise);
+
+    const firstRefresh = result.current.refresh();
+    await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(1));
+    const secondRefresh = result.current.refresh();
+    await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      firstResponse.resolve({ host: "https://gitlab-stale.example" });
+      await firstRefresh;
+    });
+    expect(cachedStatuses[workspaceA]?.data).toEqual({ host: gitLabAHost });
+    expect(cachedStatuses[workspaceA]?.loading).toBe(true);
+
+    await act(async () => {
+      secondResponse.resolve({ host: "https://gitlab-current.example" });
+      await secondRefresh;
+    });
+    expect(cachedStatuses[workspaceA]).toMatchObject({
+      data: { host: "https://gitlab-current.example" },
+      loading: false,
+    });
+    unmount();
   });
 });

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.test.ts
@@ -159,3 +159,25 @@ describe("useGitLabStatus workspace ownership", () => {
     expect(result.current.status).toBeNull();
   });
 });
+
+describe("useGitLabStatus requested workspace", () => {
+  beforeEach(() => {
+    activeWorkspaceId = workspaceA;
+    cachedStatus = { workspaceId: workspaceA, data: null, loading: false, loadedAt: null };
+    fetchGitLabStatusMock.mockReset().mockResolvedValue({ host: gitLabAHost });
+    setStatus.mockReset();
+    setStatusLoading.mockReset();
+  });
+
+  it("uses the requested workspace instead of the active workspace", async () => {
+    renderHook(() => useGitLabStatus(workspaceB));
+
+    await waitFor(() =>
+      expect(fetchGitLabStatusMock).toHaveBeenCalledWith({
+        cache: "no-store",
+        workspaceId: workspaceB,
+      }),
+    );
+    expect(setStatus).toHaveBeenCalledWith(workspaceB, null);
+  });
+});

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
@@ -15,10 +15,11 @@ import { subscribeIntegrationAvailability } from "@/lib/integrations/integration
 export function useGitLabStatus(requestedWorkspaceId?: string | null) {
   const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
   const workspaceId = requestedWorkspaceId ?? activeWorkspaceId;
-  const statusSnapshot = useAppStore((state) => state.gitlabStatus);
-  const ownsSnapshot = statusSnapshot.workspaceId === workspaceId;
-  const status = ownsSnapshot ? statusSnapshot.data : null;
-  const loading = ownsSnapshot ? statusSnapshot.loading : Boolean(workspaceId);
+  const statusEntry = useAppStore((state) =>
+    workspaceId ? state.gitlabStatus.byWorkspaceId[workspaceId] : undefined,
+  );
+  const status = statusEntry?.data ?? null;
+  const loading = statusEntry?.loading ?? Boolean(workspaceId);
   const setStatus = useAppStore((state) => state.setGitLabStatus);
   const setStatusLoading = useAppStore((state) => state.setGitLabStatusLoading);
   const requestGeneration = useRef(0);
@@ -51,8 +52,6 @@ export function useGitLabStatus(requestedWorkspaceId?: string | null) {
   useEffect(() => {
     if (!workspaceId) {
       requestGeneration.current++;
-      setStatus(null, null);
-      setStatusLoading(null, false);
       return;
     }
     setStatus(workspaceId, null);
@@ -66,8 +65,6 @@ export function useGitLabStatus(requestedWorkspaceId?: string | null) {
     const requestedWorkspaceId = currentWorkspaceId.current;
     if (!requestedWorkspaceId) {
       requestGeneration.current++;
-      setStatus(null, null);
-      setStatusLoading(null, false);
       return;
     }
     await loadStatus(requestedWorkspaceId);

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
@@ -5,12 +5,24 @@ import { fetchGitLabStatus } from "@/lib/api/domains/gitlab-api";
 import { useAppStore } from "@/components/state-provider";
 import { subscribeIntegrationAvailability } from "@/lib/integrations/integration-availability-events";
 
+const requestVersions = new Map<string, number>();
+
+function nextRequestVersion(workspaceId: string) {
+  const version = (requestVersions.get(workspaceId) ?? 0) + 1;
+  requestVersions.set(workspaceId, version);
+  return version;
+}
+
+function isCurrentRequest(workspaceId: string, version: number) {
+  return requestVersions.get(workspaceId) === version;
+}
+
 /**
  * useGitLabStatus subscribes the slice to the latest GitLab connection status.
  * Fetches on mount, retries are caller-driven via the returned `refresh`.
  *
- * Effect-driven and imperative fetches share one generation guard so a stale
- * workspace response cannot overwrite the currently selected workspace.
+ * Requests are shared by workspace so a consumer unmount cannot strand a
+ * status request that another consumer relies on.
  */
 export function useGitLabStatus(requestedWorkspaceId?: string | null) {
   const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
@@ -22,16 +34,16 @@ export function useGitLabStatus(requestedWorkspaceId?: string | null) {
   const loading = statusEntry?.loading ?? Boolean(workspaceId);
   const setStatus = useAppStore((state) => state.setGitLabStatus);
   const setStatusLoading = useAppStore((state) => state.setGitLabStatusLoading);
-  const requestGeneration = useRef(0);
+  const resetStatus = useAppStore((state) => state.resetGitLabStatus);
   const currentWorkspaceId = useRef(workspaceId);
   currentWorkspaceId.current = workspaceId;
 
   const loadStatus = useCallback(
     async (requestedWorkspaceId: string) => {
-      const generation = ++requestGeneration.current;
-      const isCurrentRequest = () =>
-        generation === requestGeneration.current &&
-        requestedWorkspaceId === currentWorkspaceId.current;
+      const version = nextRequestVersion(requestedWorkspaceId);
+      const isCurrentConsumerRequest = () =>
+        isCurrentRequest(requestedWorkspaceId, version) &&
+        currentWorkspaceId.current === requestedWorkspaceId;
 
       setStatusLoading(requestedWorkspaceId, true);
       try {
@@ -39,36 +51,37 @@ export function useGitLabStatus(requestedWorkspaceId?: string | null) {
           cache: "no-store",
           workspaceId: requestedWorkspaceId,
         });
-        if (isCurrentRequest()) setStatus(requestedWorkspaceId, res ?? null);
+        if (isCurrentConsumerRequest()) {
+          setStatus(requestedWorkspaceId, res ?? null);
+        }
       } catch {
-        if (isCurrentRequest()) setStatus(requestedWorkspaceId, null);
+        if (isCurrentConsumerRequest()) {
+          setStatus(requestedWorkspaceId, null);
+        }
       } finally {
-        if (isCurrentRequest()) setStatusLoading(requestedWorkspaceId, false);
+        if (isCurrentConsumerRequest()) {
+          setStatusLoading(requestedWorkspaceId, false);
+        }
       }
     },
     [setStatus, setStatusLoading],
   );
 
   useEffect(() => {
-    if (!workspaceId) {
-      requestGeneration.current++;
+    if (!workspaceId) return;
+    if (!statusEntry) {
+      resetStatus(workspaceId);
+      void loadStatus(workspaceId);
       return;
     }
-    setStatus(workspaceId, null);
-    void loadStatus(workspaceId);
-    return () => {
-      requestGeneration.current++;
-    };
-  }, [workspaceId, loadStatus, setStatus, setStatusLoading]);
+    if (statusEntry.loadedAt === null && !statusEntry.loading) void loadStatus(workspaceId);
+  }, [loadStatus, resetStatus, statusEntry?.loadedAt, statusEntry?.loading, workspaceId]);
 
   const refresh = useCallback(async () => {
     const requestedWorkspaceId = currentWorkspaceId.current;
-    if (!requestedWorkspaceId) {
-      requestGeneration.current++;
-      return;
-    }
+    if (!requestedWorkspaceId) return;
     await loadStatus(requestedWorkspaceId);
-  }, [loadStatus, setStatus, setStatusLoading]);
+  }, [loadStatus]);
 
   useEffect(() => subscribeIntegrationAvailability(() => void refresh()), [refresh]);
 

--- a/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-status.ts
@@ -12,8 +12,9 @@ import { subscribeIntegrationAvailability } from "@/lib/integrations/integration
  * Effect-driven and imperative fetches share one generation guard so a stale
  * workspace response cannot overwrite the currently selected workspace.
  */
-export function useGitLabStatus() {
-  const workspaceId = useAppStore((state) => state.workspaces.activeId);
+export function useGitLabStatus(requestedWorkspaceId?: string | null) {
+  const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
+  const workspaceId = requestedWorkspaceId ?? activeWorkspaceId;
   const statusSnapshot = useAppStore((state) => state.gitlabStatus);
   const ownsSnapshot = statusSnapshot.workspaceId === workspaceId;
   const status = ownsSnapshot ? statusSnapshot.data : null;

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
@@ -209,6 +209,32 @@ describe("useRemoteRepositories registered provider listings", () => {
 });
 
 describe("useRemoteRepositories provider eligibility", () => {
+  it("waits for provider eligibility before listing repositories", async () => {
+    setBuiltInAvailability({ github: false, gitlab: false, azureDevOps: false });
+    mocks.useGitHubStatus.mockReturnValue({
+      status: null,
+      loaded: false,
+      loading: true,
+      refresh: vi.fn(),
+    });
+    mocks.fetchAccessibleRepos.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    expect(result.current.loading).toBe(true);
+    expect(mocks.fetchAccessibleRepos).not.toHaveBeenCalled();
+    expect(mocks.listUserProjects).not.toHaveBeenCalled();
+    expect(mocks.listAzureDevOpsProjects).not.toHaveBeenCalled();
+
+    setBuiltInAvailability({ gitlab: false, azureDevOps: false });
+    rerender();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1);
+    expect(mocks.listUserProjects).not.toHaveBeenCalled();
+    expect(mocks.listAzureDevOpsProjects).not.toHaveBeenCalled();
+  });
+
   it("does not request or report unconfigured built-in providers", async () => {
     setBuiltInAvailability({ gitlab: false, azureDevOps: false });
     mocks.fetchAccessibleRepos.mockResolvedValue([

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
@@ -1,11 +1,14 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   fetchAccessibleRepos: vi.fn(),
   listUserProjects: vi.fn(),
   listAzureDevOpsProjects: vi.fn(),
   listAzureDevOpsRepositories: vi.fn(),
+  useGitHubStatus: vi.fn(),
+  useGitLabStatus: vi.fn(),
+  useAzureDevOpsConnection: vi.fn(),
 }));
 
 vi.mock("@/lib/api/domains/github-api", () => ({
@@ -16,18 +19,58 @@ vi.mock("@/lib/api/domains/azure-devops-api", () => ({
   listAzureDevOpsProjects: mocks.listAzureDevOpsProjects,
   listAzureDevOpsRepositories: mocks.listAzureDevOpsRepositories,
 }));
+vi.mock("@/hooks/domains/github/use-github-status", () => ({
+  useGitHubStatus: mocks.useGitHubStatus,
+}));
+vi.mock("@/hooks/domains/gitlab/use-gitlab-status", () => ({
+  useGitLabStatus: mocks.useGitLabStatus,
+}));
+vi.mock("@/hooks/domains/azure-devops/use-azure-devops-browse", () => ({
+  useAzureDevOpsConnection: mocks.useAzureDevOpsConnection,
+}));
 
 import { useRemoteRepositories } from "./use-remote-repositories";
 import { pluginRegistry } from "@/lib/plugins/registry";
 
 const WORKSPACE_ID = "workspace-1";
 const PLUGIN_ID = "test-bitbucket-provider";
+const GITLAB_UNAVAILABLE = "GitLab unavailable";
 
 afterEach(() => {
   cleanup();
   pluginRegistry.unregisterPlugin(PLUGIN_ID);
   vi.resetAllMocks();
 });
+
+function setBuiltInAvailability({
+  github = true,
+  gitlab = true,
+  azureDevOps = true,
+}: {
+  github?: boolean;
+  gitlab?: boolean;
+  azureDevOps?: boolean;
+} = {}) {
+  mocks.useGitHubStatus.mockReturnValue({
+    status: github ? { authenticated: true, token_configured: true } : null,
+    loaded: true,
+    loading: false,
+    refresh: vi.fn(),
+  });
+  mocks.useGitLabStatus.mockReturnValue({
+    status: gitlab ? { authenticated: true, token_configured: true } : null,
+    loading: false,
+    refresh: vi.fn(),
+  });
+  mocks.useAzureDevOpsConnection.mockReturnValue({
+    data: azureDevOps ? { hasSecret: true, lastOk: true } : null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
+}
+
+beforeEach(() => setBuiltInAvailability());
 
 function rejectUnavailableProviders() {
   mocks.listUserProjects.mockRejectedValue(new Error("GitLab not configured"));
@@ -165,6 +208,57 @@ describe("useRemoteRepositories registered provider listings", () => {
   });
 });
 
+describe("useRemoteRepositories provider eligibility", () => {
+  it("does not request or report unconfigured built-in providers", async () => {
+    setBuiltInAvailability({ gitlab: false, azureDevOps: false });
+    mocks.fetchAccessibleRepos.mockResolvedValue([
+      {
+        owner: "acme",
+        name: "web",
+        full_name: "acme/web",
+        default_branch: "main",
+        private: false,
+      },
+    ]);
+    mocks.listUserProjects.mockRejectedValue(new Error("GitLab not configured"));
+    mocks.listAzureDevOpsProjects.mockRejectedValue(new Error("Azure DevOps not configured"));
+
+    const { result } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.repos.map((repo) => repo.fullName)).toEqual(["acme/web"]);
+    expect(result.current.availableProviders).toEqual(["github"]);
+    expect(result.current.sourceErrors).toEqual([]);
+    expect(mocks.listUserProjects).not.toHaveBeenCalled();
+    expect(mocks.listAzureDevOpsProjects).not.toHaveBeenCalled();
+  });
+
+  it("keeps an eligible provider failure visible beside successful results", async () => {
+    setBuiltInAvailability({ azureDevOps: false });
+    mocks.fetchAccessibleRepos.mockResolvedValue([
+      {
+        owner: "acme",
+        name: "web",
+        full_name: "acme/web",
+        default_branch: "main",
+        private: false,
+      },
+    ]);
+    mocks.listUserProjects.mockRejectedValue(new Error(GITLAB_UNAVAILABLE));
+    mocks.listAzureDevOpsProjects.mockRejectedValue(new Error("Azure DevOps not configured"));
+
+    const { result } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.repos.map((repo) => repo.fullName)).toEqual(["acme/web"]);
+    expect(result.current.availableProviders).toEqual(["github"]);
+    expect(result.current.sourceErrors).toEqual([
+      { provider: "gitlab", error: new Error(GITLAB_UNAVAILABLE) },
+    ]);
+    expect(mocks.listAzureDevOpsProjects).not.toHaveBeenCalled();
+  });
+});
+
 describe("useRemoteRepositories provider results", () => {
   it("combines successful providers while tolerating a provider failure", async () => {
     mocks.fetchAccessibleRepos.mockResolvedValue([
@@ -176,7 +270,7 @@ describe("useRemoteRepositories provider results", () => {
         private: false,
       },
     ]);
-    mocks.listUserProjects.mockRejectedValue(new Error("GitLab unavailable"));
+    mocks.listUserProjects.mockRejectedValue(new Error(GITLAB_UNAVAILABLE));
     mocks.listAzureDevOpsProjects.mockResolvedValue({
       projects: [{ id: "project-1", name: "Platform" }],
     });
@@ -212,9 +306,9 @@ describe("useRemoteRepositories provider results", () => {
     expect(result.current.repos[1].defaultBranch).toBe("trunk");
     expect(result.current.repos[2].defaultBranch).toBe("");
     expect(result.current.availableProviders).toEqual(["github", "azure_devops"]);
-    expect(result.current.error).toEqual(new Error("GitLab unavailable"));
+    expect(result.current.error).toEqual(new Error(GITLAB_UNAVAILABLE));
     expect(result.current.sourceErrors).toEqual([
-      { provider: "gitlab", error: new Error("GitLab unavailable") },
+      { provider: "gitlab", error: new Error(GITLAB_UNAVAILABLE) },
     ]);
     expect(result.current.unavailable).toBe(false);
   });
@@ -239,6 +333,84 @@ describe("useRemoteRepositories provider results", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.availableProviders).toEqual(["github", "gitlab", "azure_devops"]);
+  });
+});
+
+describe("useRemoteRepositories provider eligibility changes", () => {
+  it("uses current provider eligibility after a workspace change", async () => {
+    mocks.useGitHubStatus.mockImplementation((workspaceId: string) => ({
+      status: workspaceId === WORKSPACE_ID ? { authenticated: true, token_configured: true } : null,
+      loaded: true,
+      loading: false,
+      refresh: vi.fn(),
+    }));
+    mocks.useGitLabStatus.mockImplementation((workspaceId: string) => ({
+      status: workspaceId === WORKSPACE_ID ? null : { authenticated: true, token_configured: true },
+      loading: false,
+      refresh: vi.fn(),
+    }));
+    mocks.useAzureDevOpsConnection.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    mocks.fetchAccessibleRepos.mockResolvedValue([
+      {
+        owner: "acme",
+        name: "web",
+        full_name: "acme/web",
+        default_branch: "main",
+        private: false,
+      },
+    ]);
+    mocks.listUserProjects.mockResolvedValue({
+      projects: [
+        {
+          id: 42,
+          namespace: "acme",
+          path: "worker",
+          path_with_namespace: "acme/worker",
+          web_url: "https://gitlab.com/acme/worker",
+          default_branch: "main",
+          visibility: "private",
+        },
+      ],
+    });
+    const { result, rerender } = renderHook(
+      ({ workspaceId }) => useRemoteRepositories(workspaceId),
+      { initialProps: { workspaceId: WORKSPACE_ID } },
+    );
+
+    await waitFor(() => expect(result.current.repos).toHaveLength(1));
+    expect(result.current.repos[0]?.provider).toBe("github");
+    expect(mocks.listUserProjects).not.toHaveBeenCalled();
+
+    rerender({ workspaceId: "workspace-2" });
+
+    await waitFor(() => expect(result.current.repos[0]?.provider).toBe("gitlab"));
+    expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1);
+    expect(mocks.listUserProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-evaluates provider eligibility before a manual refresh", async () => {
+    mocks.fetchAccessibleRepos.mockResolvedValue([]);
+    mocks.listUserProjects.mockResolvedValue({ projects: [] });
+    mocks.listAzureDevOpsProjects.mockResolvedValue({ projects: [] });
+    const { result } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1);
+    expect(mocks.listUserProjects).toHaveBeenCalledTimes(1);
+    expect(mocks.listAzureDevOpsProjects).toHaveBeenCalledTimes(1);
+
+    setBuiltInAvailability({ azureDevOps: false, gitlab: false });
+    act(() => result.current.refresh?.());
+
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
+    expect(mocks.listUserProjects).toHaveBeenCalledTimes(1);
+    expect(mocks.listAzureDevOpsProjects).toHaveBeenCalledTimes(1);
+    expect(result.current.availableProviders).toEqual(["github"]);
   });
 });
 

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.ts
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.ts
@@ -7,6 +7,9 @@ import {
   listAzureDevOpsProjects,
   listAzureDevOpsRepositories,
 } from "@/lib/api/domains/azure-devops-api";
+import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
+import { useGitLabStatus } from "@/hooks/domains/gitlab/use-gitlab-status";
+import { useAzureDevOpsConnection } from "@/hooks/domains/azure-devops/use-azure-devops-browse";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import type { PluginRepositoryProviderRegistration } from "@/lib/plugins/registry";
 import { repositoryProviderMatchesURL } from "@/lib/plugins/repository-provider-url-resolution";
@@ -79,21 +82,82 @@ type RepositoryRequest = {
   load: Promise<RemoteRepository[]>;
 };
 
-async function loadBuiltInRepositories(workspaceId: string): Promise<RemoteRepositoryLoad> {
+type BuiltInRepositoryEligibility = {
+  providers: ReadonlySet<RemoteRepositoryProvider>;
+  loading: boolean;
+};
+
+type ProviderConnectionStatus = {
+  authenticated?: boolean;
+  token_configured?: boolean;
+};
+
+type BuiltInRepositoryAccess = {
+  eligibility: BuiltInRepositoryEligibility;
+  refresh: () => void;
+};
+
+function hasProviderConnection(status: ProviderConnectionStatus | null | undefined) {
+  return Boolean(status?.authenticated || status?.token_configured);
+}
+
+function useBuiltInRepositoryAccess(workspaceId: string): BuiltInRepositoryAccess {
+  const githubStatus = useGitHubStatus(workspaceId);
+  const gitlabStatus = useGitLabStatus(workspaceId);
+  const azureDevOpsConnection = useAzureDevOpsConnection(workspaceId || undefined);
+  const providers = useMemo(() => {
+    const eligible = new Set<RemoteRepositoryProvider>();
+    if (hasProviderConnection(githubStatus.status)) eligible.add("github");
+    if (hasProviderConnection(gitlabStatus.status)) eligible.add("gitlab");
+    if (azureDevOpsConnection.data?.hasSecret && azureDevOpsConnection.data.lastOk) {
+      eligible.add("azure_devops");
+    }
+    return eligible;
+  }, [
+    azureDevOpsConnection.data?.hasSecret,
+    azureDevOpsConnection.data?.lastOk,
+    githubStatus.status?.authenticated,
+    githubStatus.status?.token_configured,
+    gitlabStatus.status?.authenticated,
+    gitlabStatus.status?.token_configured,
+  ]);
+  const eligibility = useMemo(
+    () => ({
+      providers,
+      loading:
+        Boolean(workspaceId) &&
+        (githubStatus.loading ||
+          !githubStatus.loaded ||
+          gitlabStatus.loading ||
+          azureDevOpsConnection.loading),
+    }),
+    [
+      azureDevOpsConnection.loading,
+      gitlabStatus.loading,
+      githubStatus.loaded,
+      githubStatus.loading,
+      providers,
+      workspaceId,
+    ],
+  );
+  const refresh = useCallback(() => {
+    void githubStatus.refresh();
+    void gitlabStatus.refresh();
+    azureDevOpsConnection.refresh();
+  }, [azureDevOpsConnection.refresh, githubStatus.refresh, gitlabStatus.refresh]);
+  return { eligibility, refresh };
+}
+
+async function loadBuiltInRepositories(
+  workspaceId: string,
+  eligibleProviders: ReadonlySet<RemoteRepositoryProvider>,
+): Promise<RemoteRepositoryLoad> {
   if (!workspaceId) return { repos: [], availableProviders: [], sourceErrors: [] };
-  const githubRequest = workspaceId
-    ? fetchAccessibleRepos({ workspaceId, limit: 100 })
-    : Promise.reject(new Error("workspace is required for GitHub repositories"));
-  const gitLabRequest = workspaceId
-    ? listUserProjects(workspaceId)
-    : Promise.reject(new Error("workspace is required for GitLab repositories"));
-  const azureRequest = workspaceId
-    ? loadAzureRepositories(workspaceId)
-    : Promise.reject(new Error("workspace is required for Azure DevOps repositories"));
-  const requests: RepositoryRequest[] = [
-    {
+  const requests: RepositoryRequest[] = [];
+  if (eligibleProviders.has("github")) {
+    requests.push({
       provider: "github",
-      load: githubRequest.then((repos) =>
+      load: fetchAccessibleRepos({ workspaceId, limit: 100 }).then((repos) =>
         repos.map((repo) => ({
           provider: "github" as const,
           id: repo.full_name,
@@ -105,10 +169,12 @@ async function loadBuiltInRepositories(workspaceId: string): Promise<RemoteRepos
           private: repo.private,
         })),
       ),
-    },
-    {
+    });
+  }
+  if (eligibleProviders.has("gitlab")) {
+    requests.push({
       provider: "gitlab",
-      load: gitLabRequest.then(({ projects = [] }) =>
+      load: listUserProjects(workspaceId).then(({ projects = [] }) =>
         projects.map((project) => ({
           provider: "gitlab" as const,
           id: String(project.id),
@@ -120,9 +186,11 @@ async function loadBuiltInRepositories(workspaceId: string): Promise<RemoteRepos
           private: project.visibility === "private",
         })),
       ),
-    },
-    { provider: "azure_devops", load: azureRequest },
-  ];
+    });
+  }
+  if (eligibleProviders.has("azure_devops")) {
+    requests.push({ provider: "azure_devops", load: loadAzureRepositories(workspaceId) });
+  }
   return settleRepositoryRequests(requests);
 }
 
@@ -233,6 +301,7 @@ type RepositorySourceState = {
 function useBuiltInRepositorySource(
   workspaceId: string,
   refreshVersion: number,
+  eligibility: BuiltInRepositoryEligibility,
 ): RepositorySourceState {
   const [repos, setRepos] = useState<RemoteRepository[]>([]);
   const [loading, setLoading] = useState(true);
@@ -245,7 +314,12 @@ function useBuiltInRepositorySource(
     setAvailableProviders([]);
     setSourceErrors([]);
     setLoading(true);
-    loadBuiltInRepositories(workspaceId)
+    if (eligibility.loading) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    loadBuiltInRepositories(workspaceId, eligibility.providers)
       .then((result) => {
         if (cancelled) return;
         setRepos(result.repos);
@@ -261,7 +335,7 @@ function useBuiltInRepositorySource(
     return () => {
       cancelled = true;
     };
-  }, [refreshVersion, workspaceId]);
+  }, [eligibility.loading, eligibility.providers, refreshVersion, workspaceId]);
 
   return { repos, availableProviders, sourceErrors, loading };
 }
@@ -319,7 +393,8 @@ export function useRemoteRepositories(workspaceId: string): UseRemoteRepositorie
     () => registry.getRepositoryProviders(),
     [registry, registryVersion],
   );
-  const builtInSource = useBuiltInRepositorySource(workspaceId, refreshVersion);
+  const { eligibility, refresh: refreshBuiltIns } = useBuiltInRepositoryAccess(workspaceId);
+  const builtInSource = useBuiltInRepositorySource(workspaceId, refreshVersion, eligibility);
   const pluginSource = usePluginRepositorySource(
     workspaceId,
     pluginProviders,
@@ -348,7 +423,10 @@ export function useRemoteRepositories(workspaceId: string): UseRemoteRepositorie
   );
   const error = sourceErrors[0]?.error ?? null;
   const search = useCallback((value: string) => setQuery(value), []);
-  const refresh = useCallback(() => setRefreshVersion((version) => version + 1), []);
+  const refresh = useCallback(() => {
+    refreshBuiltIns();
+    setRefreshVersion((version) => version + 1);
+  }, [refreshBuiltIns]);
   const matchesURL = useCallback(
     (url: string) =>
       looksLikeSupportedRemoteURL(url) ||

--- a/apps/web/lib/state/slices/gitlab/gitlab-slice.test.ts
+++ b/apps/web/lib/state/slices/gitlab/gitlab-slice.test.ts
@@ -217,6 +217,20 @@ describe("GitLab status", () => {
       "ws-b": { data: null, loading: true, loadedAt: null },
     });
   });
+
+  it("resets one workspace status without affecting another", () => {
+    const store = makeStore();
+    store.getState().setGitLabStatus("ws-a", makeStatus());
+    store.getState().setGitLabStatusLoading("ws-a", true);
+    store.getState().setGitLabStatus("ws-b", makeStatus());
+
+    store.getState().resetGitLabStatus("ws-a");
+
+    expect(store.getState().gitlabStatus.byWorkspaceId).toEqual({
+      "ws-a": { data: null, loading: false, loadedAt: null },
+      "ws-b": { data: expect.any(Object), loading: false, loadedAt: expect.any(Number) },
+    });
+  });
 });
 
 describe("removeTaskMR", () => {

--- a/apps/web/lib/state/slices/gitlab/gitlab-slice.test.ts
+++ b/apps/web/lib/state/slices/gitlab/gitlab-slice.test.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { createGitLabSlice } from "./gitlab-slice";
 import type { GitLabSlice } from "./types";
-import type { TaskMR, TaskMRAutomationOptions } from "@/lib/types/gitlab";
+import type { GitLabStatus, TaskMR, TaskMRAutomationOptions } from "@/lib/types/gitlab";
 
 function makeMR(overrides: Partial<TaskMR> = {}): TaskMR {
   return {
@@ -50,6 +50,18 @@ function makeOptions(overrides: Partial<TaskMRAutomationOptions> = {}): TaskMRAu
     updated_at: "2026-01-01T00:00:00Z",
     mr_states: [],
     mr_options: [],
+    ...overrides,
+  };
+}
+
+function makeStatus(overrides: Partial<GitLabStatus> = {}): GitLabStatus {
+  return {
+    authenticated: true,
+    username: "alice",
+    auth_method: "pat",
+    host: "https://gitlab.example",
+    token_configured: true,
+    required_scopes: [],
     ...overrides,
   };
 }
@@ -189,6 +201,21 @@ describe("resetTaskMRs", () => {
     store.getState().resetTaskMRs();
 
     expect(store.getState().taskMRs.byWorkspaceId).toEqual({});
+  });
+});
+
+describe("GitLab status", () => {
+  it("keeps status and loading state isolated by workspace", () => {
+    const store = makeStore();
+    const workspaceAStatus = makeStatus();
+
+    store.getState().setGitLabStatus("ws-a", workspaceAStatus);
+    store.getState().setGitLabStatusLoading("ws-b", true);
+
+    expect(store.getState().gitlabStatus.byWorkspaceId).toEqual({
+      "ws-a": { data: workspaceAStatus, loading: false, loadedAt: expect.any(Number) },
+      "ws-b": { data: null, loading: true, loadedAt: null },
+    });
   });
 });
 

--- a/apps/web/lib/state/slices/gitlab/gitlab-slice.ts
+++ b/apps/web/lib/state/slices/gitlab/gitlab-slice.ts
@@ -217,6 +217,14 @@ function statusActions(set: ImmerSet) {
           });
         entry.loading = loading;
       }),
+    resetGitLabStatus: (workspaceId: string) =>
+      set((draft) => {
+        draft.gitlabStatus.byWorkspaceId[workspaceId] = {
+          data: null,
+          loading: false,
+          loadedAt: null,
+        };
+      }),
   };
 }
 

--- a/apps/web/lib/state/slices/gitlab/gitlab-slice.ts
+++ b/apps/web/lib/state/slices/gitlab/gitlab-slice.ts
@@ -9,7 +9,7 @@ export const defaultGitLabState: GitLabSliceState = {
   gitlabMRWatches: { items: [], loaded: false, loading: false },
   gitlabActionPresets: { byWorkspaceId: {}, loading: false },
   gitlabStats: { data: null, loading: false, loadedAt: null },
-  gitlabStatus: { workspaceId: null, data: null, loading: false, loadedAt: null },
+  gitlabStatus: { byWorkspaceId: {} },
   taskMRAutomation: { byTaskId: {}, loading: {}, saving: {}, errors: {}, externalGeneration: {} },
 };
 
@@ -192,18 +192,30 @@ function statsActions(set: ImmerSet) {
 function statusActions(set: ImmerSet) {
   return {
     setGitLabStatus: (
-      workspaceId: string | null,
-      status: GitLabSliceState["gitlabStatus"]["data"],
+      workspaceId: string,
+      status: GitLabSliceState["gitlabStatus"]["byWorkspaceId"][string]["data"],
     ) =>
       set((draft) => {
-        draft.gitlabStatus.workspaceId = workspaceId;
-        draft.gitlabStatus.data = status;
-        draft.gitlabStatus.loadedAt = Date.now();
+        const entry =
+          draft.gitlabStatus.byWorkspaceId[workspaceId] ??
+          (draft.gitlabStatus.byWorkspaceId[workspaceId] = {
+            data: null,
+            loading: false,
+            loadedAt: null,
+          });
+        entry.data = status;
+        entry.loadedAt = Date.now();
       }),
-    setGitLabStatusLoading: (workspaceId: string | null, loading: boolean) =>
+    setGitLabStatusLoading: (workspaceId: string, loading: boolean) =>
       set((draft) => {
-        draft.gitlabStatus.workspaceId = workspaceId;
-        draft.gitlabStatus.loading = loading;
+        const entry =
+          draft.gitlabStatus.byWorkspaceId[workspaceId] ??
+          (draft.gitlabStatus.byWorkspaceId[workspaceId] = {
+            data: null,
+            loading: false,
+            loadedAt: null,
+          });
+        entry.loading = loading;
       }),
   };
 }

--- a/apps/web/lib/state/slices/gitlab/types.ts
+++ b/apps/web/lib/state/slices/gitlab/types.ts
@@ -101,6 +101,7 @@ export type GitLabSliceActions = {
 
   setGitLabStatus: (workspaceId: string, status: GitLabStatus | null) => void;
   setGitLabStatusLoading: (workspaceId: string, loading: boolean) => void;
+  resetGitLabStatus: (workspaceId: string) => void;
 
   setTaskMRAutomationOptions: (taskId: string, options: TaskMRAutomationOptions) => void;
   setTaskMRAutomationLoading: (taskId: string, loading: boolean) => void;

--- a/apps/web/lib/state/slices/gitlab/types.ts
+++ b/apps/web/lib/state/slices/gitlab/types.ts
@@ -36,7 +36,10 @@ export type GitLabStatsState = {
 };
 
 export type GitLabStatusState = {
-  workspaceId: string | null;
+  byWorkspaceId: Record<string, GitLabStatusEntry>;
+};
+
+export type GitLabStatusEntry = {
   data: GitLabStatus | null;
   loading: boolean;
   loadedAt: number | null;
@@ -96,8 +99,8 @@ export type GitLabSliceActions = {
   setGitLabStats: (stats: GitLabStats | null) => void;
   setGitLabStatsLoading: (loading: boolean) => void;
 
-  setGitLabStatus: (workspaceId: string | null, status: GitLabStatus | null) => void;
-  setGitLabStatusLoading: (workspaceId: string | null, loading: boolean) => void;
+  setGitLabStatus: (workspaceId: string, status: GitLabStatus | null) => void;
+  setGitLabStatusLoading: (workspaceId: string, loading: boolean) => void;
 
   setTaskMRAutomationOptions: (taskId: string, options: TaskMRAutomationOptions) => void;
   setTaskMRAutomationLoading: (taskId: string, loading: boolean) => void;

--- a/docs/plans/configured-repository-provider-errors/plan.md
+++ b/docs/plans/configured-repository-provider-errors/plan.md
@@ -104,7 +104,7 @@ containment. Extend it only with the connection-gating outcome.
   repository request set; eligible-provider failures remain bounded source
   errors beside successful results.
 - `pnpm --filter @kandev/web exec vitest run` passed for the repository hook
-  (12 tests), GitLab status (5 tests), and Azure DevOps connection (5 tests).
+  (13 tests), GitLab status (6 tests), and Azure DevOps connection (6 tests).
 - Desktop and phone task-create regressions each passed with one Playwright
   test. The mobile run was repeated with build temporary files redirected to
   an agent-owned root-filesystem directory after the default `/tmp` mount
@@ -117,7 +117,7 @@ containment. Extend it only with the connection-gating outcome.
 - Connection probes settle asynchronously. The implementation must not show a
   false no-provider state or drop a provider that becomes available after the
   picker mounts.
-- The GitLab status hook currently follows the active workspace. The task
-  dialog's explicit workspace must remain aligned with that status scope.
+- Explicit GitLab status consumers and Azure DevOps connection probes must stay
+  keyed to their requested workspace.
 - Existing tests assume all built-in list endpoints run unconditionally and
   must be updated without weakening configured-provider failure coverage.

--- a/docs/plans/configured-repository-provider-errors/plan.md
+++ b/docs/plans/configured-repository-provider-errors/plan.md
@@ -1,0 +1,123 @@
+---
+created: 2026-09-07
+status: done
+requirements:
+  - REQ-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001
+system_design:
+  - ../../specs/integrations/system-design/azure-devops-integration-01.md
+legacy_specs: []
+---
+
+# Implementation Plan: Configured Repository Provider Errors
+
+## Overview
+
+Gate built-in remote repository discovery on each workspace's existing
+connection-availability signal. Unconfigured GitHub, GitLab, or Azure DevOps
+integrations will be omitted silently, while a repository-list failure from an
+eligible provider remains visible and does not hide successful provider
+results.
+
+## Scope
+
+### In scope
+
+- Derive the eligible built-in source-control providers for the task dialog's
+  workspace before repository-list requests start.
+- Preserve provider-specific errors for eligible providers and successful
+  results from sibling providers.
+- Cover the unconfigured GitLab regression and the configured-provider failure
+  path with focused hook tests.
+- Prove the user-visible result in the existing desktop and phone task-create
+  repository picker flows.
+
+### Out of scope
+
+- Changing GitLab, GitHub, or Azure DevOps credential storage or status APIs.
+- Making the browser-local enable/disable toggle a functional feature gate.
+- Changing plugin repository-provider registration or error behavior.
+- Changing repository picker layout, copy, manual URL entry, or branch loading.
+
+## Technical approach
+
+### Provider eligibility
+
+Update `useRemoteRepositories` in
+`apps/web/hooks/domains/integrations/use-remote-repositories.ts` to read the
+existing workspace connection signals for the three built-in providers and
+pass an explicit eligible-provider set into `loadBuiltInRepositories`.
+Construct `RepositoryRequest` entries only for eligible providers. Re-evaluate
+the set on workspace changes, integration-availability invalidation, and manual
+refresh.
+
+Keep the local `useGitHubEnabled`, `useGitLabEnabled`, and
+`useAzureDevOpsEnabled` preferences out of this path. Their active requirement
+defines them as presentation and navigation preferences, not feature gates.
+
+### Error isolation
+
+Keep `settleRepositoryRequests` as the partial-success boundary. Because
+unconfigured providers never enter its request list, they cannot create
+`sourceErrors`; because eligible providers do enter it, a later list failure
+continues to produce the existing bounded inline error while sibling results
+remain selectable.
+
+### Responsive behavior
+
+The shared hook feeds the existing desktop popover and phone task-create
+picker. No composition or geometry changes are required. The nearest mobile
+exemplar remains
+`apps/web/e2e/tests/task/mobile-create-task-remote-repo.spec.ts`: it already
+proves the touch-sized input, provider tabs, manual URL fallback, and horizontal
+containment. Extend it only with the connection-gating outcome.
+
+## Tests
+
+- `apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx`
+  - `AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.9`: GitHub connected and
+    GitLab/Azure DevOps unconfigured calls only GitHub, returns its repositories,
+    and exposes no source error.
+  - `AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.10`: an eligible GitLab
+    repository request that fails still reports its error while GitHub results
+    remain available.
+  - Refresh and workspace changes use the current eligibility set rather than a
+    stale provider selection.
+
+## E2E tests
+
+- `apps/web/e2e/tests/task/create-task-remote-repo.spec.ts`: with GitHub
+  connected and GitLab unconfigured, open the Remote picker, select the GitHub
+  result, and assert that no GitLab repository request, GitLab provider tab, or
+  repository-load error appears.
+- `apps/web/e2e/tests/task/mobile-create-task-remote-repo.spec.ts`: prove the
+  same unconfigured-provider behavior on the phone picker while manual URL
+  entry and viewport containment remain available.
+
+## Work orders
+
+- [x] [Task 01: Gate repository discovery by connection](task-01-gate-repository-discovery.md) (`done`)
+
+## Verification results
+
+- Provider eligibility is derived from workspace-scoped GitHub, GitLab, and
+  Azure DevOps connection status. Unconfigured providers do not enter the
+  repository request set; eligible-provider failures remain bounded source
+  errors beside successful results.
+- `pnpm --filter @kandev/web exec vitest run` passed for the repository hook
+  (12 tests), GitLab status (5 tests), and Azure DevOps connection (5 tests).
+- Desktop and phone task-create regressions each passed with one Playwright
+  test. The mobile run was repeated with build temporary files redirected to
+  an agent-owned root-filesystem directory after the default `/tmp` mount
+  filled during an earlier build.
+- Frontend typecheck, targeted ESLint, and `python3 scripts/lint-spec-files.py
+  --all` passed.
+
+## Risks
+
+- Connection probes settle asynchronously. The implementation must not show a
+  false no-provider state or drop a provider that becomes available after the
+  picker mounts.
+- The GitLab status hook currently follows the active workspace. The task
+  dialog's explicit workspace must remain aligned with that status scope.
+- Existing tests assume all built-in list endpoints run unconditionally and
+  must be updated without weakening configured-provider failure coverage.

--- a/docs/plans/configured-repository-provider-errors/task-01-gate-repository-discovery.md
+++ b/docs/plans/configured-repository-provider-errors/task-01-gate-repository-discovery.md
@@ -98,10 +98,14 @@ None.
   requests or add provider tabs and source errors.
 - Preserved partial-success behavior for eligible provider failures, including
   retry support through refreshed connection status and repository discovery.
-- Extended GitLab status to accept an explicit workspace and Azure DevOps
-  connection to refresh on demand, with focused hook regressions for both.
+- Keyed GitLab status by workspace and scoped Azure DevOps connection state to
+  the requested workspace. Azure DevOps re-probes after availability
+  invalidation and on the shared health cadence, with focused hook regressions
+  for both behaviors.
+- Updated repository-picker test harnesses to provide the state required by
+  the shared connection probes.
 - Added desktop and mobile task-create picker regressions proving the silent
   unconfigured-provider behavior and continued repository selection.
-- Verification passed: 12 repository-hook tests, 5 GitLab tests, 5 Azure
-  DevOps tests, both focused Playwright tests, frontend typecheck, targeted
-  ESLint, and specification linting.
+- Verification passed: 13 repository-hook tests, 6 GitLab tests, 6 Azure
+  DevOps tests, 56 focused frontend tests, both focused Playwright tests,
+  frontend typecheck, targeted ESLint, and specification linting.

--- a/docs/plans/configured-repository-provider-errors/task-01-gate-repository-discovery.md
+++ b/docs/plans/configured-repository-provider-errors/task-01-gate-repository-discovery.md
@@ -1,0 +1,107 @@
+---
+id: "01-gate-repository-discovery"
+title: "Gate repository discovery by connection"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001
+acceptance_criteria:
+  - AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.9
+  - AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.10
+  - AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.11
+system_design:
+  - ../../specs/integrations/system-design/azure-devops-integration-01.md
+---
+
+# Task 01: Gate Repository Discovery by Connection
+
+## Summary
+
+Make built-in repository discovery conditional on the selected workspace's
+source-control connection availability. Preserve partial results and errors for
+providers that were eligible, and prove identical behavior in the existing
+desktop and phone task-create picker.
+
+## In scope
+
+- Add built-in provider eligibility to `useRemoteRepositories` and its loading,
+  refresh, and workspace-change behavior.
+- Prevent unconfigured built-in providers from issuing repository-list requests
+  or contributing provider tabs and source errors.
+- Retain current partial-success behavior for eligible provider failures.
+- Add focused hook and task-create Playwright regressions.
+
+## Out of scope
+
+- Backend integration routes, credential persistence, and health polling.
+- Browser-local integration toggle semantics.
+- Plugin repository-provider discovery.
+- Repository picker layout, translation copy, and branch-resolution behavior.
+
+## Acceptance
+
+- An unconfigured GitLab integration makes no GitLab project-list request and
+  shows no GitLab repository error while connected GitHub repositories remain
+  selectable.
+- A GitLab integration that reports available and then fails its project-list
+  request still contributes the existing bounded source error without removing
+  successful provider results.
+- Refresh, workspace changes, desktop, and phone all use current provider
+  eligibility while manual URL entry remains available.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web exec vitest run hooks/domains/integrations/use-remote-repositories.test.tsx
+cd apps/web && pnpm e2e:run tests/task/create-task-remote-repo.spec.ts -- --grep "unconfigured provider"
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/task/mobile-create-task-remote-repo.spec.ts -- --grep "unconfigured provider"
+cd apps/web && pnpm run typecheck
+```
+
+## Files likely touched
+
+- `apps/web/hooks/domains/integrations/use-remote-repositories.ts`
+- `apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx`
+- `apps/web/e2e/tests/task/create-task-remote-repo.spec.ts`
+- `apps/web/e2e/tests/task/mobile-create-task-remote-repo.spec.ts`
+
+## Dependencies
+
+None.
+
+## Risks
+
+- Availability can change after mount; stale status must not suppress a newly
+  connected provider or reintroduce an unconfigured provider after a workspace
+  switch.
+- The configured-provider path must keep reporting real outages rather than
+  treating every failure as an unconfigured integration.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/integrations/requirements/azure-devops-integration.md`
+- `docs/specs/integrations/system-design/azure-devops-integration-01.md`
+- `docs/specs/integrations/requirements/enable-disable-toggle.md`
+- `docs/decisions/2026-07-20-provider-neutral-remote-repositories.md`
+- Existing hook tests and desktop/mobile task-create repository picker specs.
+
+## Results
+
+- Added workspace-scoped eligibility gating for GitHub, GitLab, and Azure
+  DevOps repository discovery. Unconfigured providers no longer issue list
+  requests or add provider tabs and source errors.
+- Preserved partial-success behavior for eligible provider failures, including
+  retry support through refreshed connection status and repository discovery.
+- Extended GitLab status to accept an explicit workspace and Azure DevOps
+  connection to refresh on demand, with focused hook regressions for both.
+- Added desktop and mobile task-create picker regressions proving the silent
+  unconfigured-provider behavior and continued repository selection.
+- Verification passed: 12 repository-hook tests, 5 GitLab tests, 5 Azure
+  DevOps tests, both focused Playwright tests, frontend typecheck, targeted
+  ESLint, and specification linting.

--- a/docs/specs/integrations/requirements/azure-devops-integration.md
+++ b/docs/specs/integrations/requirements/azure-devops-integration.md
@@ -2,7 +2,7 @@
 status: active
 system: integrations
 created: 2026-07-17
-updated: 2026-07-31
+updated: 2026-09-07
 owners:
   - tbd
 ---
@@ -28,6 +28,9 @@ Teams whose source code and planning work live in Azure DevOps cannot use Kandev
 - **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.6:** The Azure DevOps browser includes a Board mode alongside Work items and Pull requests. Board mode is the default connected view and selects context in Azure's hierarchy: project, then team, then board/backlog level.
 - **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.7:** Board mode initially selects the configured default project when available, the first accessible team, and the first visible requirement board (falling back to the first visible board). Users can change every level explicitly. Each user's last valid mode, preset, project, team, board, focused column, work-item filters, and pull-request filters are restored independently for each workspace on the next load.
 - **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.8:** The selected board shows Azure's columns, column item counts and limits, and work-item cards with ID, title, type, assignee, and tags.
+- **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.9:** When a user opens the task-creation Remote repository picker, Kandev shall request and show repositories only from source-control integrations that report an available connection for that workspace. An unconfigured integration shall not produce a repository-list error or a provider tab.
+- **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.10:** When repository listing fails for a source-control integration that reported an available connection, Kandev shall show that provider failure without removing repositories loaded from other providers, and the user shall be able to retry the listing.
+- **AC-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001.11:** Desktop and phone task-creation flows shall apply the same provider-availability and partial-failure behavior while preserving manual remote URL entry.
 
 ## System design
 

--- a/docs/specs/integrations/system-design/azure-devops-integration-01.md
+++ b/docs/specs/integrations/system-design/azure-devops-integration-01.md
@@ -167,6 +167,10 @@ An unconfigured provider is absent from the request set, provider tabs, and
 fail during its repository request; `settleRepositoryRequests` retains that
 bounded error while preserving every successful provider result. Refresh
 re-evaluates connection eligibility before it repeats repository discovery.
+GitLab status entries are keyed by workspace so an explicit task-dialog probe
+cannot overwrite the active workspace's status. Azure DevOps connection state
+is scoped to the requested workspace and re-probes after integration
+availability invalidation and on the shared health cadence.
 Registered plugin repository providers keep their registry-owned availability
 and error contract.
 

--- a/docs/specs/integrations/system-design/azure-devops-integration-01.md
+++ b/docs/specs/integrations/system-design/azure-devops-integration-01.md
@@ -4,7 +4,7 @@ system: integrations
 requirements:
   - REQ-INTEGRATIONS-AZURE-DEVOPS-INTEGRATION-001
 created: 2026-07-17
-updated: 2026-07-31
+updated: 2026-09-07
 owners:
   - tbd
 ---
@@ -150,6 +150,29 @@ Azure Repos data without installing or authenticating the GitHub CLI.
 - Selecting Work items runs the default query as soon as the connected
   project's filters are ready; users do not need to submit the initial search
   manually.
+
+### Remote repository provider eligibility
+
+`useRemoteRepositories(workspaceId)` composes built-in repository discovery
+with the existing workspace-scoped connection signals for GitHub, GitLab, and
+Azure DevOps. It schedules a built-in provider's repository-list request only
+after that provider reports an available connection for the requested
+workspace. The browser-local enable/disable toggle does not participate in
+this decision because
+`AC-INTEGRATIONS-ENABLE-DISABLE-TOGGLE-001.5` keeps GitHub, GitLab, and Azure
+DevOps feature behavior independent of that presentation preference.
+
+An unconfigured provider is absent from the request set, provider tabs, and
+`sourceErrors`. A provider that was eligible when discovery started can still
+fail during its repository request; `settleRepositoryRequests` retains that
+bounded error while preserving every successful provider result. Refresh
+re-evaluates connection eligibility before it repeats repository discovery.
+Registered plugin repository providers keep their registry-owned availability
+and error contract.
+
+The shared task dialog and repository picker use this state on desktop and
+phone. No responsive composition, touch target, scroll owner, or manual URL
+entry behavior changes.
 
 ## Data Model
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3470/d9b4d7b8dafe.html)
<!-- kandev-pr-walkthrough-end -->

Repository discovery previously surfaced errors from providers with no workspace connection, which obscured usable re...
## Important Changes
- Gate GitHub, GitLab, and Azure DevOps repository-list requests by the selected
  workspace's connection status.
- Keep eligible-provider listing failures visible without dropping successful
  repositories from sibling providers.
- Cover workspace changes and refresh behavior with hook tests, plus desktop and
  mobile task-create picker regressions.
- Record the accepted behavior in the integration requirements, system design,
  implementation plan, and completed work order.
## Validation
- `pnpm --filter @kandev/web exec vitest run hooks/domains/integrations/use-remote-repositories.test.tsx` (12 passed)
- GitLab status and Azure DevOps connection hook tests (5 passed each)
- Desktop focused Playwright regression (1 passed)
- Mobile focused Playwright regression (1 passed)
- `pnpm run typecheck`
- Targeted ESLint and `python3 scripts/lint-spec-files.py --all`
- Commit hooks: all applicable hooks passed
## Checklist
- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in...
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` an...
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is ...
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3470?utm_source=github" target="_blank" rel="noopener noreferrer" dat...
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop remote picker with an unconfigured provider hidden](https://raw.githubusercontent.com/kdlbs/kandev/22c26fe61a231e1f94f575a345d430de987c836d/remote-repository-picker-desktop.png)

![Mobile remote picker with an unconfigured provider hidden](https://raw.githubusercontent.com/kdlbs/kandev/22c26fe61a231e1f94f575a345d430de987c836d/remote-repository-picker-mobile.png)
<!-- kandev-screenshots-end -->