### PR TITLE
test(office): cover mark-fixed skipping tasks reassigned to another agent

### DIFF
--- a/apps/backend/internal/office/service/failure_test.go
+++ b/apps/backend/internal/office/service/failure_test.go
@@ -400,6 +400,20 @@ func TestMarkAgentPausedFixed_DiscardsRecoveryForReassignedTask(t *testing.T) {
 	// run captured in the pause snapshot.
 	autoPauseAgent(t, svc, "ws-1", "agent-reassigned-from", 2)
 
+	// Precondition: the pause snapshot must include the reassigned task,
+	// otherwise the negative assertions below would pass vacuously (there
+	// would be nothing to discard).
+	var preCount int
+	if err := svc.RepoForTest().ReaderDB().Get(&preCount,
+		`SELECT COUNT(*) FROM office_agent_pause_recoveries WHERE agent_id = ? AND task_id = ?`,
+		"agent-reassigned-from", reassignedTaskID,
+	); err != nil {
+		t.Fatalf("query pre-fix snapshot: %v", err)
+	}
+	if preCount == 0 {
+		t.Fatal("test setup error: reassigned task was not captured in pause snapshot")
+	}
+
 	setTestTaskAssignee(t, svc, reassignedTaskID, "agent-reassigned-to")
 
 	if err := svc.MarkAgentPausedFixed(ctx, "user-1", "agent-reassigned-from"); err != nil {

--- a/apps/backend/internal/office/service/failure_test.go
+++ b/apps/backend/internal/office/service/failure_test.go
@@ -410,8 +410,11 @@ func TestMarkAgentPausedFixed_DiscardsRecoveryForReassignedTask(t *testing.T) {
 	); err != nil {
 		t.Fatalf("query pre-fix snapshot: %v", err)
 	}
-	if preCount == 0 {
-		t.Fatal("test setup error: reassigned task was not captured in pause snapshot")
+	if preCount != 1 {
+		t.Fatalf(
+			"test setup error: expected exactly one recovery row for reassigned task, found %d",
+			preCount,
+		)
 	}
 
 	setTestTaskAssignee(t, svc, reassignedTaskID, "agent-reassigned-to")

--- a/apps/backend/internal/office/service/failure_test.go
+++ b/apps/backend/internal/office/service/failure_test.go
@@ -381,6 +381,54 @@ func TestMarkAgentPausedFixed_UsesPauseSnapshot(t *testing.T) {
 	}
 }
 
+// A task reassigned to a different agent after the failure must not be
+// requeued for the original agent, and the stale recovery row for it
+// must be discarded (recoverPausedTask's assignee-mismatch branch).
+func TestMarkAgentPausedFixed_DiscardsRecoveryForReassignedTask(t *testing.T) {
+	svc, _ := newTestServiceWithBus(t)
+	ctx := context.Background()
+
+	createTestAgent(t, svc, "ws-1", "agent-reassigned-from")
+	reassignedTaskID := "reassigned-task"
+	insertSyntheticTask(t, svc, reassignedTaskID, "ws-1", "agent-reassigned-from")
+	failedRun := queueAndReadRun(t, svc, "agent-reassigned-from", reassignedTaskID)
+	if err := svc.HandleAgentFailure(ctx, failedRun, "boom"); err != nil {
+		t.Fatalf("handle failure: %v", err)
+	}
+	// Two more failures (on other tasks) to cross the default threshold
+	// of 3 and auto-pause the agent, with the reassigned task's failed
+	// run captured in the pause snapshot.
+	autoPauseAgent(t, svc, "ws-1", "agent-reassigned-from", 2)
+
+	setTestTaskAssignee(t, svc, reassignedTaskID, "agent-reassigned-to")
+
+	if err := svc.MarkAgentPausedFixed(ctx, "user-1", "agent-reassigned-from"); err != nil {
+		t.Fatalf("mark fixed: %v", err)
+	}
+
+	runs, err := svc.ListRuns(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	for _, run := range runs {
+		if run.Reason == service.RunReasonManualResumeAfterFailure &&
+			taskIDFromPayload(t, run.Payload) == reassignedTaskID {
+			t.Fatalf("queued recovery run for reassigned task %s", reassignedTaskID)
+		}
+	}
+
+	var recoveryCount int
+	if err := svc.RepoForTest().ReaderDB().Get(&recoveryCount,
+		`SELECT COUNT(*) FROM office_agent_pause_recoveries WHERE agent_id = ? AND task_id = ?`,
+		"agent-reassigned-from", reassignedTaskID,
+	); err != nil {
+		t.Fatalf("query pause recoveries: %v", err)
+	}
+	if recoveryCount != 0 {
+		t.Fatalf("expected recovery row for reassigned task to be deleted, found %d", recoveryCount)
+	}
+}
+
 // Threshold-agnostic: the fix must not assume the default threshold
 // of 3. A per-agent override to a different value must still recover.
 func TestMarkAgentPausedFixed_ThresholdAgnostic(t *testing.T) {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3504/b3f5e9ec3b1a.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** `MarkAgentPausedFixed`'s discard-on-reassignment branch (the code path that skips requeuing a task when it has since been handed to a different agent) has no regression test. A future edit to that assignee guard could silently start re-queuing runs for tasks that were reassigned away, and nothing in CI would catch it.

**After this:** A dedicated test, `TestMarkAgentPausedFixed_DiscardsRecoveryForReassignedTask`, fails immediately if that guard regresses.

**Who hits this:** Operators who unpause an agent after one of its failed tasks was manually reassigned to someone else — without the guard, unpausing would queue a duplicate/stale recovery run against the wrong agent's task.

**Scope:** standalone, test-only change.

**Not here:** the production fix itself. The discard-on-reassignment behavior already exists in `MarkAgentPausedFixed`/`recoverPausedTask`, added by #3464's pause-recovery snapshot — this PR only closes the missing test for it. The other half of the original card's ask (a task whose only failed run predates a later success) needs a separate repository-query change and is tracked as a follow-up card, not included here.

Before #3464, this code path was effectively unreachable: the underlying unpause bug meant an agent never actually left `paused`, so every requeue attempt was rejected before reaching this guard. #3464 fixed that bug, which means this discard logic now actually executes — and it had no coverage until this PR.

## Validation

- `go test ./internal/office/... -count=1` — all packages pass except `internal/office/repository/sqlite`'s `TestMigrate_PriorityIdempotent`, which is pre-existing (reproduces identically against `origin/main` at the same commit, unrelated to this diff — a schema-init ordering issue in a different file this PR does not touch).
- `go test ./internal/office/service/... -run TestMarkAgentPausedFixed -count=1` — `ok`
- Mutation check: replacing the assignee guard in `failure.go` with `if false && ...` makes the new test the only failing test in the package, confirming it exercises a branch nothing else covers.
- `gofmt -l` / `go vet ./internal/office/...` — clean
- `golangci-lint run ./...` — `0 issues.`
- `make lint`, `make lint-format`, `pnpm run i18n:ratchet` (apps/web) — all clean (diff has no web-facing files, so this is a no-op).
- Full-repo `go build ./...` and `go test ./...` — the only failures beyond the one noted above are pre-existing/environmental (reproduced identically against `origin/main`): host-specific `/tmp` symlink and CI-shell assumptions in unrelated packages (`launcher`, `common/config`, `agentctl/server/config`), plus a few packages that hit the 10-minute test timeout under this host's heavy concurrent load (60+ other active worktrees) — verified by re-running the specific failing tests in isolation, where they pass.
- E2E not required: the diff touches only `apps/backend/internal/office/service/failure_test.go`.

## Possible Improvements

Low risk: test-only change, zero production code touched. The pre-existing gap in `recoverPausedTask`'s stale-run guard (a task's only failed run predating a later success) is tracked separately and not addressed here.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->