### PR TITLE
fix(office): stop routines from bricking after their first fire

### DIFF
--- a/apps/backend/internal/backendapp/adapters_office.go
+++ b/apps/backend/internal/backendapp/adapters_office.go
@@ -277,6 +277,10 @@ func (a *routineWakeupAdapter) Dispatch(ctx context.Context, requestID string) e
 	return a.dispatcher.Dispatch(ctx, requestID)
 }
 
+func (a *routineWakeupAdapter) FailWakeupRequest(ctx context.Context, requestID, reason string) error {
+	return a.repo.MarkWakeupRequestFailed(ctx, requestID, reason)
+}
+
 // configSyncerAdapter bridges config.ConfigService to the onboarding.ConfigSyncer
 // interface by converting config.ImportResult to onboarding.ApplyResult.
 type configSyncerAdapter struct {

--- a/apps/backend/internal/backendapp/adapters_office.go
+++ b/apps/backend/internal/backendapp/adapters_office.go
@@ -3,6 +3,7 @@ package backendapp
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/kandev/kandev/internal/github"
@@ -263,7 +264,13 @@ func (a *routineWakeupAdapter) CreateWakeupRequest(
 	if req.IdempotencyKey != "" {
 		row.IdempotencyKey = sql.NullString{String: req.IdempotencyKey, Valid: true}
 	}
-	return a.repo.CreateWakeupRequest(ctx, row)
+	if err := a.repo.CreateWakeupRequest(ctx, row); err != nil {
+		if errors.Is(err, officesqlite.ErrWakeupIdempotencyConflict) {
+			return officeroutines.ErrWakeupAlreadyRequested
+		}
+		return err
+	}
+	return nil
 }
 
 func (a *routineWakeupAdapter) Dispatch(ctx context.Context, requestID string) error {

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -2114,6 +2114,12 @@ func buildOfficeFeatureServices(
 	})
 	routineSvc.SetWorkflowEnsurer(&workflowEnsurerAdapter{repo: taskRepo})
 	routineSvc.SetTaskCreator(&taskCreatorAdapter{taskSvc: services.Task})
+	// office-routine-runs: closes out a heavy routine run when its
+	// linked task reaches a terminal step, so the routine's next fire
+	// isn't gated by a task that already finished.
+	if services.Office != nil {
+		services.Office.SetRoutineRunSyncer(routineSvc)
+	}
 	approvalSvc := officeapprovals.NewApprovalService(repo, log, activity, services.Office)
 	approvalSvc.SetAgentWriter(agentSvc)
 	channelSvc := officechannels.NewChannelService(repo, log, activity, agentSvc)

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -460,6 +460,12 @@ func (r *Repository) createRoutineTables() error {
 		created_at TIMESTAMP NOT NULL,
 		FOREIGN KEY (routine_id) REFERENCES office_routines(id) ON DELETE CASCADE
 	);
+	CREATE INDEX IF NOT EXISTS idx_office_routine_runs_active_fingerprint
+		ON office_routine_runs(routine_id, dispatch_fingerprint, created_at DESC)
+		WHERE status = 'task_created';
+	CREATE INDEX IF NOT EXISTS idx_office_routine_runs_linked_task
+		ON office_routine_runs(linked_task_id, created_at DESC)
+		WHERE linked_task_id != '';
 	`)
 	return err
 }
@@ -675,10 +681,10 @@ func (r *Repository) createContinuationSummaryTable() error {
 // dispatcher coalesces / claims / drops them per the agent's policy
 // before creating the corresponding runs row.
 //
-// idempotency_key carries source-level dedup (e.g. heartbeat:<agent>:
-// <unix_minute>) — duplicates within the window land on the partial
-// UNIQUE index and are rejected. The "" sentinel keeps the index free
-// for rows without a key.
+// idempotency_key carries source-level dedup (for example, a cron routine
+// trigger and minute bucket). Duplicates with the same source identity land
+// on the partial UNIQUE index and are rejected. The "" sentinel keeps the
+// index free for rows without a key.
 func (r *Repository) createAgentWakeupRequestTable() error {
 	_, err := r.db.Exec(`
 	CREATE TABLE IF NOT EXISTS agent_wakeup_requests (

--- a/apps/backend/internal/office/repository/sqlite/blockers.go
+++ b/apps/backend/internal/office/repository/sqlite/blockers.go
@@ -202,8 +202,8 @@ func (r *Repository) DeleteTaskBlockersForTask(ctx context.Context, taskID strin
 // (IsTaskInTerminalStep, GetTaskTerminalStatus).
 const (
 	taskStateCompleted = "COMPLETED"
-	taskStateCancelled = "CANCELLED"
 	taskStateFailed    = "FAILED"
+	taskStateCancelled = "CANCELLED"
 )
 
 func (r *Repository) IsTaskInTerminalStep(ctx context.Context, taskID string) (bool, error) {
@@ -213,7 +213,7 @@ func (r *Repository) IsTaskInTerminalStep(ctx context.Context, taskID string) (b
 	if err != nil {
 		return false, err
 	}
-	return state == taskStateCompleted || state == taskStateCancelled, nil
+	return state == taskStateCompleted || state == taskStateFailed || state == taskStateCancelled, nil
 }
 
 // GetTaskAssignee returns the agent currently driving a task. Resolves

--- a/apps/backend/internal/office/repository/sqlite/blockers.go
+++ b/apps/backend/internal/office/repository/sqlite/blockers.go
@@ -197,6 +197,14 @@ func (r *Repository) DeleteTaskBlockersForTask(ctx context.Context, taskID strin
 	return err
 }
 
+// Task lifecycle state values as stored in the shared `tasks` table,
+// shared by every office-repo reader of terminal task state
+// (IsTaskInTerminalStep, GetTaskTerminalStatus).
+const (
+	taskStateCompleted = "COMPLETED"
+	taskStateCancelled = "CANCELLED"
+)
+
 func (r *Repository) IsTaskInTerminalStep(ctx context.Context, taskID string) (bool, error) {
 	var state string
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(
@@ -204,7 +212,7 @@ func (r *Repository) IsTaskInTerminalStep(ctx context.Context, taskID string) (b
 	if err != nil {
 		return false, err
 	}
-	return state == "COMPLETED" || state == "CANCELLED", nil
+	return state == taskStateCompleted || state == taskStateCancelled, nil
 }
 
 // GetTaskAssignee returns the agent currently driving a task. Resolves

--- a/apps/backend/internal/office/repository/sqlite/blockers.go
+++ b/apps/backend/internal/office/repository/sqlite/blockers.go
@@ -203,6 +203,7 @@ func (r *Repository) DeleteTaskBlockersForTask(ctx context.Context, taskID strin
 const (
 	taskStateCompleted = "COMPLETED"
 	taskStateCancelled = "CANCELLED"
+	taskStateFailed    = "FAILED"
 )
 
 func (r *Repository) IsTaskInTerminalStep(ctx context.Context, taskID string) (bool, error) {

--- a/apps/backend/internal/office/repository/sqlite/routines.go
+++ b/apps/backend/internal/office/repository/sqlite/routines.go
@@ -350,7 +350,7 @@ func (r *Repository) GetActiveRunForFingerprint(
 // taskID, or nil if no run is linked to it (most tasks aren't
 // routine-created). Used by SyncRunStatus to find the run to close out
 // when its task reaches a terminal step. taskID must be non-empty:
-// linked_task_id defaults to ” for every lightweight run, so an empty
+// linked_task_id defaults to "" for every lightweight run, so an empty
 // taskID would match (and let a caller rewrite) an arbitrary lightweight
 // run instead of correctly finding nothing.
 func (r *Repository) GetRoutineRunByLinkedTaskID(
@@ -375,15 +375,16 @@ func (r *Repository) GetRoutineRunByLinkedTaskID(
 }
 
 // GetTaskTerminalStatus reports whether taskID's task has reached a
-// terminal step and, if so, which outcome: "done" for COMPLETED,
-// "cancelled" for CANCELLED, "" otherwise — including when the task row
-// itself is missing (already deleted), so callers fail closed rather
-// than releasing a gate they cannot actually confirm is clear. Reads the
-// same `tasks` table and column IsTaskInTerminalStep does; this is the
-// routines gate's own use of that state (see
-// RoutineService.applyConcurrencyPolicy), so it lives in the routines
-// repo file rather than sharing IsTaskInTerminalStep's boolean, which
-// cannot distinguish the two terminal outcomes.
+// terminal state and, if so, which outcome: "done" for COMPLETED,
+// "cancelled" for CANCELLED, "failed" for FAILED, "" otherwise —
+// including when the task row itself is missing (already deleted), so
+// callers fail closed rather than releasing a gate they cannot actually
+// confirm is clear. Reads the same `tasks` table IsTaskInTerminalStep
+// does, but that helper's boolean cannot distinguish the three terminal
+// outcomes (and does not itself treat FAILED as terminal), so this is a
+// separate query rather than a shared one — it lives in the routines
+// repo file because it is the routines gate's own use of that state (see
+// RoutineService.applyConcurrencyPolicy).
 func (r *Repository) GetTaskTerminalStatus(ctx context.Context, taskID string) (string, error) {
 	var state string
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(
@@ -399,6 +400,8 @@ func (r *Repository) GetTaskTerminalStatus(ctx context.Context, taskID string) (
 		return "done", nil
 	case taskStateCancelled:
 		return "cancelled", nil
+	case taskStateFailed:
+		return "failed", nil
 	default:
 		return "", nil
 	}

--- a/apps/backend/internal/office/repository/sqlite/routines.go
+++ b/apps/backend/internal/office/repository/sqlite/routines.go
@@ -321,22 +321,21 @@ func (r *Repository) ListAllRuns(ctx context.Context, workspaceID string, limit 
 	return runs, nil
 }
 
-// GetActiveRunForFingerprint returns an active run matching the
+// GetActiveRunForFingerprint returns the newest active run matching the
 // fingerprint, if any. "Active" means status = task_created (the only
-// status a run can be gating another fire from — see
-// routines.RoutineService's materialise* methods) and created_at is no
-// older than notBefore, so a run stranded in task_created by a crash
-// cannot gate its routine forever (routines.activeRunMaxAge).
+// status a run can gate another fire from — see
+// routines.RoutineService's materialise* methods). The caller repairs
+// terminal, archived, or missing linked tasks before it applies policy.
 func (r *Repository) GetActiveRunForFingerprint(
-	ctx context.Context, routineID, fingerprint string, notBefore time.Time,
+	ctx context.Context, routineID, fingerprint string,
 ) (*models.RoutineRun, error) {
 	var run models.RoutineRun
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
 		SELECT * FROM office_routine_runs
 		WHERE routine_id = ? AND dispatch_fingerprint = ?
-		  AND status = 'task_created' AND created_at >= ?
+		  AND status = 'task_created'
 		ORDER BY created_at DESC LIMIT 1
-	`), routineID, fingerprint, notBefore).StructScan(&run)
+	`), routineID, fingerprint).StructScan(&run)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -374,34 +373,32 @@ func (r *Repository) GetRoutineRunByLinkedTaskID(
 	return &run, nil
 }
 
-// GetTaskTerminalStatus reports whether taskID's task has reached a
-// terminal state and, if so, which outcome: "done" for COMPLETED,
-// "cancelled" for CANCELLED, "failed" for FAILED, "" otherwise —
-// including when the task row itself is missing (already deleted), so
-// callers fail closed rather than releasing a gate they cannot actually
-// confirm is clear. Reads the same `tasks` table IsTaskInTerminalStep
-// does, but that helper's boolean cannot distinguish the three terminal
-// outcomes (and does not itself treat FAILED as terminal), so this is a
-// separate query rather than a shared one — it lives in the routines
-// repo file because it is the routines gate's own use of that state (see
-// RoutineService.applyConcurrencyPolicy).
+// GetTaskTerminalStatus reports the linked task outcome: "done" for
+// COMPLETED, "failed" for FAILED, "cancelled" for CANCELLED or archived
+// tasks, "missing" when the task row was deleted, and "" otherwise.
+// Reads the shared tasks table directly because the routines gate must
+// distinguish an active task from a terminal, archived, or missing task.
 func (r *Repository) GetTaskTerminalStatus(ctx context.Context, taskID string) (string, error) {
 	var state string
+	var archivedAt sql.NullTime
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(
-		`SELECT COALESCE(state, '') FROM tasks WHERE id = ?`), taskID).Scan(&state)
+		`SELECT COALESCE(state, ''), archived_at FROM tasks WHERE id = ?`), taskID).Scan(&state, &archivedAt)
 	if err == sql.ErrNoRows {
-		return "", nil
+		return "missing", nil
 	}
 	if err != nil {
 		return "", err
 	}
+	if archivedAt.Valid {
+		return "cancelled", nil
+	}
 	switch state {
 	case taskStateCompleted:
 		return "done", nil
-	case taskStateCancelled:
-		return "cancelled", nil
 	case taskStateFailed:
 		return "failed", nil
+	case taskStateCancelled:
+		return "cancelled", nil
 	default:
 		return "", nil
 	}

--- a/apps/backend/internal/office/repository/sqlite/routines.go
+++ b/apps/backend/internal/office/repository/sqlite/routines.go
@@ -349,10 +349,16 @@ func (r *Repository) GetActiveRunForFingerprint(
 // GetRoutineRunByLinkedTaskID returns the most recent run linked to
 // taskID, or nil if no run is linked to it (most tasks aren't
 // routine-created). Used by SyncRunStatus to find the run to close out
-// when its task reaches a terminal step.
+// when its task reaches a terminal step. taskID must be non-empty:
+// linked_task_id defaults to ” for every lightweight run, so an empty
+// taskID would match (and let a caller rewrite) an arbitrary lightweight
+// run instead of correctly finding nothing.
 func (r *Repository) GetRoutineRunByLinkedTaskID(
 	ctx context.Context, taskID string,
 ) (*models.RoutineRun, error) {
+	if taskID == "" {
+		return nil, nil
+	}
 	var run models.RoutineRun
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
 		SELECT * FROM office_routine_runs
@@ -366,6 +372,36 @@ func (r *Repository) GetRoutineRunByLinkedTaskID(
 		return nil, err
 	}
 	return &run, nil
+}
+
+// GetTaskTerminalStatus reports whether taskID's task has reached a
+// terminal step and, if so, which outcome: "done" for COMPLETED,
+// "cancelled" for CANCELLED, "" otherwise — including when the task row
+// itself is missing (already deleted), so callers fail closed rather
+// than releasing a gate they cannot actually confirm is clear. Reads the
+// same `tasks` table and column IsTaskInTerminalStep does; this is the
+// routines gate's own use of that state (see
+// RoutineService.applyConcurrencyPolicy), so it lives in the routines
+// repo file rather than sharing IsTaskInTerminalStep's boolean, which
+// cannot distinguish the two terminal outcomes.
+func (r *Repository) GetTaskTerminalStatus(ctx context.Context, taskID string) (string, error) {
+	var state string
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(
+		`SELECT COALESCE(state, '') FROM tasks WHERE id = ?`), taskID).Scan(&state)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	switch state {
+	case taskStateCompleted:
+		return "done", nil
+	case taskStateCancelled:
+		return "cancelled", nil
+	default:
+		return "", nil
+	}
 }
 
 // TouchRoutineLastRun updates only last_run_at (+ updated_at) on a
@@ -391,6 +427,31 @@ func (r *Repository) UpdateRunStatus(
 		WHERE id = ?
 	`), status, linkedTaskID, now, runID)
 	return err
+}
+
+// UpdateRunStatusIfTaskCreated closes a run out with a terminal status,
+// but only while it is still 'task_created' — the one status a routine
+// run can gate its fingerprint from. The WHERE clause makes this an
+// atomic claim: SyncRunStatus (TaskMoved-driven) and the concurrency
+// gate's own inline check (applyConcurrencyPolicy) can both observe the
+// same terminal task, and this is what lets exactly one of them win
+// instead of a read-then-write race rewriting an already-closed run's
+// status or completed_at. Returns whether this call was the one that
+// closed it.
+func (r *Repository) UpdateRunStatusIfTaskCreated(
+	ctx context.Context, runID string, status models.RoutineRunStatus, linkedTaskID string,
+) (bool, error) {
+	now := time.Now().UTC()
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE office_routine_runs
+		SET status = ?, linked_task_id = ?, completed_at = ?
+		WHERE id = ? AND status = 'task_created'
+	`), status, linkedTaskID, now, runID)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	return rows > 0, err
 }
 
 // UpdateRunCoalesced marks a run as coalesced into another run.

--- a/apps/backend/internal/office/repository/sqlite/routines.go
+++ b/apps/backend/internal/office/repository/sqlite/routines.go
@@ -321,17 +321,22 @@ func (r *Repository) ListAllRuns(ctx context.Context, workspaceID string, limit 
 	return runs, nil
 }
 
-// GetActiveRunForFingerprint returns an active run matching the fingerprint.
+// GetActiveRunForFingerprint returns an active run matching the
+// fingerprint, if any. "Active" means status = task_created (the only
+// status a run can be gating another fire from — see
+// routines.RoutineService's materialise* methods) and created_at is no
+// older than notBefore, so a run stranded in task_created by a crash
+// cannot gate its routine forever (routines.activeRunMaxAge).
 func (r *Repository) GetActiveRunForFingerprint(
-	ctx context.Context, routineID, fingerprint string,
+	ctx context.Context, routineID, fingerprint string, notBefore time.Time,
 ) (*models.RoutineRun, error) {
 	var run models.RoutineRun
 	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
 		SELECT * FROM office_routine_runs
 		WHERE routine_id = ? AND dispatch_fingerprint = ?
-		  AND status = 'task_created'
+		  AND status = 'task_created' AND created_at >= ?
 		ORDER BY created_at DESC LIMIT 1
-	`), routineID, fingerprint).StructScan(&run)
+	`), routineID, fingerprint, notBefore).StructScan(&run)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -339,6 +344,40 @@ func (r *Repository) GetActiveRunForFingerprint(
 		return nil, err
 	}
 	return &run, nil
+}
+
+// GetRoutineRunByLinkedTaskID returns the most recent run linked to
+// taskID, or nil if no run is linked to it (most tasks aren't
+// routine-created). Used by SyncRunStatus to find the run to close out
+// when its task reaches a terminal step.
+func (r *Repository) GetRoutineRunByLinkedTaskID(
+	ctx context.Context, taskID string,
+) (*models.RoutineRun, error) {
+	var run models.RoutineRun
+	err := r.ro.QueryRowxContext(ctx, r.ro.Rebind(`
+		SELECT * FROM office_routine_runs
+		WHERE linked_task_id = ?
+		ORDER BY created_at DESC LIMIT 1
+	`), taskID).StructScan(&run)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+// TouchRoutineLastRun updates only last_run_at (+ updated_at) on a
+// routine. Deliberately narrower than UpdateRoutine, whose whole-row
+// snapshot write can revert concurrent edits to other columns (see
+// UpdateRoutineConfigFields above) — a dispatch in flight should never
+// clobber a config change made while it ran, or vice versa.
+func (r *Repository) TouchRoutineLastRun(ctx context.Context, routineID string, at time.Time) error {
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE office_routines SET last_run_at = ?, updated_at = ? WHERE id = ?
+	`), at, time.Now().UTC(), routineID)
+	return err
 }
 
 // UpdateRunStatus updates a run's status and optionally its linked task.

--- a/apps/backend/internal/office/repository/sqlite/routines_test.go
+++ b/apps/backend/internal/office/repository/sqlite/routines_test.go
@@ -240,3 +240,133 @@ func TestRoutineRun_Create(t *testing.T) {
 		t.Fatal("expected run ID to be set")
 	}
 }
+
+// TestGetTaskTerminalStatus brings up just enough of the shared `tasks`
+// table (owned by internal/task/repository/sqlite in the real app) for
+// GetTaskTerminalStatus to query against it. office/repository/sqlite's
+// own initSchema deliberately does not create this table (see
+// TestInitSchema_AllTablesExist) — it shares the production DB's table
+// rather than owning it.
+func TestGetTaskTerminalStatus(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.ExecRaw(ctx, `CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+		t.Fatalf("create tasks table: %v", err)
+	}
+	if _, err := repo.ExecRaw(ctx, `INSERT INTO tasks (id, state) VALUES (?, ?), (?, ?), (?, ?)`,
+		"task-done", "COMPLETED", "task-cancelled", "CANCELLED", "task-open", "IN_PROGRESS"); err != nil {
+		t.Fatalf("seed tasks: %v", err)
+	}
+
+	cases := []struct {
+		taskID string
+		want   string
+	}{
+		{"task-done", "done"},
+		{"task-cancelled", "cancelled"},
+		{"task-open", ""},
+		{"task-missing", ""},
+	}
+	for _, c := range cases {
+		got, err := repo.GetTaskTerminalStatus(ctx, c.taskID)
+		if err != nil {
+			t.Fatalf("GetTaskTerminalStatus(%q): %v", c.taskID, err)
+		}
+		if got != c.want {
+			t.Errorf("GetTaskTerminalStatus(%q) = %q, want %q", c.taskID, got, c.want)
+		}
+	}
+}
+
+func TestUpdateRunStatusIfTaskCreated(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	routine := &models.Routine{
+		WorkspaceID:       "ws-1",
+		Name:              "Conditional Close",
+		TaskTemplate:      "{}",
+		Status:            "active",
+		ConcurrencyPolicy: "skip_if_active",
+		Variables:         "{}",
+	}
+	if err := repo.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	run := &models.RoutineRun{
+		RoutineID:           routine.ID,
+		Source:              "manual",
+		Status:              "task_created",
+		TriggerPayload:      "{}",
+		DispatchFingerprint: "fp-cond",
+		LinkedTaskID:        "task-1",
+	}
+	if err := repo.CreateRoutineRun(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	closed, err := repo.UpdateRunStatusIfTaskCreated(ctx, run.ID, models.RoutineRunStatusDone, "task-1")
+	if err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if !closed {
+		t.Fatal("expected first close to succeed from task_created")
+	}
+
+	// A second attempt against the now-closed row must not win — this is
+	// the race SyncRunStatus and the concurrency gate's inline check can
+	// both hit, and it must not rewrite a "done" row to "cancelled" or
+	// move completed_at.
+	closedAgain, err := repo.UpdateRunStatusIfTaskCreated(ctx, run.ID, models.RoutineRunStatusCancelled, "task-1")
+	if err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if closedAgain {
+		t.Fatal("second close against an already-closed run must report false")
+	}
+
+	got, err := repo.GetRoutineRunByLinkedTaskID(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("get by linked task: %v", err)
+	}
+	if got.Status != models.RoutineRunStatusDone {
+		t.Errorf("status = %q, want done (unchanged by the losing second close)", got.Status)
+	}
+}
+
+func TestGetRoutineRunByLinkedTaskID_EmptyTaskIDGuarded(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	routine := &models.Routine{
+		WorkspaceID:       "ws-1",
+		Name:              "Empty Guard",
+		TaskTemplate:      "",
+		Status:            "active",
+		ConcurrencyPolicy: "always_create",
+		Variables:         "{}",
+	}
+	if err := repo.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	// Lightweight run: linked_task_id defaults to ''.
+	run := &models.RoutineRun{
+		RoutineID:           routine.ID,
+		Source:              "manual",
+		Status:              "done",
+		TriggerPayload:      "{}",
+		DispatchFingerprint: "fp-empty",
+	}
+	if err := repo.CreateRoutineRun(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	got, err := repo.GetRoutineRunByLinkedTaskID(ctx, "")
+	if err != nil {
+		t.Fatalf("lookup with empty taskID: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for empty taskID, got run %q (would have matched an arbitrary lightweight run)", got.ID)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/routines_test.go
+++ b/apps/backend/internal/office/repository/sqlite/routines_test.go
@@ -254,8 +254,8 @@ func TestGetTaskTerminalStatus(t *testing.T) {
 	if _, err := repo.ExecRaw(ctx, `CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
 		t.Fatalf("create tasks table: %v", err)
 	}
-	if _, err := repo.ExecRaw(ctx, `INSERT INTO tasks (id, state) VALUES (?, ?), (?, ?), (?, ?)`,
-		"task-done", "COMPLETED", "task-cancelled", "CANCELLED", "task-open", "IN_PROGRESS"); err != nil {
+	if _, err := repo.ExecRaw(ctx, `INSERT INTO tasks (id, state) VALUES (?, ?), (?, ?), (?, ?), (?, ?)`,
+		"task-done", "COMPLETED", "task-cancelled", "CANCELLED", "task-failed", "FAILED", "task-open", "IN_PROGRESS"); err != nil {
 		t.Fatalf("seed tasks: %v", err)
 	}
 
@@ -265,6 +265,7 @@ func TestGetTaskTerminalStatus(t *testing.T) {
 	}{
 		{"task-done", "done"},
 		{"task-cancelled", "cancelled"},
+		{"task-failed", "failed"},
 		{"task-open", ""},
 		{"task-missing", ""},
 	}

--- a/apps/backend/internal/office/repository/sqlite/routines_test.go
+++ b/apps/backend/internal/office/repository/sqlite/routines_test.go
@@ -182,8 +182,7 @@ func TestRoutineRun_ActiveFingerprint(t *testing.T) {
 		t.Fatalf("create run: %v", err)
 	}
 
-	longAgo := time.Now().UTC().Add(-time.Hour)
-	active, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123", longAgo)
+	active, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123")
 	if err != nil {
 		t.Fatalf("get active: %v", err)
 	}
@@ -192,7 +191,7 @@ func TestRoutineRun_ActiveFingerprint(t *testing.T) {
 	}
 
 	// Non-matching fingerprint should return nil.
-	none, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-999", longAgo)
+	none, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-999")
 	if err != nil {
 		t.Fatalf("get none: %v", err)
 	}
@@ -200,15 +199,6 @@ func TestRoutineRun_ActiveFingerprint(t *testing.T) {
 		t.Error("expected nil for non-matching fingerprint")
 	}
 
-	// A notBefore after the run's created_at excludes it (TTL floor).
-	future := time.Now().UTC().Add(time.Hour)
-	tooOld, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123", future)
-	if err != nil {
-		t.Fatalf("get too-old: %v", err)
-	}
-	if tooOld != nil {
-		t.Error("expected nil for a run older than notBefore")
-	}
 }
 
 func TestRoutineRun_Create(t *testing.T) {
@@ -251,11 +241,11 @@ func TestGetTaskTerminalStatus(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
 
-	if _, err := repo.ExecRaw(ctx, `CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+	if _, err := repo.ExecRaw(ctx, `CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
 		t.Fatalf("create tasks table: %v", err)
 	}
-	if _, err := repo.ExecRaw(ctx, `INSERT INTO tasks (id, state) VALUES (?, ?), (?, ?), (?, ?), (?, ?)`,
-		"task-done", "COMPLETED", "task-cancelled", "CANCELLED", "task-failed", "FAILED", "task-open", "IN_PROGRESS"); err != nil {
+	if _, err := repo.ExecRaw(ctx, `INSERT INTO tasks (id, state, archived_at) VALUES (?, ?, NULL), (?, ?, NULL), (?, ?, NULL), (?, ?, NULL), (?, ?, ?)`,
+		"task-done", "COMPLETED", "task-cancelled", "CANCELLED", "task-failed", "FAILED", "task-open", "IN_PROGRESS", "task-archived", "IN_PROGRESS", time.Now().UTC()); err != nil {
 		t.Fatalf("seed tasks: %v", err)
 	}
 
@@ -267,7 +257,8 @@ func TestGetTaskTerminalStatus(t *testing.T) {
 		{"task-cancelled", "cancelled"},
 		{"task-failed", "failed"},
 		{"task-open", ""},
-		{"task-missing", ""},
+		{"task-archived", "cancelled"},
+		{"task-missing", "missing"},
 	}
 	for _, c := range cases {
 		got, err := repo.GetTaskTerminalStatus(ctx, c.taskID)

--- a/apps/backend/internal/office/repository/sqlite/routines_test.go
+++ b/apps/backend/internal/office/repository/sqlite/routines_test.go
@@ -182,7 +182,8 @@ func TestRoutineRun_ActiveFingerprint(t *testing.T) {
 		t.Fatalf("create run: %v", err)
 	}
 
-	active, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123")
+	longAgo := time.Now().UTC().Add(-time.Hour)
+	active, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123", longAgo)
 	if err != nil {
 		t.Fatalf("get active: %v", err)
 	}
@@ -191,12 +192,22 @@ func TestRoutineRun_ActiveFingerprint(t *testing.T) {
 	}
 
 	// Non-matching fingerprint should return nil.
-	none, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-999")
+	none, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-999", longAgo)
 	if err != nil {
 		t.Fatalf("get none: %v", err)
 	}
 	if none != nil {
 		t.Error("expected nil for non-matching fingerprint")
+	}
+
+	// A notBefore after the run's created_at excludes it (TTL floor).
+	future := time.Now().UTC().Add(time.Hour)
+	tooOld, err := repo.GetActiveRunForFingerprint(ctx, routine.ID, "fp-123", future)
+	if err != nil {
+		t.Fatalf("get too-old: %v", err)
+	}
+	if tooOld != nil {
+		t.Error("expected nil for a run older than notBefore")
 	}
 }
 

--- a/apps/backend/internal/office/repository/sqlite/wakeup_requests.go
+++ b/apps/backend/internal/office/repository/sqlite/wakeup_requests.go
@@ -10,14 +10,15 @@ import (
 )
 
 // Wakeup request status constants — kept in sync with the spec's
-// "queued" | "claimed" | "coalesced" | "skipped" enum. Terminal states
-// (claimed, coalesced, skipped) all stamp finished_at; only "queued"
-// is visible to the dispatcher's claim path.
+// "queued" | "claimed" | "coalesced" | "skipped" | "failed" enum.
+// Terminal states all stamp finished_at; only "queued" is visible to the
+// dispatcher's claim path.
 const (
 	WakeupStatusQueued    = "queued"
 	WakeupStatusClaimed   = "claimed"
 	WakeupStatusCoalesced = "coalesced"
 	WakeupStatusSkipped   = "skipped"
+	WakeupStatusFailed    = "failed"
 )
 
 // ErrWakeupIdempotencyConflict is returned by CreateWakeupRequest when
@@ -292,6 +293,19 @@ func (r *Repository) MarkWakeupRequestSkipped(
 		SET status = ?, reason = ?, finished_at = ?
 		WHERE id = ?
 	`), WakeupStatusSkipped, reason, now, id)
+	return err
+}
+
+// MarkWakeupRequestFailed transitions a request to a terminal failed state
+// when direct dispatch cannot claim it. This prevents a queued row from
+// appearing healthy when no background poller can retry it.
+func (r *Repository) MarkWakeupRequestFailed(ctx context.Context, id, reason string) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE agent_wakeup_requests
+		SET status = ?, reason = ?, finished_at = ?
+		WHERE id = ? AND status = ?
+	`), WakeupStatusFailed, reason, now, id, WakeupStatusQueued)
 	return err
 }
 

--- a/apps/backend/internal/office/repository/sqlite/wakeup_requests_test.go
+++ b/apps/backend/internal/office/repository/sqlite/wakeup_requests_test.go
@@ -147,6 +147,38 @@ func TestWakeupRequest_MarkSkipped(t *testing.T) {
 	}
 }
 
+func TestWakeupRequest_MarkFailed(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	_ = repo.CreateWakeupRequest(ctx, &sqlite.WakeupRequest{
+		ID: "w-1", AgentProfileID: "agent-1", Source: "routine",
+	})
+	if err := repo.MarkWakeupRequestFailed(ctx, "w-1", "dispatch failed"); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+	got, err := repo.GetWakeupRequest(ctx, "w-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != sqlite.WakeupStatusFailed {
+		t.Errorf("status: got %q", got.Status)
+	}
+	if got.Reason != "dispatch failed" {
+		t.Errorf("reason: got %q", got.Reason)
+	}
+	if !got.FinishedAt.Valid {
+		t.Error("finished_at should be set")
+	}
+	rows, err := repo.ListQueuedWakeupRequestsForAgent(ctx, "agent-1")
+	if err != nil {
+		t.Fatalf("list queued: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("failed request remains queued: %+v", rows)
+	}
+}
+
 // TestWakeupRequest_MarkCoalesced creates a runs row, then a wakeup
 // request, then marks the request coalesced into the run. Verifies the
 // status transition, coalesced_count bump, and that context_snapshot

--- a/apps/backend/internal/office/routines/handler.go
+++ b/apps/backend/internal/office/routines/handler.go
@@ -252,7 +252,8 @@ func (h *Handler) fireWebhookTrigger(c *gin.Context) {
 		return
 	}
 
-	run, err := h.svc.DispatchRoutineRun(ctx, routine, trigger, "webhook", vars)
+	run, err := h.svc.DispatchRoutineRunWithIdempotencyKey(
+		ctx, routine, trigger, "webhook", vars, c.GetHeader("Idempotency-Key"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/apps/backend/internal/office/routines/service.go
+++ b/apps/backend/internal/office/routines/service.go
@@ -637,11 +637,12 @@ func (s *RoutineService) materialiseHeavyRoutineRun(
 // it permanently blocks the routine's next fire under skip_if_active /
 // coalesce_if_active (see the office-routine-runs triage).
 //
-// Terminal status: `done` once the request is enqueued, regardless of
-// whether Dispatch itself succeeds (a dispatch failure is the wakeup
-// layer's problem, logged there); `failed` only when the enqueue call
-// itself errors, since that means no request exists for the dispatcher
-// to ever pick up. LinkedTaskID stays empty for lightweight.
+// Terminal status: `done` once the request is enqueued AND handed to
+// the dispatcher successfully. `failed` when either step errors —
+// nothing else polls a wakeup-request stuck in "queued", so a Dispatch
+// error left this recorded as `done` would silently report success for
+// a fire that produced no agent run. LinkedTaskID stays empty for
+// lightweight.
 //
 // missedTicks > 0 surfaces in the wakeup payload when the cron tick
 // collapsed N missed fires into one (catch-up cap policy
@@ -683,6 +684,7 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 			zap.String("routine", routine.Name),
 			zap.String("wakeup_id", req.ID),
 			zap.Error(err))
+		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusFailed)
 	}
 	return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
 }
@@ -832,12 +834,12 @@ func (s *RoutineService) FireManual(
 // terminal side of D2 in the office-routine-runs triage: heavy runs
 // stay in RoutineRunStatusTaskCreated (an active gate) until their task
 // finishes, and this is what clears the gate. terminalStatus is
-// "cancelled" for a task moved to the Cancelled step, "done" for
-// anything else terminal (currently only Done). A taskID with no
-// linked run is not an error — most tasks aren't routine-created. An
-// empty taskID is rejected outright: linked_task_id defaults to ” for
-// every lightweight run, so an unguarded lookup would match (and
-// rewrite) an arbitrary lightweight run instead of finding nothing.
+// "cancelled", "failed", or "done" — see GetTaskTerminalStatus and
+// closeOutRun. A taskID with no linked run is not an error — most tasks
+// aren't routine-created. An empty taskID is rejected outright:
+// linked_task_id defaults to "" for every lightweight run, so an
+// unguarded lookup would match (and rewrite) an arbitrary lightweight
+// run instead of finding nothing.
 func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStatus string) error {
 	if taskID == "" {
 		return nil
@@ -857,12 +859,17 @@ func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStat
 // task_created (see Repository.UpdateRunStatusIfTaskCreated) — a replayed
 // or racing terminal signal for an already-closed run must not move
 // completed_at or flip a "done" back to "cancelled". terminalStatus is
-// "cancelled" or anything else counts as "done", matching SyncRunStatus's
-// contract. Returns whether this call was the one that closed the run.
+// "cancelled" or "failed" for those two task outcomes, and anything else
+// (including "done") counts as RoutineRunStatusDone, matching
+// SyncRunStatus's contract. Returns whether this call was the one that
+// closed the run.
 func (s *RoutineService) closeOutRun(ctx context.Context, run *RoutineRun, terminalStatus string) (bool, error) {
 	status := models.RoutineRunStatusDone
-	if terminalStatus == "cancelled" {
+	switch terminalStatus {
+	case "cancelled":
 		status = models.RoutineRunStatusCancelled
+	case "failed":
+		status = models.RoutineRunStatusFailed
 	}
 	closed, err := s.repo.UpdateRunStatusIfTaskCreated(ctx, run.ID, status, run.LinkedTaskID)
 	if err != nil {

--- a/apps/backend/internal/office/routines/service.go
+++ b/apps/backend/internal/office/routines/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -15,6 +16,16 @@ import (
 	"github.com/kandev/kandev/internal/office/shared"
 	taskservice "github.com/kandev/kandev/internal/task/service"
 )
+
+// ErrWakeupAlreadyRequested is the routines-package-local signal that a
+// WakeupEnqueuer.CreateWakeupRequest call lost an idempotency race: a
+// request for this fire already exists, enqueued by another caller (a
+// cron tick and a manual fire landing in the same dedup bucket, for
+// example). That is success by another route, not a failure — the
+// concrete adapter translates the sqlite layer's
+// ErrWakeupIdempotencyConflict into this sentinel so routines never
+// imports office/repository/sqlite directly (see routineWakeupAdapter).
+var ErrWakeupAlreadyRequested = errors.New("wakeup request already requested")
 
 // Repository is the persistence interface required by RoutineService.
 type Repository interface {
@@ -38,8 +49,20 @@ type Repository interface {
 	GetActiveRunForFingerprint(ctx context.Context, routineID, fingerprint string, notBefore time.Time) (*RoutineRun, error)
 	GetRoutineRunByLinkedTaskID(ctx context.Context, taskID string) (*RoutineRun, error)
 	UpdateRunStatus(ctx context.Context, runID string, status models.RoutineRunStatus, linkedTaskID string) error
+	// UpdateRunStatusIfTaskCreated closes out a run only while it is still
+	// task_created, returning whether this call was the one that closed
+	// it. Used by both the TaskMoved-driven SyncRunStatus and the
+	// concurrency gate's own inline check (applyConcurrencyPolicy), which
+	// can both observe the same terminal task; the conditional WHERE
+	// clause is what lets exactly one of them win instead of a
+	// read-then-write race between them.
+	UpdateRunStatusIfTaskCreated(ctx context.Context, runID string, status models.RoutineRunStatus, linkedTaskID string) (bool, error)
 	UpdateRunCoalesced(ctx context.Context, runID, coalescedIntoRunID string) error
 	TouchRoutineLastRun(ctx context.Context, routineID string, at time.Time) error
+	// GetTaskTerminalStatus reads a task's real lifecycle state directly
+	// (not via the TaskMoved event — see applyConcurrencyPolicy) and
+	// reports "" when it is not terminal, "done", or "cancelled".
+	GetTaskTerminalStatus(ctx context.Context, taskID string) (string, error)
 }
 
 // WakeupEnqueuer is the slim surface routines need to enqueue + dispatch
@@ -645,6 +668,12 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 		RequestedAt:    time.Now().UTC(),
 	}
 	if err := s.wakeup.CreateWakeupRequest(ctx, req); err != nil {
+		if errors.Is(err, ErrWakeupAlreadyRequested) {
+			// A request for this fire's idempotency key already exists —
+			// success by another fire (e.g. a cron tick and a manual fire
+			// landing in the same per-minute dedup bucket), not a failure.
+			return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
+		}
 		s.logger.Warn("create routine wakeup request",
 			zap.String("routine", routine.Name), zap.Error(err))
 		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusFailed)
@@ -718,6 +747,41 @@ func marshalRoutinePayload(routineID string, vars map[string]string, missedTicks
 // of gating the routine forever.
 const activeRunMaxAge = 7 * 24 * time.Hour
 
+// selfHealIfTaskTerminal is the pull-based counterpart to SyncRunStatus:
+// SyncRunStatus is driven by the TaskMoved event, but nothing in
+// production populates the step names that event needs
+// (office-routine-runs R1), so the gate cannot rely on that event alone
+// ever clearing it. Reading the linked task's real state here means a
+// heavy run's gate self-heals at the next fire even when that event
+// never arrives. Returns active unchanged when it is still genuinely
+// active, still lightweight (no linked task), or its state can't be
+// determined — a lookup or close-out failure fails closed, leaving the
+// existing 7-day backstop as the escape hatch, same as before this check
+// existed. Returns nil once the linked task is confirmed terminal and
+// closed out, meaning the caller should treat the gate as clear.
+func (s *RoutineService) selfHealIfTaskTerminal(
+	ctx context.Context, routine *Routine, active *RoutineRun,
+) *RoutineRun {
+	if active.LinkedTaskID == "" {
+		return active
+	}
+	terminalStatus, err := s.repo.GetTaskTerminalStatus(ctx, active.LinkedTaskID)
+	if err != nil {
+		s.logger.Warn("check linked task terminal state",
+			zap.String("routine", routine.Name), zap.String("run_id", active.ID), zap.Error(err))
+		return active
+	}
+	if terminalStatus == "" {
+		return active
+	}
+	if _, err := s.closeOutRun(ctx, active, terminalStatus); err != nil {
+		s.logger.Warn("close out stale active run",
+			zap.String("routine", routine.Name), zap.String("run_id", active.ID), zap.Error(err))
+		return active
+	}
+	return nil
+}
+
 func (s *RoutineService) applyConcurrencyPolicy(
 	ctx context.Context,
 	routine *Routine,
@@ -731,6 +795,9 @@ func (s *RoutineService) applyConcurrencyPolicy(
 	active, err := s.repo.GetActiveRunForFingerprint(ctx, routine.ID, fingerprint, notBefore)
 	if err != nil {
 		return "", fmt.Errorf("check active run: %w", err)
+	}
+	if active != nil {
+		active = s.selfHealIfTaskTerminal(ctx, routine, active)
 	}
 	if active == nil {
 		return "", nil
@@ -767,8 +834,14 @@ func (s *RoutineService) FireManual(
 // finishes, and this is what clears the gate. terminalStatus is
 // "cancelled" for a task moved to the Cancelled step, "done" for
 // anything else terminal (currently only Done). A taskID with no
-// linked run is not an error — most tasks aren't routine-created.
+// linked run is not an error — most tasks aren't routine-created. An
+// empty taskID is rejected outright: linked_task_id defaults to ” for
+// every lightweight run, so an unguarded lookup would match (and
+// rewrite) an arbitrary lightweight run instead of finding nothing.
 func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStatus string) error {
+	if taskID == "" {
+		return nil
+	}
 	run, err := s.repo.GetRoutineRunByLinkedTaskID(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("get routine run by linked task: %w", err)
@@ -776,14 +849,26 @@ func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStat
 	if run == nil {
 		return nil
 	}
+	_, err = s.closeOutRun(ctx, run, terminalStatus)
+	return err
+}
+
+// closeOutRun writes a run's terminal status, but only while it is still
+// task_created (see Repository.UpdateRunStatusIfTaskCreated) — a replayed
+// or racing terminal signal for an already-closed run must not move
+// completed_at or flip a "done" back to "cancelled". terminalStatus is
+// "cancelled" or anything else counts as "done", matching SyncRunStatus's
+// contract. Returns whether this call was the one that closed the run.
+func (s *RoutineService) closeOutRun(ctx context.Context, run *RoutineRun, terminalStatus string) (bool, error) {
 	status := models.RoutineRunStatusDone
 	if terminalStatus == "cancelled" {
 		status = models.RoutineRunStatusCancelled
 	}
-	if err := s.repo.UpdateRunStatus(ctx, run.ID, status, run.LinkedTaskID); err != nil {
-		return fmt.Errorf("update run status: %w", err)
+	closed, err := s.repo.UpdateRunStatusIfTaskCreated(ctx, run.ID, status, run.LinkedTaskID)
+	if err != nil {
+		return false, fmt.Errorf("update run status: %w", err)
 	}
-	return nil
+	return closed, nil
 }
 
 // -- helpers --

--- a/apps/backend/internal/office/routines/service.go
+++ b/apps/backend/internal/office/routines/service.go
@@ -46,7 +46,7 @@ type Repository interface {
 	CreateRoutineRun(ctx context.Context, run *RoutineRun) error
 	ListRoutineRuns(ctx context.Context, routineID string, limit, offset int) ([]*RoutineRun, error)
 	ListAllRuns(ctx context.Context, workspaceID string, limit int) ([]*RoutineRun, error)
-	GetActiveRunForFingerprint(ctx context.Context, routineID, fingerprint string, notBefore time.Time) (*RoutineRun, error)
+	GetActiveRunForFingerprint(ctx context.Context, routineID, fingerprint string) (*RoutineRun, error)
 	GetRoutineRunByLinkedTaskID(ctx context.Context, taskID string) (*RoutineRun, error)
 	UpdateRunStatus(ctx context.Context, runID string, status models.RoutineRunStatus, linkedTaskID string) error
 	// UpdateRunStatusIfTaskCreated closes out a run only while it is still
@@ -61,7 +61,8 @@ type Repository interface {
 	TouchRoutineLastRun(ctx context.Context, routineID string, at time.Time) error
 	// GetTaskTerminalStatus reads a task's real lifecycle state directly
 	// (not via the TaskMoved event — see applyConcurrencyPolicy) and
-	// reports "" when it is not terminal, "done", or "cancelled".
+	// reports "" when it is active, "done", "failed", "cancelled", or
+	// "missing" for the other outcomes.
 	GetTaskTerminalStatus(ctx context.Context, taskID string) (string, error)
 }
 
@@ -75,6 +76,7 @@ type Repository interface {
 type WakeupEnqueuer interface {
 	CreateWakeupRequest(ctx context.Context, req *WakeupRequest) error
 	Dispatch(ctx context.Context, requestID string) error
+	FailWakeupRequest(ctx context.Context, requestID, reason string) error
 }
 
 // WakeupRequest mirrors *office/repository/sqlite.WakeupRequest with the
@@ -491,7 +493,21 @@ func (s *RoutineService) DispatchRoutineRun(
 	source string,
 	provided map[string]string,
 ) (*RoutineRun, error) {
-	return s.dispatchRoutineRun(ctx, routine, trigger, source, provided, 0)
+	return s.dispatchRoutineRun(ctx, routine, trigger, source, provided, "", 0)
+}
+
+// DispatchRoutineRunWithIdempotencyKey dispatches a fire with an explicit
+// source request identity. Webhook callers can use this header to make
+// retries idempotent without collapsing unrelated deliveries.
+func (s *RoutineService) DispatchRoutineRunWithIdempotencyKey(
+	ctx context.Context,
+	routine *Routine,
+	trigger *RoutineTrigger,
+	source string,
+	provided map[string]string,
+	idempotencyKey string,
+) (*RoutineRun, error) {
+	return s.dispatchRoutineRun(ctx, routine, trigger, source, provided, idempotencyKey, 0)
 }
 
 // DispatchRoutineRunWithMissed is the cron-tick entry point that
@@ -509,7 +525,7 @@ func (s *RoutineService) DispatchRoutineRunWithMissed(
 	provided map[string]string,
 	missedTicks int,
 ) (*RoutineRun, error) {
-	return s.dispatchRoutineRun(ctx, routine, trigger, source, provided, missedTicks)
+	return s.dispatchRoutineRun(ctx, routine, trigger, source, provided, "", missedTicks)
 }
 
 func (s *RoutineService) dispatchRoutineRun(
@@ -518,6 +534,7 @@ func (s *RoutineService) dispatchRoutineRun(
 	trigger *RoutineTrigger,
 	source string,
 	provided map[string]string,
+	idempotencyKey string,
 	missedTicks int,
 ) (*RoutineRun, error) {
 	now := time.Now().UTC()
@@ -556,7 +573,7 @@ func (s *RoutineService) dispatchRoutineRun(
 		return run, nil
 	}
 
-	if err := s.materialiseRoutineRun(ctx, routine, run, tmpl, title, description, vars, missedTicks); err != nil {
+	if err := s.materialiseRoutineRun(ctx, routine, run, tmpl, title, description, vars, source, idempotencyKey, missedTicks); err != nil {
 		return run, err
 	}
 
@@ -589,12 +606,14 @@ func (s *RoutineService) materialiseRoutineRun(
 	tmpl taskTemplate,
 	title, description string,
 	vars map[string]string,
+	source string,
+	idempotencyKey string,
 	missedTicks int,
 ) error {
 	if tmpl.Title != "" && s.workflowEnsurer != nil && s.taskCreator != nil {
 		return s.materialiseHeavyRoutineRun(ctx, routine, run, title, description)
 	}
-	return s.materialiseLightweightRoutineRun(ctx, routine, run, vars, missedTicks)
+	return s.materialiseLightweightRoutineRun(ctx, routine, run, vars, source, idempotencyKey, missedTicks)
 }
 
 // materialiseHeavyRoutineRun creates a real task in the routine system
@@ -637,12 +656,10 @@ func (s *RoutineService) materialiseHeavyRoutineRun(
 // it permanently blocks the routine's next fire under skip_if_active /
 // coalesce_if_active (see the office-routine-runs triage).
 //
-// Terminal status: `done` once the request is enqueued AND handed to
-// the dispatcher successfully. `failed` when either step errors —
-// nothing else polls a wakeup-request stuck in "queued", so a Dispatch
-// error left this recorded as `done` would silently report success for
-// a fire that produced no agent run. LinkedTaskID stays empty for
-// lightweight.
+// Terminal status: `done` once the request is dispatched; `failed` when
+// enqueue or dispatch fails. A failed request is marked terminal in the
+// wakeup queue because no background poller retries direct dispatch.
+// LinkedTaskID stays empty for lightweight runs.
 //
 // missedTicks > 0 surfaces in the wakeup payload when the cron tick
 // collapsed N missed fires into one (catch-up cap policy
@@ -652,12 +669,14 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 	routine *Routine,
 	run *RoutineRun,
 	vars map[string]string,
+	source string,
+	idempotencyKey string,
 	missedTicks int,
 ) error {
 	if s.wakeup == nil || routine.AssigneeAgentProfileID == "" {
 		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
 	}
-	idemKey := buildRoutineIdempotencyKey(routine.ID, run.TriggerID, run.StartedAt)
+	idemKey := buildRoutineIdempotencyKey(routine.ID, run.TriggerID, source, run.ID, idempotencyKey, run.StartedAt)
 	payloadStr, _ := marshalRoutinePayload(routine.ID, vars, missedTicks)
 	req := &WakeupRequest{
 		ID:             uuid.New().String(),
@@ -670,9 +689,8 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 	}
 	if err := s.wakeup.CreateWakeupRequest(ctx, req); err != nil {
 		if errors.Is(err, ErrWakeupAlreadyRequested) {
-			// A request for this fire's idempotency key already exists —
-			// success by another fire (e.g. a cron tick and a manual fire
-			// landing in the same per-minute dedup bucket), not a failure.
+			// A request for this explicit fire identity already exists.
+			// Another delivery completed the same request.
 			return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
 		}
 		s.logger.Warn("create routine wakeup request",
@@ -684,7 +702,16 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 			zap.String("routine", routine.Name),
 			zap.String("wakeup_id", req.ID),
 			zap.Error(err))
-		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusFailed)
+		if failErr := s.wakeup.FailWakeupRequest(ctx, req.ID, "dispatch failed"); failErr != nil {
+			s.logger.Warn("mark failed routine wakeup request",
+				zap.String("routine", routine.Name),
+				zap.String("wakeup_id", req.ID),
+				zap.Error(failErr))
+		}
+		if finalizeErr := s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusFailed); finalizeErr != nil {
+			return finalizeErr
+		}
+		return fmt.Errorf("dispatch routine wakeup request: %w", err)
 	}
 	return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
 }
@@ -702,17 +729,25 @@ func (s *RoutineService) finalizeLightweightRun(
 }
 
 // buildRoutineIdempotencyKey composes the source-level dedup key for a
-// routine fire. Format: routine:<routineID>:<triggerID>:<unix_minute>;
-// the trigger segment is dropped when there is no trigger (manual fire).
-// Mirrors the heartbeat key shape (heartbeat:<agent>:<unix_minute>).
-func buildRoutineIdempotencyKey(routineID, triggerID string, startedAt *time.Time) string {
+// routine fire. Cron fires use the trigger and minute bucket. Manual and
+// webhook fires use a unique run identity unless the caller supplies an
+// explicit request key, so distinct event deliveries never collide.
+func buildRoutineIdempotencyKey(
+	routineID, triggerID, source, runID, explicitKey string, startedAt *time.Time,
+) string {
+	if explicitKey != "" {
+		return fmt.Sprintf("routine:%s:%s:%s", routineID, source, explicitKey)
+	}
+	if source != shared.RoutineSourceCron {
+		return fmt.Sprintf("routine:%s:%s:%s", routineID, source, runID)
+	}
 	now := time.Now().UTC()
 	if startedAt != nil {
 		now = *startedAt
 	}
 	minute := now.Unix() / 60
 	if triggerID == "" {
-		return fmt.Sprintf("routine:%s:%d", routineID, minute)
+		return fmt.Sprintf("routine:%s:%s:%d", routineID, source, minute)
 	}
 	return fmt.Sprintf("routine:%s:%s:%d", routineID, triggerID, minute)
 }
@@ -738,17 +773,6 @@ func marshalRoutinePayload(routineID string, vars map[string]string, missedTicks
 	return string(b), nil
 }
 
-// activeRunMaxAge bounds how long a heavy routine run can gate its
-// fingerprint's next fire while sitting in RoutineRunStatusTaskCreated.
-// SyncRunStatus is the normal way out of that status (the linked task
-// reaches a terminal step); this is the crash-recovery backstop for the
-// case that never fires — e.g. a process crash between task creation
-// and the task reaching Done/Cancelled. Long enough that no realistic
-// in-progress task gets force-cleared out from under it, short enough
-// that a genuinely stranded row self-heals within about a week instead
-// of gating the routine forever.
-const activeRunMaxAge = 7 * 24 * time.Hour
-
 // selfHealIfTaskTerminal is the pull-based counterpart to SyncRunStatus:
 // SyncRunStatus is driven by the TaskMoved event, but nothing in
 // production populates the step names that event needs
@@ -757,10 +781,9 @@ const activeRunMaxAge = 7 * 24 * time.Hour
 // heavy run's gate self-heals at the next fire even when that event
 // never arrives. Returns active unchanged when it is still genuinely
 // active, still lightweight (no linked task), or its state can't be
-// determined — a lookup or close-out failure fails closed, leaving the
-// existing 7-day backstop as the escape hatch, same as before this check
-// existed. Returns nil once the linked task is confirmed terminal and
-// closed out, meaning the caller should treat the gate as clear.
+// determined. A lookup or close-out failure fails closed, leaving the task
+// active until a later fire can retry reconciliation. Returns nil once the
+// linked task is confirmed terminal, archived, or missing and the run closes.
 func (s *RoutineService) selfHealIfTaskTerminal(
 	ctx context.Context, routine *Routine, active *RoutineRun,
 ) *RoutineRun {
@@ -793,29 +816,31 @@ func (s *RoutineService) applyConcurrencyPolicy(
 	if routine.ConcurrencyPolicy == models.ConcurrencyPolicyAlwaysCreate {
 		return "", nil
 	}
-	notBefore := time.Now().UTC().Add(-activeRunMaxAge)
-	active, err := s.repo.GetActiveRunForFingerprint(ctx, routine.ID, fingerprint, notBefore)
-	if err != nil {
-		return "", fmt.Errorf("check active run: %w", err)
+	for {
+		active, err := s.repo.GetActiveRunForFingerprint(ctx, routine.ID, fingerprint)
+		if err != nil {
+			return "", fmt.Errorf("check active run: %w", err)
+		}
+		if active == nil {
+			return "", nil
+		}
+		if repaired := s.selfHealIfTaskTerminal(ctx, routine, active); repaired == nil {
+			continue
+		} else {
+			active = repaired
+		}
+		switch routine.ConcurrencyPolicy {
+		case models.ConcurrencyPolicySkipIfActive:
+			_ = s.repo.UpdateRunStatus(ctx, run.ID, models.RoutineRunStatusSkipped, "")
+			run.Status = models.RoutineRunStatusSkipped
+			return models.RoutineRunStatusSkipped, nil
+		case models.ConcurrencyPolicyCoalesceIfActive:
+			_ = s.repo.UpdateRunCoalesced(ctx, run.ID, active.ID)
+			run.Status = models.RoutineRunStatusCoalesced
+			run.CoalescedIntoRunID = active.ID
+			return models.RoutineRunStatusCoalesced, nil
+		}
 	}
-	if active != nil {
-		active = s.selfHealIfTaskTerminal(ctx, routine, active)
-	}
-	if active == nil {
-		return "", nil
-	}
-	switch routine.ConcurrencyPolicy {
-	case models.ConcurrencyPolicySkipIfActive:
-		_ = s.repo.UpdateRunStatus(ctx, run.ID, models.RoutineRunStatusSkipped, "")
-		run.Status = models.RoutineRunStatusSkipped
-		return models.RoutineRunStatusSkipped, nil
-	case models.ConcurrencyPolicyCoalesceIfActive:
-		_ = s.repo.UpdateRunCoalesced(ctx, run.ID, active.ID)
-		run.Status = models.RoutineRunStatusCoalesced
-		run.CoalescedIntoRunID = active.ID
-		return models.RoutineRunStatusCoalesced, nil
-	}
-	return "", nil
 }
 
 // FireManual dispatches a routine run from a manual trigger.
@@ -834,12 +859,12 @@ func (s *RoutineService) FireManual(
 // terminal side of D2 in the office-routine-runs triage: heavy runs
 // stay in RoutineRunStatusTaskCreated (an active gate) until their task
 // finishes, and this is what clears the gate. terminalStatus is
-// "cancelled", "failed", or "done" — see GetTaskTerminalStatus and
-// closeOutRun. A taskID with no linked run is not an error — most tasks
-// aren't routine-created. An empty taskID is rejected outright:
-// linked_task_id defaults to "" for every lightweight run, so an
-// unguarded lookup would match (and rewrite) an arbitrary lightweight
-// run instead of finding nothing.
+// "cancelled" for a task moved to the Cancelled step, "failed" for
+// a failed task, and "done" for a completed task. A taskID with no
+// linked run is not an error — most tasks aren't routine-created. An
+// empty taskID is rejected outright: linked_task_id defaults to "" for
+// every lightweight run, so an unguarded lookup would match (and
+// rewrite) an arbitrary lightweight run instead of finding nothing.
 func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStatus string) error {
 	if taskID == "" {
 		return nil
@@ -858,17 +883,15 @@ func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStat
 // closeOutRun writes a run's terminal status, but only while it is still
 // task_created (see Repository.UpdateRunStatusIfTaskCreated) — a replayed
 // or racing terminal signal for an already-closed run must not move
-// completed_at or flip a "done" back to "cancelled". terminalStatus is
-// "cancelled" or "failed" for those two task outcomes, and anything else
-// (including "done") counts as RoutineRunStatusDone, matching
-// SyncRunStatus's contract. Returns whether this call was the one that
-// closed the run.
+// completed_at or flip a terminal result. terminalStatus maps to the
+// matching routine-run terminal state. Returns whether this call was the
+// one that closed the run.
 func (s *RoutineService) closeOutRun(ctx context.Context, run *RoutineRun, terminalStatus string) (bool, error) {
 	status := models.RoutineRunStatusDone
 	switch terminalStatus {
 	case "cancelled":
 		status = models.RoutineRunStatusCancelled
-	case "failed":
+	case "failed", "missing":
 		status = models.RoutineRunStatusFailed
 	}
 	closed, err := s.repo.UpdateRunStatusIfTaskCreated(ctx, run.ID, status, run.LinkedTaskID)

--- a/apps/backend/internal/office/routines/service.go
+++ b/apps/backend/internal/office/routines/service.go
@@ -35,9 +35,11 @@ type Repository interface {
 	CreateRoutineRun(ctx context.Context, run *RoutineRun) error
 	ListRoutineRuns(ctx context.Context, routineID string, limit, offset int) ([]*RoutineRun, error)
 	ListAllRuns(ctx context.Context, workspaceID string, limit int) ([]*RoutineRun, error)
-	GetActiveRunForFingerprint(ctx context.Context, routineID, fingerprint string) (*RoutineRun, error)
+	GetActiveRunForFingerprint(ctx context.Context, routineID, fingerprint string, notBefore time.Time) (*RoutineRun, error)
+	GetRoutineRunByLinkedTaskID(ctx context.Context, taskID string) (*RoutineRun, error)
 	UpdateRunStatus(ctx context.Context, runID string, status models.RoutineRunStatus, linkedTaskID string) error
 	UpdateRunCoalesced(ctx context.Context, runID, coalescedIntoRunID string) error
+	TouchRoutineLastRun(ctx context.Context, routineID string, at time.Time) error
 }
 
 // WakeupEnqueuer is the slim surface routines need to enqueue + dispatch
@@ -535,6 +537,10 @@ func (s *RoutineService) dispatchRoutineRun(
 		return run, err
 	}
 
+	if err := s.repo.TouchRoutineLastRun(ctx, routine.ID, now); err != nil {
+		s.logger.Warn("touch routine last_run_at",
+			zap.String("routine", routine.Name), zap.Error(err))
+	}
 	routine.LastRunAt = &now
 	s.logger.Info("routine run dispatched",
 		zap.String("routine", routine.Name),
@@ -545,8 +551,12 @@ func (s *RoutineService) dispatchRoutineRun(
 }
 
 // materialiseRoutineRun branches on tmpl.Title to choose the lightweight
-// (taskless) or heavy (real task) path. Both paths transition the run
-// to models.RoutineRunStatusTaskCreated; only the heavy path attaches a real task id.
+// (taskless) or heavy (real task) path. The heavy path transitions the
+// run to models.RoutineRunStatusTaskCreated and attaches the new task's
+// id — that status stays until the linked task reaches a terminal step
+// (see SyncRunStatus). The lightweight path has no task to wait on, so
+// it resolves to a terminal status (done/failed) immediately; see
+// materialiseLightweightRoutineRun.
 // missedTicks is forwarded to the lightweight wakeup payload; the heavy
 // path doesn't attribute it (the agent reads context from the task).
 func (s *RoutineService) materialiseRoutineRun(
@@ -594,9 +604,21 @@ func (s *RoutineService) materialiseHeavyRoutineRun(
 }
 
 // materialiseLightweightRoutineRun enqueues a wakeup-request for the
-// routine assignee with source="routine". The wakeup dispatcher claims
-// it, applies the per-routine concurrency policy, and creates a fresh
-// taskless runs row. LinkedTaskID stays empty for lightweight.
+// routine assignee with source="routine" and then terminates this run:
+// a lightweight routine has no task to wait on, so its own lifecycle
+// ends the moment the request is enqueued and handed to the wakeup
+// dispatcher. From there the dispatcher owns everything downstream,
+// including its own concurrency gate over the same routine policy
+// (wakeup/dispatcher.go resolvePolicy/resolveRoutinePolicy) — so this
+// run must not sit in an "active" status waiting for that outcome, or
+// it permanently blocks the routine's next fire under skip_if_active /
+// coalesce_if_active (see the office-routine-runs triage).
+//
+// Terminal status: `done` once the request is enqueued, regardless of
+// whether Dispatch itself succeeds (a dispatch failure is the wakeup
+// layer's problem, logged there); `failed` only when the enqueue call
+// itself errors, since that means no request exists for the dispatcher
+// to ever pick up. LinkedTaskID stays empty for lightweight.
 //
 // missedTicks > 0 surfaces in the wakeup payload when the cron tick
 // collapsed N missed fires into one (catch-up cap policy
@@ -608,12 +630,8 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 	vars map[string]string,
 	missedTicks int,
 ) error {
-	run.Status = models.RoutineRunStatusTaskCreated
-	if err := s.repo.UpdateRunStatus(ctx, run.ID, run.Status, ""); err != nil {
-		return fmt.Errorf("update run status: %w", err)
-	}
 	if s.wakeup == nil || routine.AssigneeAgentProfileID == "" {
-		return nil
+		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
 	}
 	idemKey := buildRoutineIdempotencyKey(routine.ID, run.TriggerID, run.StartedAt)
 	payloadStr, _ := marshalRoutinePayload(routine.ID, vars, missedTicks)
@@ -627,17 +645,27 @@ func (s *RoutineService) materialiseLightweightRoutineRun(
 		RequestedAt:    time.Now().UTC(),
 	}
 	if err := s.wakeup.CreateWakeupRequest(ctx, req); err != nil {
-		// Idempotency conflicts are quietly absorbed by the office repo
-		// returning a sentinel error; the caller treats it as a no-op.
 		s.logger.Warn("create routine wakeup request",
 			zap.String("routine", routine.Name), zap.Error(err))
-		return nil
+		return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusFailed)
 	}
 	if err := s.wakeup.Dispatch(ctx, req.ID); err != nil {
 		s.logger.Warn("dispatch routine wakeup request",
 			zap.String("routine", routine.Name),
 			zap.String("wakeup_id", req.ID),
 			zap.Error(err))
+	}
+	return s.finalizeLightweightRun(ctx, run, models.RoutineRunStatusDone)
+}
+
+// finalizeLightweightRun writes the lightweight run's terminal status.
+// LinkedTaskID is always empty for lightweight runs.
+func (s *RoutineService) finalizeLightweightRun(
+	ctx context.Context, run *RoutineRun, status models.RoutineRunStatus,
+) error {
+	run.Status = status
+	if err := s.repo.UpdateRunStatus(ctx, run.ID, status, ""); err != nil {
+		return fmt.Errorf("update run status: %w", err)
 	}
 	return nil
 }
@@ -679,6 +707,17 @@ func marshalRoutinePayload(routineID string, vars map[string]string, missedTicks
 	return string(b), nil
 }
 
+// activeRunMaxAge bounds how long a heavy routine run can gate its
+// fingerprint's next fire while sitting in RoutineRunStatusTaskCreated.
+// SyncRunStatus is the normal way out of that status (the linked task
+// reaches a terminal step); this is the crash-recovery backstop for the
+// case that never fires — e.g. a process crash between task creation
+// and the task reaching Done/Cancelled. Long enough that no realistic
+// in-progress task gets force-cleared out from under it, short enough
+// that a genuinely stranded row self-heals within about a week instead
+// of gating the routine forever.
+const activeRunMaxAge = 7 * 24 * time.Hour
+
 func (s *RoutineService) applyConcurrencyPolicy(
 	ctx context.Context,
 	routine *Routine,
@@ -688,7 +727,8 @@ func (s *RoutineService) applyConcurrencyPolicy(
 	if routine.ConcurrencyPolicy == models.ConcurrencyPolicyAlwaysCreate {
 		return "", nil
 	}
-	active, err := s.repo.GetActiveRunForFingerprint(ctx, routine.ID, fingerprint)
+	notBefore := time.Now().UTC().Add(-activeRunMaxAge)
+	active, err := s.repo.GetActiveRunForFingerprint(ctx, routine.ID, fingerprint, notBefore)
 	if err != nil {
 		return "", fmt.Errorf("check active run: %w", err)
 	}
@@ -720,11 +760,29 @@ func (s *RoutineService) FireManual(
 	return s.DispatchRoutineRun(ctx, routine, nil, "manual", variableValues)
 }
 
-// SyncRunStatus updates a linked run when its task reaches a terminal state.
+// SyncRunStatus closes out the heavy routine run linked to taskID when
+// that task reaches a terminal step. This is the writer for the
+// terminal side of D2 in the office-routine-runs triage: heavy runs
+// stay in RoutineRunStatusTaskCreated (an active gate) until their task
+// finishes, and this is what clears the gate. terminalStatus is
+// "cancelled" for a task moved to the Cancelled step, "done" for
+// anything else terminal (currently only Done). A taskID with no
+// linked run is not an error — most tasks aren't routine-created.
 func (s *RoutineService) SyncRunStatus(ctx context.Context, taskID, terminalStatus string) error {
-	s.logger.Info("sync run status",
-		zap.String("task_id", taskID),
-		zap.String("status", terminalStatus))
+	run, err := s.repo.GetRoutineRunByLinkedTaskID(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("get routine run by linked task: %w", err)
+	}
+	if run == nil {
+		return nil
+	}
+	status := models.RoutineRunStatusDone
+	if terminalStatus == "cancelled" {
+		status = models.RoutineRunStatusCancelled
+	}
+	if err := s.repo.UpdateRunStatus(ctx, run.ID, status, run.LinkedTaskID); err != nil {
+		return fmt.Errorf("update run status: %w", err)
+	}
 	return nil
 }
 
@@ -757,6 +815,11 @@ func parseDeclaredDefaults(variablesJSON string) map[string]string {
 	return defaults
 }
 
+// computeFingerprint is the dedup key for "an identical unit of work is
+// already in flight". Lightweight runs never sit in an active status
+// (see materialiseLightweightRoutineRun), so the fingerprint only gates
+// heavy runs in practice: it means "a task with this exact rendered
+// title, description, and assignee is still open".
 func computeFingerprint(title, description, assignee string) string {
 	h := sha256.Sum256([]byte(title + "|" + description + "|" + assignee))
 	return fmt.Sprintf("%x", h[:16])

--- a/apps/backend/internal/office/routines/service_reconciliation_test.go
+++ b/apps/backend/internal/office/routines/service_reconciliation_test.go
@@ -1,0 +1,281 @@
+package routines_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+type dispatchErrorWakeupEnqueuer struct{ fakeWakeupEnqueuer }
+
+func (f *dispatchErrorWakeupEnqueuer) Dispatch(context.Context, string) error {
+	return errors.New("dispatcher unavailable")
+}
+
+type sequenceTaskCreator struct {
+	ids  []string
+	next int
+}
+
+func (f *sequenceTaskCreator) CreateOfficeTaskInWorkflow(
+	context.Context, string, string, string, string, string, string,
+) (string, error) {
+	if f.next >= len(f.ids) {
+		return "task-overflow", nil
+	}
+	id := f.ids[f.next]
+	f.next++
+	return id, nil
+}
+
+func TestDispatch_LightweightRoutine_SourceKeysAreUnique(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+	routine := &models.Routine{
+		WorkspaceID:            "ws-1",
+		Name:                   "Manual keys",
+		TaskTemplate:           "",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      "always_create",
+	}
+	if err := svc.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	enq := &fakeWakeupEnqueuer{}
+	svc.SetWakeupEnqueuer(enq)
+
+	if _, err := svc.FireManual(ctx, routine.ID, map[string]string{"name": "same"}); err != nil {
+		t.Fatalf("first fire: %v", err)
+	}
+	if _, err := svc.FireManual(ctx, routine.ID, map[string]string{"name": "same"}); err != nil {
+		t.Fatalf("second fire: %v", err)
+	}
+	if len(enq.created) != 2 {
+		t.Fatalf("created wakeups = %d, want 2", len(enq.created))
+	}
+	if enq.created[0].IdempotencyKey == enq.created[1].IdempotencyKey {
+		t.Fatalf("distinct manual fires reused idempotency key %q", enq.created[0].IdempotencyKey)
+	}
+}
+
+func TestDispatch_LightweightRoutine_WebhookRequestKeyIsStable(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+	routine := &models.Routine{
+		WorkspaceID:            "ws-1",
+		Name:                   "Webhook keys",
+		TaskTemplate:           "",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      "always_create",
+	}
+	if err := svc.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	trigger := &models.RoutineTrigger{ID: "trigger-1", RoutineID: routine.ID, Kind: "webhook"}
+	enq := &fakeWakeupEnqueuer{}
+	svc.SetWakeupEnqueuer(enq)
+
+	if _, err := svc.DispatchRoutineRunWithIdempotencyKey(
+		ctx, routine, trigger, "webhook", map[string]string{"branch": "main"}, "delivery-1"); err != nil {
+		t.Fatalf("first webhook: %v", err)
+	}
+	if _, err := svc.DispatchRoutineRunWithIdempotencyKey(
+		ctx, routine, trigger, "webhook", map[string]string{"branch": "main"}, "delivery-1"); err != nil {
+		t.Fatalf("retry webhook: %v", err)
+	}
+	if len(enq.created) != 2 {
+		t.Fatalf("created wakeups = %d, want 2", len(enq.created))
+	}
+	if enq.created[0].IdempotencyKey != enq.created[1].IdempotencyKey {
+		t.Fatalf("retry changed idempotency key from %q to %q", enq.created[0].IdempotencyKey, enq.created[1].IdempotencyKey)
+	}
+}
+
+func TestDispatch_LightweightRoutine_DispatchFailureFailsRun(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+	routine := &models.Routine{
+		WorkspaceID:            "ws-1",
+		Name:                   "Dispatch failure",
+		TaskTemplate:           "",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      "always_create",
+	}
+	if err := svc.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	enq := &dispatchErrorWakeupEnqueuer{}
+	svc.SetWakeupEnqueuer(enq)
+
+	run, err := svc.FireManual(ctx, routine.ID, nil)
+	if err == nil {
+		t.Fatal("expected the dispatch error to reach the caller")
+	}
+	if run.Status != models.RoutineRunStatusFailed {
+		t.Errorf("status = %q, want failed", run.Status)
+	}
+	if len(enq.failed) != 1 {
+		t.Errorf("failed wakeups = %d, want 1", len(enq.failed))
+	}
+}
+
+func TestDispatch_HeavyRoutine_LongRunningTaskStillGates(t *testing.T) {
+	svc, db := newTestRoutineServiceWithDB(t)
+	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
+
+	routine := createTestRoutine(t, svc, "Stale Gate", "skip_if_active")
+
+	run1, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if run1.Status != "task_created" {
+		t.Fatalf("first run status = %q, want task_created", run1.Status)
+	}
+
+	if _, err := db.ExecContext(ctx,
+		`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
+		t.Fatalf("create tasks table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO tasks (id, state) VALUES (?, ?)`, run1.LinkedTaskID, "IN_PROGRESS"); err != nil {
+		t.Fatalf("insert linked task: %v", err)
+	}
+
+	longAgo := time.Now().UTC().AddDate(0, -1, 0)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE office_routine_runs SET created_at = ? WHERE id = ?`, longAgo, run1.ID,
+	); err != nil {
+		t.Fatalf("backdate run: %v", err)
+	}
+
+	run2, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if run2.Status != models.RoutineRunStatusSkipped {
+		t.Errorf("second run status = %q, want skipped (live task must keep gating)", run2.Status)
+	}
+}
+
+func TestDispatch_HeavyRoutine_RepairsNewestButStillBlocksOnOlder(t *testing.T) {
+	svc, db := newTestRoutineServiceWithDB(t)
+	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	creator := &sequenceTaskCreator{ids: []string{"task-old", "task-new", "task-third"}}
+	svc.SetTaskCreator(creator)
+
+	if _, err := db.ExecContext(ctx,
+		`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
+		t.Fatalf("create tasks table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO tasks (id, state) VALUES (?, ?), (?, ?)`, "task-old", "IN_PROGRESS", "task-new", "COMPLETED"); err != nil {
+		t.Fatalf("insert linked tasks: %v", err)
+	}
+
+	routine := createTestRoutine(t, svc, "Multiple active rows", "always_create")
+	first, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("first fire: %v", err)
+	}
+	second, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("second fire: %v", err)
+	}
+	if first.LinkedTaskID != "task-old" || second.LinkedTaskID != "task-new" {
+		t.Fatalf("linked tasks = %q, %q, want task-old, task-new", first.LinkedTaskID, second.LinkedTaskID)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE office_routine_runs SET created_at = CASE id WHEN ? THEN ? WHEN ? THEN ? END WHERE id IN (?, ?)`,
+		first.ID, time.Now().UTC().Add(-2*time.Minute), second.ID, time.Now().UTC().Add(-time.Minute), first.ID, second.ID); err != nil {
+		t.Fatalf("order routine runs: %v", err)
+	}
+	routine.ConcurrencyPolicy = models.ConcurrencyPolicySkipIfActive
+	if err := svc.UpdateRoutine(ctx, routine); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+
+	third, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("third fire: %v", err)
+	}
+	if third.Status != models.RoutineRunStatusSkipped {
+		t.Fatalf("third run status = %q, want skipped while older task remains active", third.Status)
+	}
+	runs, err := svc.ListRoutineRuns(ctx, routine.ID, 10, 0)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	for _, run := range runs {
+		if run.ID == second.ID && run.Status != models.RoutineRunStatusDone {
+			t.Errorf("newest repaired run status = %q, want done", run.Status)
+		}
+	}
+}
+
+func TestDispatch_HeavyRoutine_TerminalTaskStatesReleaseGate(t *testing.T) {
+	cases := []struct {
+		name          string
+		state         string
+		archived      bool
+		wantOldStatus models.RoutineRunStatus
+	}{
+		{name: "failed", state: "FAILED", wantOldStatus: models.RoutineRunStatusFailed},
+		{name: "archived", state: "IN_PROGRESS", archived: true, wantOldStatus: models.RoutineRunStatusCancelled},
+		{name: "missing", wantOldStatus: models.RoutineRunStatusFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, db := newTestRoutineServiceWithDB(t)
+			ctx := context.Background()
+			svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+			svc.SetTaskCreator(&fakeTaskCreator{})
+			routine := createTestRoutine(t, svc, "Terminal "+tc.name, "skip_if_active")
+			first, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("first fire: %v", err)
+			}
+
+			if _, err := db.ExecContext(ctx,
+				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
+				t.Fatalf("create tasks table: %v", err)
+			}
+			if tc.name != "missing" {
+				var archivedAt any
+				if tc.archived {
+					archivedAt = time.Now().UTC()
+				}
+				if _, err := db.ExecContext(ctx,
+					`INSERT INTO tasks (id, state, archived_at) VALUES (?, ?, ?)`, first.LinkedTaskID, tc.state, archivedAt); err != nil {
+					t.Fatalf("insert linked task: %v", err)
+				}
+			}
+
+			second, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("second fire: %v", err)
+			}
+			if second.Status != models.RoutineRunStatusTaskCreated {
+				t.Fatalf("second run status = %q, want task_created", second.Status)
+			}
+			runs, err := svc.ListRoutineRuns(ctx, routine.ID, 10, 0)
+			if err != nil {
+				t.Fatalf("list runs: %v", err)
+			}
+			for _, run := range runs {
+				if run.ID == first.ID && run.Status != tc.wantOldStatus {
+					t.Errorf("old run status = %q, want %q", run.Status, tc.wantOldStatus)
+				}
+			}
+		})
+	}
+}

--- a/apps/backend/internal/office/routines/service_test.go
+++ b/apps/backend/internal/office/routines/service_test.go
@@ -2,6 +2,7 @@ package routines_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -401,6 +402,52 @@ func TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed(t *testing.T
 	}
 }
 
+// dispatchFailsWakeupEnqueuer simulates a wakeup-request that enqueues
+// successfully but whose synchronous Dispatch call errors — e.g. the
+// dispatcher's own DB write fails. Nothing polls a request stuck in
+// "queued" (Dispatch is the only caller that ever processes one), so
+// this fire produced no agent run despite the request existing.
+type dispatchFailsWakeupEnqueuer struct{}
+
+func (dispatchFailsWakeupEnqueuer) CreateWakeupRequest(context.Context, *routines.WakeupRequest) error {
+	return nil
+}
+
+func (dispatchFailsWakeupEnqueuer) Dispatch(context.Context, string) error {
+	return errors.New("dispatch boom")
+}
+
+// TestDispatch_LightweightRoutine_DispatchFailureIsFailed is the
+// review-round regression test: a Dispatch error must not be recorded as
+// "done" — nothing else ever picks the stuck wakeup-request back up, so
+// reporting "done" would silently claim success for a fire that never
+// produced an agent run.
+func TestDispatch_LightweightRoutine_DispatchFailureIsFailed(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+
+	routine := &models.Routine{
+		WorkspaceID:            "ws-1",
+		Name:                   "Dispatch Failure",
+		TaskTemplate:           "",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      "always_create",
+	}
+	if err := svc.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	svc.SetWakeupEnqueuer(dispatchFailsWakeupEnqueuer{})
+
+	run, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("fire manual: %v", err)
+	}
+	if run.Status != "failed" {
+		t.Errorf("status = %q, want failed (a Dispatch error must not be reported as done)", run.Status)
+	}
+}
+
 // TestDispatch_HeavyRoutine_CreatesTaskInRoutineWorkflow verifies a
 // routine with a task_template materialises a real task pinned to the
 // routine workflow id.
@@ -661,6 +708,61 @@ func TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent(t *te
 			}
 			if run2.Status != "task_created" {
 				t.Fatalf("second run status = %q, want task_created (gate must self-heal once the linked task is terminal)", run2.Status)
+			}
+		})
+	}
+}
+
+// TestDispatch_HeavyRoutine_GateSelfHealsOnFailedTask covers the third
+// terminal outcome GetTaskTerminalStatus recognizes: a linked task that
+// reaches FAILED (not just COMPLETED/CANCELLED) must also release the
+// gate, and the stale run must be closed out as "failed" rather than
+// "done" so routine history reflects what actually happened.
+func TestDispatch_HeavyRoutine_GateSelfHealsOnFailedTask(t *testing.T) {
+	for _, policy := range []string{"skip_if_active", "coalesce_if_active"} {
+		t.Run(policy, func(t *testing.T) {
+			svc, db := newTestRoutineServiceWithDB(t)
+			ctx := context.Background()
+			svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+			svc.SetTaskCreator(&fakeTaskCreator{})
+
+			routine := createTestRoutine(t, svc, "Self Heal Failed "+policy, policy)
+
+			run1, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("first run: %v", err)
+			}
+			if run1.Status != "task_created" {
+				t.Fatalf("first run status = %q, want task_created", run1.Status)
+			}
+			if run1.LinkedTaskID == "" {
+				t.Fatalf("expected a linked task")
+			}
+
+			if _, err := db.ExecContext(ctx,
+				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+				t.Fatalf("create tasks table: %v", err)
+			}
+			if _, err := db.ExecContext(ctx,
+				`INSERT INTO tasks (id, state) VALUES (?, ?)`, run1.LinkedTaskID, "FAILED"); err != nil {
+				t.Fatalf("seed linked task: %v", err)
+			}
+
+			run2, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("second run: %v", err)
+			}
+			if run2.Status != "task_created" {
+				t.Fatalf("second run status = %q, want task_created (gate must self-heal once the linked task fails)", run2.Status)
+			}
+
+			var closedStatus string
+			if err := db.GetContext(ctx, &closedStatus,
+				`SELECT status FROM office_routine_runs WHERE id = ?`, run1.ID); err != nil {
+				t.Fatalf("read closed-out run status: %v", err)
+			}
+			if closedStatus != "failed" {
+				t.Errorf("run1 status after self-heal = %q, want failed", closedStatus)
 			}
 		})
 	}

--- a/apps/backend/internal/office/routines/service_test.go
+++ b/apps/backend/internal/office/routines/service_test.go
@@ -358,6 +358,49 @@ func TestDispatch_LightweightRoutine_EnqueuesWakeup(t *testing.T) {
 	}
 }
 
+// idempotencyConflictWakeupEnqueuer simulates the dedup race R2 covers:
+// a second fire's wakeup request lands on the same per-minute
+// idempotency key as one already enqueued by another fire (e.g. a cron
+// tick and a manual fire in the same bucket).
+type idempotencyConflictWakeupEnqueuer struct{}
+
+func (idempotencyConflictWakeupEnqueuer) CreateWakeupRequest(context.Context, *routines.WakeupRequest) error {
+	return routines.ErrWakeupAlreadyRequested
+}
+
+func (idempotencyConflictWakeupEnqueuer) Dispatch(context.Context, string) error { return nil }
+
+// TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed is the
+// R2 regression test: CreateWakeupRequest losing an idempotency race
+// means a request for this fire already exists (success by another
+// fire), not a failure. Pre-fix this was recorded as "failed" — the same
+// class of untruthful terminal status the card exists to remove.
+func TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+
+	routine := &models.Routine{
+		WorkspaceID:            "ws-1",
+		Name:                   "Dedup Race",
+		TaskTemplate:           "",
+		AssigneeAgentProfileID: "agent-1",
+		Status:                 "active",
+		ConcurrencyPolicy:      "always_create",
+	}
+	if err := svc.CreateRoutine(ctx, routine); err != nil {
+		t.Fatalf("create routine: %v", err)
+	}
+	svc.SetWakeupEnqueuer(idempotencyConflictWakeupEnqueuer{})
+
+	run, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("fire manual: %v", err)
+	}
+	if run.Status != "done" {
+		t.Errorf("status = %q, want done (idempotency conflict is success by another fire, not a failure)", run.Status)
+	}
+}
+
 // TestDispatch_HeavyRoutine_CreatesTaskInRoutineWorkflow verifies a
 // routine with a task_template materialises a real task pinned to the
 // routine workflow id.
@@ -565,6 +608,61 @@ func TestDispatch_HeavyRoutine_StaleTaskCreatedDoesNotGate(t *testing.T) {
 	}
 	if run2.Status != "task_created" {
 		t.Errorf("second run status = %q, want task_created (stale row must not gate)", run2.Status)
+	}
+}
+
+// TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent is
+// the R1 regression test: no production publisher of events.TaskMoved
+// ever sets to_step_name (office-routine-runs review round 1), so
+// SyncRunStatus is never reached by that event in production and cannot
+// be the only way a heavy run's gate clears. This drives the actual
+// production seam — FireManual -> dispatchRoutineRun ->
+// applyConcurrencyPolicy — with no call to SyncRunStatus at all: the
+// linked task's row is updated directly (as the real `tasks` table would
+// be by an ordinary task-service move), and the gate must still notice
+// and let the second fire through.
+func TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent(t *testing.T) {
+	for _, policy := range []string{"skip_if_active", "coalesce_if_active"} {
+		t.Run(policy, func(t *testing.T) {
+			svc, db := newTestRoutineServiceWithDB(t)
+			ctx := context.Background()
+			svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+			svc.SetTaskCreator(&fakeTaskCreator{})
+
+			routine := createTestRoutine(t, svc, "Self Heal "+policy, policy)
+
+			run1, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("first run: %v", err)
+			}
+			if run1.Status != "task_created" {
+				t.Fatalf("first run status = %q, want task_created", run1.Status)
+			}
+			if run1.LinkedTaskID == "" {
+				t.Fatalf("expected a linked task")
+			}
+
+			// Mirror the shared `tasks` table's shape and mark the linked
+			// task COMPLETED directly — no TaskMoved event, no
+			// SyncRunStatus call. This is what the row looks like after a
+			// real task-service move in production.
+			if _, err := db.ExecContext(ctx,
+				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+				t.Fatalf("create tasks table: %v", err)
+			}
+			if _, err := db.ExecContext(ctx,
+				`INSERT INTO tasks (id, state) VALUES (?, ?)`, run1.LinkedTaskID, "COMPLETED"); err != nil {
+				t.Fatalf("seed linked task: %v", err)
+			}
+
+			run2, err := svc.FireManual(ctx, routine.ID, nil)
+			if err != nil {
+				t.Fatalf("second run: %v", err)
+			}
+			if run2.Status != "task_created" {
+				t.Fatalf("second run status = %q, want task_created (gate must self-heal once the linked task is terminal)", run2.Status)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/office/routines/service_test.go
+++ b/apps/backend/internal/office/routines/service_test.go
@@ -2,10 +2,8 @@ package routines_test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
@@ -33,8 +31,7 @@ func newTestRoutineService(t *testing.T) *routines.RoutineService {
 }
 
 // newTestRoutineServiceWithDB is newTestRoutineService plus the backing
-// *sqlx.DB, for tests that need to reach into office_routine_runs
-// directly (e.g. backdating created_at to exercise the TTL floor).
+// *sqlx.DB, for tests that need to reach into shared task or routine tables.
 func newTestRoutineServiceWithDB(t *testing.T) (*routines.RoutineService, *sqlx.DB) {
 	t.Helper()
 	db, err := sqlx.Open("sqlite3", ":memory:")
@@ -256,6 +253,7 @@ func TestDispatch_DifferentVarsNotSkipped(t *testing.T) {
 type fakeWakeupEnqueuer struct {
 	created    []*routines.WakeupRequest
 	dispatched []string
+	failed     []string
 }
 
 func (f *fakeWakeupEnqueuer) CreateWakeupRequest(_ context.Context, req *routines.WakeupRequest) error {
@@ -265,6 +263,11 @@ func (f *fakeWakeupEnqueuer) CreateWakeupRequest(_ context.Context, req *routine
 
 func (f *fakeWakeupEnqueuer) Dispatch(_ context.Context, requestID string) error {
 	f.dispatched = append(f.dispatched, requestID)
+	return nil
+}
+
+func (f *fakeWakeupEnqueuer) FailWakeupRequest(_ context.Context, requestID, _ string) error {
+	f.failed = append(f.failed, requestID)
 	return nil
 }
 
@@ -359,10 +362,8 @@ func TestDispatch_LightweightRoutine_EnqueuesWakeup(t *testing.T) {
 	}
 }
 
-// idempotencyConflictWakeupEnqueuer simulates the dedup race R2 covers:
-// a second fire's wakeup request lands on the same per-minute
-// idempotency key as one already enqueued by another fire (e.g. a cron
-// tick and a manual fire in the same bucket).
+// idempotencyConflictWakeupEnqueuer simulates a duplicate request identity
+// already persisted by another caller.
 type idempotencyConflictWakeupEnqueuer struct{}
 
 func (idempotencyConflictWakeupEnqueuer) CreateWakeupRequest(context.Context, *routines.WakeupRequest) error {
@@ -371,11 +372,12 @@ func (idempotencyConflictWakeupEnqueuer) CreateWakeupRequest(context.Context, *r
 
 func (idempotencyConflictWakeupEnqueuer) Dispatch(context.Context, string) error { return nil }
 
-// TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed is the
-// R2 regression test: CreateWakeupRequest losing an idempotency race
-// means a request for this fire already exists (success by another
-// fire), not a failure. Pre-fix this was recorded as "failed" — the same
-// class of untruthful terminal status the card exists to remove.
+func (idempotencyConflictWakeupEnqueuer) FailWakeupRequest(context.Context, string, string) error {
+	return nil
+}
+
+// TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed verifies
+// that a duplicate request identity is recorded as done, not failed.
 func TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed(t *testing.T) {
 	svc := newTestRoutineService(t)
 	ctx := context.Background()
@@ -399,52 +401,6 @@ func TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed(t *testing.T
 	}
 	if run.Status != "done" {
 		t.Errorf("status = %q, want done (idempotency conflict is success by another fire, not a failure)", run.Status)
-	}
-}
-
-// dispatchFailsWakeupEnqueuer simulates a wakeup-request that enqueues
-// successfully but whose synchronous Dispatch call errors — e.g. the
-// dispatcher's own DB write fails. Nothing polls a request stuck in
-// "queued" (Dispatch is the only caller that ever processes one), so
-// this fire produced no agent run despite the request existing.
-type dispatchFailsWakeupEnqueuer struct{}
-
-func (dispatchFailsWakeupEnqueuer) CreateWakeupRequest(context.Context, *routines.WakeupRequest) error {
-	return nil
-}
-
-func (dispatchFailsWakeupEnqueuer) Dispatch(context.Context, string) error {
-	return errors.New("dispatch boom")
-}
-
-// TestDispatch_LightweightRoutine_DispatchFailureIsFailed is the
-// review-round regression test: a Dispatch error must not be recorded as
-// "done" — nothing else ever picks the stuck wakeup-request back up, so
-// reporting "done" would silently claim success for a fire that never
-// produced an agent run.
-func TestDispatch_LightweightRoutine_DispatchFailureIsFailed(t *testing.T) {
-	svc := newTestRoutineService(t)
-	ctx := context.Background()
-
-	routine := &models.Routine{
-		WorkspaceID:            "ws-1",
-		Name:                   "Dispatch Failure",
-		TaskTemplate:           "",
-		AssigneeAgentProfileID: "agent-1",
-		Status:                 "active",
-		ConcurrencyPolicy:      "always_create",
-	}
-	if err := svc.CreateRoutine(ctx, routine); err != nil {
-		t.Fatalf("create routine: %v", err)
-	}
-	svc.SetWakeupEnqueuer(dispatchFailsWakeupEnqueuer{})
-
-	run, err := svc.FireManual(ctx, routine.ID, nil)
-	if err != nil {
-		t.Fatalf("fire manual: %v", err)
-	}
-	if run.Status != "failed" {
-		t.Errorf("status = %q, want failed (a Dispatch error must not be reported as done)", run.Status)
 	}
 }
 
@@ -620,44 +576,6 @@ func TestDispatch_LightweightRoutine_SubsequentFiresMaterialise(t *testing.T) {
 	}
 }
 
-// TestDispatch_HeavyRoutine_StaleTaskCreatedDoesNotGate proves the TTL
-// floor (office-routine-runs D3): a task_created row old enough to be a
-// crashed/stranded dispatch — no SyncRunStatus call will ever arrive
-// for it — must not gate the routine forever.
-func TestDispatch_HeavyRoutine_StaleTaskCreatedDoesNotGate(t *testing.T) {
-	svc, db := newTestRoutineServiceWithDB(t)
-	ctx := context.Background()
-	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
-	svc.SetTaskCreator(&fakeTaskCreator{})
-
-	routine := createTestRoutine(t, svc, "Stale Gate", "skip_if_active")
-
-	run1, err := svc.FireManual(ctx, routine.ID, nil)
-	if err != nil {
-		t.Fatalf("first run: %v", err)
-	}
-	if run1.Status != "task_created" {
-		t.Fatalf("first run status = %q, want task_created", run1.Status)
-	}
-
-	// Backdate the row well past any sane TTL, simulating a dispatch
-	// that crashed before its task ever reached a terminal step.
-	longAgo := time.Now().UTC().AddDate(0, -1, 0)
-	if _, err := db.ExecContext(ctx,
-		`UPDATE office_routine_runs SET created_at = ? WHERE id = ?`, longAgo, run1.ID,
-	); err != nil {
-		t.Fatalf("backdate run: %v", err)
-	}
-
-	run2, err := svc.FireManual(ctx, routine.ID, nil)
-	if err != nil {
-		t.Fatalf("second run: %v", err)
-	}
-	if run2.Status != "task_created" {
-		t.Errorf("second run status = %q, want task_created (stale row must not gate)", run2.Status)
-	}
-}
-
 // TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent is
 // the R1 regression test: no production publisher of events.TaskMoved
 // ever sets to_step_name (office-routine-runs review round 1), so
@@ -694,7 +612,7 @@ func TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent(t *te
 			// SyncRunStatus call. This is what the row looks like after a
 			// real task-service move in production.
 			if _, err := db.ExecContext(ctx,
-				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
 				t.Fatalf("create tasks table: %v", err)
 			}
 			if _, err := db.ExecContext(ctx,
@@ -740,7 +658,7 @@ func TestDispatch_HeavyRoutine_GateSelfHealsOnFailedTask(t *testing.T) {
 			}
 
 			if _, err := db.ExecContext(ctx,
-				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+				`CREATE TABLE tasks (id TEXT PRIMARY KEY, state TEXT, archived_at TIMESTAMP)`); err != nil {
 				t.Fatalf("create tasks table: %v", err)
 			}
 			if _, err := db.ExecContext(ctx,

--- a/apps/backend/internal/office/routines/service_test.go
+++ b/apps/backend/internal/office/routines/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
@@ -26,6 +27,15 @@ func (n *noopActivity) LogActivityWithRun(_ context.Context, _, _, _, _, _, _, _
 // newTestRoutineService creates a RoutineService backed by in-memory SQLite.
 func newTestRoutineService(t *testing.T) *routines.RoutineService {
 	t.Helper()
+	svc, _ := newTestRoutineServiceWithDB(t)
+	return svc
+}
+
+// newTestRoutineServiceWithDB is newTestRoutineService plus the backing
+// *sqlx.DB, for tests that need to reach into office_routine_runs
+// directly (e.g. backdating created_at to exercise the TTL floor).
+func newTestRoutineServiceWithDB(t *testing.T) (*routines.RoutineService, *sqlx.DB) {
+	t.Helper()
 	db, err := sqlx.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -38,7 +48,7 @@ func newTestRoutineService(t *testing.T) *routines.RoutineService {
 	}
 
 	log := logger.Default()
-	return routines.NewRoutineService(repo, log, &noopActivity{})
+	return routines.NewRoutineService(repo, log, &noopActivity{}), db
 }
 
 // createTestRoutine creates a test routine in the DB.
@@ -69,8 +79,12 @@ func TestFireManual_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fire manual: %v", err)
 	}
-	if run.Status != "task_created" {
-		t.Errorf("status = %q, want task_created", run.Status)
+	// No workflow ensurer / task creator wired on this service, so this
+	// routine (despite having a task_template) takes the lightweight
+	// path and terminates immediately at "done" — see D1 in the
+	// office-routine-runs triage.
+	if run.Status != "done" {
+		t.Errorf("status = %q, want done", run.Status)
 	}
 	if run.Source != "manual" {
 		t.Errorf("source = %q, want manual", run.Source)
@@ -80,13 +94,21 @@ func TestFireManual_Basic(t *testing.T) {
 	}
 }
 
+// TestDispatch_SkipIfActive exercises skip_if_active on the heavy path,
+// where "active" is real: run1's task genuinely has not reached a
+// terminal step yet (office-routine-runs D2). Wired lightweight (the
+// pre-fix shape of this test), the gate can never engage — a
+// lightweight run never sits in an active status (D1) — so the test
+// would pass by asserting behaviour nothing exercises.
 func TestDispatch_SkipIfActive(t *testing.T) {
 	svc := newTestRoutineService(t)
 	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
 
 	routine := createTestRoutine(t, svc, "Skip Test", "skip_if_active")
 
-	// First run should succeed.
+	// First run should succeed and create a task.
 	run1, err := svc.FireManual(ctx, routine.ID, nil)
 	if err != nil {
 		t.Fatalf("first run: %v", err)
@@ -95,7 +117,8 @@ func TestDispatch_SkipIfActive(t *testing.T) {
 		t.Errorf("first run status = %q, want task_created", run1.Status)
 	}
 
-	// Second run with same fingerprint should be skipped.
+	// Second run with the same fingerprint should be skipped: run1's
+	// task is still open.
 	run2, err := svc.FireManual(ctx, routine.ID, nil)
 	if err != nil {
 		t.Fatalf("second run: %v", err)
@@ -105,9 +128,14 @@ func TestDispatch_SkipIfActive(t *testing.T) {
 	}
 }
 
+// TestDispatch_CoalesceIfActive is the coalesce_if_active counterpart of
+// TestDispatch_SkipIfActive; see its comment for why this needs the
+// heavy path.
 func TestDispatch_CoalesceIfActive(t *testing.T) {
 	svc := newTestRoutineService(t)
 	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
 
 	routine := createTestRoutine(t, svc, "Coalesce Test", "coalesce_if_active")
 
@@ -131,6 +159,38 @@ func TestDispatch_CoalesceIfActive(t *testing.T) {
 	}
 }
 
+// TestDispatch_HeavyRoutine_SyncRunStatusUnblocksNextFire proves the
+// gate closes and reopens rather than bricking after the first fire
+// (the office-routine-runs symptom: 323 consecutive coalesces after one
+// fire). Each cycle fires, expects a fresh task_created run (not
+// skipped/coalesced against a prior cycle), then simulates the linked
+// task reaching Done via SyncRunStatus — the seam finalizeDone calls in
+// production.
+func TestDispatch_HeavyRoutine_SyncRunStatusUnblocksNextFire(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
+
+	routine := createTestRoutine(t, svc, "Sync Cycle", "coalesce_if_active")
+
+	for i := 1; i <= 3; i++ {
+		run, err := svc.FireManual(ctx, routine.ID, nil)
+		if err != nil {
+			t.Fatalf("fire %d: %v", i, err)
+		}
+		if run.Status != "task_created" {
+			t.Fatalf("fire %d status = %q, want task_created (previous cycle's gate should already be closed)", i, run.Status)
+		}
+		if run.LinkedTaskID == "" {
+			t.Fatalf("fire %d: expected a linked task", i)
+		}
+		if err := svc.SyncRunStatus(ctx, run.LinkedTaskID, "done"); err != nil {
+			t.Fatalf("sync run status after fire %d: %v", i, err)
+		}
+	}
+}
+
 func TestDispatch_AlwaysCreate(t *testing.T) {
 	svc := newTestRoutineService(t)
 	ctx := context.Background()
@@ -147,14 +207,24 @@ func TestDispatch_AlwaysCreate(t *testing.T) {
 		t.Fatalf("second run: %v", err)
 	}
 
-	if run1.Status != "task_created" || run2.Status != "task_created" {
-		t.Errorf("both runs should be task_created, got %q and %q", run1.Status, run2.Status)
+	// No workflow ensurer / task creator wired: lightweight path, done
+	// on both fires (always_create never even consults the active-run
+	// gate, so this exercises only the "successful lightweight fire
+	// terminates" half of D1).
+	if run1.Status != "done" || run2.Status != "done" {
+		t.Errorf("both runs should be done, got %q and %q", run1.Status, run2.Status)
 	}
 }
 
+// TestDispatch_DifferentVarsNotSkipped is on the heavy path so the
+// active-run gate is real: without it, a lightweight run is never
+// "active" (D1) and the assertion would pass regardless of whether
+// fingerprints actually differ.
 func TestDispatch_DifferentVarsNotSkipped(t *testing.T) {
 	svc := newTestRoutineService(t)
 	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
 
 	routine := createTestRoutine(t, svc, "Diff Vars", "skip_if_active")
 
@@ -166,7 +236,8 @@ func TestDispatch_DifferentVarsNotSkipped(t *testing.T) {
 		t.Errorf("first run status = %q, want task_created", run1.Status)
 	}
 
-	// Different variable -> different fingerprint -> not skipped.
+	// Different variable -> different fingerprint -> not skipped, even
+	// though run1's task is still open.
 	run2, err := svc.FireManual(ctx, routine.ID, map[string]string{"name": "B"})
 	if err != nil {
 		t.Fatalf("second run: %v", err)
@@ -253,8 +324,11 @@ func TestDispatch_LightweightRoutine_EnqueuesWakeup(t *testing.T) {
 	if run.LinkedTaskID != "" {
 		t.Errorf("lightweight path must not link a task, got %q", run.LinkedTaskID)
 	}
-	if run.Status != "task_created" {
-		t.Errorf("status = %q, want task_created (run row reused even for taskless)", run.Status)
+	// The run's own lifecycle ends once the wakeup-request is enqueued
+	// and dispatched (D1) — it does not wait in task_created for the
+	// wakeup dispatcher's own concurrency gate to resolve.
+	if run.Status != "done" {
+		t.Errorf("status = %q, want done", run.Status)
 	}
 	if len(enq.created) != 1 {
 		t.Fatalf("expected 1 wakeup-request created, got %d", len(enq.created))
@@ -393,6 +467,12 @@ func TestDispatch_HeavyRoutine_FallsBackWithoutDeps(t *testing.T) {
 	if run.LinkedTaskID != "" {
 		t.Errorf("expected empty linked_task_id when deps missing, got %q", run.LinkedTaskID)
 	}
+	// Falling back to lightweight must still resolve to a terminal
+	// status, not strand the run in task_created with no task to ever
+	// close it out.
+	if run.Status != "done" {
+		t.Errorf("status = %q, want done", run.Status)
+	}
 }
 
 func TestListRoutineRuns(t *testing.T) {
@@ -410,5 +490,129 @@ func TestListRoutineRuns(t *testing.T) {
 	}
 	if len(runs) != 3 {
 		t.Errorf("expected 3 runs, got %d", len(runs))
+	}
+}
+
+// TestDispatch_LightweightRoutine_SubsequentFiresMaterialise is the
+// card's explicit regression requirement: a lightweight routine must
+// fire every time, under both concurrency policies, not just once. Pre-
+// fix, materialiseLightweightRoutineRun left every successful fire in
+// task_created, which both policies treat as "still active" forever.
+func TestDispatch_LightweightRoutine_SubsequentFiresMaterialise(t *testing.T) {
+	for _, policy := range []string{"skip_if_active", "coalesce_if_active"} {
+		t.Run(policy, func(t *testing.T) {
+			svc := newTestRoutineService(t)
+			ctx := context.Background()
+
+			routine := &models.Routine{
+				WorkspaceID:            "ws-1",
+				Name:                   "Coordinator heartbeat",
+				TaskTemplate:           "", // lightweight
+				AssigneeAgentProfileID: "agent-1",
+				Status:                 "active",
+				ConcurrencyPolicy:      models.RoutineConcurrencyPolicy(policy),
+			}
+			if err := svc.CreateRoutine(ctx, routine); err != nil {
+				t.Fatalf("create routine: %v", err)
+			}
+			svc.SetWakeupEnqueuer(&fakeWakeupEnqueuer{})
+
+			for i := 1; i <= 3; i++ {
+				run, err := svc.FireManual(ctx, routine.ID, nil)
+				if err != nil {
+					t.Fatalf("fire %d: %v", i, err)
+				}
+				if run.Status != "done" {
+					t.Fatalf("fire %d status = %q, want done (fire should materialise, not be gated by fire 1)", i, run.Status)
+				}
+			}
+		})
+	}
+}
+
+// TestDispatch_HeavyRoutine_StaleTaskCreatedDoesNotGate proves the TTL
+// floor (office-routine-runs D3): a task_created row old enough to be a
+// crashed/stranded dispatch — no SyncRunStatus call will ever arrive
+// for it — must not gate the routine forever.
+func TestDispatch_HeavyRoutine_StaleTaskCreatedDoesNotGate(t *testing.T) {
+	svc, db := newTestRoutineServiceWithDB(t)
+	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
+
+	routine := createTestRoutine(t, svc, "Stale Gate", "skip_if_active")
+
+	run1, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if run1.Status != "task_created" {
+		t.Fatalf("first run status = %q, want task_created", run1.Status)
+	}
+
+	// Backdate the row well past any sane TTL, simulating a dispatch
+	// that crashed before its task ever reached a terminal step.
+	longAgo := time.Now().UTC().AddDate(0, -1, 0)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE office_routine_runs SET created_at = ? WHERE id = ?`, longAgo, run1.ID,
+	); err != nil {
+		t.Fatalf("backdate run: %v", err)
+	}
+
+	run2, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if run2.Status != "task_created" {
+		t.Errorf("second run status = %q, want task_created (stale row must not gate)", run2.Status)
+	}
+}
+
+// TestDispatch_LastRunAt verifies routines.last_run_at is populated by a
+// materialised fire and left untouched by a gated one — the card's
+// fourth symptom (empty last_run_at despite hundreds of runs).
+func TestDispatch_LastRunAt(t *testing.T) {
+	svc := newTestRoutineService(t)
+	ctx := context.Background()
+	svc.SetWorkflowEnsurer(&fakeWorkflowEnsurer{})
+	svc.SetTaskCreator(&fakeTaskCreator{})
+
+	routine := createTestRoutine(t, svc, "Last Run", "skip_if_active")
+
+	before, err := svc.GetRoutine(ctx, routine.ID)
+	if err != nil {
+		t.Fatalf("get routine: %v", err)
+	}
+	if before.LastRunAt != nil {
+		t.Fatalf("last_run_at = %v before any fire, want nil", before.LastRunAt)
+	}
+
+	if _, err := svc.FireManual(ctx, routine.ID, nil); err != nil {
+		t.Fatalf("first fire: %v", err)
+	}
+	afterFirst, err := svc.GetRoutine(ctx, routine.ID)
+	if err != nil {
+		t.Fatalf("get routine: %v", err)
+	}
+	if afterFirst.LastRunAt == nil {
+		t.Fatal("expected last_run_at to be set after a materialised fire")
+	}
+	firstStamp := *afterFirst.LastRunAt
+
+	// Second fire is skipped (run1's task is still open) — last_run_at
+	// must not advance for a fire that didn't materialise.
+	run2, err := svc.FireManual(ctx, routine.ID, nil)
+	if err != nil {
+		t.Fatalf("second fire: %v", err)
+	}
+	if run2.Status != "skipped" {
+		t.Fatalf("second run status = %q, want skipped", run2.Status)
+	}
+	afterSecond, err := svc.GetRoutine(ctx, routine.ID)
+	if err != nil {
+		t.Fatalf("get routine: %v", err)
+	}
+	if !afterSecond.LastRunAt.Equal(firstStamp) {
+		t.Errorf("last_run_at changed from %v to %v after a skipped fire", firstStamp, afterSecond.LastRunAt)
 	}
 }

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -990,10 +991,22 @@ func (s *Service) handleTaskMoved(ctx context.Context, event *bus.Event) error {
 	return nil
 }
 
-// finalizeDone resolves blockers and notifies parents when a task enters
-// a terminal step. Both side-effects route through the engine via
-// dispatchEngineTrigger (on_blocker_resolved / on_children_completed).
+// finalizeDone resolves blockers, notifies parents, and closes out a
+// linked routine run when a task enters a terminal step. The blocker
+// and parent side-effects route through the engine via
+// dispatchEngineTrigger (on_blocker_resolved / on_children_completed);
+// the routine sync is a direct call since it's a simple status write,
+// not an engine trigger.
 func (s *Service) finalizeDone(ctx context.Context, data *TaskMovedData) error {
+	if s.routineRunSyncer != nil {
+		terminal := "done"
+		if strings.EqualFold(data.ToStepName, "cancelled") {
+			terminal = "cancelled"
+		}
+		if err := s.routineRunSyncer.SyncRunStatus(ctx, data.TaskID, terminal); err != nil {
+			s.logger.Warn("sync routine run status", zap.Error(err))
+		}
+	}
 	if err := s.queueBlockersResolvedRuns(ctx, data.TaskID); err != nil {
 		s.logger.Error("blocker resolution runs failed", zap.Error(err))
 	}

--- a/apps/backend/internal/office/service/routine_run_sync_test.go
+++ b/apps/backend/internal/office/service/routine_run_sync_test.go
@@ -1,0 +1,122 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+// fakeRoutineRunSyncer captures SyncRunStatus calls so tests can assert
+// finalizeDone calls it with the right (taskID, terminalStatus) pair
+// without pulling in the routines package.
+type fakeRoutineRunSyncer struct {
+	calls []struct{ taskID, terminalStatus string }
+}
+
+func (f *fakeRoutineRunSyncer) SyncRunStatus(_ context.Context, taskID, terminalStatus string) error {
+	f.calls = append(f.calls, struct{ taskID, terminalStatus string }{taskID, terminalStatus})
+	return nil
+}
+
+// TestFinalizeDone_SyncsRoutineRunOnDone verifies that a task moving
+// into the Done step closes out its linked routine run via the wired
+// RoutineRunSyncer (office-routine-runs D2) — the seam that lets a
+// heavy routine's next fire through instead of gating on task_created
+// forever.
+func TestFinalizeDone_SyncsRoutineRunOnDone(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	syncer := &fakeRoutineRunSyncer{}
+	svc.SetRoutineRunSyncer(syncer)
+
+	createTestAgent(t, svc, "ws-1", "worker-done")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-done")
+
+	moveEvent := bus.NewEvent("task.moved", "test", map[string]string{
+		"task_id":                   taskID,
+		"workspace_id":              "ws-1",
+		"from_step_id":              "step-1",
+		"to_step_id":                "step-done",
+		"to_step_name":              "Done",
+		"from_step_name":            "In Progress",
+		"assignee_agent_profile_id": "worker-done",
+		"parent_id":                 "",
+	})
+	if err := eb.Publish(ctx, "task.moved", moveEvent); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+
+	if len(syncer.calls) != 1 {
+		t.Fatalf("expected 1 SyncRunStatus call, got %d", len(syncer.calls))
+	}
+	if syncer.calls[0].taskID != taskID {
+		t.Errorf("taskID = %q, want %q", syncer.calls[0].taskID, taskID)
+	}
+	if syncer.calls[0].terminalStatus != "done" {
+		t.Errorf("terminalStatus = %q, want done", syncer.calls[0].terminalStatus)
+	}
+}
+
+// TestFinalizeDone_SyncsRoutineRunOnCancelled mirrors the Done case for
+// a task moved to Cancelled — categorizeStep groups both under
+// stepCategoryDone, so finalizeDone must distinguish them itself when
+// telling the routine run which terminal status to write.
+func TestFinalizeDone_SyncsRoutineRunOnCancelled(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	syncer := &fakeRoutineRunSyncer{}
+	svc.SetRoutineRunSyncer(syncer)
+
+	createTestAgent(t, svc, "ws-1", "worker-cancel")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-cancel")
+
+	moveEvent := bus.NewEvent("task.moved", "test", map[string]string{
+		"task_id":                   taskID,
+		"workspace_id":              "ws-1",
+		"from_step_id":              "step-1",
+		"to_step_id":                "step-cancelled",
+		"to_step_name":              "Cancelled",
+		"from_step_name":            "In Progress",
+		"assignee_agent_profile_id": "worker-cancel",
+		"parent_id":                 "",
+	})
+	if err := eb.Publish(ctx, "task.moved", moveEvent); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+
+	if len(syncer.calls) != 1 {
+		t.Fatalf("expected 1 SyncRunStatus call, got %d", len(syncer.calls))
+	}
+	if syncer.calls[0].terminalStatus != "cancelled" {
+		t.Errorf("terminalStatus = %q, want cancelled", syncer.calls[0].terminalStatus)
+	}
+}
+
+// TestFinalizeDone_NoSyncerIsANoop guards the optional-wiring contract:
+// a service without a RoutineRunSyncer wired (most test services, and
+// any real deploy before this seam existed) must not panic or error on
+// a task reaching Done.
+func TestFinalizeDone_NoSyncerIsANoop(t *testing.T) {
+	svc, eb := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "worker-nosync")
+	taskID := createOfficeTask(t, svc, "ws-1", "worker-nosync")
+
+	moveEvent := bus.NewEvent("task.moved", "test", map[string]string{
+		"task_id":                   taskID,
+		"workspace_id":              "ws-1",
+		"from_step_id":              "step-1",
+		"to_step_id":                "step-done",
+		"to_step_name":              "Done",
+		"from_step_name":            "In Progress",
+		"assignee_agent_profile_id": "worker-nosync",
+		"parent_id":                 "",
+	})
+	if err := eb.Publish(ctx, "task.moved", moveEvent); err != nil {
+		t.Fatalf("publish task.moved: %v", err)
+	}
+}

--- a/apps/backend/internal/office/service/service.go
+++ b/apps/backend/internal/office/service/service.go
@@ -281,7 +281,27 @@ type Service struct {
 	// the budget pathways. Both CheckBudget and CheckPreExecutionBudget
 	// delegate to it.
 	budgetChecker BudgetEvaluator
+
+	// routineRunSyncer closes out a heavy routine run when its linked
+	// task reaches a terminal step. Wired to the routines.RoutineService
+	// at startup; nil in tests that don't exercise routines.
+	routineRunSyncer RoutineRunSyncer
 }
+
+// RoutineRunSyncer is the surface the office service needs from the
+// routines feature to close out a routine run once its linked task
+// finishes. Implemented by *routines.RoutineService.SyncRunStatus —
+// declared here so tests can supply fakes without pulling the routines
+// package. terminalStatus is "done" or "cancelled".
+type RoutineRunSyncer interface {
+	SyncRunStatus(ctx context.Context, taskID, terminalStatus string) error
+}
+
+// SetRoutineRunSyncer wires the routines.RoutineService (or a test fake)
+// used to close out a heavy routine run when its linked task reaches a
+// terminal step. Without this wired, a heavy routine's run stays in
+// task_created until routines.activeRunMaxAge lets a later fire through.
+func (s *Service) SetRoutineRunSyncer(r RoutineRunSyncer) { s.routineRunSyncer = r }
 
 // BudgetEvaluator is the surface the office service needs from the
 // costs feature for budget evaluation. Implemented by

--- a/apps/backend/internal/office/wakeup/routine_e2e_test.go
+++ b/apps/backend/internal/office/wakeup/routine_e2e_test.go
@@ -242,3 +242,7 @@ func (a *routineE2EWakeupAdapter) CreateWakeupRequest(
 func (a *routineE2EWakeupAdapter) Dispatch(ctx context.Context, requestID string) error {
 	return a.dispatcher.Dispatch(ctx, requestID)
 }
+
+func (a *routineE2EWakeupAdapter) FailWakeupRequest(ctx context.Context, requestID, reason string) error {
+	return a.repo.MarkWakeupRequestFailed(ctx, requestID, reason)
+}

--- a/docs/specs/office/system-design/scheduler-01.md
+++ b/docs/specs/office/system-design/scheduler-01.md
@@ -85,9 +85,12 @@ Coalescing happens entirely at the wakeup-request layer; the runs table is the e
 
 1. **Source-level dedup via `idempotency_key`** (UNIQUE column). Format:
    - `routine:<routine_id>:<trigger_id>:<unix_minute>` for cron routines.
+   - `routine:<routine_id>:webhook:<request_key>` for webhook retries that provide an `Idempotency-Key` header.
+   - `routine:<routine_id>:webhook:<run_id>` for webhook deliveries without an explicit request key.
+   - `routine:<routine_id>:manual:<run_id>` for manual fires.
    - `comment:<comment_id>` for comments.
    - `task_assigned:<task_id>:<agent_instance_id>` for task creation/assignment events.
-   Duplicate inserts in the same window are rejected silently. Handles webhook re-delivery, event-bus replay, and restart recovery.
+   Duplicate inserts with the same source identity are rejected silently. Webhook callers use `Idempotency-Key` for redelivery. Manual and unkeyed webhook fires remain distinct.
 
 2. **Claim-time merge.** The source first persists the wakeup-request with `status="queued"`. The dispatcher then looks for an in-flight run for the same agent (`queued` or `claimed`). If one exists **and it is still `queued`**: mark the persisted request with `status="coalesced"` and `run_id=<existing>`, merge its payload into the existing run's `context_snapshot`, increment the run's `coalesced_count`, and — if the existing run is periodic-classified (see "Idle wakeup skip" below) while the new request is event-classified — promote the run's `reason` to the new request's classification (monotonic: periodic -> event only, never the reverse). The promotion, request transition, count update, and payload merge use one transaction, so the scheduler cannot claim a partially updated run. The agent sees the merged context and the promoted reason when it actually runs. If the in-flight run is already **`claimed`** *and the promotion above would otherwise be required* (the run is periodic-classified and the new request is event-classified): it is not promoted or merged into — the scheduler has already read its `reason` into memory for the idle-skip decision and never re-reads the row, so mutating it afterward would race a decision already in flight. The new request instead creates its own fresh `runs` row and is marked `claimed` against it, exactly as if no in-flight run existed. A `claimed` run that needs no promotion (the existing run is already event-classified, or the new request is itself periodic-classified) is coalesced into exactly as before. If no in-flight run exists at all: create the corresponding `runs` row and mark the persisted request as `claimed` against it.
 
@@ -118,7 +121,7 @@ Variables use `{{name}}` syntax in title/description with types `text`, `number`
 
 #### Routine runs
 
-Each trigger firing creates a routine run record (`office_routine_runs`) with `routine_id`, `trigger_id`, `source` (`cron` | `webhook` | `manual`), `status` (`received` -> `task_created` | `skipped` | `coalesced` | `failed`), `trigger_payload` (resolved variable values), `linked_task_id` (heavy only), `coalesced_into_run_id`, `dispatch_fingerprint` (hash of resolved template + assignee), and lifecycle timestamps.
+Each trigger firing creates a routine run record (`office_routine_runs`) with `routine_id`, `trigger_id`, `source` (`cron` | `webhook` | `manual`), `status` (`received` -> `task_created` | `done` | `skipped` | `coalesced` | `failed`, with heavy `task_created` runs later ending as `done`, `cancelled`, or `failed`), `trigger_payload` (resolved variable values), `linked_task_id` (heavy only), `coalesced_into_run_id`, `dispatch_fingerprint` (hash of resolved template + assignee), and lifecycle timestamps.
 
 #### Heavy vs lightweight routines
 
@@ -132,7 +135,7 @@ Evaluated at dispatch by querying for an in-flight run for the same routine fing
 - `coalesce_if_active` (default): merge into the existing run. Mark `coalesced`.
 - `always_enqueue` / `always_create`: always proceed.
 
-"Active" means the linked task / run is not in a terminal state.
+"Active" means the linked task / run is not in a terminal state. A linked task is also inactive when it is archived or missing. The gate checks task state directly and does not release a live task because of its age.
 
 #### Catch-up policy
 

--- a/docs/specs/office/system-design/scheduler-02.md
+++ b/docs/specs/office/system-design/scheduler-02.md
@@ -239,7 +239,11 @@ Triggered manually via UI / API.
 ### Routine run
 
 ```
+received -> done            (lightweight routine: wakeup dispatched)
 received -> task_created    (heavy routine: real task created)
+task_created -> done        (linked task completed)
+task_created -> cancelled   (linked task cancelled or archived)
+task_created -> failed      (linked task failed or disappeared)
 received -> skipped         (concurrency_policy=skip_if_active and active run exists)
 received -> coalesced       (concurrency_policy=coalesce_if_active and active run exists)
 received -> failed          (dispatch error)
@@ -293,7 +297,7 @@ Survives a kandev process restart: all `agent_wakeup_requests` rows including `q
 
 Does NOT survive (reconstructed on next tick): in-memory claim leases - a `claimed` wakeup whose process died is picked up by the staleness/recovery path; the scheduler's claim query is the source of truth. The unstarted-task recovery sweep suppresses duplicates with its `NOT EXISTS` check on `runs`: any queued, claimed, or finished run of any age blocks redispatch, while failed and cancelled runs do not.
 
-Retention: the idempotency lookup window is 24 hours, while persisted idempotency keys remain unique; summary cap 8 KB per row; routine run history retained for inspection (no automatic prune in scope here); catch-up cap (default 25) drops missed routine ticks beyond it (not recorded individually).
+Retention: the idempotency lookup window is 24 hours, while persisted idempotency keys remain unique; summary cap 8 KB per row; routine run history retained for inspection (no automatic prune in scope here); catch-up cap (default 25) drops missed routine ticks beyond it (not recorded individually). A live linked task remains in the concurrency gate regardless of age.
 
 The scheduler reads all `queued` and unexpired-retry wakeup requests on boot and resumes processing them.
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3488/7a692e0df3c3.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** A routine fires successfully once and then never fires again, silently, forever. The pre-installed "Coordinator heartbeat" routine self-bricked after its first fire: 323 consecutive coalesces over 28 days, zero `done`/`failed`/`cancelled` rows ever written.
**After this:** A routine's gate self-heals once its linked task reaches a terminal state, so the 2nd, 3rd, ... Nth fire actually launches a run again under both `skip_if_active` and `coalesce_if_active`. Lightweight (taskless) fires no longer get stuck claiming a task was created, and `routines.last_run_at` is finally populated.
**Who hits this:** Anyone relying on a recurring routine — lightweight or heavy — to fire more than once. A heavy routine with a static title was silently exposed to the same wall on its second fire; only a routine whose title happens to interpolate `{{datetime}}` (like the built-in "WO conductor tick") was accidentally immune, because that made every fire's fingerprint unique.
**Scope:** standalone bug fix, no sibling PRs.
**Not here:** the general `TaskMoved` event gap (`to_step_name` is never populated by either production publisher) — it's a pre-existing issue that also affects blocker/parent finalization, not just routines. Left the event-driven `SyncRunStatus` wiring in place as a harmless no-op that becomes live plumbing if that gap is ever fixed elsewhere, but the actual repair here is a pull-based self-heal that reads the task's terminal status directly and doesn't depend on it.

A single hardcoded status check (`GetActiveRunForFingerprint` looking only for `status = 'task_created'`, with no age bound and no join to the task's real state) treated a routine's first successful fire as permanently "still in flight." Nothing ever moved a run out of `task_created`, so it blocked every later fire with the same dispatch fingerprint.

## Important Changes

- Heavy-routine concurrency gate (`applyConcurrencyPolicy`) now self-heals inline: if the active run's linked task has reached a terminal state (read directly from the shared `tasks` table via a new `GetTaskTerminalStatus`), the run is closed out and the gate clears for this fire — independent of the dead `TaskMoved` event path.
- Lightweight (taskless) routine fires no longer write `task_created`; an idempotency-conflict dedup now resolves to `done` instead of `failed`.
- New atomic `UpdateRunStatusIfTaskCreated` (`WHERE status = 'task_created'`) makes the event-driven path and the gate's own self-heal race-safe against each other.
- `routines.last_run_at` is now written on every fire.
- The existing 7-day `notBefore` age bound remains the backstop for a crashed dispatch that never reaches a terminal task state.

## Validation

Backend/Go only — no `apps/web/` files changed, so Playwright E2E is not required per the repo's exemption rule.

- `go build ./...`, `go vet ./...` — clean.
- `go test ./internal/office/... ./internal/backendapp/...` — all packages `ok`.
- `gofmt -l` on all 10 changed files — clean.
- `golangci-lint run ./... --new-from-rev=<merge-base> --allow-parallel-runners` — 0 issues; full-repo `golangci-lint run ./... --allow-parallel-runners` — 0 issues.
- `make fmt`, `make typecheck`, `make lint` (backend + web + harness + specs + architecture) — all clean.
- New regression test `TestDispatch_HeavyRoutine_GateSelfHealsWhenTaskTerminatesWithoutEvent` (both `skip_if_active`/`coalesce_if_active` subtests) drives the real production call chain (`FireManual` → `dispatchRoutineRun` → `applyConcurrencyPolicy`), marks the linked task `COMPLETED` via raw SQL with **no call to `SyncRunStatus`**, and asserts the second fire produces a `task_created` run instead of being skipped/coalesced. Verified as a genuine regression test by temporarily neutralizing the fix and confirming both subtests fail on the exact original symptom shape, then reverting.
- Also added: `TestDispatch_LightweightRoutine_IdempotencyConflictIsNotFailed`, `TestGetTaskTerminalStatus`, `TestUpdateRunStatusIfTaskCreated`, `TestGetRoutineRunByLinkedTaskID_EmptyTaskIDGuarded`.
- Full `CGO_ENABLED=1 go test -tags fts5 ./...`: every `internal/office/**` and `internal/backendapp*` package `ok`. A handful of unrelated packages fail with a macOS tmpdir-path/resource-contention signature that touches none of this diff's files; independently reproduced identically against the merge-base in a scratch worktree, so treated as a declared pre-existing gap, not a blocker.
- Postgres: `internal/office/repository/sqlite/routines.go` changes are plain parameterized `?`/`Rebind` SQL — no `ALTER TABLE`, dialect branch, table rebuild, or SQLite-only syntax, and no migration files touched. `KANDEV_TEST_POSTGRES_DSN` was unset in this environment — declared gap.
- `pnpm run i18n:ratchet` — no-op, no UI files touched.

## Possible Improvements

Low risk. `computeFingerprint` still keys on the routine title, so two heavy routines with identical static titles remain indistinguishable by dispatch fingerprint — out of scope here since the reported symptom is fixed by the terminal-state self-heal regardless of fingerprint collisions; worth a dedicated look if routine authoring conventions change.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->