### PR TITLE
test(office): prove a dropped children-completed wake gets recovered

### DIFF
--- a/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/service"
+	"github.com/kandev/kandev/internal/workflow/engine"
 )
 
 // adoptOffice satisfies HasOfficeAdoption via an office_projects row, the
@@ -322,6 +323,176 @@ func TestParentWakeReconciler_UnresolvedAndPausedDoNotStarveHealthyParent(t *tes
 		}
 	}
 	t.Fatalf("zz-healthy-parent was never dispatched across 3 ticks behind 10 sticky candidates: %#v", dispatcher.Calls())
+}
+
+// oneShotFailureDispatcher wraps a queueRunDispatcher and fails the first
+// call for a chosen trigger, then delegates every other call (including
+// later calls for that same trigger) to the wrapped dispatcher. It records
+// every call it sees so a test can assert dispatch counts and operation ids
+// on both the failed attempt and the later recovery.
+type oneShotFailureDispatcher struct {
+	inner       *queueRunDispatcher
+	failTrigger engine.Trigger
+	failArmed   bool
+	failErr     error
+	calls       []dispatcherCall
+}
+
+func (d *oneShotFailureDispatcher) HandleTrigger(
+	ctx context.Context, taskID string, trigger engine.Trigger, payload any, opID string,
+) error {
+	d.calls = append(d.calls, dispatcherCall{taskID, trigger, payload, opID})
+	if d.failArmed && trigger == d.failTrigger {
+		d.failArmed = false
+		return d.failErr
+	}
+	return d.inner.HandleTrigger(ctx, taskID, trigger, payload, opID)
+}
+
+// publishChildDone publishes the task.moved event that fires
+// finalizeDone -> queueChildrenCompletedRun for parentID, the same event
+// shape TestWakeOperationID_UnifiedAcrossEdgeAndReconcilerPaths uses.
+func publishChildDone(t *testing.T, eb bus.EventBus, parentID, workerID string) {
+	t.Helper()
+	ctx := context.Background()
+	moveEvent := bus.NewEvent("task.moved", "test", map[string]string{
+		"task_id":                   parentID + "-child-0",
+		"workspace_id":              "ws-1",
+		"from_step_id":              "step-1",
+		"to_step_id":                "step-done",
+		"to_step_name":              "Done",
+		"from_step_name":            "In Progress",
+		"assignee_agent_profile_id": workerID,
+		"parent_id":                 parentID,
+	})
+	if err := eb.Publish(ctx, "task.moved", moveEvent); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+}
+
+// TestParentWakeReconciler_RecoversFailedEdgeDispatch is the regression test
+// requested on PR #3271's review (discussion r3909576685): queueChildrenCompletedRun
+// can fail after AreAllChildrenTerminal succeeds (for example when
+// GetChildSetKey errors), and finalizeDone only logs that failure at Warn
+// because ParentWakeReconciler is the documented recovery path. This proves
+// the recovery actually happens: the edge-triggered dispatch is made to fail
+// once, then a reconciler Tick must re-deliver the same wake (same operation
+// id) as a real queued run.
+func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	dispatcher := &oneShotFailureDispatcher{
+		inner:       &queueRunDispatcher{svc: svc},
+		failTrigger: engine.TriggerOnChildrenCompleted,
+		failArmed:   true,
+		failErr:     fmt.Errorf("injected get child set key failure"),
+	}
+	svc.SetWorkflowEngineDispatcher(dispatcher)
+
+	adoptOffice(t, svc, "ws-1")
+	seedStuckParent(t, svc, "ws-1", "parent-1", "worker-1")
+
+	// Edge-triggered path: the child lands in Done, firing
+	// finalizeDone -> queueChildrenCompletedRun for parent-1, which fails
+	// on the injected dispatcher error and is swallowed at Warn.
+	publishChildDone(t, eb, "parent-1", "worker-1")
+
+	if len(dispatcher.calls) != 1 {
+		t.Fatalf("want exactly one dispatch attempt after the failed edge publish, got %d: %#v",
+			len(dispatcher.calls), dispatcher.calls)
+	}
+	edgeOpID := dispatcher.calls[0].opID
+	if edgeOpID == "" {
+		t.Fatal("failed edge dispatch attempt carried an empty operation id")
+	}
+	runs, err := svc.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("failed edge dispatch left a queued run: %#v", runs)
+	}
+	receipt, err := svc.GetWakeReceiptForTest(ctx, "parent-1")
+	if err != nil {
+		t.Fatalf("get wake receipt: %v", err)
+	}
+	if receipt != nil {
+		t.Fatalf("failed edge dispatch left a receipt: %#v", receipt)
+	}
+
+	// Level-triggered path: ListStuckParents still finds parent-1 stuck
+	// because nothing was persisted for it, so Tick must re-deliver.
+	handler := service.NewParentWakeReconciler(service.NewSchedulerIntegration(svc, 0))
+	if err := handler.Tick(ctx); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	if len(dispatcher.calls) != 2 {
+		t.Fatalf("want a second dispatch attempt from the reconciler, got %d: %#v",
+			len(dispatcher.calls), dispatcher.calls)
+	}
+	reconcilerOpID := dispatcher.calls[1].opID
+	if reconcilerOpID != edgeOpID {
+		t.Fatalf("reconciler recovery used a different operation id than the failed edge attempt: edge=%q reconciler=%q",
+			edgeOpID, reconcilerOpID)
+	}
+
+	runsAfter, err := svc.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("list runs after tick: %v", err)
+	}
+	if len(runsAfter) != 1 {
+		t.Fatalf("want exactly one queued run after recovery, got %d: %#v", len(runsAfter), runsAfter)
+	}
+	if runsAfter[0].Reason != service.RunReasonTaskChildrenCompleted {
+		t.Fatalf("recovered run reason = %q, want %q", runsAfter[0].Reason, service.RunReasonTaskChildrenCompleted)
+	}
+
+	receiptAfter, err := svc.GetWakeReceiptForTest(ctx, "parent-1")
+	if err != nil {
+		t.Fatalf("get wake receipt after tick: %v", err)
+	}
+	if receiptAfter == nil || receiptAfter.DeliveryOperationID != edgeOpID {
+		t.Fatalf("recovery receipt = %#v, want an operation id matching the failed edge attempt %q", receiptAfter, edgeOpID)
+	}
+}
+
+// TestParentWakeReconciler_DoesNotDoubleQueueASuccessfulEdgeDispatch is the
+// non-vacuity control for TestParentWakeReconciler_RecoversFailedEdgeDispatch:
+// identical setup, but the edge dispatch is left to succeed. It must be the
+// one that queues the run, and the following Tick must add nothing, proving
+// the recovery assertions above discriminate on the edge path's outcome
+// rather than passing regardless of it.
+func TestParentWakeReconciler_DoesNotDoubleQueueASuccessfulEdgeDispatch(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	adoptOffice(t, svc, "ws-1")
+	seedStuckParent(t, svc, "ws-1", "parent-1", "worker-1")
+
+	publishChildDone(t, eb, "parent-1", "worker-1")
+
+	runs, err := svc.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("successful edge dispatch did not queue a run: %#v", runs)
+	}
+
+	handler := service.NewParentWakeReconciler(service.NewSchedulerIntegration(svc, 0))
+	if err := handler.Tick(ctx); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	runsAfter, err := svc.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("list runs after tick: %v", err)
+	}
+	if len(runsAfter) != 1 {
+		t.Fatalf("tick added a run behind a successful edge dispatch: %#v", runsAfter)
+	}
 }
 
 // TestWakeOperationID_UnifiedAcrossEdgeAndReconcilerPaths is the regression

