### PR TITLE
fix(backend): stop routine tasks from getting office skills they can't run

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/skill/deployer.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/deployer.go
@@ -85,6 +85,11 @@ type Request struct {
 	ExecutorType  string
 	WorkspaceID   string
 	SessionID     string
+	// OfficeRuntime reports whether the finalized launch env carries the
+	// Office runtime variables (KANDEV_CLI, KANDEV_API_KEY, ...) that
+	// bundled system skills depend on. When false, system skills are
+	// omitted from the manifest — see appendSkills.
+	OfficeRuntime bool
 }
 
 // Deploy materialises the profile's skills and instructions into the
@@ -95,7 +100,7 @@ func (d *Deployer) Deploy(ctx context.Context, req Request) (DeployResult, error
 	if req.Profile == nil {
 		return DeployResult{}, errors.New("skill deploy: profile is required")
 	}
-	manifest := d.buildManifest(ctx, req.Profile, d.workspaceSlugFn(req.WorkspaceID))
+	manifest := d.buildManifest(ctx, req.Profile, d.workspaceSlugFn(req.WorkspaceID), req.OfficeRuntime)
 	result := d.deliver(ctx, manifest, req.ExecutorType, req.WorkspacePath)
 	return result, nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/skill/deployer.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/deployer.go
@@ -85,10 +85,10 @@ type Request struct {
 	ExecutorType  string
 	WorkspaceID   string
 	SessionID     string
-	// OfficeRuntime reports whether the finalized launch env carries the
-	// Office runtime variables (KANDEV_CLI, KANDEV_API_KEY, ...) that
-	// bundled system skills depend on. When false, system skills are
-	// omitted from the manifest — see appendSkills.
+	// OfficeRuntime reports whether backend selected Office mode and the
+	// finalized launch env contains a non-empty KANDEV_CLI. Office launch
+	// validation checks the remaining runtime variables before this hook runs.
+	// When false, system skills are omitted from the manifest. See appendSkills.
 	OfficeRuntime bool
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/skill/deployer_officeruntime_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/deployer_officeruntime_test.go
@@ -1,0 +1,102 @@
+package skill_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle/skill"
+	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
+	"github.com/kandev/kandev/internal/office/configloader"
+)
+
+// TestDeploy_OfficeRuntimeGatesSystemSkills is the regression test for
+// the heavy-routine defect: a launch whose finalized env carries none
+// of the Office runtime variables (KANDEV_CLI, KANDEV_API_KEY, ...)
+// must not receive bundled system (Office) skills, since every one of
+// their instructions depends on those variables. A launch that does
+// have Office runtime env (the office scheduler path) keeps receiving
+// them. A user-authored (non-system) skill lands either way.
+func TestDeploy_OfficeRuntimeGatesSystemSkills(t *testing.T) {
+	slugs, err := configloader.BundledSkillSlugs()
+	if err != nil || len(slugs) == 0 {
+		t.Fatalf("BundledSkillSlugs: %v (len=%d)", err, len(slugs))
+	}
+
+	skills := make(map[string]*skill.Skill, len(slugs)+1)
+	skillIDs := make([]string, 0, len(slugs)+1)
+	for _, slug := range slugs {
+		content, err := configloader.BundledSkillContent(slug)
+		if err != nil {
+			t.Fatalf("BundledSkillContent(%s): %v", slug, err)
+		}
+		skills[slug] = &skill.Skill{Slug: slug, Content: string(content), IsSystem: true}
+		skillIDs = append(skillIDs, slug)
+	}
+	// Control: a user-authored skill must land regardless of OfficeRuntime.
+	skills["sk-user"] = &skill.Skill{Slug: "sk-user", Content: "# user skill"}
+	skillIDs = append(skillIDs, "sk-user")
+
+	skillIDsJSON, err := json.Marshal(skillIDs)
+	if err != nil {
+		t.Fatalf("marshal skill ids: %v", err)
+	}
+	reader := &fakeSkillReader{skills: skills}
+
+	deployedDirs := func(t *testing.T, officeRuntime bool) map[string]bool {
+		t.Helper()
+		base := t.TempDir()
+		worktree := t.TempDir()
+		d := newDeployer(t, base, reader, &fakeInstructionLister{})
+		if _, err := d.Deploy(context.Background(), skill.Request{
+			Profile: &settingsmodels.AgentProfile{
+				ID:       "routine-agent",
+				SkillIDs: string(skillIDsJSON),
+			},
+			ExecutorType:  "worktree",
+			WorkspacePath: worktree,
+			OfficeRuntime: officeRuntime,
+		}); err != nil {
+			t.Fatalf("Deploy: %v", err)
+		}
+		root := filepath.Join(worktree, skill.DefaultProjectSkillDir)
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return map[string]bool{}
+			}
+			t.Fatalf("ReadDir: %v", err)
+		}
+		got := make(map[string]bool, len(entries))
+		for _, e := range entries {
+			got[e.Name()] = true
+		}
+		return got
+	}
+
+	t.Run("no office runtime env: zero system skills land", func(t *testing.T) {
+		got := deployedDirs(t, false)
+		for _, s := range slugs {
+			if got[skill.DirName(s)] {
+				t.Errorf("system skill %q should not be deployed without office runtime env", s)
+			}
+		}
+		if !got[skill.DirName("sk-user")] {
+			t.Errorf("user skill should still be deployed without office runtime env")
+		}
+	})
+
+	t.Run("office runtime env present: all skills land", func(t *testing.T) {
+		got := deployedDirs(t, true)
+		for _, s := range slugs {
+			if !got[skill.DirName(s)] {
+				t.Errorf("system skill %q should be deployed with office runtime env", s)
+			}
+		}
+		if !got[skill.DirName("sk-user")] {
+			t.Errorf("user skill should be deployed with office runtime env")
+		}
+	})
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/skill/manifest.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/manifest.go
@@ -18,7 +18,7 @@ import (
 // SkillIDs (the new merged column) and DesiredSkills (legacy office
 // column) and union the two into a single list of slugs / IDs. Empty
 // slots are dropped before lookup.
-func (d *Deployer) buildManifest(ctx context.Context, profile *settingsmodels.AgentProfile, workspaceSlug string) *Manifest {
+func (d *Deployer) buildManifest(ctx context.Context, profile *settingsmodels.AgentProfile, workspaceSlug string, officeRuntime bool) *Manifest {
 	// Profile.AgentID IS the agent type ID after ADR 0005 — the
 	// agent_profiles row's agent_id column points at the agents
 	// table (claude-acp, codex-acp, ...). No extra resolver needed.
@@ -29,15 +29,18 @@ func (d *Deployer) buildManifest(ctx context.Context, profile *settingsmodels.Ag
 		AgentID:         profile.ID,
 		ProjectSkillDir: d.resolveProjectSkillDir(agentTypeID),
 	}
-	d.appendSkills(ctx, manifest, profile)
+	d.appendSkills(ctx, manifest, profile, officeRuntime)
 	d.appendInstructions(ctx, manifest, profile.ID)
 	return manifest
 }
 
 // appendSkills resolves every desired slug / id on the profile to a
 // runtime Skill record. Lookups that fail are logged at debug level
-// and dropped — a missing skill must never abort a launch.
-func (d *Deployer) appendSkills(ctx context.Context, manifest *Manifest, profile *settingsmodels.AgentProfile) {
+// and dropped — a missing skill must never abort a launch. System
+// skills (bundled Office protocol/task-ops skills) are skipped unless
+// officeRuntime is true: their instructions depend on Office runtime
+// env that only the office scheduler launch path provides.
+func (d *Deployer) appendSkills(ctx context.Context, manifest *Manifest, profile *settingsmodels.AgentProfile, officeRuntime bool) {
 	if d.skillReader == nil {
 		return
 	}
@@ -46,6 +49,11 @@ func (d *Deployer) appendSkills(ctx context.Context, manifest *Manifest, profile
 		if err != nil || skill == nil {
 			d.logger.Debug("skip skill in manifest",
 				zap.String("key", key), zap.Error(err))
+			continue
+		}
+		if skill.IsSystem && !officeRuntime {
+			d.logger.Debug("skip system skill: no office runtime env",
+				zap.String("key", key))
 			continue
 		}
 		manifest.Skills = append(manifest.Skills, *skill)

--- a/apps/backend/internal/agent/runtime/lifecycle/skill/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/types.go
@@ -28,9 +28,8 @@ type Skill struct {
 	// deployer.
 	SourceType string
 	// IsSystem marks a bundled Office skill (e.g. kandev-protocol,
-	// kandev-task-ops) rather than a user-authored one. System skills
-	// depend on Office runtime env (KANDEV_CLI, KANDEV_API_KEY, ...)
-	// that only the office scheduler launch path provides.
+	// kandev-task-ops) rather than a user-authored one. The deployer
+	// includes system skills only when the launch has Office runtime support.
 	IsSystem bool
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/skill/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill/types.go
@@ -27,6 +27,11 @@ type Skill struct {
 	// resolved upstream by the SkillReader before reaching the
 	// deployer.
 	SourceType string
+	// IsSystem marks a bundled Office skill (e.g. kandev-protocol,
+	// kandev-task-ops) rather than a user-authored one. System skills
+	// depend on Office runtime env (KANDEV_CLI, KANDEV_API_KEY, ...)
+	// that only the office scheduler launch path provides.
+	IsSystem bool
 }
 
 // SkillFile is a supporting file inside a skill package. Paths are

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deploy.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deploy.go
@@ -44,6 +44,7 @@ func (m *Manager) runSkillDeploy(ctx context.Context, original, prepared *Launch
 		ExecutorType:  prepared.ExecutorType,
 		WorkspaceID:   profile.WorkspaceID,
 		SessionID:     original.SessionID,
+		OfficeRuntime: prepared.Env["KANDEV_CLI"] != "",
 	}
 	result, err := m.skillDeployer.DeploySkills(ctx, req)
 	if err != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deploy.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deploy.go
@@ -2,8 +2,11 @@ package lifecycle
 
 import (
 	"context"
+	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/mcpmode"
 )
 
 // MetadataKeyInstructionsDir carries the per-launch path where the
@@ -44,7 +47,7 @@ func (m *Manager) runSkillDeploy(ctx context.Context, original, prepared *Launch
 		ExecutorType:  prepared.ExecutorType,
 		WorkspaceID:   profile.WorkspaceID,
 		SessionID:     original.SessionID,
-		OfficeRuntime: prepared.Env["KANDEV_CLI"] != "",
+		OfficeRuntime: prepared.McpMode == mcpmode.Office && strings.TrimSpace(prepared.Env["KANDEV_CLI"]) != "",
 	}
 	result, err := m.skillDeployer.DeploySkills(ctx, req)
 	if err != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deploy_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deploy_test.go
@@ -8,6 +8,7 @@ import (
 
 	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/common/mcpmode"
 )
 
 // fakeProfileReader returns a canned profile (or error) so we can drive the
@@ -173,48 +174,62 @@ func TestRunSkillDeploy_MergesMetadataOnPreparedRequest(t *testing.T) {
 	}
 }
 
-// TestRunSkillDeploy_OfficeRuntimeFromEnv verifies OfficeRuntime is derived
-// from the presence of KANDEV_CLI in the prepared (finalized) launch env —
-// present for an office scheduler launch, absent for a kanban launch (e.g.
-// a heavy-routine task), which is the signal system skills gate on.
-func TestRunSkillDeploy_OfficeRuntimeFromEnv(t *testing.T) {
+// TestRunSkillDeploy_OfficeRuntimeRequiresOfficeMode verifies that system
+// skills are enabled only for an Office-mode launch with a usable CLI path.
+func TestRunSkillDeploy_OfficeRuntimeRequiresOfficeMode(t *testing.T) {
 	rich := &settingsmodels.AgentProfile{ID: "p1", AgentID: "a1", SkillIDs: `["sk-foo"]`}
 
-	t.Run("KANDEV_CLI absent", func(t *testing.T) {
-		mgr := newSkillDeployTestManager(t)
-		rec := &recordingDeployer{}
-		mgr.skillDeployer = rec
-		mgr.agentProfileReader = &fakeProfileReader{profile: rich}
+	tests := []struct {
+		name string
+		mode string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "Office mode with CLI",
+			mode: mcpmode.Office,
+			env:  map[string]string{"KANDEV_CLI": "/usr/local/bin/agentctl"},
+			want: true,
+		},
+		{
+			name: "task mode with CLI",
+			mode: mcpmode.Task,
+			env:  map[string]string{"KANDEV_CLI": "/usr/local/bin/agentctl"},
+			want: false,
+		},
+		{
+			name: "Office mode with whitespace CLI",
+			mode: mcpmode.Office,
+			env:  map[string]string{"KANDEV_CLI": "   "},
+			want: false,
+		},
+		{
+			name: "Office mode without CLI",
+			mode: mcpmode.Office,
+			env:  map[string]string{"GITLAB_TOKEN": "x"},
+			want: false,
+		},
+	}
 
-		mgr.runSkillDeploy(context.Background(),
-			&LaunchRequest{AgentProfileID: "p1"},
-			&LaunchRequest{WorkspacePath: "/tmp/ws", Env: map[string]string{"GITLAB_TOKEN": "x"}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := newSkillDeployTestManager(t)
+			rec := &recordingDeployer{}
+			mgr.skillDeployer = rec
+			mgr.agentProfileReader = &fakeProfileReader{profile: rich}
 
-		if rec.called.Load() != 1 {
-			t.Fatalf("expected deployer once, got %d", rec.called.Load())
-		}
-		if rec.last.OfficeRuntime {
-			t.Errorf("OfficeRuntime should be false without KANDEV_CLI in env")
-		}
-	})
+			mgr.runSkillDeploy(context.Background(),
+				&LaunchRequest{AgentProfileID: "p1"},
+				&LaunchRequest{WorkspacePath: "/tmp/ws", Env: tt.env, McpMode: tt.mode})
 
-	t.Run("KANDEV_CLI present", func(t *testing.T) {
-		mgr := newSkillDeployTestManager(t)
-		rec := &recordingDeployer{}
-		mgr.skillDeployer = rec
-		mgr.agentProfileReader = &fakeProfileReader{profile: rich}
-
-		mgr.runSkillDeploy(context.Background(),
-			&LaunchRequest{AgentProfileID: "p1"},
-			&LaunchRequest{WorkspacePath: "/tmp/ws", Env: map[string]string{"KANDEV_CLI": "/usr/local/bin/agentctl"}})
-
-		if rec.called.Load() != 1 {
-			t.Fatalf("expected deployer once, got %d", rec.called.Load())
-		}
-		if !rec.last.OfficeRuntime {
-			t.Errorf("OfficeRuntime should be true with KANDEV_CLI in env")
-		}
-	})
+			if rec.called.Load() != 1 {
+				t.Fatalf("expected deployer once, got %d", rec.called.Load())
+			}
+			if rec.last.OfficeRuntime != tt.want {
+				t.Errorf("OfficeRuntime = %t, want %t", rec.last.OfficeRuntime, tt.want)
+			}
+		})
+	}
 }
 
 // TestRunSkillDeploy_NoProfileID verifies that a launch without a profile id

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deploy_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deploy_test.go
@@ -173,6 +173,50 @@ func TestRunSkillDeploy_MergesMetadataOnPreparedRequest(t *testing.T) {
 	}
 }
 
+// TestRunSkillDeploy_OfficeRuntimeFromEnv verifies OfficeRuntime is derived
+// from the presence of KANDEV_CLI in the prepared (finalized) launch env —
+// present for an office scheduler launch, absent for a kanban launch (e.g.
+// a heavy-routine task), which is the signal system skills gate on.
+func TestRunSkillDeploy_OfficeRuntimeFromEnv(t *testing.T) {
+	rich := &settingsmodels.AgentProfile{ID: "p1", AgentID: "a1", SkillIDs: `["sk-foo"]`}
+
+	t.Run("KANDEV_CLI absent", func(t *testing.T) {
+		mgr := newSkillDeployTestManager(t)
+		rec := &recordingDeployer{}
+		mgr.skillDeployer = rec
+		mgr.agentProfileReader = &fakeProfileReader{profile: rich}
+
+		mgr.runSkillDeploy(context.Background(),
+			&LaunchRequest{AgentProfileID: "p1"},
+			&LaunchRequest{WorkspacePath: "/tmp/ws", Env: map[string]string{"GITLAB_TOKEN": "x"}})
+
+		if rec.called.Load() != 1 {
+			t.Fatalf("expected deployer once, got %d", rec.called.Load())
+		}
+		if rec.last.OfficeRuntime {
+			t.Errorf("OfficeRuntime should be false without KANDEV_CLI in env")
+		}
+	})
+
+	t.Run("KANDEV_CLI present", func(t *testing.T) {
+		mgr := newSkillDeployTestManager(t)
+		rec := &recordingDeployer{}
+		mgr.skillDeployer = rec
+		mgr.agentProfileReader = &fakeProfileReader{profile: rich}
+
+		mgr.runSkillDeploy(context.Background(),
+			&LaunchRequest{AgentProfileID: "p1"},
+			&LaunchRequest{WorkspacePath: "/tmp/ws", Env: map[string]string{"KANDEV_CLI": "/usr/local/bin/agentctl"}})
+
+		if rec.called.Load() != 1 {
+			t.Fatalf("expected deployer once, got %d", rec.called.Load())
+		}
+		if !rec.last.OfficeRuntime {
+			t.Errorf("OfficeRuntime should be true with KANDEV_CLI in env")
+		}
+	})
+}
+
 // TestRunSkillDeploy_NoProfileID verifies that a launch without a profile id
 // (legacy / pass-through executions) short-circuits.
 func TestRunSkillDeploy_NoProfileID(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deployer.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deployer.go
@@ -32,6 +32,10 @@ type SkillDeployRequest struct {
 	ExecutorType  string
 	WorkspaceID   string
 	SessionID     string
+	// OfficeRuntime reports whether the finalized launch env carries the
+	// Office runtime variables (KANDEV_CLI, KANDEV_API_KEY, ...) that
+	// bundled system skills depend on.
+	OfficeRuntime bool
 }
 
 // SkillDeployResult carries the side-effects a successful deploy produced

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deployer.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deployer.go
@@ -32,9 +32,9 @@ type SkillDeployRequest struct {
 	ExecutorType  string
 	WorkspaceID   string
 	SessionID     string
-	// OfficeRuntime reports whether the finalized launch env carries the
-	// Office runtime variables (KANDEV_CLI, KANDEV_API_KEY, ...) that
-	// bundled system skills depend on.
+	// OfficeRuntime reports whether backend selected Office mode and the
+	// finalized launch env contains a non-empty KANDEV_CLI. Office launch
+	// validation checks the remaining runtime variables before this hook runs.
 	OfficeRuntime bool
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deployer_adapter.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deployer_adapter.go
@@ -40,6 +40,7 @@ func (a *skillDeployerAdapter) DeploySkills(ctx context.Context, req SkillDeploy
 		ExecutorType:  req.ExecutorType,
 		WorkspaceID:   req.WorkspaceID,
 		SessionID:     req.SessionID,
+		OfficeRuntime: req.OfficeRuntime,
 	})
 	if err != nil {
 		return SkillDeployResult{}, err

--- a/apps/backend/internal/agent/runtime/lifecycle/skill_deployer_adapter_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/skill_deployer_adapter_test.go
@@ -1,0 +1,42 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle/skill"
+)
+
+type capturingConcreteDeployer struct {
+	req skill.Request
+}
+
+func (d *capturingConcreteDeployer) Deploy(_ context.Context, req skill.Request) (skill.DeployResult, error) {
+	d.req = req
+	return skill.DeployResult{}, nil
+}
+
+func TestSkillDeployerAdapterPreservesOfficeRuntime(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want bool
+	}{
+		{name: "non-Office launch", want: false},
+		{name: "Office launch", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := &capturingConcreteDeployer{}
+			adapter := NewSkillDeployerAdapter(inner)
+
+			_, err := adapter.DeploySkills(context.Background(), SkillDeployRequest{
+				OfficeRuntime: tt.want,
+			})
+			if err != nil {
+				t.Fatalf("DeploySkills: %v", err)
+			}
+			if inner.req.OfficeRuntime != tt.want {
+				t.Errorf("OfficeRuntime = %t, want %t", inner.req.OfficeRuntime, tt.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/office/skills/runtime_adapter.go
+++ b/apps/backend/internal/office/skills/runtime_adapter.go
@@ -55,6 +55,7 @@ func (a *SkillReaderAdapter) GetSkillFromConfig(ctx context.Context, idOrSlug st
 		Content:    sk.Content,
 		Files:      runtimeSkillFiles(sk.FileInventory),
 		SourceType: string(sk.SourceType),
+		IsSystem:   sk.IsSystem,
 	}, nil
 }
 

--- a/apps/backend/internal/office/skills/runtime_adapter_test.go
+++ b/apps/backend/internal/office/skills/runtime_adapter_test.go
@@ -20,6 +20,7 @@ func TestSkillReaderAdapterMapsInventoryFiles(t *testing.T) {
 		Slug:          "office-admin",
 		Content:       "# Office Admin\n",
 		FileInventory: `[{"path":"references/tasks.md","content":"# Tasks\n"},{"path":"empty.md"}]`,
+		IsSystem:      true,
 	}})
 
 	got, err := adapter.GetSkillFromConfig(context.Background(), "office-admin")
@@ -34,5 +35,8 @@ func TestSkillReaderAdapterMapsInventoryFiles(t *testing.T) {
 	}
 	if got.Files[0].Path != "references/tasks.md" || got.Files[0].Content != "# Tasks\n" {
 		t.Errorf("file = %+v", got.Files[0])
+	}
+	if !got.IsSystem {
+		t.Error("IsSystem = false, want true")
 	}
 }

--- a/apps/web/e2e/tests/office/agent-launch-context.spec.ts
+++ b/apps/web/e2e/tests/office/agent-launch-context.spec.ts
@@ -30,16 +30,16 @@ const AGENTCTL_BIN = path.join(BACKEND_DIR, "bin", "agentctl");
 test.describe("Office agent launch context", () => {
   test("bundled system skills materialise on the agent's worktree at launch", async ({
     apiClient,
-    seedData,
+    officeApi,
+    officeSeed,
   }) => {
     test.setTimeout(60_000);
 
-    // 1. Prime the bundled system-skill sync for the seedData workspace
-    //    (the lazy sync runs on the first /skills list). The kanban
-    //    seed workspace shares the same lazy-sync path as office.
+    // 1. Prime the bundled system-skill sync for the Office workspace
+    //    (the lazy sync runs on the first /skills list).
     const primingRes = await apiClient.rawRequest(
       "GET",
-      `/api/v1/office/workspaces/${seedData.workspaceId}/skills`,
+      `/api/v1/office/workspaces/${officeSeed.workspaceId}/skills`,
     );
     expect(primingRes.ok).toBe(true);
     const primed = (await primingRes.json()) as { skills?: Array<{ slug: string }> };
@@ -49,21 +49,21 @@ test.describe("Office agent launch context", () => {
     // 2. Attach the bundled slug to the seed agent's desired_skills.
     //    The runtime materializer resolves slugs against the
     //    workspace skill registry at session start.
-    await apiClient.setProfileDesiredSkills(seedData.agentProfileId, ["kandev-protocol"]);
+    await apiClient.setProfileDesiredSkills(officeSeed.agentId, ["kandev-protocol"]);
 
     try {
-      // 3. Launch a real session.
-      const task = await apiClient.createTaskWithAgent(
-        seedData.workspaceId,
+      // 3. Create and assign a real Office task. Office ownership determines
+      // the MCP mode and causes the scheduler to inject the Office runtime
+      // context used by the system-skill deployer.
+      const task = await officeApi.createTask(
+        officeSeed.workspaceId,
         "Launch context — bundled skills",
-        seedData.agentProfileId,
         {
           description: "/e2e:simple-message",
-          workflow_id: seedData.workflowId,
-          workflow_step_id: seedData.startStepId,
-          repository_ids: [seedData.repositoryId],
+          workflow_id: officeSeed.workflowId,
         },
       );
+      await officeApi.assignTask(task.id as string, officeSeed.agentId);
 
       // 4. Wait for the task's worktree path to settle.
       let worktreePath = "";
@@ -95,7 +95,7 @@ test.describe("Office agent launch context", () => {
       expect(content).toMatch(/kandev/i);
     } finally {
       // Tidy up so the worker's next test doesn't inherit the attach.
-      await apiClient.setProfileDesiredSkills(seedData.agentProfileId, []);
+      await apiClient.setProfileDesiredSkills(officeSeed.agentId, []);
     }
   });
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3502/792864210c42.html)
<!-- kandev-pr-walkthrough-end -->

Heavy Office routine tasks launch through the same kanban path as an ordinary task rather than the Office scheduler path, so they never receive `KANDEV_CLI` in their environment — yet they still received the bundled Office skills, every one of which shells out to `$KANDEV_CLI`. This change stops deploying those system skills to a launch whose finalized environment doesn't actually carry Office runtime env.

**Today:** A heavy (task_template) Office routine's agent still gets the bundled `kandev-task-ops` and `kandev-approvals` skills, because they're written per-workspace and were never gated on how the task launched. The first office-skill command the agent tries expands to a bare `kandev ...` with no CLI on the PATH and fails.
**After this:** Bundled system skills are only deployed when the launch's finalized environment actually carries `KANDEV_CLI` — the same signal the Office scheduler path always sets. A routine-task agent simply doesn't receive skills it can't execute. User-authored skills (`is_system = false`) are unaffected.
**Who hits this:** Any workspace running heavy Office routines; today every one of those agents hits a guaranteed failure on its first office-skill invocation.
**Scope:** standalone — narrow, single-purpose fix, no sibling PRs.
**Not here:** making routine tasks `IsFromOffice` (rejected — that flag gates ~20 other behaviours, including a hard launch refusal in `task_operations.go`); injecting `KANDEV_CLI` alone (rejected — other required Office env vars, e.g. `KANDEV_API_KEY`, would still be missing, trading a clear absence for an auth failure instead).

## Important Changes

- `skill.Skill` gains `IsSystem bool`, threaded from config (`office/skills/runtime_adapter.go`) through to the deploy request.
- `skill.Request.OfficeRuntime bool` — set from whether `KANDEV_CLI` is present in the finalized launch env (`skill_deploy.go`, at the point the env is already resolved) — gates `IsSystem` skills out of the manifest (`skill/manifest.go`) when false.

**Known trade-off:** the gate keys on `KANDEV_CLI` being present in the finalized launch env. An install with `agentctlBinaryPath` unset (`office/service/env_builder.go:33`) never sets `KANDEV_CLI`, even for a genuine Office launch, so it would also stop receiving Office system skills. That's a mis-configured install, and a silently-absent skill is preferable to one guaranteed to fail — but it's a real trade-off, called out here rather than left implicit.

**Known gap (Kubernetes executor):** on the k8s executor this gate is blunted by a pre-existing bug in `executor_kubernetes_files.go` — it has no `cleanKandevSkills` equivalent, so system skills already materialized on a retained PVC survive a manifest that now omits them. That bug is pre-existing, outside this diff, and tracked separately.

## Validation

- `go build -tags fts5 ./...` — build OK; `go vet ./...` — OK.
- `go test -tags fts5 -count=1 ./internal/agent/runtime/lifecycle/skill/... ./internal/office/skills/... ./internal/office/configloader/...` — all `ok`.
- `golangci-lint run ./...` (`make -C apps/backend lint`) — `0 issues.`
- `make -C apps/backend test` (full suite) — fails on the same pre-existing, environment-dependent packages as a scratch worktree built from this PR's merge base (temp-dir path length limits, unavailable NATS/turn-table test doubles, etc.); none of the failing packages exercise this diff. Two packages that failed only under full-suite contention (`internal/common/subproc`, `internal/github`) pass cleanly run in isolation.
- `make typecheck`, `make lint`, `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — all clean. (`lint-harness` fails locally on a pre-existing Python 3.9-vs-3.10 syntax issue in `.github/scripts/lint-harness-files.py`, unrelated to and unchanged by this diff.)
- No `apps/web` files changed, so Playwright e2e was not required for this change.

## Possible Improvements

Low risk. Coverage gap noted in review: no test currently spans the Office scheduler → lifecycle boundary, or exercises a prior-system-skills → gated transition end-to-end; this PR's tests cover the gate itself at the deploy-request/manifest level.

## Checklist

- [x] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. (Backend-internal skill deployment behavior; no public docs reference this gate.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->