### PR TITLE
fix(worktree): add task git metadata projection primitives

### DIFF
--- a/apps/backend/internal/worktree/git_metadata.go
+++ b/apps/backend/internal/worktree/git_metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -304,7 +305,7 @@ func canonicalDirectory(path string) (string, error) {
 }
 
 func readGitdirPointer(gitEntry, checkout string) (string, error) {
-	content, err := os.ReadFile(gitEntry)
+	content, err := readRegularMetadataFile(gitEntry)
 	if err != nil {
 		return "", err
 	}
@@ -328,14 +329,7 @@ func readGitdirPointer(gitEntry, checkout string) (string, error) {
 }
 
 func readMetadataPathStrict(path, relativeTo string) (string, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return "", err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return "", errors.New("metadata pointer is not regular file")
-	}
-	content, err := os.ReadFile(path)
+	content, err := readRegularMetadataFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -350,14 +344,7 @@ func readMetadataPathStrict(path, relativeTo string) (string, error) {
 }
 
 func readSubmoduleCoreWorktree(configPath, relativeTo string) (string, error) {
-	info, err := os.Lstat(configPath)
-	if err != nil {
-		return "", err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return "", errors.New("submodule config is not a regular file")
-	}
-	content, err := os.ReadFile(configPath)
+	content, err := readRegularMetadataFile(configPath)
 	if err != nil {
 		return "", err
 	}
@@ -408,9 +395,47 @@ func parseSubmoduleConfigLine(section, worktree, rawLine string) (string, string
 		return section, worktree, errors.New("git worktree configuration is not allowed")
 	}
 	if strings.EqualFold(section, "core") && strings.EqualFold(strings.TrimSpace(key), "worktree") {
-		worktree = strings.TrimSpace(value)
+		parsedWorktree, err := parseGitConfigValue(value)
+		if err != nil {
+			return section, worktree, err
+		}
+		worktree = parsedWorktree
 	}
 	return section, worktree, nil
+}
+
+func parseGitConfigValue(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if !strings.HasPrefix(value, "\"") {
+		return value, nil
+	}
+	if len(value) < 2 || !strings.HasSuffix(value, "\"") {
+		return "", errors.New("unterminated quoted git config value")
+	}
+	var decoded strings.Builder
+	for i := 1; i < len(value)-1; i++ {
+		if value[i] != '\\' {
+			decoded.WriteByte(value[i])
+			continue
+		}
+		i++
+		if i == len(value)-1 {
+			return "", errors.New("invalid git config escape")
+		}
+		switch value[i] {
+		case '\\', '"':
+			decoded.WriteByte(value[i])
+		case 'n':
+			decoded.WriteByte('\n')
+		case 't':
+			decoded.WriteByte('\t')
+		case 'b':
+			decoded.WriteByte('\b')
+		default:
+			return "", errors.New("invalid git config escape")
+		}
+	}
+	return decoded.String(), nil
 }
 
 func parseSubmoduleConfigSection(line string) (string, error) {
@@ -446,14 +471,7 @@ func directChildName(parent, child string) (string, error) {
 }
 
 func readCurrentBranchRef(headPath string) (string, error) {
-	info, err := os.Lstat(headPath)
-	if err != nil {
-		return "", err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return "", errors.New("HEAD is not a regular file")
-	}
-	content, err := os.ReadFile(headPath)
+	content, err := readRegularMetadataFile(headPath)
 	if err != nil {
 		return "", err
 	}
@@ -466,6 +484,29 @@ func readCurrentBranchRef(headPath string) (string, error) {
 		return "", errors.New("invalid HEAD ref")
 	}
 	return ref, nil
+}
+
+// readRegularMetadataFile reads exactly the inode it validates. Opening first
+// keeps a later path replacement from changing the bytes we authorize, while
+// the post-open Lstat rejects a symlink that was followed during open.
+func readRegularMetadataFile(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	entry, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if entry.Mode()&os.ModeSymlink != 0 || !entry.Mode().IsRegular() || !os.SameFile(opened, entry) {
+		return nil, errors.New("metadata pointer is not a stable regular file")
+	}
+	return io.ReadAll(file)
 }
 
 // ValidBranchRef reports whether ref is a canonical local branch ref that is

--- a/apps/backend/internal/worktree/git_metadata.go
+++ b/apps/backend/internal/worktree/git_metadata.go
@@ -494,7 +494,7 @@ func readRegularMetadataFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	opened, err := file.Stat()
 	if err != nil {
 		return nil, err

--- a/apps/backend/internal/worktree/git_metadata.go
+++ b/apps/backend/internal/worktree/git_metadata.go
@@ -1,0 +1,539 @@
+package worktree
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kandev/kandev/internal/common/securityutil"
+)
+
+// GitMetadataProjectionVersion changes whenever the shape of the metadata
+// permission contract changes. Hashes are freshness diagnostics only; callers
+// must always resolve the projection again before installing permissions.
+const GitMetadataProjectionVersion = 2
+
+// ErrGitMetadataProjectionInvalid is returned when checkout metadata cannot
+// prove that it belongs to the checkout being authorized.
+var ErrGitMetadataProjectionInvalid = errors.New("git metadata projection invalid")
+
+// GitMetadataProjection describes exactly the Git metadata a task checkout
+// needs for ordinary add and commit operations. CommonDir is intentionally not
+// included in AgentWritablePaths: callers must grant only its listed children.
+type GitMetadataProjection struct {
+	Version            int
+	CheckoutPath       string
+	GitDir             string
+	CommonDir          string
+	WorktreesDir       string
+	ObjectDir          string
+	CurrentRef         string
+	CurrentRefPath     string
+	ReflogPath         string
+	AgentWritablePaths []string
+	// MountSupportPaths are executor-only backing mounts. POSIX requires the
+	// parent directory to be writable for Git's create-and-rename lock protocol,
+	// but these paths must never become agent filesystem-policy grants. The
+	// agent policy reopens only the exact ref, reflog, and lock paths above.
+	MountSupportPaths []string
+	// TrustedCommonDir is derived from the server-owned repository record when
+	// this is a task materialization. It is not a grant itself; revalidation
+	// uses it to reject a checkout whose .git pointer is swapped to another
+	// otherwise-valid repository relationship.
+	TrustedCommonDir string
+	Hash             string
+}
+
+// ResolveGitMetadata validates checkout Git metadata and returns a narrow
+// projection. The checkout path is server-owned input; .git contents are
+// treated solely as evidence that must reciprocally validate.
+func ResolveGitMetadata(checkoutPath string) (*GitMetadataProjection, error) {
+	checkout, err := canonicalDirectory(checkoutPath)
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	gitEntry := filepath.Join(checkout, ".git")
+	entryInfo, err := os.Lstat(gitEntry)
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, invalidGitMetadata(errors.New(".git is symbolic link"))
+	}
+	if entryInfo.IsDir() {
+		return resolveRegularGitMetadata(checkout, gitEntry)
+	}
+	if !entryInfo.Mode().IsRegular() {
+		return nil, invalidGitMetadata(errors.New(".git is not directory or pointer"))
+	}
+	return resolveLinkedGitMetadata(checkout, gitEntry)
+}
+
+// ResolveGitMetadataForRepository binds a task checkout to its server-owned
+// source repository. A linked-worktree pointer is evidence only: it must lead
+// to the same common Git directory as the durable repository record, not just
+// to any syntactically valid worktree administration directory.
+func ResolveGitMetadataForRepository(checkoutPath, repositoryPath string) (*GitMetadataProjection, error) {
+	projection, err := ResolveGitMetadata(checkoutPath)
+	if err != nil {
+		return nil, err
+	}
+	trustedCommonDir, err := resolveTrustedRepositoryCommonDir(repositoryPath)
+	if err != nil {
+		return nil, invalidGitMetadata(errors.New("trusted repository metadata is invalid"))
+	}
+	trustedCheckout, err := canonicalDirectory(repositoryPath)
+	if err != nil {
+		return nil, invalidGitMetadata(errors.New("trusted repository checkout is invalid"))
+	}
+	if projection.CommonDir != trustedCommonDir {
+		return nil, invalidGitMetadata(errors.New("checkout common directory does not match trusted repository"))
+	}
+	// A task checkout must be a distinct linked worktree, never the source
+	// repository's own working tree. Without this check a caller that (by bug
+	// or forged durable state) passes checkoutPath == repositoryPath would
+	// receive a projection over the source checkout itself, granting Git
+	// metadata write access and an ACP root to the repository the task was
+	// cloned from.
+	if projection.CheckoutPath == trustedCheckout {
+		return nil, invalidGitMetadata(errors.New("task checkout must not be the source repository"))
+	}
+	// A regular .git directory (not a linked worktree) here would otherwise
+	// have no shared locking or cleanup relationship with the trusted
+	// repository.
+	if projection.GitDir == projection.CommonDir {
+		return nil, invalidGitMetadata(errors.New("task checkout is not a trusted linked worktree"))
+	}
+	projection.TrustedCommonDir = trustedCommonDir
+	projection.Hash = projectionHash(projection)
+	return projection, nil
+}
+
+func resolveTrustedRepositoryCommonDir(repositoryPath string) (string, error) {
+	repository, err := ResolveGitMetadata(repositoryPath)
+	if err == nil {
+		return repository.CommonDir, nil
+	}
+	commonDir, submoduleErr := resolveTrustedSubmoduleCommonDir(repositoryPath)
+	if submoduleErr == nil {
+		return commonDir, nil
+	}
+	return "", errors.Join(err, submoduleErr)
+}
+
+func resolveTrustedSubmoduleCommonDir(repositoryPath string) (string, error) {
+	checkout, err := canonicalDirectory(repositoryPath)
+	if err != nil {
+		return "", err
+	}
+	gitEntry := filepath.Join(checkout, ".git")
+	entryInfo, err := os.Lstat(gitEntry)
+	if err != nil {
+		return "", err
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 || !entryInfo.Mode().IsRegular() {
+		return "", errors.New("trusted repository is not a submodule")
+	}
+	gitDir, err := readGitdirPointer(gitEntry, checkout)
+	if err != nil {
+		return "", err
+	}
+	if err := rejectSymlinkComponents(gitDir); err != nil {
+		return "", err
+	}
+	if _, err := os.Lstat(filepath.Join(gitDir, "commondir")); err == nil {
+		return "", errors.New("submodule metadata must not redirect common directory")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	projected, err := buildGitMetadataProjection(checkout, gitDir, gitDir, "")
+	if err != nil {
+		return "", err
+	}
+	worktreePath, err := readSubmoduleCoreWorktree(filepath.Join(gitDir, "config"), gitDir)
+	if err != nil {
+		return "", err
+	}
+	if worktreePath != checkout {
+		return "", errors.New("submodule metadata does not point back to trusted repository")
+	}
+	return projected.CommonDir, nil
+}
+
+// Revalidate detects replacement or redirection of any metadata used by this
+// projection immediately before a policy or mount is installed.
+func (p *GitMetadataProjection) Revalidate() error {
+	if p == nil {
+		return invalidGitMetadata(errors.New("projection is nil"))
+	}
+	current, err := ResolveGitMetadata(p.CheckoutPath)
+	if err != nil {
+		return err
+	}
+	if p.TrustedCommonDir != "" {
+		if current.CommonDir != p.TrustedCommonDir {
+			return invalidGitMetadata(errors.New("checkout common directory changed after resolution"))
+		}
+		current.TrustedCommonDir = p.TrustedCommonDir
+		current.Hash = projectionHash(current)
+	}
+	if current.Hash != p.Hash {
+		return invalidGitMetadata(errors.New("projection changed after resolution"))
+	}
+	return nil
+}
+
+func resolveRegularGitMetadata(checkout, gitDir string) (*GitMetadataProjection, error) {
+	if err := rejectSymlinkComponents(gitDir); err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	if _, err := os.Lstat(filepath.Join(gitDir, "commondir")); err == nil {
+		return nil, invalidGitMetadata(errors.New("regular repository redirects common directory"))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, invalidGitMetadata(err)
+	}
+	return buildGitMetadataProjection(checkout, gitDir, gitDir, "")
+}
+
+func resolveLinkedGitMetadata(checkout, gitEntry string) (*GitMetadataProjection, error) {
+	gitDir, err := readGitdirPointer(gitEntry, checkout)
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	if err := rejectSymlinkComponents(gitDir); err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	backPointer, err := readMetadataPathStrict(filepath.Join(gitDir, "gitdir"), gitDir)
+	if err != nil || backPointer != gitEntry {
+		return nil, invalidGitMetadata(errors.New("linked worktree reciprocal pointer mismatch"))
+	}
+	commonDir, err := readMetadataPathStrict(filepath.Join(gitDir, "commondir"), gitDir)
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	if err := rejectSymlinkComponents(commonDir); err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	worktreesDir := filepath.Join(commonDir, "worktrees")
+	name, err := directChildName(worktreesDir, gitDir)
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	return buildGitMetadataProjection(checkout, gitDir, commonDir, name)
+}
+
+func buildGitMetadataProjection(checkout, gitDir, commonDir, worktreeName string) (*GitMetadataProjection, error) {
+	ref, err := readCurrentBranchRef(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	objectDir := filepath.Join(commonDir, "objects")
+	if err := rejectSymlinkComponents(objectDir); err != nil {
+		return nil, invalidGitMetadata(err)
+	}
+	writablePaths := []string{gitDir, objectDir}
+	mountSupportPaths := []string{gitDir}
+	if gitDir != commonDir {
+		mountSupportPaths = append(mountSupportPaths, objectDir)
+	}
+	refPath, reflogPath := "", ""
+	if ref != "" {
+		refPath = filepath.Join(commonDir, filepath.FromSlash(ref))
+		reflogPath = filepath.Join(commonDir, "logs", filepath.FromSlash(ref))
+		if err := rejectSymlinkComponents(refPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, invalidGitMetadata(err)
+		}
+		if err := rejectSymlinkComponents(reflogPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, invalidGitMetadata(err)
+		}
+		// Git creates ref.lock and reflog lock siblings before replacing the
+		// current files. Agent policy therefore grants only those four exact
+		// paths. Docker still needs writable backing mounts at the parent
+		// directories for the native create-and-rename protocol; those mount-only
+		// prerequisites are kept separate so they cannot authorize sibling refs.
+		writablePaths = append(writablePaths,
+			refPath, refPath+".lock",
+			reflogPath, reflogPath+".lock",
+		)
+		mountSupportPaths = append(mountSupportPaths, filepath.Dir(refPath), filepath.Dir(reflogPath))
+	}
+	projection := &GitMetadataProjection{
+		Version:            GitMetadataProjectionVersion,
+		CheckoutPath:       checkout,
+		GitDir:             gitDir,
+		CommonDir:          commonDir,
+		WorktreesDir:       filepath.Join(commonDir, "worktrees"),
+		ObjectDir:          objectDir,
+		CurrentRef:         ref,
+		CurrentRefPath:     refPath,
+		ReflogPath:         reflogPath,
+		AgentWritablePaths: uniqueGitMetadataPaths(writablePaths),
+		MountSupportPaths:  uniqueGitMetadataPaths(mountSupportPaths),
+	}
+	if worktreeName == "" {
+		projection.WorktreesDir = ""
+	}
+	projection.Hash = projectionHash(projection)
+	return projection, nil
+}
+
+func canonicalDirectory(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("checkout path is empty")
+	}
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", errors.New("checkout is not directory")
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func readGitdirPointer(gitEntry, checkout string) (string, error) {
+	content, err := os.ReadFile(gitEntry)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir:") {
+		return "", errors.New("invalid gitdir pointer")
+	}
+	path := strings.TrimSpace(strings.TrimPrefix(line, "gitdir:"))
+	if path == "" {
+		return "", errors.New("empty gitdir pointer")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(checkout, path)
+	}
+	return canonicalExistingPath(path)
+}
+
+func readMetadataPathStrict(path, relativeTo string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", errors.New("metadata pointer is not regular file")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(content))
+	if value == "" {
+		return "", errors.New("metadata pointer is empty")
+	}
+	if !filepath.IsAbs(value) {
+		value = filepath.Join(relativeTo, value)
+	}
+	return canonicalExistingPath(value)
+}
+
+func readSubmoduleCoreWorktree(configPath, relativeTo string) (string, error) {
+	info, err := os.Lstat(configPath)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", errors.New("submodule config is not a regular file")
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", err
+	}
+	worktree, err := parseSubmoduleCoreWorktree(string(content))
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(worktree) {
+		worktree = filepath.Join(relativeTo, worktree)
+	}
+	return canonicalExistingPath(worktree)
+}
+
+func parseSubmoduleCoreWorktree(config string) (string, error) {
+	section := ""
+	worktree := ""
+	for _, rawLine := range strings.Split(config, "\n") {
+		nextSection, nextWorktree, err := parseSubmoduleConfigLine(section, worktree, rawLine)
+		if err != nil {
+			return "", err
+		}
+		section = nextSection
+		worktree = nextWorktree
+	}
+	if worktree == "" {
+		return "", errors.New("core.worktree is missing")
+	}
+	return worktree, nil
+}
+
+func parseSubmoduleConfigLine(section, worktree, rawLine string) (string, string, error) {
+	line := strings.TrimSpace(rawLine)
+	if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+		return section, worktree, nil
+	}
+	if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+		nextSection, err := parseSubmoduleConfigSection(line)
+		return nextSection, worktree, err
+	}
+	key, value, found := strings.Cut(line, "=")
+	if !found {
+		if strings.EqualFold(strings.TrimSpace(key), "worktreeConfig") {
+			return section, worktree, errors.New("git worktree configuration is not allowed")
+		}
+		return section, worktree, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(key), "worktreeConfig") && strings.TrimSpace(value) != "false" {
+		return section, worktree, errors.New("git worktree configuration is not allowed")
+	}
+	if strings.EqualFold(section, "core") && strings.EqualFold(strings.TrimSpace(key), "worktree") {
+		worktree = strings.TrimSpace(value)
+	}
+	return section, worktree, nil
+}
+
+func parseSubmoduleConfigSection(line string) (string, error) {
+	section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+	fields := strings.Fields(section)
+	if len(fields) == 0 {
+		return "", errors.New("git config section is empty")
+	}
+	if sectionName := strings.ToLower(fields[0]); sectionName == "include" || sectionName == "includeif" {
+		return "", errors.New("submodule config includes are not allowed")
+	}
+	return section, nil
+}
+
+func canonicalExistingPath(path string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func directChildName(parent, child string) (string, error) {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil || rel == "." || rel == ".." || filepath.Dir(rel) != "." {
+		return "", errors.New("linked worktree gitdir is outside common worktrees directory")
+	}
+	return rel, nil
+}
+
+func readCurrentBranchRef(headPath string) (string, error) {
+	info, err := os.Lstat(headPath)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", errors.New("HEAD is not a regular file")
+	}
+	content, err := os.ReadFile(headPath)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(value, "ref: ") {
+		return "", nil // detached HEAD: commits update HEAD, which is in GitDir.
+	}
+	ref := strings.TrimSpace(strings.TrimPrefix(value, "ref: "))
+	if !ValidBranchRef(ref) {
+		return "", errors.New("invalid HEAD ref")
+	}
+	return ref, nil
+}
+
+// ValidBranchRef reports whether ref is a canonical local branch ref that is
+// safe to use below a Git metadata directory. The branch-name suffix is
+// validated against the same allowlist the rest of the backend uses for
+// task and base branch names, so a HEAD ref this resolver trusts can never
+// be rejected downstream (or vice versa) by a different validation rule.
+func ValidBranchRef(ref string) bool {
+	if !strings.HasPrefix(ref, "refs/heads/") || strings.ContainsAny(ref, "\\\x00\n\r") {
+		return false
+	}
+	name := strings.TrimPrefix(ref, "refs/heads/")
+	if !securityutil.IsValidBranchName(name) {
+		return false
+	}
+	for _, part := range strings.Split(ref, "/") {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func rejectSymlinkComponents(path string) error {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	volume := filepath.VolumeName(abs)
+	current := volume + string(filepath.Separator)
+	for _, part := range strings.Split(strings.TrimPrefix(abs, current), string(filepath.Separator)) {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return nil
+		}
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symbolic link in metadata path")
+		}
+	}
+	return nil
+}
+
+func uniqueGitMetadataPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	result := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		result = append(result, path)
+	}
+	return result
+}
+
+func projectionHash(p *GitMetadataProjection) string {
+	parts := append([]string{fmt.Sprintf("v%d", p.Version), p.CheckoutPath, p.GitDir, p.CommonDir, p.TrustedCommonDir, p.CurrentRef}, p.AgentWritablePaths...)
+	parts = append(parts, "mount-support")
+	parts = append(parts, p.MountSupportPaths...)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func invalidGitMetadata(err error) error {
+	return fmt.Errorf("%w: %v", ErrGitMetadataProjectionInvalid, err)
+}

--- a/apps/backend/internal/worktree/git_metadata.go
+++ b/apps/backend/internal/worktree/git_metadata.go
@@ -319,6 +319,11 @@ func readGitdirPointer(gitEntry, checkout string) (string, error) {
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(checkout, path)
 	}
+	// EvalSymlinks below is only for canonical identity comparison. Refuse a
+	// pointer that traverses one before canonicalization can erase the evidence.
+	if err := rejectSymlinkComponents(path); err != nil {
+		return "", err
+	}
 	return canonicalExistingPath(path)
 }
 