--- a/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
@@ -410,8 +410,8 @@ func publishChildDone(t *testing.T, eb bus.EventBus, parentID, workerID string) 
 
 // TestParentWakeReconciler_RecoversFailedEdgeDispatch is the regression test
 // requested on PR #3271's review (discussion r3909576685): queueChildrenCompletedRun
-// can fail after AreAllChildrenTerminal succeeds (for example when
-// GetChildSetKey errors), and finalizeDone only logs that failure at Warn
+// can fail after AreAllChildrenTerminal succeeds, including when the workflow
+// dispatcher returns an error, and finalizeDone only logs that failure at Warn
 // because ParentWakeReconciler is the documented recovery path. This proves
 // the recovery actually happens: the edge-triggered dispatch is made to fail
 // once, then a reconciler Tick must re-deliver the same wake (same operation
@@ -440,6 +440,10 @@ func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("want exactly one dispatch attempt after the failed edge publish, got %d: %#v",
 			len(calls), calls)
+	}
+	if calls[0].taskID != "parent-1" || calls[0].trigger != engine.TriggerOnChildrenCompleted {
+		t.Fatalf("failed edge dispatch = task %q, trigger %q; want task parent-1, trigger %q",
+			calls[0].taskID, calls[0].trigger, engine.TriggerOnChildrenCompleted)
 	}
 	edgeOpID := calls[0].opID
 	if edgeOpID == "" {
@@ -471,6 +475,10 @@ func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("want a second dispatch attempt from the reconciler, got %d: %#v",
 			len(calls), calls)
+	}
+	if calls[1].taskID != "parent-1" || calls[1].trigger != engine.TriggerOnChildrenCompleted {
+		t.Fatalf("reconciler dispatch = task %q, trigger %q; want task parent-1, trigger %q",
+			calls[1].taskID, calls[1].trigger, engine.TriggerOnChildrenCompleted)
 	}
 	reconcilerOpID := calls[1].opID
 	if reconcilerOpID != edgeOpID {

--- a/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
+++ b/apps/backend/internal/office/service/scheduler_wake_reconciler_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/kandev/kandev/internal/events/bus"
@@ -335,18 +336,55 @@ type oneShotFailureDispatcher struct {
 	failTrigger engine.Trigger
 	failArmed   bool
 	failErr     error
-	calls       []dispatcherCall
+
+	mu    sync.Mutex
+	calls []dispatcherCall
 }
 
 func (d *oneShotFailureDispatcher) HandleTrigger(
 	ctx context.Context, taskID string, trigger engine.Trigger, payload any, opID string,
 ) error {
+	d.mu.Lock()
 	d.calls = append(d.calls, dispatcherCall{taskID, trigger, payload, opID})
+	d.mu.Unlock()
 	if d.failArmed && trigger == d.failTrigger {
 		d.failArmed = false
 		return d.failErr
 	}
 	return d.inner.HandleTrigger(ctx, taskID, trigger, payload, opID)
+}
+
+func (d *oneShotFailureDispatcher) Calls() []dispatcherCall {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]dispatcherCall, len(d.calls))
+	copy(out, d.calls)
+	return out
+}
+
+// countingDispatcher wraps a queueRunDispatcher and counts every call it
+// sees, so a test can assert the reconciler never even attempted a
+// dispatch instead of only checking the resulting run count.
+type countingDispatcher struct {
+	inner *queueRunDispatcher
+
+	mu sync.Mutex
+	n  int
+}
+
+func (d *countingDispatcher) HandleTrigger(
+	ctx context.Context, taskID string, trigger engine.Trigger, payload any, opID string,
+) error {
+	d.mu.Lock()
+	d.n++
+	d.mu.Unlock()
+	return d.inner.HandleTrigger(ctx, taskID, trigger, payload, opID)
+}
+
+func (d *countingDispatcher) Count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.n
 }
 
 // publishChildDone publishes the task.moved event that fires
