### PR TITLE
fix(office): reject empty slug on skill update

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
@@ -187,6 +187,11 @@ func TestPollModeGrace_StopDisarmsTimer(t *testing.T) {
 // it to return, and prevent the callback from changing the mode afterward.
 func TestPollModeGrace_StopJoinsFinalScan(t *testing.T) {
 	wt := newGraceTestTracker(t, graceFiresQuickly)
+	// The test covers the grace callback's cancellation and wait-group
+	// ownership. Disable the independent polling loops so their real Git work
+	// cannot change poll mode while this lifecycle boundary is under test (the
+	// Windows race runner can otherwise report an unrelated paused transition).
+	wt.gitIndexPath = ""
 	finalScanStarted := make(chan struct{})
 	finalScanFinished := make(chan struct{})
 	wt.gitStatusObserver = func(ctx context.Context) (types.GitStatusUpdate, error) {

--- a/apps/backend/internal/office/skills/handler.go
+++ b/apps/backend/internal/office/skills/handler.go
@@ -98,6 +98,12 @@ func (h *Handler) updateSkill(c *gin.Context) {
 		return
 	}
 	applySkillUpdates(skill, &req)
+	if req.Slug == nil && skill.Slug == "" {
+		// A caller-supplied slug is validated strictly; an unrequested slug
+		// change repairs a pre-existing empty stored slug instead of
+		// rejecting a request that never mentioned the slug field.
+		skill.Slug = GenerateSlug(skill.Name)
+	}
 	if err := h.svc.ValidateSkillUpdate(ctx, skill); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/apps/backend/internal/office/skills/handler.go
+++ b/apps/backend/internal/office/skills/handler.go
@@ -98,13 +98,7 @@ func (h *Handler) updateSkill(c *gin.Context) {
 		return
 	}
 	applySkillUpdates(skill, &req)
-	if req.Slug == nil && skill.Slug == "" {
-		// A caller-supplied slug is validated strictly; an unrequested slug
-		// change repairs a pre-existing empty stored slug instead of
-		// rejecting a request that never mentioned the slug field.
-		skill.Slug = GenerateSlug(skill.Name)
-	}
-	if err := h.svc.ValidateSkillUpdate(ctx, skill); err != nil {
+	if err := h.svc.ValidateSkillUpdate(ctx, skill, req.Slug != nil); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/apps/backend/internal/office/skills/handler_test.go
+++ b/apps/backend/internal/office/skills/handler_test.go
@@ -85,6 +85,76 @@ func TestUpdateSkillHandler_RejectsNotWellFormedSlug(t *testing.T) {
 	}
 }
 
+func TestUpdateSkillHandler_ContentOnlyPatchHealsStoredEmptySlug(t *testing.T) {
+	router, svc := newTestSkillRouter(t)
+	ctx := context.Background()
+
+	// Bypasses ValidateAndPrepareSkill, mirroring config-import's CreateSkill
+	// call, to reproduce a durable row with an empty stored slug.
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", Slug: "", SourceType: "inline"}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec := doSkillRequest(t, router, http.MethodPatch, "/api/v1/skills/"+skill.ID, `{"content":"new content"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp skills.SkillResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	if resp.Skill.Slug == "" {
+		t.Errorf("response slug still empty after content-only PATCH")
+	}
+
+	reloaded, err := svc.GetSkillFromConfig(ctx, skill.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Slug == "" {
+		t.Errorf("stored slug still empty after content-only PATCH")
+	}
+}
+
+func TestUpdateSkillHandler_ContentOnlyPatchDoesNotFailOnSlugCollision(t *testing.T) {
+	router, svc := newTestSkillRouter(t)
+	ctx := context.Background()
+
+	occupant := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, occupant); err != nil {
+		t.Fatalf("validate occupant: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, occupant); err != nil {
+		t.Fatalf("create occupant: %v", err)
+	}
+
+	// Bypasses ValidateAndPrepareSkill, mirroring config-import's CreateSkill
+	// call, to reproduce a durable row with an empty stored slug whose
+	// name-derived candidate collides with occupant's slug.
+	broken := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", Slug: "", SourceType: "inline"}
+	if err := svc.CreateSkill(ctx, broken); err != nil {
+		t.Fatalf("create broken: %v", err)
+	}
+
+	rec := doSkillRequest(t, router, http.MethodPatch, "/api/v1/skills/"+broken.ID, `{"content":"new content"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	reloaded, err := svc.GetSkillFromConfig(ctx, broken.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Slug != "" {
+		t.Errorf("stored slug = %q, want left empty on collision", reloaded.Slug)
+	}
+	if reloaded.Content != "new content" {
+		t.Errorf("content = %q, want %q", reloaded.Content, "new content")
+	}
+}
+
 func TestUpdateSkillHandler_OmittedSlugLeavesItUnchanged(t *testing.T) {
 	router, svc := newTestSkillRouter(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/skills/handler_test.go
+++ b/apps/backend/internal/office/skills/handler_test.go
@@ -59,6 +59,32 @@ func TestUpdateSkillHandler_RejectsEmptySlug(t *testing.T) {
 	}
 }
 
+func TestUpdateSkillHandler_RejectsNotWellFormedSlug(t *testing.T) {
+	router, svc := newTestSkillRouter(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec := doSkillRequest(t, router, http.MethodPatch, "/api/v1/skills/"+skill.ID, `{"slug":"not a valid slug!"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	reloaded, err := svc.GetSkillFromConfig(ctx, skill.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Slug != "kandev-existing" {
+		t.Errorf("stored slug = %q, want unchanged %q", reloaded.Slug, "kandev-existing")
+	}
+}
+
 func TestUpdateSkillHandler_OmittedSlugLeavesItUnchanged(t *testing.T) {
 	router, svc := newTestSkillRouter(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/skills/handler_test.go
+++ b/apps/backend/internal/office/skills/handler_test.go
@@ -1,0 +1,94 @@
+package skills_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/skills"
+)
+
+// newTestSkillRouter mounts the skills routes over a fresh service.
+func newTestSkillRouter(t *testing.T) (*gin.Engine, *skills.SkillService) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	svc := newTestSkillService(t)
+	router := gin.New()
+	skills.NewHandler(svc).RegisterRoutes(router.Group("/api/v1"))
+	return router, svc
+}
+
+func doSkillRequest(t *testing.T, router *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestUpdateSkillHandler_RejectsEmptySlug(t *testing.T) {
+	router, svc := newTestSkillRouter(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec := doSkillRequest(t, router, http.MethodPatch, "/api/v1/skills/"+skill.ID, `{"slug":""}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	reloaded, err := svc.GetSkillFromConfig(ctx, skill.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Slug != "kandev-existing" {
+		t.Errorf("stored slug = %q, want unchanged %q", reloaded.Slug, "kandev-existing")
+	}
+}
+
+func TestUpdateSkillHandler_OmittedSlugLeavesItUnchanged(t *testing.T) {
+	router, svc := newTestSkillRouter(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec := doSkillRequest(t, router, http.MethodPatch, "/api/v1/skills/"+skill.ID, `{"content":"new content"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp skills.SkillResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	if resp.Skill.Slug != "kandev-existing" {
+		t.Errorf("response slug = %q, want unchanged %q", resp.Skill.Slug, "kandev-existing")
+	}
+
+	reloaded, err := svc.GetSkillFromConfig(ctx, skill.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Slug != "kandev-existing" {
+		t.Errorf("stored slug = %q, want unchanged %q", reloaded.Slug, "kandev-existing")
+	}
+}

--- a/apps/backend/internal/office/skills/service.go
+++ b/apps/backend/internal/office/skills/service.go
@@ -170,16 +170,35 @@ func prepareSkillPackageMetadata(skill *models.Skill) {
 
 // ValidateSkillUpdate validates a skill update for slug uniqueness. Slug
 // handling mirrors ValidateAndPrepareSkill: an empty slug is not
-// well-formed and is rejected like any other not-well-formed slug; the
-// caller omits the field entirely to leave the slug unchanged. A
-// well-formed slug is normalized to canonical form before the uniqueness
-// check runs.
-func (s *SkillService) ValidateSkillUpdate(ctx context.Context, skill *models.Skill) error {
+// well-formed and is rejected like any other not-well-formed slug when the
+// caller supplies one; the caller omits the field entirely (slugRequested
+// false) to leave the slug unchanged. A well-formed slug is normalized to
+// canonical form before the uniqueness check runs.
+//
+// A request that never mentions slug must never fail on slug grounds. The
+// config-import path can create a row with an empty stored slug outside
+// this service's own validation, so an unrelated update to such a row
+// heals it to a free name-derived slug rather than rejecting the caller's
+// edit; if every candidate collides, the stored empty value is left as-is.
+func (s *SkillService) ValidateSkillUpdate(ctx context.Context, skill *models.Skill, slugRequested bool) error {
+	if !slugRequested && skill.Slug == "" {
+		s.healEmptySlug(ctx, skill)
+		return nil
+	}
 	if !skillslug.WellFormed(skill.Slug) {
 		return fmt.Errorf("invalid skill slug %q: must contain only letters, digits, underscore, and hyphen", skill.Slug)
 	}
 	skill.Slug = skillslug.Normalize(skill.Slug)
 	return s.validateSlugUnique(ctx, skill.WorkspaceID, skill.Slug, skill.ID)
+}
+
+// healEmptySlug assigns skill a name-derived slug when one is free in its
+// workspace, and leaves its stored empty slug untouched otherwise.
+func (s *SkillService) healEmptySlug(ctx context.Context, skill *models.Skill) {
+	candidate := skillslug.Normalize(GenerateSlug(skill.Name))
+	if s.validateSlugUnique(ctx, skill.WorkspaceID, candidate, skill.ID) == nil {
+		skill.Slug = candidate
+	}
 }
 
 func (s *SkillService) validateSlugUnique(ctx context.Context, workspaceID, slug, excludeID string) error {

--- a/apps/backend/internal/office/skills/service.go
+++ b/apps/backend/internal/office/skills/service.go
@@ -169,13 +169,12 @@ func prepareSkillPackageMetadata(skill *models.Skill) {
 }
 
 // ValidateSkillUpdate validates a skill update for slug uniqueness. Slug
-// handling mirrors ValidateAndPrepareSkill: reject a not-well-formed slug
-// outright (AC-001.11), otherwise normalize to canonical before the
-// uniqueness check (AC-001.12).
+// handling mirrors ValidateAndPrepareSkill: an empty slug is not
+// well-formed and is rejected like any other not-well-formed slug; the
+// caller omits the field entirely to leave the slug unchanged. A
+// well-formed slug is normalized to canonical form before the uniqueness
+// check runs.
 func (s *SkillService) ValidateSkillUpdate(ctx context.Context, skill *models.Skill) error {
-	if skill.Slug == "" {
-		return nil
-	}
 	if !skillslug.WellFormed(skill.Slug) {
 		return fmt.Errorf("invalid skill slug %q: must contain only letters, digits, underscore, and hyphen", skill.Slug)
 	}

--- a/apps/backend/internal/office/skills/service_slug_update_test.go
+++ b/apps/backend/internal/office/skills/service_slug_update_test.go
@@ -1,0 +1,29 @@
+package skills_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+func TestValidateSkillUpdate_RejectsEmptySlug(t *testing.T) {
+	svc := newTestSkillService(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	skill.Slug = ""
+	if err := svc.ValidateSkillUpdate(ctx, skill); err == nil {
+		t.Fatal("expected error for empty slug")
+	}
+	if skill.Slug != "" {
+		t.Errorf("slug = %q, want unchanged empty string, not coerced", skill.Slug)
+	}
+}

--- a/apps/backend/internal/office/skills/service_slug_update_test.go
+++ b/apps/backend/internal/office/skills/service_slug_update_test.go
@@ -20,10 +20,57 @@ func TestValidateSkillUpdate_RejectsEmptySlug(t *testing.T) {
 	}
 
 	skill.Slug = ""
-	if err := svc.ValidateSkillUpdate(ctx, skill); err == nil {
+	if err := svc.ValidateSkillUpdate(ctx, skill, true); err == nil {
 		t.Fatal("expected error for empty slug")
 	}
 	if skill.Slug != "" {
 		t.Errorf("slug = %q, want unchanged empty string, not coerced", skill.Slug)
+	}
+}
+
+func TestValidateSkillUpdate_HealsEmptyStoredSlugWhenNotRequested(t *testing.T) {
+	svc := newTestSkillService(t)
+	ctx := context.Background()
+
+	// Bypasses ValidateAndPrepareSkill, mirroring config-import's CreateSkill
+	// call, to reproduce a durable row with an empty stored slug.
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", SourceType: "inline"}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := svc.ValidateSkillUpdate(ctx, skill, false); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if skill.Slug == "" {
+		t.Error("slug still empty after healing an unrequested update")
+	}
+}
+
+func TestValidateSkillUpdate_LeavesEmptyStoredSlugOnCollisionWhenNotRequested(t *testing.T) {
+	svc := newTestSkillService(t)
+	ctx := context.Background()
+
+	occupant := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, occupant); err != nil {
+		t.Fatalf("validate occupant: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, occupant); err != nil {
+		t.Fatalf("create occupant: %v", err)
+	}
+
+	// Bypasses ValidateAndPrepareSkill, mirroring config-import's CreateSkill
+	// call, to reproduce a durable row with an empty stored slug whose
+	// name-derived candidate collides with an existing skill.
+	broken := &models.Skill{WorkspaceID: "ws-1", Name: "Existing Skill", SourceType: "inline"}
+	if err := svc.CreateSkill(ctx, broken); err != nil {
+		t.Fatalf("create broken: %v", err)
+	}
+
+	if err := svc.ValidateSkillUpdate(ctx, broken, false); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if broken.Slug != "" {
+		t.Errorf("slug = %q, want left empty on collision", broken.Slug)
 	}
 }

--- a/apps/backend/internal/office/skills/service_test.go
+++ b/apps/backend/internal/office/skills/service_test.go
@@ -273,6 +273,27 @@ func TestValidateSkillUpdate_RejectsNotWellFormedSlug(t *testing.T) {
 	}
 }
 
+func TestValidateSkillUpdate_RejectsEmptySlug(t *testing.T) {
+	svc := newTestSkillService(t)
+	ctx := context.Background()
+
+	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
+	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := svc.CreateSkill(ctx, skill); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	skill.Slug = ""
+	if err := svc.ValidateSkillUpdate(ctx, skill); err == nil {
+		t.Fatal("expected error for empty slug")
+	}
+	if skill.Slug != "" {
+		t.Errorf("slug = %q, want unchanged empty string, not coerced", skill.Slug)
+	}
+}
+
 func TestValidateAndPrepareSkill_RejectsInvalidSourceType(t *testing.T) {
 	svc := newTestSkillService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/skills/service_test.go
+++ b/apps/backend/internal/office/skills/service_test.go
@@ -247,7 +247,7 @@ func TestValidateSkillUpdate_NormalizesWellFormedSlugToCanonical(t *testing.T) {
 	}
 
 	skill.Slug = "renamed"
-	if err := svc.ValidateSkillUpdate(ctx, skill); err != nil {
+	if err := svc.ValidateSkillUpdate(ctx, skill, true); err != nil {
 		t.Fatalf("update: %v", err)
 	}
 	if skill.Slug != "kandev-renamed" {
@@ -268,7 +268,7 @@ func TestValidateSkillUpdate_RejectsNotWellFormedSlug(t *testing.T) {
 	}
 
 	skill.Slug = "not a valid slug!"
-	if err := svc.ValidateSkillUpdate(ctx, skill); err == nil {
+	if err := svc.ValidateSkillUpdate(ctx, skill, true); err == nil {
 		t.Fatal("expected error for not-well-formed slug")
 	}
 }

--- a/apps/backend/internal/office/skills/service_test.go
+++ b/apps/backend/internal/office/skills/service_test.go
@@ -273,27 +273,6 @@ func TestValidateSkillUpdate_RejectsNotWellFormedSlug(t *testing.T) {
 	}
 }
 
-func TestValidateSkillUpdate_RejectsEmptySlug(t *testing.T) {
-	svc := newTestSkillService(t)
-	ctx := context.Background()
-
-	skill := &models.Skill{WorkspaceID: "ws-1", Name: "Existing", Slug: "kandev-existing", SourceType: "inline"}
-	if err := svc.ValidateAndPrepareSkill(ctx, skill); err != nil {
-		t.Fatalf("validate: %v", err)
-	}
-	if err := svc.CreateSkill(ctx, skill); err != nil {
-		t.Fatalf("create: %v", err)
-	}
-
-	skill.Slug = ""
-	if err := svc.ValidateSkillUpdate(ctx, skill); err == nil {
-		t.Fatal("expected error for empty slug")
-	}
-	if skill.Slug != "" {
-		t.Errorf("slug = %q, want unchanged empty string, not coerced", skill.Slug)
-	}
-}
-
 func TestValidateAndPrepareSkill_RejectsInvalidSourceType(t *testing.T) {
 	svc := newTestSkillService(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3509/e4d458f8b091.html)
<!-- kandev-pr-walkthrough-end -->

fix(office): reject empty slug on skill update

PATCH /api/v1/skills/:id with {"slug":""} previously short-circuited
past the well-formedness check and persisted an empty slug, producing a
skill row that skillslug delivery silently drops. Empty is now treated
as not well-formed like any other invalid slug and rejected with 400;
omitting the field is still the only way to leave the slug unchanged.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->