--- a/apps/backend/internal/worktree/git_metadata_test.go
+++ b/apps/backend/internal/worktree/git_metadata_test.go
@@ -73,6 +73,29 @@ func TestResolveGitMetadataRejectsSymlinkedGitEntry(t *testing.T) {
 	}
 }
 
+func TestResolveGitMetadataRejectsLinkedWorktreePointerThroughSymlink(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+
+	gitDir := runGitMetadata(t, checkout, "rev-parse", "--path-format=absolute", "--git-dir")
+	linkedMetadata := filepath.Join(t.TempDir(), "linked-metadata")
+	if err := os.Symlink(filepath.Dir(gitDir), linkedMetadata); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(checkout, ".git"),
+		[]byte("gitdir: "+filepath.Join(linkedMetadata, filepath.Base(gitDir))+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolveGitMetadata(checkout); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadata error = %v, want symlinked gitdir pointer rejection", err)
+	}
+}
+
 func TestResolveGitMetadataRejectsSymlinkedLinkedWorktreeHead(t *testing.T) {
 	repo := initGitMetadataRepository(t)
 	checkout := filepath.Join(t.TempDir(), "task-checkout")

--- a/apps/backend/internal/worktree/git_metadata_test.go
+++ b/apps/backend/internal/worktree/git_metadata_test.go
@@ -43,6 +43,60 @@ func TestResolveGitMetadata_LinkedWorktreeContainsOnlyOwnedMetadata(t *testing.T
 	}
 }
 
