### PR TITLE
fix(web): retain eligible providers during refresh

### DIFF
--- a/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
@@ -33,6 +33,7 @@ import { useRemoteRepositories } from "./use-remote-repositories";
 import { pluginRegistry } from "@/lib/plugins/registry";
 
 const WORKSPACE_ID = "workspace-1";
+const NEXT_WORKSPACE_ID = "workspace-2";
 const PLUGIN_ID = "test-bitbucket-provider";
 const GITLAB_UNAVAILABLE = "GitLab unavailable";
 
@@ -83,6 +84,14 @@ function expectWorkspaceScopedGitHubRequest() {
     limit: 100,
   });
 }
+
+const githubRepo = (name: string) => ({
+  owner: "acme",
+  name,
+  full_name: `acme/${name}`,
+  default_branch: "main",
+  private: false,
+});
 
 describe("useRemoteRepositories registered providers", () => {
   it("isolates a provider URL matcher failure", async () => {
@@ -412,7 +421,7 @@ describe("useRemoteRepositories provider eligibility changes", () => {
     expect(result.current.repos[0]?.provider).toBe("github");
     expect(mocks.listUserProjects).not.toHaveBeenCalled();
 
-    rerender({ workspaceId: "workspace-2" });
+    rerender({ workspaceId: NEXT_WORKSPACE_ID });
 
     await waitFor(() => expect(result.current.repos[0]?.provider).toBe("gitlab"));
     expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1);
@@ -458,6 +467,7 @@ describe("useRemoteRepositories provider refreshes", () => {
 
     await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
     expect(result.current.availableProviders).toEqual(["github"]);
+    expect(result.current.repos).toEqual([]);
 
     act(() => resolveRefresh?.([]));
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -535,7 +545,7 @@ describe("useRemoteRepositories workspace scope", () => {
     );
     await waitFor(() => expect(result.current.repos).toHaveLength(1));
 
-    rerender({ workspaceId: "workspace-2" });
+    rerender({ workspaceId: NEXT_WORKSPACE_ID });
     await waitFor(() => expect(result.current.loading).toBe(true));
     expect(result.current.repos).toEqual([]);
 
@@ -556,35 +566,35 @@ describe("useRemoteRepositories workspace scope", () => {
     );
 
     await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1));
-    rerender({ workspaceId: "workspace-2" });
+    rerender({ workspaceId: NEXT_WORKSPACE_ID });
     await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
 
-    await act(async () => {
-      resolveFirst?.([
-        {
-          owner: "acme",
-          name: "stale",
-          full_name: "acme/stale",
-          default_branch: "main",
-          private: false,
-        },
-      ]);
-    });
+    await act(async () => resolveFirst?.([githubRepo("stale")]));
     expect(result.current.repos).toEqual([]);
 
-    await act(async () => {
-      resolveSecond?.([
-        {
-          owner: "acme",
-          name: "current",
-          full_name: "acme/current",
-          default_branch: "main",
-          private: false,
-        },
-      ]);
-    });
+    await act(async () => resolveSecond?.([githubRepo("current")]));
     await waitFor(() =>
       expect(result.current.repos.map((repo) => repo.fullName)).toEqual(["acme/current"]),
     );
+  });
+
+  it("ignores a result resolved before the next workspace request starts", async () => {
+    setBuiltInAvailability({ gitlab: false, azureDevOps: false });
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    mocks.fetchAccessibleRepos
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const { result, rerender } = renderHook(
+      ({ workspaceId }) => useRemoteRepositories(workspaceId),
+      { initialProps: { workspaceId: WORKSPACE_ID } },
+    );
+
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resolveFirst?.([githubRepo("stale")]);
+      rerender({ workspaceId: NEXT_WORKSPACE_ID });
+    });
+    expect(result.current.repos).toEqual([]);
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
@@ -438,6 +438,28 @@ describe("useRemoteRepositories provider eligibility changes", () => {
     expect(mocks.listAzureDevOpsProjects).toHaveBeenCalledTimes(1);
     expect(result.current.availableProviders).toEqual(["github"]);
   });
+
+  it("keeps currently eligible providers available while a refresh is loading", async () => {
+    mocks.fetchAccessibleRepos.mockResolvedValue([]);
+    mocks.listUserProjects.mockResolvedValue({ projects: [] });
+    mocks.listAzureDevOpsProjects.mockResolvedValue({ projects: [] });
+    const { result } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    let resolveRefresh: ((repos: never[]) => void) | undefined;
+    mocks.fetchAccessibleRepos.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRefresh = resolve)),
+    );
+    setBuiltInAvailability({ azureDevOps: false, gitlab: false });
+
+    act(() => result.current.refresh?.());
+
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
+    expect(result.current.availableProviders).toEqual(["github"]);
+
+    act(() => resolveRefresh?.([]));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
 });
 
 describe("useRemoteRepositories workspace scope", () => {
@@ -492,5 +514,50 @@ describe("useRemoteRepositories workspace scope", () => {
 
     act(() => resolveNext?.({ projects: [] }));
     await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it("does not publish a stale repository result after a workspace change", async () => {
+    setBuiltInAvailability({ gitlab: false, azureDevOps: false });
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    let resolveSecond: ((value: unknown) => void) | undefined;
+    mocks.fetchAccessibleRepos
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
+    const { result, rerender } = renderHook(
+      ({ workspaceId }) => useRemoteRepositories(workspaceId),
+      { initialProps: { workspaceId: WORKSPACE_ID } },
+    );
+
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1));
+    rerender({ workspaceId: "workspace-2" });
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveFirst?.([
+        {
+          owner: "acme",
+          name: "stale",
+          full_name: "acme/stale",
+          default_branch: "main",
+          private: false,
+        },
+      ]);
+    });
+    expect(result.current.repos).toEqual([]);
+
+    await act(async () => {
+      resolveSecond?.([
+        {
+          owner: "acme",
+          name: "current",
+          full_name: "acme/current",
+          default_branch: "main",
+          private: false,
+        },
+      ]);
+    });
+    await waitFor(() =>
+      expect(result.current.repos.map((repo) => repo.fullName)).toEqual(["acme/current"]),
+    );
   });
 });

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.test.tsx
@@ -418,7 +418,9 @@ describe("useRemoteRepositories provider eligibility changes", () => {
     expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(1);
     expect(mocks.listUserProjects).toHaveBeenCalledTimes(1);
   });
