### PR TITLE
test(orchestrator): make the route-claim regression test catch the race it is for

### DIFF
--- a/apps/backend/internal/orchestrator/dynamic_policy_recovery_race_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_policy_recovery_race_test.go
@@ -42,35 +42,9 @@ func TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce(t *testing.T) {
 	)
 
 	repo := setupTestRepo(t)
-	seedSession(t, repo, taskID, sessionID, "step-race")
-
 	resolver := newDynamicPolicyRaceResolver(t, repo, dynamicProfileID, concreteProfileID)
-
-	session, err := repo.GetTaskSession(ctx, sessionID)
-	if err != nil {
-		t.Fatalf("get session: %v", err)
-	}
-	session.AgentProfileID = dynamicProfileID
-	session.ExecutionProfileID = concreteProfileID
-	session.RouteGeneration = 4
-	if err := repo.UpdateTaskSession(ctx, session); err != nil {
-		t.Fatalf("update session: %v", err)
-	}
-	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
-
-	elapsedDeadline := time.Now().UTC().Add(-time.Minute)
-	if err := repo.SaveRouteState(ctx, dynamicruntime.RouteState{
-		SessionID: sessionID, LogicalProfileID: dynamicProfileID,
-		ExecutionProfileID: concreteProfileID, Generation: 4, ProfileVersion: 1,
-		Status:          "retry_wait",
-		PolicyStateJSON: `{"deadline":"` + elapsedDeadline.Format(time.RFC3339Nano) + `"}`,
-		UpdatedAt:       time.Now().UTC(),
-	}); err != nil {
-		t.Fatalf("SaveRouteState: %v", err)
-	}
-	if _, _, err := resolver.EngineForTest().LoadState(ctx, sessionID); err != nil {
-		t.Fatalf("warm engine cache: %v", err)
-	}
+	seedDynamicPolicyRecoveryState(t, repo, taskID, sessionID, executionID, dynamicProfileID, concreteProfileID)
+	warmDynamicPolicyRecoveryState(t, resolver, sessionID, "warm engine cache")
 
 	var launches int32
 	agentManager := &mockAgentManager{
@@ -181,6 +155,47 @@ func newDynamicPolicyRaceResolverWithPersistence(
 	}
 }
 
