### PR TITLE
fix(backend): stop DST fall-back from firing automations twice

### DIFF
--- a/apps/backend/internal/automation/scheduler.go
+++ b/apps/backend/internal/automation/scheduler.go
@@ -198,7 +198,40 @@ func nextCronFire(expr, timezone string, after time.Time) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse cron expression: %w", err)
 	}
-	return schedule.Next(after), nil
+
+	// @every is a pure interval (cron.ConstantDelaySchedule), not a wall-clock
+	// schedule, so DST fall-back suppression does not apply to it.
+	spec, ok := schedule.(*cron.SpecSchedule)
+	if !ok {
+		return schedule.Next(after), nil
+	}
+
+	// schedule.Next returns its candidate in the input's location, so the
+	// input must already be in the schedule's own location for ZoneBounds to
+	// see the same transitions the schedule fires against.
+	candidate := spec.Next(after.In(spec.Location))
+	for !candidate.IsZero() && isAmbiguousFallBack(candidate) {
+		candidate = spec.Next(candidate)
+	}
+	return candidate, nil
+}
+
+// isAmbiguousFallBack reports whether t falls within the repeated wall-clock
+// window created by a DST "fall back" transition: after the transition, the
+// first (transition-end - transition-start)-wide slice of the new period
+// repeats wall-clock times already fired once in the pre-transition offset.
+func isAmbiguousFallBack(t time.Time) bool {
+	start, _ := t.ZoneBounds()
+	if start.IsZero() {
+		return false
+	}
+	_, prevOffset := start.Add(-time.Second).Zone()
+	_, currOffset := t.Zone()
+	delta := time.Duration(prevOffset-currOffset) * time.Second
+	if delta <= 0 {
+		return false
+	}
+	return t.Sub(start) < delta
 }
 
 func hasCronTZPrefix(expr string) bool {

--- a/apps/backend/internal/automation/scheduler.go
+++ b/apps/backend/internal/automation/scheduler.go
@@ -211,6 +211,12 @@ func nextCronFire(expr, timezone string, after time.Time) (time.Time, error) {
 	// see the same transitions the schedule fires against.
 	candidate := spec.Next(after.In(spec.Location))
 	for !candidate.IsZero() && isAmbiguousFallBack(candidate) {
+		transitionStart, _ := candidate.ZoneBounds()
+		if !after.Before(transitionStart) {
+			break
+		}
+		// The repeated window is bounded by the offset delta, so this advances
+		// at most one candidate per matching schedule slot in that window.
 		candidate = spec.Next(candidate)
 	}
 	return candidate, nil

--- a/apps/backend/internal/automation/scheduler_cron_test.go
+++ b/apps/backend/internal/automation/scheduler_cron_test.go
@@ -316,6 +316,32 @@ func TestNextCronFire_DSTFallBackFiresOnce_HalfHourOffset(t *testing.T) {
 	}
 }
 
+// TestNextCronFire_DSTFallBack_MultipleAmbiguousOccurrences_HourRestricted
+// covers the same multi-iteration loop as
+// TestNextCronFire_DSTFallBack_MultipleAmbiguousOccurrences but with an
+// hour-pinned expression: when the anchor is already past 01:59 EDT, every
+// occurrence of the repeated EST 1am hour (01:00, 01:10, ..., 01:50 EST) is
+// ambiguous and must be skipped. Because the expression pins hour=1, the next
+// match isn't 02:00 same day (hour doesn't match) but 01:00 the following
+// day — an easy case to get wrong by assuming the loop always exits at the
+// top of the next hour.
+func TestNextCronFire_DSTFallBack_MultipleAmbiguousOccurrences_HourRestricted(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	after := time.Date(2026, time.November, 1, 1, 59, 0, 0, loc) // last pre-transition minute (EDT)
+	got, err := nextCronFire("*/10 1 * * *", "America/New_York", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	want := time.Date(2026, time.November, 2, 1, 0, 0, 0, loc) // every EST repeat of hour=1 today is skipped
+	if !got.Equal(want) {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
 // TestNextCronFire_DSTFallBackNonRegression pins the boundaries the fix must
 // leave untouched: a slot outside the repeated hour, plain UTC (no
 // transitions), and the spring-forward gap.

--- a/apps/backend/internal/automation/scheduler_cron_test.go
+++ b/apps/backend/internal/automation/scheduler_cron_test.go
@@ -165,6 +165,249 @@ func TestNextCronFire_InvalidExpression(t *testing.T) {
 	}
 }
 
+// TestNextCronFire_DSTFallBackFiresOnce covers the US fall-back boundary
+// (2026-11-01, America/New_York, clocks fall from 02:00 EDT back to 01:00
+// EST): a "30 1 * * *" schedule's wall-clock slot occurs twice as two
+// distinct absolute instants. robfig's raw SpecSchedule.Next would return the
+// first (-04:00) occurrence, and feeding that back in would return the
+// second (-05:00) occurrence of the *same* local day rather than advancing to
+// the next day. nextCronFire must suppress the repeat.
+func TestNextCronFire_DSTFallBackFiresOnce(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	after := time.Date(2026, time.November, 1, 0, 59, 0, 0, loc) // unambiguous, before the repeated hour
+	first, err := nextCronFire("30 1 * * *", "America/New_York", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	wantFirst := time.Date(2026, time.November, 1, 1, 30, 0, 0, loc) // -04:00 (EDT)
+	if !first.Equal(wantFirst) {
+		t.Fatalf("first fall-back fire: got %s, want %s", first, wantFirst)
+	}
+	if _, offset := first.Zone(); offset != -4*3600 {
+		t.Fatalf("first fall-back fire should be EDT (-04:00), got offset %d", offset)
+	}
+
+	second, err := nextCronFire("30 1 * * *", "America/New_York", first)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	// The ambiguous -05:00 sibling of the same local day must be skipped;
+	// the next fire is the following day's 01:30 EST.
+	wantSecond := time.Date(2026, time.November, 2, 1, 30, 0, 0, loc)
+	if !second.Equal(wantSecond) {
+		t.Fatalf("second fall-back fire: got %s, want %s (must skip repeated-hour sibling)", second, wantSecond)
+	}
+}
+
+// TestNextCronFire_DSTFallBackFiresOnce_EuropeLondon covers a zone family
+// where Go's ambiguous-time-construction rules resolve differently than for
+// America/New_York (a naive time.Date reconstruction of the wall clock would
+// pick a different occurrence in this zone family than in others): London
+// falls back from BST (+01:00) to GMT (+00:00) on 2026-10-25. The second
+// occurrence of "30 1 * * *" must still be suppressed.
+func TestNextCronFire_DSTFallBackFiresOnce_EuropeLondon(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	after := time.Date(2026, time.October, 25, 0, 59, 0, 0, loc) // unambiguous, before the repeated hour
+	first, err := nextCronFire("30 1 * * *", "Europe/London", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	if _, offset := first.Zone(); offset != 3600 {
+		t.Fatalf("first fall-back fire should be BST (+01:00), got offset %d", offset)
+	}
+
+	second, err := nextCronFire("30 1 * * *", "Europe/London", first)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	wantSecond := time.Date(2026, time.October, 26, 1, 30, 0, 0, loc)
+	if !second.Equal(wantSecond) {
+		t.Fatalf("second fall-back fire: got %s, want %s (must skip repeated-hour sibling)", second, wantSecond)
+	}
+}
+
+// TestNextCronFire_DSTFallBackFiresOnce_HalfHourOffset covers a zone with a
+// non-hour-wide DST transition (Australia/Lord_Howe: +11:00 -> +10:30, a
+// 30-minute fall-back on 2026-04-05), proving the suppression window is
+// sized to the actual offset delta rather than hardcoded to an hour.
+func TestNextCronFire_DSTFallBackFiresOnce_HalfHourOffset(t *testing.T) {
+	loc, err := time.LoadLocation("Australia/Lord_Howe")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	after := time.Date(2026, time.April, 5, 0, 59, 0, 0, loc) // unambiguous, before the repeated (half-)hour
+	first, err := nextCronFire("30 1 * * *", "Australia/Lord_Howe", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	if _, offset := first.Zone(); offset != 11*3600 {
+		t.Fatalf("first fall-back fire should be +11:00, got offset %d", offset)
+	}
+
+	second, err := nextCronFire("30 1 * * *", "Australia/Lord_Howe", first)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	wantSecond := time.Date(2026, time.April, 6, 1, 30, 0, 0, loc)
+	if !second.Equal(wantSecond) {
+		t.Fatalf("second fall-back fire: got %s, want %s (must skip repeated-hour sibling)", second, wantSecond)
+	}
+}
+
+// TestNextCronFire_DSTFallBackNonRegression pins the boundaries the fix must
+// leave untouched: a slot outside the repeated hour, plain UTC (no
+// transitions), and the spring-forward gap.
+func TestNextCronFire_DSTFallBackNonRegression(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	t.Run("outside repeated hour still fires once at expected instant", func(t *testing.T) {
+		after := time.Date(2026, time.November, 1, 1, 0, 0, 0, loc)
+		got, err := nextCronFire("0 3 * * *", "America/New_York", after)
+		if err != nil {
+			t.Fatalf("nextCronFire error: %v", err)
+		}
+		want := time.Date(2026, time.November, 1, 3, 0, 0, 0, loc) // EST, post-transition
+		if !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("UTC has no transitions to suppress", func(t *testing.T) {
+		after := time.Date(2026, time.November, 1, 0, 0, 0, 0, time.UTC)
+		got, err := nextCronFire("30 1 * * *", "UTC", after)
+		if err != nil {
+			t.Fatalf("nextCronFire error: %v", err)
+		}
+		want := time.Date(2026, time.November, 1, 1, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("spring-forward gap is unaffected", func(t *testing.T) {
+		// 2026-03-08 is the US spring-forward day (02:00 EST -> 03:00 EDT), so
+		// 02:30 never exists that day; robfig already skips the non-existent
+		// slot to the next valid occurrence (the following day), and this
+		// change must not alter that.
+		after := time.Date(2026, time.March, 8, 0, 0, 0, 0, loc)
+		got, err := nextCronFire("30 2 * * *", "America/New_York", after)
+		if err != nil {
+			t.Fatalf("nextCronFire error: %v", err)
+		}
+		want := time.Date(2026, time.March, 9, 2, 30, 0, 0, loc) // EDT, next day (02:30 doesn't exist on the 8th)
+		if !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+}
+
+// TestNextCronFire_EveryIntervalUnaffectedByFallBack proves @every
+// (cron.ConstantDelaySchedule) is exempt from the wall-clock DST policy: it
+// must keep firing every interval straight through the repeated hour rather
+// than having fires displaced or dropped.
+func TestNextCronFire_EveryIntervalUnaffectedByFallBack(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	after := time.Date(2026, time.November, 1, 1, 15, 0, 0, loc)
+	wantOffsets := []time.Duration{30 * time.Minute, 30 * time.Minute, 30 * time.Minute}
+
+	got := after
+	for i, want := range wantOffsets {
+		next, err := nextCronFire("@every 30m", "America/New_York", got)
+		if err != nil {
+			t.Fatalf("nextCronFire error: %v", err)
+		}
+		if delta := next.Sub(got); delta != want {
+			t.Fatalf("fire %d: interval was %s, want %s", i, delta, want)
+		}
+		got = next
+	}
+}
+
+// TestNextCronFire_UnsatisfiableExpressionReturnsZeroWithoutHanging pins the
+// existing (out-of-scope) zero-time behavior for an unsatisfiable expression
+// and proves the fall-back suppression loop added by this change does not
+// spin forever on it.
+func TestNextCronFire_UnsatisfiableExpressionReturnsZeroWithoutHanging(t *testing.T) {
+	done := make(chan struct{})
+	var got time.Time
+	var err error
+	go func() {
+		got, err = nextCronFire("0 0 30 2 *", "America/New_York", time.Now())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("nextCronFire did not return for an unsatisfiable expression")
+	}
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("expected zero time for unsatisfiable expression, got %s", got)
+	}
+}
+
+// TestCronScheduler_DSTFallBack_FiresOnceThenWaits is the end-to-end
+// regression through shouldFire, mirroring
+// TestCronScheduler_PinnedExpression_FiresWhenDueThenWaits: after firing at
+// 01:30 EDT with LastEvaluatedAt advanced, the trigger must not be due again
+// at the ambiguous 01:30 EST sibling.
+func TestCronScheduler_DSTFallBack_FiresOnceThenWaits(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	svc := newTestService(t)
+	log, _ := logger.NewFromZap(zap.NewNop())
+	cs := NewCronScheduler(svc, log)
+
+	created := time.Date(2026, time.November, 1, 1, 0, 0, 0, loc)
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "30 1 * * *", Timezone: "America/New_York"})
+	trig := &AutomationTrigger{
+		Type:      TriggerTypeScheduled,
+		Config:    cfg,
+		Enabled:   true,
+		CreatedAt: created,
+	}
+
+	fireInstant := time.Date(2026, time.November, 1, 1, 30, 0, 0, loc) // -04:00
+	if !cs.shouldFire(trig, fireInstant) {
+		t.Fatal("trigger should be due at the first (EDT) 01:30 occurrence")
+	}
+	trig.LastEvaluatedAt = &fireInstant
+
+	// The ambiguous second occurrence (-05:00, same wall-clock reading) must
+	// not be seen as due again.
+	ambiguousSibling := fireInstant.Add(time.Hour)
+	if cs.shouldFire(trig, ambiguousSibling) {
+		t.Fatal("trigger must not refire at the repeated-hour sibling instant")
+	}
+
+	// The next day's 01:30 EST is genuinely due.
+	nextDay := time.Date(2026, time.November, 2, 1, 35, 0, 0, loc)
+	if !cs.shouldFire(trig, nextDay) {
+		t.Fatal("trigger should be due again the next day at 01:30 EST")
+	}
+}
+
 // TestCronScheduler_PinnedExpression_FiresWhenDueThenWaits is the end-to-end
 // regression for the pinned-expression bug through shouldFire: a "daily at
 // 09:00 UTC" trigger created at 08:00 is not due at 08:59, is due at 09:00, and

--- a/apps/backend/internal/automation/scheduler_cron_test.go
+++ b/apps/backend/internal/automation/scheduler_cron_test.go
@@ -203,6 +203,59 @@ func TestNextCronFire_DSTFallBackFiresOnce(t *testing.T) {
 	}
 }
 
+// TestNextCronFire_DSTFallBack_FirstEligiblePostTransition keeps the first
+// eligible run when a trigger is created during the repeated post-transition
+// hour. The 01:30 EST occurrence is not a duplicate when the anchor is already
+// after the 01:00 EST transition.
+func TestNextCronFire_DSTFallBack_FirstEligiblePostTransition(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	// 01:15 EST, after the fall-back transition. Construct the instant in UTC
+	// so the anchor does not depend on time.Date's ambiguous-time choice.
+	after := time.Date(2026, time.November, 1, 6, 15, 0, 0, time.UTC).In(loc)
+	got, err := nextCronFire("30 1 * * *", "America/New_York", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+
+	want := time.Date(2026, time.November, 1, 6, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("post-transition first fire: got %s, want %s", got, want)
+	}
+	if _, offset := got.In(loc).Zone(); offset != -5*3600 {
+		t.Fatalf("post-transition first fire should be EST (-05:00), got offset %d", offset)
+	}
+}
+
+// TestNextCronFire_DSTFallBack_MultipleAmbiguousOccurrences pins the loop
+// running more than once. An anchor after the pre-transition 01:00 hour must
+// skip every matching occurrence in the repeated hour before 02:00 EST.
+func TestNextCronFire_DSTFallBack_MultipleAmbiguousOccurrences(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	// 01:59 EDT, the last pre-transition minute. Construct the instant in UTC
+	// so the anchor is not affected by ambiguous-time construction rules.
+	after := time.Date(2026, time.November, 1, 5, 59, 0, 0, time.UTC).In(loc)
+	got, err := nextCronFire("*/10 * * * *", "America/New_York", after)
+	if err != nil {
+		t.Fatalf("nextCronFire error: %v", err)
+	}
+
+	want := time.Date(2026, time.November, 1, 7, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("post-transition repeated-hour scan: got %s, want %s", got, want)
+	}
+	if _, offset := got.In(loc).Zone(); offset != -5*3600 {
+		t.Fatalf("next fire should be EST (-05:00), got offset %d", offset)
+	}
+}
+
 // TestNextCronFire_DSTFallBackFiresOnce_EuropeLondon covers a zone family
 // where Go's ambiguous-time-construction rules resolve differently than for
 // America/New_York (a naive time.Date reconstruction of the wall clock would


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3490/250933b4bd8f.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** A scheduled automation pinned to a wall-clock cron time (e.g. `"30 1 * * *"`) runs twice, once at each UTC offset, on the day clocks "fall back" for DST in its timezone (e.g. America/New_York, first Sunday of November) — a real duplicated, potentially paid, automation run once per zone per year.
**After this:** The automation fires exactly once for that wall-clock slot, same as any other day.
**Who hits this:** Any workspace with a scheduled automation pinned to a timezone that observes DST, once a year on the fall-back date.
**Scope:** Standalone. A parallel fix for the same defect in Office's own (separately implemented) cron scheduler is in progress on another branch; this PR only touches the `automation` package's scheduler and does not change Office code.
**Not here:** Office routines' cron scheduler (`internal/office/shared/cron.go`) — different code path, fixed separately.

Kandev's `automation` package dedups a cron fire by absolute minute (`scheduled:<id>:<unix-minute>`). On a DST fall-back boundary, robfig/cron's `SpecSchedule.Next` returns the wall-clock-matching instant literally, and a repeated wall-clock hour occurs as two distinct absolute instants (e.g. 01:30 EDT and 01:30 EST) — each gets its own dedup key, so both fire.

`nextCronFire` now detects when the computed candidate is the second (post-transition) occurrence of an ambiguous fall-back slot, by comparing the wall-clock zone's pre-transition offset (via `ZoneBounds`) against the candidate's own offset, and advances to the next non-ambiguous occurrence instead. `@every`-style schedules (`ConstantDelaySchedule`) are untouched — they have no wall-clock DST policy to begin with.

## Validation

- `go test ./internal/automation/... -run 'DSTFallBack|Unsatisfiable|EveryIntervalUnaffected' -v` — all 7 new/updated DST and loop-termination tests pass (America/New_York, Europe/London, Lord Howe Island's half-hour offset, spring-forward non-regression, `@every` non-regression, unsatisfiable-expression guard, and an end-to-end scheduler test).
- `go test ./internal/automation/... -v -count=1` — full package passes (`ok`, ~2.8s), both pre- and post-rebase onto current `main`.
- Reverted the fix locally and reran the new tests against it — they fail with the exact duplicate-fire symptom (e.g. `got 2026-11-01 01:30:00 -0500 EST, want 2026-11-02 01:30:00 -0500 EST`), confirming the tests actually catch the bug.
- `golangci-lint run ./internal/automation/...` and repo-wide `golangci-lint run ./...` — 0 issues.
- `gofmt -l` on both changed files — clean.
- `make lint-format` (Prettier) and `pnpm run i18n:ratchet` — pass trivially (this diff is Go-only, no `apps/web/**` changes).
- E2E and the Postgres store-conformance suite were not required: the diff is confined to `internal/automation/scheduler.go`'s unexported `nextCronFire` plus its test file — no `apps/web/**`, schema, or SQL changes.
- `go build ./...` (full backend, post-rebase) — clean.

## Possible Improvements

Low risk: the fix is a pure addition (a suppression loop) inside one unexported function with no external callers outside the `automation` package; behavior for non-DST-boundary schedules and `@every` schedules is unchanged (covered by non-regression tests).

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Internal scheduling bugfix, no user-facing behavior or docs to update.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->