@@ -386,7 +424,7 @@ func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
 		inner:       &queueRunDispatcher{svc: svc},
 		failTrigger: engine.TriggerOnChildrenCompleted,
 		failArmed:   true,
-		failErr:     fmt.Errorf("injected get child set key failure"),
+		failErr:     fmt.Errorf("injected on_children_completed dispatch failure"),
 	}
 	svc.SetWorkflowEngineDispatcher(dispatcher)
 
@@ -398,11 +436,12 @@ func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
 	// on the injected dispatcher error and is swallowed at Warn.
 	publishChildDone(t, eb, "parent-1", "worker-1")
 
-	if len(dispatcher.calls) != 1 {
+	calls := dispatcher.Calls()
+	if len(calls) != 1 {
 		t.Fatalf("want exactly one dispatch attempt after the failed edge publish, got %d: %#v",
-			len(dispatcher.calls), dispatcher.calls)
+			len(calls), calls)
 	}
-	edgeOpID := dispatcher.calls[0].opID
+	edgeOpID := calls[0].opID
 	if edgeOpID == "" {
 		t.Fatal("failed edge dispatch attempt carried an empty operation id")
 	}
@@ -428,11 +467,12 @@ func TestParentWakeReconciler_RecoversFailedEdgeDispatch(t *testing.T) {
 		t.Fatalf("tick: %v", err)
 	}
 
-	if len(dispatcher.calls) != 2 {
+	calls = dispatcher.Calls()
+	if len(calls) != 2 {
 		t.Fatalf("want a second dispatch attempt from the reconciler, got %d: %#v",
-			len(dispatcher.calls), dispatcher.calls)
+			len(calls), calls)
 	}