+});
 
+describe("useRemoteRepositories provider refreshes", () => {
   it("re-evaluates provider eligibility before a manual refresh", async () => {
     mocks.fetchAccessibleRepos.mockResolvedValue([]);
     mocks.listUserProjects.mockResolvedValue({ projects: [] });
@@ -458,6 +460,31 @@ describe("useRemoteRepositories provider eligibility changes", () => {
     expect(result.current.availableProviders).toEqual(["github"]);
 
     act(() => resolveRefresh?.([]));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it("clears a provider error while its refresh retry is loading", async () => {
+    setBuiltInAvailability({ gitlab: false, azureDevOps: false });
+    mocks.fetchAccessibleRepos.mockRejectedValueOnce(new Error("GitHub unavailable"));
+    const { result } = renderHook(() => useRemoteRepositories(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sourceErrors).toEqual([
+      { provider: "github", error: new Error("GitHub unavailable") },
+    ]);
+
+    let resolveRetry: ((repos: never[]) => void) | undefined;
+    mocks.fetchAccessibleRepos.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRetry = resolve)),
+    );
+
+    act(() => result.current.refresh?.());
+
+    await waitFor(() => expect(mocks.fetchAccessibleRepos).toHaveBeenCalledTimes(2));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.sourceErrors).toEqual([]);
+
+    act(() => resolveRetry?.([]));
     await waitFor(() => expect(result.current.loading).toBe(false));
   });
 });

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.ts
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.ts
@@ -317,9 +317,7 @@ function useBuiltInRepositorySource(
     setAvailableProviders((current) =>
       sameWorkspace ? current.filter((provider) => eligibility.providers.has(provider)) : [],
     );
-    setSourceErrors((current) =>
-      sameWorkspace ? current.filter(({ provider }) => eligibility.providers.has(provider)) : [],
-    );
+    setSourceErrors([]);
     setLoading(true);
     if (eligibility.loading) {
       return () => {

--- a/apps/web/hooks/domains/integrations/use-remote-repositories.ts
+++ b/apps/web/hooks/domains/integrations/use-remote-repositories.ts
@@ -307,12 +307,19 @@ function useBuiltInRepositorySource(
   const [loading, setLoading] = useState(true);
   const [sourceErrors, setSourceErrors] = useState<RemoteRepositorySourceError[]>([]);
   const [availableProviders, setAvailableProviders] = useState<RemoteRepositoryProvider[]>([]);
+  const workspaceRef = useRef(workspaceId);
 
   useEffect(() => {
     let cancelled = false;
+    const sameWorkspace = workspaceRef.current === workspaceId;
+    workspaceRef.current = workspaceId;
     setRepos([]);
-    setAvailableProviders([]);
-    setSourceErrors([]);
+    setAvailableProviders((current) =>
+      sameWorkspace ? current.filter((provider) => eligibility.providers.has(provider)) : [],
+    );
+    setSourceErrors((current) =>
+      sameWorkspace ? current.filter(({ provider }) => eligibility.providers.has(provider)) : [],
+    );
     setLoading(true);
     if (eligibility.loading) {
       return () => {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3498/b17dc78c56de.html)
<!-- kandev-pr-walkthrough-end -->

Repository-provider refreshes no longer briefly hide still-eligible providers while their latest results load. The hook also now proves that a stale response from a prior workspace cannot publish.

## Validation

- `pnpm --filter @kandev/web test -- --run hooks/domains/integrations/use-remote-repositories.test.tsx`
- `pnpm --filter @kandev/web lint -- hooks/domains/integrations/use-remote-repositories.ts hooks/domains/integrations/use-remote-repositories.test.tsx`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web test` (1,883 files passed; 3 unrelated HTTP Git fixture failures because guarded Docker blocks the required bridge-gateway probe)

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop remote picker with an unconfigured provider hidden](https://raw.githubusercontent.com/yattdev/kandev/fff9198aeddaf3a8a73dd3415d56ffc954ccc4a7/create-task-remote-repo--remote-repository-picker-desktop.png)

![Mobile remote picker with an unconfigured provider hidden](https://raw.githubusercontent.com/yattdev/kandev/fff9198aeddaf3a8a73dd3415d56ffc954ccc4a7/mobile-create-task-remote-repo--remote-repository-picker-mobile.png)
<!-- kandev-screenshots-end -->