+func TestResolveGitMetadata_DetachedHeadDoesNotGrantBranchPaths(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	runGitMetadata(t, checkout, "checkout", "--detach")
+
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatalf("ResolveGitMetadata: %v", err)
+	}
+	if projection.CurrentRef != "" {
+		t.Fatalf("CurrentRef = %q, want empty detached HEAD ref", projection.CurrentRef)
+	}
+	if projection.CurrentRefPath != "" || projection.ReflogPath != "" {
+		t.Fatalf("branch paths = (%q, %q), want empty for detached HEAD", projection.CurrentRefPath, projection.ReflogPath)
+	}
+	for _, path := range projection.AgentWritablePaths {
+		if path == projection.CurrentRefPath || path == projection.ReflogPath {
+			t.Fatalf("AgentWritablePaths contains detached branch path %q: %#v", path, projection.AgentWritablePaths)
+		}
+	}
+}
+
+func TestGitMetadataProjectionRevalidateRejectsChangedHeadWithoutTrustedRepository(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projection.TrustedCommonDir != "" {
+		t.Fatalf("TrustedCommonDir = %q, want empty direct projection", projection.TrustedCommonDir)
+	}
+
+	gitDir := runGitMetadata(t, checkout, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/other-branch\n"), 0o600); err != nil {
+		t.Fatalf("replace HEAD: %v", err)
+	}
+	if err := projection.Revalidate(); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("Revalidate error = %v, want changed direct projection rejection", err)
+	}
+}
+
+func TestParseSubmoduleCoreWorktreeAcceptsQuotedValue(t *testing.T) {
+	worktree, err := parseSubmoduleCoreWorktree("[core]\n\tworktree = \"/tmp/worktree with spaces\"\n")
+	if err != nil {
+		t.Fatalf("parseSubmoduleCoreWorktree: %v", err)
+	}
+	if worktree != "/tmp/worktree with spaces" {
+		t.Fatalf("worktree = %q, want unquoted path", worktree)
+	}
+}
+
 func TestResolveGitMetadataRejectsForgedLinkedWorktreePointer(t *testing.T) {
 	repo := initGitMetadataRepository(t)
 	checkout := filepath.Join(t.TempDir(), "task-checkout")

--- a/apps/backend/internal/worktree/git_metadata_test.go
+++ b/apps/backend/internal/worktree/git_metadata_test.go
@@ -1,0 +1,451 @@
+package worktree
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveGitMetadata_LinkedWorktreeContainsOnlyOwnedMetadata(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatalf("ResolveGitMetadata: %v", err)
+	}
+
+	if projection.CheckoutPath != checkout {
+		t.Fatalf("CheckoutPath = %q, want %q", projection.CheckoutPath, checkout)
+	}
+	if projection.GitDir == filepath.Join(repo, ".git") {
+		t.Fatal("GitDir must be the linked worktree metadata directory, not the source .git")
+	}
+	if projection.CommonDir != filepath.Join(repo, ".git") {
+		t.Fatalf("CommonDir = %q, want %q", projection.CommonDir, filepath.Join(repo, ".git"))
+	}
+	if projection.CurrentRef != "refs/heads/task-branch" {
+		t.Fatalf("CurrentRef = %q", projection.CurrentRef)
+	}
+	if !containsGitMetadataPath(projection.AgentWritablePaths, projection.GitDir) {
+		t.Fatalf("AgentWritablePaths must contain owned GitDir: %#v", projection.AgentWritablePaths)
+	}
+	if containsGitMetadataPath(projection.AgentWritablePaths, projection.CommonDir) {
+		t.Fatalf("AgentWritablePaths must not contain common .git root: %#v", projection.AgentWritablePaths)
+	}
+	if err := projection.Revalidate(); err != nil {
+		t.Fatalf("Revalidate: %v", err)
+	}
+}
+
+func TestResolveGitMetadataRejectsForgedLinkedWorktreePointer(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+
+	gitDir := runGitMetadata(t, checkout, "rev-parse", "--git-dir")
+	if err := os.WriteFile(filepath.Join(gitDir, "gitdir"), []byte(filepath.Join(t.TempDir(), ".git")+"\n"), 0o600); err != nil {
+		t.Fatalf("forge reciprocal gitdir: %v", err)
+	}
+	if _, err := ResolveGitMetadata(checkout); err == nil {
+		t.Fatal("ResolveGitMetadata accepted forged reciprocal pointer")
+	}
+}
+
+func TestResolveGitMetadataRejectsSymlinkedGitEntry(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	gitEntry := filepath.Join(checkout, ".git")
+	if err := os.Remove(gitEntry); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(t.TempDir(), "forged-git"), gitEntry); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := ResolveGitMetadata(checkout); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadata error = %v, want symlink rejection", err)
+	}
+}
+
+func TestResolveGitMetadataRejectsSymlinkedLinkedWorktreeHead(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	gitDir := runGitMetadata(t, checkout, "rev-parse", "--path-format=absolute", "--git-dir")
+	headPath := filepath.Join(gitDir, "HEAD")
+	headTarget := filepath.Join(t.TempDir(), "HEAD")
+	if err := os.WriteFile(headTarget, []byte("ref: refs/heads/task-branch\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(headPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(headTarget, headPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := ResolveGitMetadata(checkout); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadata error = %v, want symlinked HEAD rejection", err)
+	}
+}
+
+func TestResolveGitMetadataRejectsTraversalCurrentBranchRef(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	gitDir := runGitMetadata(t, checkout, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/../../config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveGitMetadata(checkout); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadata error = %v, want ref traversal rejection", err)
+	}
+}
+
+func TestValidBranchRefRejectsNullByte(t *testing.T) {
+	if ValidBranchRef("refs/heads/main\x00unsafe") {
+		t.Fatal("ValidBranchRef accepted a null byte in the branch ref")
+	}
+}
+
+func TestValidBranchRefRejectsCarriageReturnAndNewline(t *testing.T) {
+	for _, ref := range []string{"refs/heads/main\r", "refs/heads/ma\nin"} {
+		if ValidBranchRef(ref) {
+			t.Fatalf("ValidBranchRef accepted control character ref %q", ref)
+		}
+	}
+}
+
+func TestValidBranchRefRejectsNonCanonicalBranchName(t *testing.T) {
+	// securityutil.IsValidBranchName requires the branch name to start with an
+	// alphanumeric character; a leading dash could otherwise be misread as a
+	// git command-line flag by any future caller that shells out with the ref.
+	if ValidBranchRef("refs/heads/-flag-like") {
+		t.Fatal("ValidBranchRef accepted a branch name starting with a dash")
+	}
+}
+
+func TestResolveGitMetadataForRepositoryRejectsDifferentValidCommonDirectory(t *testing.T) {
+	repositoryA := initGitMetadataRepository(t)
+	repositoryB := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repositoryB, "worktree", "add", "-b", "task-branch", checkout)
+
+	if _, err := ResolveGitMetadataForRepository(checkout, repositoryA); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadataForRepository error = %v, want trusted repository rejection", err)
+	}
+}
+
+func TestResolveGitMetadataForRepositoryRejectsCheckoutEqualToRepository(t *testing.T) {
+	// A task checkout must always be a distinct linked worktree. If a caller
+	// (by bug or forged durable state) passes the trusted repository's own
+	// path as checkoutPath, the self-comparison used to detect "is this a
+	// linked worktree" trivially matches; ResolveGitMetadataForRepository must
+	// still reject it rather than granting the source checkout a projection.
+	repository := initGitMetadataRepository(t)
+
+	if _, err := ResolveGitMetadataForRepository(repository, repository); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadataForRepository error = %v, want rejection of checkoutPath == repositoryPath", err)
+	}
+}
+
+func TestResolveGitMetadataForRepositoryAcceptsTrustedSubmoduleSource(t *testing.T) {
+	source := initGitMetadataRepository(t)
+	superproject := initGitMetadataRepository(t)
+	submodulePath := filepath.Join(superproject, "vendor", "module")
+	runGitMetadata(t, superproject, "-c", "protocol.file.allow=always", "submodule", "add", source, submodulePath)
+	runGitMetadata(t, superproject, "commit", "-m", "add submodule")
+	taskCheckout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, submodulePath, "worktree", "add", "-b", "task-submodule", taskCheckout)
+
+	projection, err := ResolveGitMetadataForRepository(taskCheckout, submodulePath)
+	if err != nil {
+		t.Fatalf("ResolveGitMetadataForRepository for submodule source: %v", err)
+	}
+
+	trustedCommonDir := runGitMetadata(t, submodulePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if projection.CommonDir != trustedCommonDir || projection.TrustedCommonDir != trustedCommonDir {
+		t.Fatalf("trusted common dir = (%q, %q), want %q", projection.CommonDir, projection.TrustedCommonDir, trustedCommonDir)
+	}
+	if projection.CheckoutPath == submodulePath {
+		t.Fatal("submodule task projection must target the task checkout, not the source submodule checkout")
+	}
+}
+
+func TestGitMetadataProjectionRevalidateRejectsCommonDirectorySwap(t *testing.T) {
+	repositoryA := initGitMetadataRepository(t)
+	repositoryB := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repositoryA, "worktree", "add", "-b", "task-branch", checkout)
+	projection, err := ResolveGitMetadataForRepository(checkout, repositoryA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitPointer := filepath.Join(checkout, ".git")
+	replacement := filepath.Join(t.TempDir(), "replacement")
+	runGitMetadata(t, repositoryB, "worktree", "add", "-b", "replacement", replacement)
+	replacementGitDir := runGitMetadata(t, replacement, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err := os.WriteFile(filepath.Join(replacementGitDir, "gitdir"), []byte(gitPointer+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gitPointer, []byte("gitdir: "+replacementGitDir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadFile(gitPointer); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Revalidate(); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("Revalidate error = %v, want common-directory swap rejection", err)
+	}
+}
+
+func TestGitMetadataProjectionPreservesNativeIndexLockAndCommit(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siblingRefPath := filepath.Join(projection.CommonDir, "refs", "heads", "main")
+	siblingReflogPath := filepath.Join(projection.CommonDir, "logs", "refs", "heads", "main")
+	siblingRefBefore, err := os.ReadFile(siblingRefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siblingReflogBefore, err := os.ReadFile(siblingReflogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(projection.GitDir, "index.lock")
+	if err := os.WriteFile(lockPath, []byte("held"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command("git", "-C", checkout, "add", "tracked.txt").CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "index.lock") {
+		t.Fatalf("git add error=%v output=%s, want native index.lock conflict", err, output)
+	}
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, "tracked.txt"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitMetadata(t, checkout, "add", "tracked.txt")
+	refLockPath := projection.CurrentRefPath + ".lock"
+	if err := os.WriteFile(refLockPath, []byte("held"), 0o600); err != nil {
+		t.Fatalf("hold current branch ref lock: %v", err)
+	}
+	output, err = exec.Command("git", "-C", checkout, "commit", "-m", "blocked by ref lock").CombinedOutput()
+	if err == nil || !strings.Contains(string(output), ".lock") {
+		t.Fatalf("git commit error=%v output=%s, want native ref lock conflict", err, output)
+	}
+	if err := os.Remove(refLockPath); err != nil {
+		t.Fatal(err)
+	}
+	runGitMetadata(t, checkout, "commit", "-m", "task change")
+	runGitMetadata(t, checkout, "fsck", "--strict")
+	for path, before := range map[string][]byte{
+		siblingRefPath:    siblingRefBefore,
+		siblingReflogPath: siblingReflogBefore,
+	} {
+		after, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !bytes.Equal(after, before) {
+			t.Fatalf("task commit mutated sibling metadata %q", path)
+		}
+	}
+}
+
+// TestGitMetadataProjectionRepairsReadOnlyExternalIndexLock reproduces the
+// task-sandbox symptom: the checkout itself is writable, but Git cannot create
+// index.lock in the linked worktree metadata. Reapplying the generated owned
+// metadata grant restores ordinary add/commit without changing source or
+// sibling metadata.
+func TestGitMetadataProjectionRepairsReadOnlyExternalIndexLock(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, "tracked.txt"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	gitDirInfo, err := os.Stat(projection.GitDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(projection.GitDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(projection.GitDir, gitDirInfo.Mode().Perm()) })
+	probePath := filepath.Join(projection.GitDir, "permission-probe")
+	if err := os.WriteFile(probePath, []byte("probe"), 0o600); err == nil {
+		_ = os.Remove(probePath)
+		t.Skip("test environment bypasses Git metadata directory permissions")
+	}
+	output, err := exec.Command("git", "-C", checkout, "add", "tracked.txt").CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "index.lock") {
+		t.Fatalf("git add error=%v output=%s, want read-only index.lock failure", err, output)
+	}
+
+	if err := os.Chmod(projection.GitDir, gitDirInfo.Mode().Perm()); err != nil {
+		t.Fatal(err)
+	}
+	runGitMetadata(t, checkout, "add", "tracked.txt")
+	runGitMetadata(t, checkout, "commit", "-m", "task change")
+	runGitMetadata(t, checkout, "fsck", "--strict")
+}
+
+func TestGitMetadataProjectionSeparatesExactRefWritesFromMountSupport(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, exactPath := range []string{
+		projection.CurrentRefPath,
+		projection.CurrentRefPath + ".lock",
+		projection.ReflogPath,
+		projection.ReflogPath + ".lock",
+	} {
+		if !containsGitMetadataPath(projection.AgentWritablePaths, exactPath) {
+			t.Fatalf("AgentWritablePaths = %#v, missing exact Git update path %q", projection.AgentWritablePaths, exactPath)
+		}
+	}
+	for _, parent := range []string{
+		filepath.Dir(projection.CurrentRefPath),
+		filepath.Dir(projection.ReflogPath),
+	} {
+		if containsGitMetadataPath(projection.AgentWritablePaths, parent) {
+			t.Fatalf("AgentWritablePaths = %#v, grants sibling mutation through parent %q", projection.AgentWritablePaths, parent)
+		}
+		if !containsGitMetadataPath(projection.MountSupportPaths, parent) {
+			t.Fatalf("MountSupportPaths = %#v, missing native lock parent %q", projection.MountSupportPaths, parent)
+		}
+	}
+}
+
+func TestGitMetadataProjectionRejectsSymlinkedObjectsDirectory(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	commonDir := runGitMetadata(t, repo, "rev-parse", "--path-format=absolute", "--git-dir")
+
+	realObjects := filepath.Join(commonDir, "objects")
+	forgedTarget := t.TempDir()
+	if err := os.Rename(realObjects, forgedTarget+"-moved"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(forgedTarget+"-moved", realObjects); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := ResolveGitMetadata(checkout); !errors.Is(err, ErrGitMetadataProjectionInvalid) {
+		t.Fatalf("ResolveGitMetadata error = %v, want symlinked objects directory rejection", err)
+	}
+}
+
+func TestGitMetadataProjectionUsesExactPathsForPotentialReflogCreation(t *testing.T) {
+	repo := initGitMetadataRepository(t)
+	runGitMetadata(t, repo, "config", "core.logAllRefUpdates", "false")
+	checkout := filepath.Join(t.TempDir(), "task-checkout")
+	runGitMetadata(t, repo, "worktree", "add", "-b", "task-branch", checkout)
+	commonDir := runGitMetadata(t, repo, "rev-parse", "--path-format=absolute", "--git-dir")
+	reflogPath := filepath.Join(commonDir, "logs", "refs", "heads", "task-branch")
+	if _, err := os.Stat(reflogPath); err == nil {
+		t.Fatalf("test setup: reflog unexpectedly exists at %q", reflogPath)
+	}
+
+	projection, err := ResolveGitMetadata(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsGitMetadataPath(projection.AgentWritablePaths, projection.ReflogPath) {
+		t.Fatalf("AgentWritablePaths must authorize only the potential reflog file: %#v", projection.AgentWritablePaths)
+	}
+	if !containsGitMetadataPath(projection.AgentWritablePaths, projection.ReflogPath+".lock") {
+		t.Fatalf("AgentWritablePaths must authorize only the potential reflog lock: %#v", projection.AgentWritablePaths)
+	}
+	if containsGitMetadataPath(projection.AgentWritablePaths, filepath.Dir(projection.ReflogPath)) {
+		t.Fatalf("AgentWritablePaths must not authorize sibling reflogs through their parent: %#v", projection.AgentWritablePaths)
+	}
+}
+
+func TestGitMetadataProjectionSupportsMultipleTaskRepositories(t *testing.T) {
+	repoA := initGitMetadataRepository(t)
+	repoB := initGitMetadataRepository(t)
+	checkoutA := filepath.Join(t.TempDir(), "primary")
+	checkoutB := filepath.Join(t.TempDir(), "attached")
+	runGitMetadata(t, repoA, "worktree", "add", "-b", "task-a", checkoutA)
+	runGitMetadata(t, repoB, "worktree", "add", "-b", "task-b", checkoutB)
+
+	projectionA, err := ResolveGitMetadata(checkoutA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionB, err := ResolveGitMetadata(checkoutB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projectionA.GitDir == projectionB.GitDir || projectionA.CommonDir == projectionB.CommonDir {
+		t.Fatalf("multi-repository projections overlap: %#v %#v", projectionA, projectionB)
+	}
+	for _, checkout := range []string{checkoutA, checkoutB} {
+		if err := os.WriteFile(filepath.Join(checkout, "tracked.txt"), []byte("changed\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runGitMetadata(t, checkout, "add", "tracked.txt")
+		runGitMetadata(t, checkout, "commit", "-m", "task change")
+		runGitMetadata(t, checkout, "fsck", "--strict")
+	}
+}
+
+func initGitMetadataRepository(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGitMetadata(t, "", "init", "-b", "main", repo)
+	runGitMetadata(t, repo, "config", "user.email", "test@example.com")
+	runGitMetadata(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("initial\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	runGitMetadata(t, repo, "add", "tracked.txt")
+	runGitMetadata(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+func runGitMetadata(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	cmdArgs := args
+	if directory != "" {
+		cmdArgs = append([]string{"-C", directory}, args...)
+	}
+	output, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", cmdArgs, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func containsGitMetadataPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Provides the validated, task-scoped Git metadata projection resolver required to safely describe linked-worktree state without granting the common Git directory. This is the first bounded successor to umbrella #3242; C2 will consume it for lifecycle installation only after this PR merges.

## Important Changes

- Adds a hardened resolver for regular and linked checkouts, reciprocal pointers, current refs, and projection freshness.
- Keeps the projection inert: this PR installs no sandbox policy, executor mount, or source-checkout permission.
- Covers malformed metadata and native Git lock behavior.

## Validation

- `go test ./internal/worktree -count=1`
- `go test -race ./internal/worktree -count=1`
- Normal commit hooks: changed-code Go lint, gofmt, architecture checks, and Conventional Commits validation.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-3496-bwo7.sprites.app |
| **Commit** | `5504448` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->