-	reconcilerOpID := dispatcher.calls[1].opID
+	reconcilerOpID := calls[1].opID
 	if reconcilerOpID != edgeOpID {
 		t.Fatalf("reconciler recovery used a different operation id than the failed edge attempt: edge=%q reconciler=%q",
 			edgeOpID, reconcilerOpID)
@@ -468,6 +508,9 @@ func TestParentWakeReconciler_DoesNotDoubleQueueASuccessfulEdgeDispatch(t *testi
 	svc, eb := newTestServiceWithBus(t)
 	ctx := context.Background()
 
+	dispatcher := &countingDispatcher{inner: &queueRunDispatcher{svc: svc}}
+	svc.SetWorkflowEngineDispatcher(dispatcher)
+
 	adoptOffice(t, svc, "ws-1")
 	seedStuckParent(t, svc, "ws-1", "parent-1", "worker-1")
 
@@ -480,10 +523,17 @@ func TestParentWakeReconciler_DoesNotDoubleQueueASuccessfulEdgeDispatch(t *testi
 	if len(runs) != 1 {
 		t.Fatalf("successful edge dispatch did not queue a run: %#v", runs)
 	}
+	if dispatcher.Count() != 1 {
+		t.Fatalf("want exactly one dispatch attempt from the successful edge publish, got %d", dispatcher.Count())
+	}
 
 	handler := service.NewParentWakeReconciler(service.NewSchedulerIntegration(svc, 0))
 	if err := handler.Tick(ctx); err != nil {
 		t.Fatalf("tick: %v", err)
+	}
+
+	if dispatcher.Count() != 1 {
+		t.Fatalf("want the reconciler to skip dispatch entirely behind a successful edge delivery, got %d attempts", dispatcher.Count())
 	}
 
 	runsAfter, err := svc.ListRuns(ctx, "ws-1")


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3486/2904323d11ce.html)
<!-- kandev-pr-walkthrough-end -->

Adds the regression test a github-actions review bot asked for on #3271: proof that `ParentWakeReconciler` actually recovers a parent's `on_children_completed` wake when the edge-triggered dispatch fails, since #3271 downgraded that failure's log level from Error to Warn on the strength of an until-now-untested assumption.

**Today:** If `queueChildrenCompletedRun` fails partway (e.g. a transient DB error), the parent's wake is silently dropped on the edge path and only logged at Warn — nothing in the test suite proved the reconciler's recovery sweep actually re-queues it.
**After this:** A new test drives that exact failure through `ParentWakeReconciler.Tick` and asserts a second dispatch attempt with the same operation id, one queued run, and a receipt whose delivery id matches. A control test alongside it proves a *successful* edge dispatch is not double-queued by the same sweep.
**Who hits this:** Contributors changing the office wake/reconciler path — this closes the exact gap the review bot flagged on #3271, which was previously an assumption baked into a comment, not a test.
**Scope:** Standalone follow-up to #3271; no sibling PRs.
**Not here:** No production code changes — this is test-only coverage. Two pre-existing, unrelated test failures on this environment are noted below (not caused by this diff, not fixed here).

## Validation

```
$ go test -tags fts5 ./internal/office/service/... -run 'TestParentWakeReconciler|TestWakeOperationID' -count=1
ok  	github.com/kandev/kandev/internal/office/service	0.928s

$ go test -tags fts5 -race ./internal/office/service/... -run 'TestParentWakeReconciler|TestWakeOperationID' -count=5
ok  	github.com/kandev/kandev/internal/office/service	2.455s

$ make fmt && make typecheck && make lint && make lint-format
✓ all clean (0 lint issues across backend, web, harness, specs, architecture)

$ cd apps/web && pnpm run i18n:ratchet
✓ i18n new-code ratchet — no UI source added or modified
```

`make test` (full suite) has two pre-existing failure sets on this environment, both proven unrelated to this diff (identical failures reproduce on a clean checkout with none of this branch's changes):

1. `internal/worktree` + several dependents (`internal/task/service`, `internal/task/handlers`, `internal/launcher`, `internal/system/storage/workspaces`, `internal/agent/...`, `internal/agentctl/...`) — this macOS sandbox's `/var/folders` symlink layout trips the worktree manager's own path-safety checks. Reproduces identically on a scratch clone of the merge base.
2. `internal/office/repository/sqlite`'s `TestMigrate_PriorityIdempotent` — fails deterministically on current `main` (`3d042e9d8`) with no relation to this branch (`git diff origin/main HEAD --stat` shows only the one test file this PR adds). Introduced by an unrelated commit between the old and current `main` tip; filed as a follow-up (kandev task `4f422031-3cd1-4893-85ee-3e9f77ec2f63`).

## Possible Improvements

Low risk — test-only change, zero production code touched. Review noted a few test-rigor nitpicks (a doc-comment could more precisely name the injected failure point, and the control test could assert on the dispatcher directly rather than only counting runs); judged non-blocking and left as-is to keep the diff minimal.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->