### PR TITLE
test(workspace): cover retained source cleanup across sequential sessions

### DIFF
--- a/apps/web/e2e/tests/session/executor-reuse.spec.ts
+++ b/apps/web/e2e/tests/session/executor-reuse.spec.ts
@@ -49,6 +49,11 @@ test.describe("Executor reuse", () => {
     expect(env!.status).toBe("ready");
     // executor_type should be present (standalone for mock agent)
     expect(env!.executor_type).toBeDefined();
+
+    // Keep cleanup and verification in one attempt so a retry cannot recreate
+    // the worker-scoped seed checkout and mask a cleanup regression.
+    await apiClient.e2eReset(seedData.workspaceId, [seedData.workflowId]);
+    expect(existsSync(seedData.repositoryPath)).toBe(true);
   });
 
   test("second session reuses same task environment by default", async ({
@@ -57,11 +62,6 @@ test.describe("Executor reuse", () => {
     seedData,
   }) => {
     test.setTimeout(120_000);
-
-    // The suite seed is shared by this worker and must outlive the previous
-    // test's task cleanup. Reuse validation deliberately fails closed when it
-    // does not.
-    expect(existsSync(seedData.repositoryPath)).toBe(true);
 
     // 1. Create task with first session
     const task = await apiClient.createTaskWithAgent(

--- a/apps/web/e2e/tests/session/executor-reuse.spec.ts
+++ b/apps/web/e2e/tests/session/executor-reuse.spec.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { test, expect } from "../../fixtures/test-base";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
@@ -56,6 +57,11 @@ test.describe("Executor reuse", () => {
     seedData,
   }) => {
     test.setTimeout(120_000);
+
+    // The suite seed is shared by this worker and must outlive the previous
+    // test's task cleanup. Reuse validation deliberately fails closed when it
+    // does not.
+    expect(existsSync(seedData.repositoryPath)).toBe(true);
 
     // 1. Create task with first session
     const task = await apiClient.createTaskWithAgent(


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3501/97d9807121bc.html)
<!-- kandev-pr-walkthrough-end -->

Adds the missing sequential retained-workspace E2E regression on current main. The production empty-ID cleanup guard is already present on main; this follow-up preserves source-cleanup behavior with regression coverage. The test creates the task, invokes reset/cleanup, and asserts the retained source checkout within the same Playwright attempt, so retries cannot pass using a fresh worker-scoped fixture.

Validation at exact head `97d9807121bcd6f05b8021043734579daf3eba41`: the focused retained-workspace Playwright regression passed 3/3 with `--retries=2`; focused worktree and task-service Go suites passed. Independent Review passed in gpt-5.5 session `0ffe792a-9221-41af-bb1d-e84d151d101f`; distinct QA passed in gpt-5.6-sol session `00c43643-4228-4231-b95c-849d7159acf8`. No visual product changes or screenshots are required.

Source head: `97d9807121bcd6f05b8021043734579daf3eba41` on `yattdev:delivery/reuse-workspace-source-cleanup-c69`. Historical task branch and both backup refs remain preserved; no history rewrite. Coordinator task: `957da1cb-063b-4c2e-b406-6d04ad158fb9`.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->