### PR TITLE
test(backend): cover manual-resume task-scoped coalescing at the repository layer

### DIFF
--- a/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
+++ b/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
@@ -71,6 +71,60 @@ func TestCoalesceRun_DoesNotMergeDifferentTaskRuns(t *testing.T) {
 	checkString(t, "payload", got.Payload, `{"task_id":"task-a"}`)
 }
 
+// TestCoalesceRun_ManualResumeAfterFailure_DoesNotMergeDifferentTaskRuns
+// pins the same task-scoping guarantee as
+// TestCoalesceRun_DoesNotMergeDifferentTaskRuns for the
+// manual_resume_after_failure reason: an agent auto-paused across several
+// tasks must queue one run per task instead of coalescing task-b's wake
+// into task-a's already-queued run and dropping task-a's launch.
+func TestCoalesceRun_ManualResumeAfterFailure_DoesNotMergeDifferentTaskRuns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	queued := mustCreateRun(t, repo, &models.Run{
+		ID: "task-a", AgentProfileID: "a1", Reason: "manual_resume_after_failure",
+		Payload: `{"task_id":"task-a"}`, Status: "queued", CoalescedCount: 1,
+	})
+
+	merged, err := repo.CoalesceRun(ctx, "a1", "manual_resume_after_failure", 3600, `{"task_id":"task-b"}`)
+	if err != nil {
+		t.Fatalf("coalesce: %v", err)
+	}
+	if merged {
+		t.Fatal("coalesce = true for a different task, want false")
+	}
+
+	got := mustGetRun(t, repo, queued.ID)
+	checkInt(t, "coalesced_count", got.CoalescedCount, 1)
+	checkString(t, "payload", got.Payload, `{"task_id":"task-a"}`)
+}
+
+// TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates proves
+// the task-scoping predicate added for manual_resume_after_failure still
+// allows genuine duplicates (repeated wakes for the same task) to coalesce
+// onto one row.
+func TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	queued := mustCreateRun(t, repo, &models.Run{
+		ID: "task-a", AgentProfileID: "a1", Reason: "manual_resume_after_failure",
+		Payload: `{"task_id":"task-a"}`, Status: "queued", CoalescedCount: 1,
+	})
+
+	merged, err := repo.CoalesceRun(ctx, "a1", "manual_resume_after_failure", 3600, `{"task_id":"task-a"}`)
+	if err != nil {
+		t.Fatalf("coalesce: %v", err)
+	}
+	if !merged {
+		t.Fatal("coalesce = false for the same task, want true")
+	}
+
+	got := mustGetRun(t, repo, queued.ID)
+	checkInt(t, "coalesced_count", got.CoalescedCount, 2)
+	if n := countRuns(t, repo); n != 1 {
+		t.Errorf("%d rows after coalescing, want 1 (no new run may be created)", n)
+	}
+}
+
 // TestCoalesceRun_RepeatedCoalesceAccumulatesOnOneRow pins the counter
 // arithmetic across several merges into the same run.
 func TestCoalesceRun_RepeatedCoalesceAccumulatesOnOneRow(t *testing.T) {

--- a/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
+++ b/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
@@ -107,10 +107,10 @@ func TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates(t *testin
 	ctx := context.Background()
 	queued := mustCreateRun(t, repo, &models.Run{
 		ID: "task-a", AgentProfileID: "a1", Reason: "manual_resume_after_failure",
-		Payload: `{"task_id":"task-a"}`, Status: "queued", CoalescedCount: 1,
+		Payload: `{"task_id":"task-a","attempt":1}`, Status: "queued", CoalescedCount: 1,
 	})
 
-	merged, err := repo.CoalesceRun(ctx, "a1", "manual_resume_after_failure", 3600, `{"task_id":"task-a"}`)
+	merged, err := repo.CoalesceRun(ctx, "a1", "manual_resume_after_failure", 3600, `{"task_id":"task-a","attempt":2}`)
 	if err != nil {
 		t.Fatalf("coalesce: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates(t *testin
 
 	got := mustGetRun(t, repo, queued.ID)
 	checkInt(t, "coalesced_count", got.CoalescedCount, 2)
-	checkString(t, "payload", got.Payload, `{"task_id":"task-a"}`)
+	checkString(t, "payload", got.Payload, `{"task_id":"task-a","attempt":2}`)
 	if n := countRuns(t, repo); n != 1 {
 		t.Errorf("%d rows after coalescing, want 1 (no new run may be created)", n)
 	}

--- a/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
+++ b/apps/backend/internal/runs/repository/sqlite/runs_queue_test.go
@@ -120,6 +120,7 @@ func TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates(t *testin
 
 	got := mustGetRun(t, repo, queued.ID)
 	checkInt(t, "coalesced_count", got.CoalescedCount, 2)
+	checkString(t, "payload", got.Payload, `{"task_id":"task-a"}`)
 	if n := countRuns(t, repo); n != 1 {
 		t.Errorf("%d rows after coalescing, want 1 (no new run may be created)", n)
 	}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3487/7db5b70dc438.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** `CoalesceRun`'s task-scoping predicate for `manual_resume_after_failure` wakes (added by PR #3464, merged to `main` while this branch was in review) has no direct repository-level test — every existing assertion of it goes through `internal/runs/service` or `internal/office/service`, so a regression in the predicate itself would surface only several layers up, in a full agent-auto-pause scenario.
**After this:** Two repository-level tests mirror the existing `task_assigned` coverage pattern, asserting directly against `CoalesceRun` that a manual-resume wake for a different task never merges into another task's queued run, while a genuine same-task duplicate still coalesces onto one row.
**Who hits this:** Whoever next touches `CoalesceRun`'s task-scoping predicate or the reasons it covers.
**Scope:** standalone, test-only, backend (`internal/runs/repository/sqlite`).
**Not here:** the production fix itself. This branch was opened against an agent auto-paused across N tasks queuing only 1 requeue run instead of N (its payload silently dropping N-1 launches) — [PR #3464](https://github.com/kdlbs/kandev/pull/3464) merged independently and fixed exactly this, at both the `CoalesceRun` predicate and the `requeueRunForTask` idempotency key, with its own end-to-end regression test (`TestMarkAgentPausedFixed_RequeuesEachAffectedTask`). This PR only adds the lower-layer coverage that fix didn't include.

This branch originally carried a production fix for the same defect (`taskScopedCoalesceReasons` map in `CoalesceRun`), functionally identical to what #3464 shipped (`isTaskScopedCoalescingReason`). Once #3464 landed on `main` first, that diff became a no-op duplicate and was dropped; what's left is the incremental test coverage below.

## Validation

```
$ go build ./...                                                   # clean
$ go vet ./internal/runs/... ./internal/office/...                 # clean
$ go test ./internal/runs/repository/sqlite/... -run TestCoalesceRun -v
--- PASS: TestCoalesceRun_MergesIntoMostRecentQueuedRun
--- PASS: TestCoalesceRun_DoesNotMergeDifferentTaskRuns
--- PASS: TestCoalesceRun_ManualResumeAfterFailure_DoesNotMergeDifferentTaskRuns   (new)
--- PASS: TestCoalesceRun_ManualResumeAfterFailure_MergesSameTaskDuplicates        (new)
--- PASS: TestCoalesceRun_RepeatedCoalesceAccumulatesOnOneRow
--- PASS: TestCoalesceRun_NoEligibleRunLeavesEverythingAlone
--- PASS: TestCoalesceRun_HonoursTheWindow
--- PASS: TestCoalesceRun_SkipsCommentKeyedRuns
ok  	github.com/kandev/kandev/internal/runs/repository/sqlite

$ go test ./internal/runs/... ./internal/office/... -count=1        # all ok
$ gofmt -l <changed file>                                           # clean
$ golangci-lint run ./... --new-from-rev=origin/main --timeout=5m   # 0 issues
$ make typecheck                                                    # clean (0 apps/web files touched)
$ make lint-format && pnpm run i18n:ratchet                         # clean
```

`make test` at repo root has pre-existing failures in `internal/worktree` and `internal/task/service` unrelated to this diff (macOS `/var/folders` TMPDIR is a symlink, and these tests' own safety checks reject symlinked paths) — reproduced identically on `origin/main`'s merge-base in a scratch worktree, before this change. E2E is not required: 0 files changed under `apps/web/`.

## Possible Improvements

None — this is additive test coverage with no production code change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->