+// seedDynamicPolicyRecoveryState creates one due route state and its session projection.
+func seedDynamicPolicyRecoveryState(
+	t *testing.T,
+	repo *sqliterepo.Repository,
+	taskID, sessionID, executionID, dynamicProfileID, concreteProfileID string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	seedSession(t, repo, taskID, sessionID, "step-race")
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = dynamicProfileID
+	session.ExecutionProfileID = concreteProfileID
+	session.RouteGeneration = 4
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
+
+	elapsedDeadline := time.Now().UTC().Add(-time.Minute)
+	if err := repo.SaveRouteState(ctx, dynamicruntime.RouteState{
+		SessionID: sessionID, LogicalProfileID: dynamicProfileID,
+		ExecutionProfileID: concreteProfileID, Generation: 4, ProfileVersion: 1,
+		Status:          "retry_wait",
+		PolicyStateJSON: `{"deadline":"` + elapsedDeadline.Format(time.RFC3339Nano) + `"}`,
+		UpdatedAt:       time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveRouteState: %v", err)
+	}
+}
+
+// warmDynamicPolicyRecoveryState loads the route into one engine's local cache.
+func warmDynamicPolicyRecoveryState(t *testing.T, resolver *dynamicPolicyRaceResolver, sessionID, label string) {
+	t.Helper()
+	if _, _, err := resolver.EngineForTest().LoadState(context.Background(), sessionID); err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
 // claimRendezvousBarrier wraps the real repository's durable claim so the
 // first two concurrent callers are guaranteed to both arrive at
 // ClaimRouteStateFrom before either one executes it, rather than leaving
@@ -223,10 +238,12 @@ func (b *claimRendezvousBarrier) rendezvous() bool {
 	if seen != 1 {
 		return true
 	}
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 	select {
 	case <-release:
 		return true
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		b.t.Errorf("claim rendezvous timed out waiting for a second caller")
 		return false
 	}
@@ -266,40 +283,12 @@ func TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS(t *testing.T) {
 	)
 
 	repo := setupTestRepo(t)
-	seedSession(t, repo, taskID, sessionID, "step-race")
-
 	barrier := newClaimRendezvousBarrier(t, repo)
 	resolverA := newDynamicPolicyRaceResolverWithPersistence(t, repo, dynamicProfileID, concreteProfileID, barrier)
 	resolverB := newDynamicPolicyRaceResolverWithPersistence(t, repo, dynamicProfileID, concreteProfileID, barrier)
-
-	session, err := repo.GetTaskSession(ctx, sessionID)
-	if err != nil {
-		t.Fatalf("get session: %v", err)
-	}
-	session.AgentProfileID = dynamicProfileID
-	session.ExecutionProfileID = concreteProfileID
-	session.RouteGeneration = 4
-	if err := repo.UpdateTaskSession(ctx, session); err != nil {
-		t.Fatalf("update session: %v", err)
-	}
-	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
-
-	elapsedDeadline := time.Now().UTC().Add(-time.Minute)
-	if err := repo.SaveRouteState(ctx, dynamicruntime.RouteState{
-		SessionID: sessionID, LogicalProfileID: dynamicProfileID,
-		ExecutionProfileID: concreteProfileID, Generation: 4, ProfileVersion: 1,
-		Status:          "retry_wait",
-		PolicyStateJSON: `{"deadline":"` + elapsedDeadline.Format(time.RFC3339Nano) + `"}`,
-		UpdatedAt:       time.Now().UTC(),
-	}); err != nil {
-		t.Fatalf("SaveRouteState: %v", err)
-	}
-	if _, _, err := resolverA.EngineForTest().LoadState(ctx, sessionID); err != nil {
-		t.Fatalf("warm engine A cache: %v", err)
-	}
-	if _, _, err := resolverB.EngineForTest().LoadState(ctx, sessionID); err != nil {
-		t.Fatalf("warm engine B cache: %v", err)
-	}
+	seedDynamicPolicyRecoveryState(t, repo, taskID, sessionID, executionID, dynamicProfileID, concreteProfileID)
+	warmDynamicPolicyRecoveryState(t, resolverA, sessionID, "warm engine A cache")
+	warmDynamicPolicyRecoveryState(t, resolverB, sessionID, "warm engine B cache")
 
 	var launches int32
 	agentManager := &mockAgentManager{

--- a/apps/backend/internal/orchestrator/dynamic_policy_recovery_race_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_policy_recovery_race_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,14 +23,14 @@ import (
 
 // TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce reproduces two
 // recovery-timer fires racing on the same due generation (e.g. a duplicate
-// schedule or a backend-restart reschedule overlapping a still-live timer).
-// Before this fix, runDynamicPolicyRecovery held no per-session guard and
-// Engine.resumePending's durable claim predicate did not include the observed
-// status, so both callers could claim the same retry_wait -> retrying
-// transition and both launch a successor, delivering the same prompt twice.
-// With the exact-status CAS (ClaimRouteStatus) plus the shared
-// acquireCancelInFlightGuard held through the claim and session projection,
-// exactly one caller claims the transition and only it reaches the launch.
+// schedule or a backend-restart reschedule overlapping a still-live timer)
+// within one Service. Both goroutines share svc.acquireCancelInFlightGuard,
+// so they are strictly serialized before either reaches the durable claim:
+// the loser's fresh loadDueDynamicPolicyState re-read then sees the winner's
+// "retrying" status and returns early, never reaching ResumePendingRoute at
+// all. The exact-status CAS in ClaimRouteStateFrom is never exercised here —
+// see TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS for a test
+// that forces two independent Service instances to actually contend on it.
 func TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce(t *testing.T) {
 	ctx := context.Background()
 	const (
@@ -121,6 +122,16 @@ func (r *dynamicPolicyRaceResolver) EngineForTest() *dynamicruntime.Engine { ret
 func newDynamicPolicyRaceResolver(
 	t *testing.T, repo *sqliterepo.Repository, dynamicProfileID, concreteProfileID string,
 ) *dynamicPolicyRaceResolver {
+	return newDynamicPolicyRaceResolverWithPersistence(t, repo, dynamicProfileID, concreteProfileID, repo)
+}
+
+// newDynamicPolicyRaceResolverWithPersistence lets a caller substitute the
+// engine's durable persistence (e.g. a rendezvous barrier around
+// ClaimRouteStateFrom) while state reads still go through the real repo.
+func newDynamicPolicyRaceResolverWithPersistence(
+	t *testing.T, repo *sqliterepo.Repository, dynamicProfileID, concreteProfileID string,
+	persistence dynamicruntime.Persistence,
+) *dynamicPolicyRaceResolver {
 	t.Helper()
 	dbPath := t.TempDir() + "/agent-settings.db"
 	db, err := sqlx.Open("sqlite3", dbPath)
@@ -161,11 +172,174 @@ func newDynamicPolicyRaceResolver(
 		t.Fatal(err)
 	}
 	engine := dynamicruntime.NewEngine(
-		dynamicruntime.WithPersistence(repo),
+		dynamicruntime.WithPersistence(persistence),
 		dynamicruntime.WithStateLoader(repo),
 	)
 	return &dynamicPolicyRaceResolver{
 		ProfileExecutionResolver: agentruntime.NewProfileExecutionResolver(profileRepo, engine, true),
 		engine:                   engine,
+	}
+}
+
+// claimRendezvousBarrier wraps the real repository's durable claim so the
+// first two concurrent callers are guaranteed to both arrive at
+// ClaimRouteStateFrom before either one executes it, rather than leaving
+// that to goroutine scheduling luck. Only that first pair rendezvous: a
+// buggy claim can let both callers proceed to a downstream recovery path
+// (e.g. markDynamicRouteActionRequired) that reaches this same method again,
+// and those later calls pass straight through rather than waiting for a
+// third party that will never arrive. It forwards every other
+// Persistence/StateLoader method straight to the embedded repository.
+type claimRendezvousBarrier struct {
+	*sqliterepo.Repository
+	t *testing.T
+
+	mu      sync.Mutex
+	seen    int
+	release chan struct{}
+}
+
+func newClaimRendezvousBarrier(t *testing.T, repo *sqliterepo.Repository) *claimRendezvousBarrier {
+	return &claimRendezvousBarrier{Repository: repo, t: t}
+}
+
+// rendezvous blocks the first arrival until a second one arrives, then
+// releases both together; the third and any later arrival never blocks. It
+// reports (via t.Errorf, safe from any goroutine) and returns false if no
+// second caller shows up within the timeout, so a regression that stops a
+// caller short of the claim fails the test instead of hanging it.
+func (b *claimRendezvousBarrier) rendezvous() bool {
+	b.mu.Lock()
+	b.seen++
+	seen := b.seen
+	if seen == 1 {
+		b.release = make(chan struct{})
+	}
+	release := b.release
+	if seen == 2 {
+		close(release)
+	}
+	b.mu.Unlock()
+	if seen != 1 {
+		return true
+	}
+	select {
+	case <-release:
+		return true
+	case <-time.After(5 * time.Second):
+		b.t.Errorf("claim rendezvous timed out waiting for a second caller")
+		return false
+	}
+}
+
+func (b *claimRendezvousBarrier) ClaimRouteStateFrom(
+	ctx context.Context,
+	expectedGeneration int64,
+	expectedStatus string,
+	state dynamicruntime.RouteState,
+) (bool, error) {
+	if !b.rendezvous() {
+		return false, errors.New("claim rendezvous timed out waiting for a second caller")
+	}
+	return b.Repository.ClaimRouteStateFrom(ctx, expectedGeneration, expectedStatus, state)
+}
+
+// TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS complements
+// TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce: that test's two
+// goroutines share one Service, so svc.acquireCancelInFlightGuard serializes
+// them before either reaches the durable claim and the SQL CAS in
+// ClaimRouteStateFrom is never the discriminator. This test uses two
+// independent Service instances -- as two separate backend processes racing
+// the same durable row would -- each with its own cancelInFlight map and its
+// own Engine (cache-warmed independently), sharing only the underlying
+// repository. A rendezvous barrier around ClaimRouteStateFrom forces both to
+// arrive at the durable claim before either executes it, so only the SQL
+// predicate decides the winner.
+func TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS(t *testing.T) {
+	ctx := context.Background()
+	const (
+		taskID            = "task-policy-race-cas"
+		sessionID         = "session-policy-race-cas"
+		executionID       = "execution-policy-race-cas"
+		dynamicProfileID  = "profile-dynamic-race-cas"
+		concreteProfileID = "profile-concrete-race-cas"
+	)
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, taskID, sessionID, "step-race")
+
+	barrier := newClaimRendezvousBarrier(t, repo)
+	resolverA := newDynamicPolicyRaceResolverWithPersistence(t, repo, dynamicProfileID, concreteProfileID, barrier)
+	resolverB := newDynamicPolicyRaceResolverWithPersistence(t, repo, dynamicProfileID, concreteProfileID, barrier)
+
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = dynamicProfileID
+	session.ExecutionProfileID = concreteProfileID
+	session.RouteGeneration = 4
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
+
+	elapsedDeadline := time.Now().UTC().Add(-time.Minute)
+	if err := repo.SaveRouteState(ctx, dynamicruntime.RouteState{
+		SessionID: sessionID, LogicalProfileID: dynamicProfileID,
+		ExecutionProfileID: concreteProfileID, Generation: 4, ProfileVersion: 1,
+		Status:          "retry_wait",
+		PolicyStateJSON: `{"deadline":"` + elapsedDeadline.Format(time.RFC3339Nano) + `"}`,
+		UpdatedAt:       time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveRouteState: %v", err)
+	}
+	if _, _, err := resolverA.EngineForTest().LoadState(ctx, sessionID); err != nil {
+		t.Fatalf("warm engine A cache: %v", err)
+	}
+	if _, _, err := resolverB.EngineForTest().LoadState(ctx, sessionID); err != nil {
+		t.Fatalf("warm engine B cache: %v", err)
+	}
+
+	var launches int32
+	agentManager := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			atomic.AddInt32(&launches, 1)
+			return &executor.LaunchAgentResponse{AgentExecutionID: "relaunch-" + req.SessionID}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step-race"] = &wfmodels.WorkflowStep{ID: "step-race", WorkflowID: "wf1", Name: "Work"}
+
+	svcA := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentManager)
+	svcA.SetProfileExecutionResolver(resolverA.ProfileExecutionResolver)
+	svcA.lastTurnPrompt.Store(sessionID, capturedPrompt{text: "retry the task"})
+
+	svcB := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentManager)
+	svcB.SetProfileExecutionResolver(resolverB.ProfileExecutionResolver)
+	svcB.lastTurnPrompt.Store(sessionID, capturedPrompt{text: "retry the task"})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		svcA.runDynamicPolicyRecovery(ctx, sessionID, 4)
+	}()
+	go func() {
+		defer wg.Done()
+		svcB.runDynamicPolicyRecovery(ctx, sessionID, 4)
+	}()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&launches); got != 1 {
+		t.Fatalf("successor launches = %d, want exactly 1 (duplicate prompt delivery)", got)
+	}
+	agentManager.mu.Lock()
+	stopCalls := len(agentManager.stopAgentWithReasonArgs)
+	agentManager.mu.Unlock()
+	if stopCalls != 1 {
+		t.Fatalf("predecessor stop calls = %d, want exactly 1", stopCalls)
 	}
 }

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_concurrency_test.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_concurrency_test.go
@@ -39,6 +39,12 @@ func TestConcurrentResumePendingClaimsExactlyOneGeneration(t *testing.T) {
 		t.Fatalf("SaveRouteState: %v", err)
 	}
 
+	// Each caller gets its own Engine, cache-warmed independently via
+	// LoadState below, so neither caller's in-memory cache reflects the
+	// other's claim. Both are therefore guaranteed to reach the durable
+	// ClaimRouteStateFrom call regardless of goroutine scheduling, making the
+	// SQL CAS predicate the sole discriminator without needing a rendezvous
+	// barrier here.
 	const callers = 2
 	engines := make([]*dynamicruntime.Engine, callers)
 	for i := range engines {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3489/a8af6b48d9e7.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** The dynamic-route atomic-claim regression test from #3360 can pass even if the SQL compare-and-swap bug it's meant to catch comes back. If the Go scheduler happens to run the two competing goroutines back-to-back, the second one gets rejected by an in-memory cache check before it ever reaches the database claim, so the SQL predicate is never exercised.
**After this:** Both goroutines are forced through a rendezvous barrier before either reaches the database claim, so the test reliably drives both callers onto the real SQL CAS on every run. Verified against the reverted predicate: 5/5 failures with the barrier, versus previously passing regardless of the bug.
**Who hits this:** Anyone changing the claim logic in `internal/task/repository/sqlite/dynamic_route.go` or the resume path in `internal/agent/runtime/dynamic.Engine` — without this, a regression there could ship past a test that reports green no matter what.
**Scope:** standalone — closes the residual flagged during #3360's own review (https://github.com/kdlbs/kandev/pull/3360#discussion_r3931702953) rather than fixed inline, since the bugfix PR was scoped narrowly.
**Not here:** No production code changes; the atomic-claim fix itself already shipped in #3360.

Adds a real rendezvous barrier to the dynamic-route concurrency regression tests so they can no longer pass vacuously under a lucky goroutine scheduling order.

## Important Changes

- Added `claimRendezvousBarrier`, a test-only wrapper over `*sqliterepo.Repository` that blocks the first of two concurrent `ClaimRouteStateFrom` calls until a second arrives, then releases both together — forcing both callers past the in-memory cache and onto the real SQL CAS. A third+ call passes through immediately (a buggy claim lets both callers reach a downstream path that calls the method again); a stuck rendezvous reports via `t.Errorf` and returns an error instead of hanging.
- Added `TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS`, which runs two independent, independently cache-warmed `*Service`/`Engine` instances sharing one repository through the barrier, so the SQL CAS is what actually adjudicates the race.
- Corrected a stale doc comment on `TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce`.
- The sibling SQLite-level test (`dynamic_route_concurrency_test.go`) gets a comment only, no barrier: its per-caller Engines are cache-warmed via `LoadState` before either goroutine runs, so both callers reach the CAS regardless of scheduling — mutation testing already kills it 50/50 without a barrier.

## Validation

Exact commands from the task's Verify step, both green:

```
$ go test -tags fts5 -race -run TestConcurrentResumePendingClaimsExactlyOneGeneration ./internal/task/repository/sqlite/...
ok  	github.com/kandev/kandev/internal/task/repository/sqlite	5.241s

$ go test -tags fts5 -race -v ./internal/orchestrator/ -run 'TestConcurrentDynamicPolicyRecovery'
--- PASS: TestConcurrentDynamicPolicyRecoveryLaunchesExactlyOnce (2.26s)
--- PASS: TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS (2.74s)
ok  	github.com/kandev/kandev/internal/orchestrator	9.453s
```

Mutation kill (proves the test now actually catches the bug): reverting the CAS predicate in `dynamic_route.go` from `WHERE session_id=? AND route_generation=? AND state=?` back to dropping `state=?` makes `TestConcurrentDynamicPolicyRecoveryClaimContendsOnSQLCAS` fail 5/5 runs (`successor launches = 2, want exactly 1`); the sibling `...LaunchesExactlyOnce` test correctly stays green, since a shared in-process guard serializes it short of the CAS. Predicate restored afterward and confirmed unchanged in the diff.

Also run and clean: `gofmt -l` on both changed files, `go vet` on both packages, `golangci-lint run ./internal/orchestrator/... ./internal/task/repository/sqlite/... --new-from-rev=<base>` (0 issues), full backend `go test -tags fts5 -timeout 30m` on both changed packages (each passes in isolation with headroom past the default 10-minute per-package timeout), `pnpm run typecheck`, `pnpm --filter @kandev/web lint`, and `pnpm run i18n:ratchet` (no web files touched by this diff).

E2E was not run: this change is two Go test files with no `apps/web`, schema, migration, or event-bus changes.

## Possible Improvements

Low risk — test-only change, no production code touched. The rendezvous barrier's timeout is a fixed 5s; if a future change made the second caller reach the claim much more slowly, the test would fail loudly with a named `t.Errorf` rather than hang, so this is a non-issue today.

## Checklist

- [x] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->