### PR TITLE
fix(backend): retry SSH agentctl handshake rejection instead of failing the launch

### DIFF
--- a/apps/backend/cmd/agentctl/main.go
+++ b/apps/backend/cmd/agentctl/main.go
@@ -126,6 +126,9 @@ func runMain() int {
 	log.Info("starting agentctl",
 		zap.Int("port", cfg.Port),
 		zap.String("log_level", cfg.LogLevel))
+	log.Info("agentctl bootstrap nonce mode",
+		zap.Bool("configured", cfg.BootstrapNonceConfigured()),
+		zap.String("nonce_fingerprint", cfg.BootstrapNonceFingerprint()))
 
 	run(cfg, log)
 	return 0

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -406,20 +406,8 @@ func (r *SSHExecutor) startAndForwardAgentctl(
 	req *ExecutorCreateRequest,
 	platform SSHRemotePlatform,
 ) (int, int, *SSHPortForwarder, string, error) {
-	nonce, err := generateBootstrapNonce()
-	if err != nil {
-		return 0, 0, nil, "", fmt.Errorf("ssh: generate bootstrap nonce: %w", err)
-	}
-	// Keep only the managed broker values in the long-lived remote process.
-	// sshAgentctlLaunchEnv adds the bootstrap credentials required for the
-	// authenticated control handshake without forwarding profile secrets.
-	env := sshAgentctlLaunchEnv(
-		managedGitCredentialBrokerEnv(sshRemoteContributionEnv(req, agentctlBin)),
-		nonce,
-		req.AgentctlStartupConfig,
-	)
 	shell := sshShellForRemote(req.Metadata, platform)
-	controlPort, pid, err := startRemoteAgentctl(ctx, client, shell, agentctlBin, taskDir, sessionDir, env, r.logger)
+	controlPort, pid, authToken, err := r.startAgentctlAndHandshake(ctx, client, shell, agentctlBin, taskDir, sessionDir, req)
 	if err != nil {
 		r.report(req.OnProgress, "Starting agent controller", PrepareStepFailed, err.Error())
 		return 0, 0, nil, "", err
@@ -430,11 +418,6 @@ func (r *SSHExecutor) startAndForwardAgentctl(
 	// The per-instance server's workspace is the remote task dir, not the
 	// host-side req.WorkspacePath (which is meaningless on the remote).
 	// Passed explicitly so we don't briefly mutate the caller's request.
-	authToken, ierr := remoteControlHandshake(ctx, client, controlPort, nonce)
-	if ierr != nil {
-		_ = stopRemoteAgentctl(ctx, client, sessionDir, pid)
-		return 0, 0, nil, "", ierr
-	}
 	instancePort, ierr := createRemoteAgentInstance(
 		ctx, client, controlPort, taskDir, agentctlBin, req, authToken, r.logger,
 	)
@@ -459,6 +442,50 @@ func (r *SSHExecutor) startAndForwardAgentctl(
 	r.report(req.OnProgress, "Connecting to agent controller", PrepareStepCompleted,
 		fmt.Sprintf("local:%d -> remote:%d", fwd.LocalPort(), instancePort))
 	return instancePort, pid, fwd, authToken, nil
+}
+
+// startAgentctlAndHandshake starts a fresh agentctl instance and completes
+// its bootstrap handshake, retrying with a brand-new instance (fresh nonce,
+// fresh port) when the handshake is rejected by whatever is listening on the
+// picked port — see retryAgentctlHandshake. Any other failure is terminal.
+func (r *SSHExecutor) startAgentctlAndHandshake(
+	ctx context.Context,
+	client *ssh.Client,
+	shell, agentctlBin, taskDir, sessionDir string,
+	req *ExecutorCreateRequest,
+) (int, int, string, error) {
+	attempt := func() (int, int, string, error) {
+		nonce, err := generateBootstrapNonce()
+		if err != nil {
+			return 0, 0, "", fmt.Errorf("ssh: generate bootstrap nonce: %w", err)
+		}
+		// Keep only the managed broker values in the long-lived remote
+		// process. sshAgentctlLaunchEnv adds the bootstrap credentials
+		// required for the authenticated control handshake without
+		// forwarding profile secrets.
+		env := sshAgentctlLaunchEnv(
+			managedGitCredentialBrokerEnv(sshRemoteContributionEnv(req, agentctlBin)),
+			nonce,
+			req.AgentctlStartupConfig,
+		)
+		port, pid, err := startRemoteAgentctl(ctx, client, shell, agentctlBin, taskDir, sessionDir, env, r.logger)
+		if err != nil {
+			return 0, 0, "", err
+		}
+		token, err := remoteControlHandshake(ctx, client, port, nonce)
+		if err != nil {
+			if errors.Is(err, errSSHAgentctlHandshakeRejected) {
+				err = fmt.Errorf("%w (port %d, pid %d); log:\n%s",
+					err, port, pid, readRemoteAgentctlLogTail(ctx, client, sessionDir))
+			}
+			return port, pid, "", err
+		}
+		return port, pid, token, nil
+	}
+	teardown := func(_, pid int) {
+		_ = stopRemoteAgentctl(ctx, client, sessionDir, pid)
+	}
+	return retryAgentctlHandshake(attempt, teardown)
 }
 
 func sshAgentctlLaunchEnv(base map[string]string, nonce string, startup ...commonconfig.AgentctlStartupConfig) map[string]string {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -459,6 +459,7 @@ func (r *SSHExecutor) startAgentctlAndHandshake(
 		if err != nil {
 			return 0, 0, "", fmt.Errorf("ssh: generate bootstrap nonce: %w", err)
 		}
+		nonceFingerprint := commonconfig.NonceFingerprint(nonce)
 		// Keep only the managed broker values in the long-lived remote
 		// process. sshAgentctlLaunchEnv adds the bootstrap credentials
 		// required for the authenticated control handshake without
@@ -470,13 +471,23 @@ func (r *SSHExecutor) startAgentctlAndHandshake(
 		)
 		port, pid, err := startRemoteAgentctl(ctx, client, shell, agentctlBin, taskDir, sessionDir, env, r.logger)
 		if err != nil {
-			return 0, 0, "", err
+			// Preserve port/pid so retryAgentctlHandshake's "if pid > 0"
+			// teardown fires even for a start-time failure (e.g. a
+			// ready-timeout) that left a live process behind.
+			return port, pid, "", err
 		}
+		r.logger.Debug("ssh: sending agentctl bootstrap handshake",
+			zap.Int("port", port), zap.Int("pid", pid),
+			zap.String("nonce_fingerprint", nonceFingerprint))
 		token, err := remoteControlHandshake(ctx, client, port, nonce)
 		if err != nil {
 			if errors.Is(err, errSSHAgentctlHandshakeRejected) {
-				err = fmt.Errorf("%w (port %d, pid %d); log:\n%s",
-					err, port, pid, readRemoteAgentctlLogTail(ctx, client, sessionDir))
+				// The fingerprint lets this rejection be correlated against
+				// agentctl's own handshake log line for the same nonce —
+				// distinguishing a mismatch/already-burned nonce from
+				// bootstrap mode never having been configured on the remote.
+				err = fmt.Errorf("%w (port %d, pid %d, nonce %s); log:\n%s",
+					err, port, pid, nonceFingerprint, readRemoteAgentctlLogTail(ctx, client, sessionDir))
 			}
 			return port, pid, "", err
 		}
@@ -485,7 +496,7 @@ func (r *SSHExecutor) startAgentctlAndHandshake(
 	teardown := func(_, pid int) {
 		_ = stopRemoteAgentctl(ctx, client, sessionDir, pid)
 	}
-	return retryAgentctlHandshake(attempt, teardown)
+	return retryAgentctlHandshake(ctx, attempt, teardown, sleepOrContextDone)
 }
 
 func sshAgentctlLaunchEnv(base map[string]string, nonce string, startup ...commonconfig.AgentctlStartupConfig) map[string]string {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -486,15 +486,20 @@ func (r *SSHExecutor) startAgentctlAndHandshake(
 				// agentctl's own handshake log line for the same nonce —
 				// distinguishing a mismatch/already-burned nonce from
 				// bootstrap mode never having been configured on the remote.
+				logCtx, logCancel := sshRemoteCleanupContext(ctx)
+				logTail := readRemoteAgentctlLogTail(logCtx, client, sessionDir)
+				logCancel()
 				err = fmt.Errorf("%w (port %d, pid %d, nonce %s); log:\n%s",
-					err, port, pid, nonceFingerprint, readRemoteAgentctlLogTail(ctx, client, sessionDir))
+					err, port, pid, nonceFingerprint, logTail)
 			}
 			return port, pid, "", err
 		}
 		return port, pid, token, nil
 	}
-	teardown := func(_, pid int) {
-		_ = stopRemoteAgentctl(ctx, client, sessionDir, pid)
+	teardown := func(_, pid int) error {
+		cleanupCtx, cleanupCancel := sshRemoteCleanupContext(ctx)
+		defer cleanupCancel()
+		return stopRemoteAgentctl(cleanupCtx, client, sessionDir, pid)
 	}
 	return retryAgentctlHandshake(ctx, attempt, teardown, sleepOrContextDone)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_control_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_control_test.go
@@ -63,6 +63,9 @@ func TestRemoteControlHandshake(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "403") {
 			t.Fatalf("error = %v, want the status code", err)
 		}
+		if !errors.Is(err, errSSHAgentctlHandshakeRejected) {
+			t.Fatalf("error = %v, want it to wrap errSSHAgentctlHandshakeRejected so the launch retry can classify it", err)
+		}
 	})
 
 	t.Run("empty token is an error", func(t *testing.T) {
@@ -77,6 +80,9 @@ func TestRemoteControlHandshake(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "no token") {
 			t.Fatalf("error = %v, want missing-token error", err)
 		}
+		if errors.Is(err, errSSHAgentctlHandshakeRejected) {
+			t.Fatalf("error = %v, a 200 with a malformed body is not a rejected-listener error", err)
+		}
 	})
 
 	t.Run("unreachable control port is an error", func(t *testing.T) {
@@ -84,6 +90,9 @@ func TestRemoteControlHandshake(t *testing.T) {
 		_, err := remoteControlHandshake(context.Background(), server.dial(t), 39429, "nonce")
 		if err == nil || !strings.Contains(err.Error(), "agentctl handshake") {
 			t.Fatalf("error = %v, want dial failure", err)
+		}
+		if errors.Is(err, errSSHAgentctlHandshakeRejected) {
+			t.Fatalf("error = %v, a transport failure is not a rejected-listener error", err)
 		}
 	})
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_control_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_control_test.go
@@ -68,6 +68,23 @@ func TestRemoteControlHandshake(t *testing.T) {
 		}
 	})
 
+	t.Run("non-403 non-200 is not classified as the nonce-rejection retry sentinel", func(t *testing.T) {
+		httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer httpServer.Close()
+		server := newFakeSSHServer(t, nil)
+		server.forwardTo(strings.TrimPrefix(httpServer.URL, "http://"))
+
+		_, err := remoteControlHandshake(context.Background(), server.dial(t), 39429, "nonce")
+		if err == nil || !strings.Contains(err.Error(), "500") {
+			t.Fatalf("error = %v, want the status code", err)
+		}
+		if errors.Is(err, errSSHAgentctlHandshakeRejected) {
+			t.Fatalf("error = %v, only 403 is the nonce rejection — a 500 must not trigger a fresh-instance retry", err)
+		}
+	})
+
 	t.Run("empty token is an error", func(t *testing.T) {
 		httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = io.WriteString(w, `{"token":""}`)

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
@@ -1,11 +1,19 @@
 package lifecycle
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
+
+// noDelay is a zero-wait stand-in for retryAgentctlHandshake's delay
+// parameter, used by every test below that isn't specifically exercising the
+// backoff itself — it keeps the retry-classification tests fast regardless of
+// the production sshAgentctlHandshakeRetryDelay value.
+func noDelay(context.Context, time.Duration) error { return nil }
 
 // TestRetryAgentctlHandshakeRetriesRejectedHandshakes covers the launch-time
 // fix for the terminal "ssh: agentctl handshake returned 403" failure: a
@@ -27,7 +35,7 @@ func TestRetryAgentctlHandshakeRetriesRejectedHandshakes(t *testing.T) {
 		torndown = append(torndown, port)
 	}
 
-	port, pid, token, err := retryAgentctlHandshake(attempt, teardown)
+	port, pid, token, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 	if err != nil {
 		t.Fatalf("retryAgentctlHandshake: %v", err)
 	}
@@ -56,7 +64,7 @@ func TestRetryAgentctlHandshakeDoesNotRetryOtherFailures(t *testing.T) {
 		}
 		teardown := func(int, int) { teardownCalls++ }
 
-		_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+		_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("error = %v, want %v", err, wantErr)
 		}
@@ -73,7 +81,7 @@ func TestRetryAgentctlHandshakeDoesNotRetryOtherFailures(t *testing.T) {
 		}
 		teardown := func(port, pid int) { torndownPort, torndownPID = port, pid }
 
-		_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+		_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("error = %v, want %v", err, wantErr)
 		}
@@ -100,7 +108,7 @@ func TestRetryAgentctlHandshakeExhaustsAttemptsWithDiagnosis(t *testing.T) {
 	}
 	teardown := func(int, int) { torndown++ }
 
-	_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+	_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 	if err == nil {
 		t.Fatal("expected an error after exhausting every attempt")
 	}
@@ -115,5 +123,70 @@ func TestRetryAgentctlHandshakeExhaustsAttemptsWithDiagnosis(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "log:") || !strings.Contains(got, "pid") {
 		t.Fatalf("error = %q, want the last attempt's diagnosis preserved", got)
+	}
+}
+
+// TestRetryAgentctlHandshakeWaitsBetweenRejectedAttempts is the regression
+// test for the corrected root cause: two SSH launches on the same runner
+// within ~15-30s race the picked port's bootstrap nonce, and a near-zero
+// retry loop burns every attempt in under a second — well inside that
+// window — so it cannot durably win the race. This proves the retry now
+// actually waits between attempts (not just that it retries at all, which
+// the tests above already cover with a zero delay).
+func TestRetryAgentctlHandshakeWaitsBetweenRejectedAttempts(t *testing.T) {
+	var delays []time.Duration
+	fakeDelay := func(_ context.Context, d time.Duration) error {
+		delays = append(delays, d)
+		return nil
+	}
+	var attempts int
+	attempt := func() (int, int, string, error) {
+		attempts++
+		if attempts < 3 {
+			return 5000 + attempts, 100 + attempts, "", fmt.Errorf("%w: status 403", errSSHAgentctlHandshakeRejected)
+		}
+		return 5003, 103, "token-3", nil
+	}
+	teardown := func(int, int) {}
+
+	_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, fakeDelay)
+	if err != nil {
+		t.Fatalf("retryAgentctlHandshake: %v", err)
+	}
+	if len(delays) != 2 {
+		t.Fatalf("delay calls = %d, want 2 (once between attempts 1->2 and 2->3, never after the final attempt)", len(delays))
+	}
+	for _, d := range delays {
+		if d != sshAgentctlHandshakeRetryDelay {
+			t.Fatalf("delay = %v, want %v (sized against the operator-observed 15-30s overlap window)", d, sshAgentctlHandshakeRetryDelay)
+		}
+	}
+}
+
+// TestRetryAgentctlHandshakeDelayCancellationAbortsRetry covers ctx
+// cancellation during the backoff wait: the retry must stop immediately
+// (not burn the remaining attempts) and still report the cancellation, while
+// the already-rejected attempt is still torn down.
+func TestRetryAgentctlHandshakeDelayCancellationAbortsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var attempts int
+	attempt := func() (int, int, string, error) {
+		attempts++
+		return 5001, 101, "", fmt.Errorf("%w: status 403", errSSHAgentctlHandshakeRejected)
+	}
+	var teardownCalls int
+	teardown := func(int, int) { teardownCalls++ }
+	cancelledDelay := func(ctx context.Context, _ time.Duration) error { return ctx.Err() }
+
+	_, _, _, err := retryAgentctlHandshake(ctx, attempt, teardown, cancelledDelay)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (cancellation must stop the retry before a second attempt)", attempts)
+	}
+	if teardownCalls != 1 {
+		t.Fatalf("teardown calls = %d, want 1 (the first rejected attempt is still torn down)", teardownCalls)
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
@@ -31,8 +31,9 @@ func TestRetryAgentctlHandshakeRetriesRejectedHandshakes(t *testing.T) {
 		}
 		return 5003, 103, "token-3", nil
 	}
-	teardown := func(port, pid int) {
+	teardown := func(port, pid int) error {
 		torndown = append(torndown, port)
+		return nil
 	}
 
 	port, pid, token, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
@@ -62,7 +63,7 @@ func TestRetryAgentctlHandshakeDoesNotRetryOtherFailures(t *testing.T) {
 		attempt := func() (int, int, string, error) {
 			return 0, 0, "", wantErr
 		}
-		teardown := func(int, int) { teardownCalls++ }
+		teardown := func(int, int) error { teardownCalls++; return nil }
 
 		_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 		if !errors.Is(err, wantErr) {
@@ -79,7 +80,10 @@ func TestRetryAgentctlHandshakeDoesNotRetryOtherFailures(t *testing.T) {
 		attempt := func() (int, int, string, error) {
 			return 5001, 101, "", wantErr
 		}
-		teardown := func(port, pid int) { torndownPort, torndownPID = port, pid }
+		teardown := func(port, pid int) error {
+			torndownPort, torndownPID = port, pid
+			return nil
+		}
 
 		_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 		if !errors.Is(err, wantErr) {
@@ -106,7 +110,7 @@ func TestRetryAgentctlHandshakeExhaustsAttemptsWithDiagnosis(t *testing.T) {
 			errSSHAgentctlHandshakeRejected, 6000+attempts, 200+attempts,
 		)
 	}
-	teardown := func(int, int) { torndown++ }
+	teardown := func(int, int) error { torndown++; return nil }
 
 	_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
 	if err == nil {
@@ -147,7 +151,7 @@ func TestRetryAgentctlHandshakeWaitsBetweenRejectedAttempts(t *testing.T) {
 		}
 		return 5003, 103, "token-3", nil
 	}
-	teardown := func(int, int) {}
+	teardown := func(int, int) error { return nil }
 
 	_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, fakeDelay)
 	if err != nil {
@@ -176,7 +180,7 @@ func TestRetryAgentctlHandshakeDelayCancellationAbortsRetry(t *testing.T) {
 		return 5001, 101, "", fmt.Errorf("%w: status 403", errSSHAgentctlHandshakeRejected)
 	}
 	var teardownCalls int
-	teardown := func(int, int) { teardownCalls++ }
+	teardown := func(int, int) error { teardownCalls++; return nil }
 	cancelledDelay := func(ctx context.Context, _ time.Duration) error { return ctx.Err() }
 
 	_, _, _, err := retryAgentctlHandshake(ctx, attempt, teardown, cancelledDelay)
@@ -188,5 +192,26 @@ func TestRetryAgentctlHandshakeDelayCancellationAbortsRetry(t *testing.T) {
 	}
 	if teardownCalls != 1 {
 		t.Fatalf("teardown calls = %d, want 1 (the first rejected attempt is still torn down)", teardownCalls)
+	}
+}
+
+func TestRetryAgentctlHandshakeStopsWhenTeardownFails(t *testing.T) {
+	wantTeardownErr := errors.New("remote cleanup failed")
+	var attempts int
+	attempt := func() (int, int, string, error) {
+		attempts++
+		return 5001, 101, "", fmt.Errorf("%w: status 403", errSSHAgentctlHandshakeRejected)
+	}
+	teardown := func(int, int) error { return wantTeardownErr }
+
+	_, _, _, err := retryAgentctlHandshake(context.Background(), attempt, teardown, noDelay)
+	if !errors.Is(err, wantTeardownErr) {
+		t.Fatalf("error = %v, want teardown error %v", err, wantTeardownErr)
+	}
+	if !errors.Is(err, errSSHAgentctlHandshakeRejected) {
+		t.Fatalf("error = %v, want original handshake rejection preserved", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 after teardown failure", attempts)
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_handshake_retry_test.go
@@ -1,0 +1,119 @@
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestRetryAgentctlHandshakeRetriesRejectedHandshakes covers the launch-time
+// fix for the terminal "ssh: agentctl handshake returned 403" failure: a
+// handshake rejected by whatever agentctl is currently listening on the
+// picked port must not kill the launch outright. retryAgentctlHandshake tears
+// the failed attempt down and tries again with a fresh instance.
+func TestRetryAgentctlHandshakeRetriesRejectedHandshakes(t *testing.T) {
+	var attempts int
+	var torndown []int // ports handed to teardown, in order
+
+	attempt := func() (port, pid int, token string, err error) {
+		attempts++
+		if attempts < 3 {
+			return 5000 + attempts, 100 + attempts, "", fmt.Errorf("%w: status 403", errSSHAgentctlHandshakeRejected)
+		}
+		return 5003, 103, "token-3", nil
+	}
+	teardown := func(port, pid int) {
+		torndown = append(torndown, port)
+	}
+
+	port, pid, token, err := retryAgentctlHandshake(attempt, teardown)
+	if err != nil {
+		t.Fatalf("retryAgentctlHandshake: %v", err)
+	}
+	if port != 5003 || pid != 103 || token != "token-3" {
+		t.Fatalf("result = port %d pid %d token %q, want 5003/103/token-3", port, pid, token)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if len(torndown) != 2 || torndown[0] != 5001 || torndown[1] != 5002 {
+		t.Fatalf("torndown = %v, want the two rejected instances torn down before the retry", torndown)
+	}
+}
+
+// TestRetryAgentctlHandshakeDoesNotRetryOtherFailures covers every other
+// failure shape (bind exhaustion inside start, transport failure, malformed
+// handshake response): the launch must fail on the first attempt, exactly as
+// before this change, and must still tear down an agentctl that reached a
+// non-zero pid before failing.
+func TestRetryAgentctlHandshakeDoesNotRetryOtherFailures(t *testing.T) {
+	t.Run("start failure never started an instance, so nothing to tear down", func(t *testing.T) {
+		wantErr := errors.New("remote launch failed")
+		var teardownCalls int
+		attempt := func() (int, int, string, error) {
+			return 0, 0, "", wantErr
+		}
+		teardown := func(int, int) { teardownCalls++ }
+
+		_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want %v", err, wantErr)
+		}
+		if teardownCalls != 0 {
+			t.Fatalf("teardown calls = %d, want 0 (agentctl never started)", teardownCalls)
+		}
+	})
+
+	t.Run("a started agentctl is torn down even for a non-rejection handshake failure", func(t *testing.T) {
+		wantErr := errors.New("ssh: agentctl handshake returned no token")
+		var torndownPort, torndownPID int
+		attempt := func() (int, int, string, error) {
+			return 5001, 101, "", wantErr
+		}
+		teardown := func(port, pid int) { torndownPort, torndownPID = port, pid }
+
+		_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want %v", err, wantErr)
+		}
+		if torndownPort != 5001 || torndownPID != 101 {
+			t.Fatalf("teardown = (%d, %d), want (5001, 101)", torndownPort, torndownPID)
+		}
+	})
+}
+
+// TestRetryAgentctlHandshakeExhaustsAttemptsWithDiagnosis covers the case a
+// stale listener never goes away within the retry budget: the launch must
+// still fail, but the returned error carries the last attempt's diagnosis
+// (the sentinel plus whatever the attempt closure attached, e.g. port/pid/log
+// tail) instead of a bare "handshake returned 403".
+func TestRetryAgentctlHandshakeExhaustsAttemptsWithDiagnosis(t *testing.T) {
+	var attempts int
+	var torndown int
+	attempt := func() (int, int, string, error) {
+		attempts++
+		return 6000 + attempts, 200 + attempts, "", fmt.Errorf(
+			"%w (port %d, pid %d); log:\nHTTP server bound successfully",
+			errSSHAgentctlHandshakeRejected, 6000+attempts, 200+attempts,
+		)
+	}
+	teardown := func(int, int) { torndown++ }
+
+	_, _, _, err := retryAgentctlHandshake(attempt, teardown)
+	if err == nil {
+		t.Fatal("expected an error after exhausting every attempt")
+	}
+	if !errors.Is(err, errSSHAgentctlHandshakeRejected) {
+		t.Fatalf("error = %v, want it to still wrap errSSHAgentctlHandshakeRejected", err)
+	}
+	if attempts != sshAgentctlHandshakeAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, sshAgentctlHandshakeAttempts)
+	}
+	if torndown != sshAgentctlHandshakeAttempts {
+		t.Fatalf("torndown = %d, want every exhausted attempt torn down", torndown)
+	}
+	if got := err.Error(); !strings.Contains(got, "log:") || !strings.Contains(got, "pid") {
+		t.Fatalf("error = %q, want the last attempt's diagnosis preserved", got)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -635,8 +635,14 @@ func awaitRemoteAgentctlReady(
 				lastLines(logOut, sshAgentctlLogTailLines))
 		}
 		// Also catch "exited without binding" via pid check — if the wrapper
-		// exited before logging, kill -0 fails and we fail fast.
-		if !isRemoteAgentctlAlive(ctx, client, pid) {
+		// exited before logging, kill -0 confirms absence and we fail fast.
+		alive, probeErr := probeRemoteAgentctlLiveness(ctx, client, pid)
+		if !alive {
+			if probeErr != nil {
+				return pid, fmt.Errorf(
+					"ssh: agentctl readiness probe failed: %w; log tail:\n%s",
+					probeErr, lastLines(logOut, sshAgentctlLogTailLines))
+			}
 			return 0, fmt.Errorf(
 				"ssh: agentctl exited before becoming ready; log tail:\n%s",
 				lastLines(logOut, sshAgentctlLogTailLines))
@@ -645,11 +651,10 @@ func awaitRemoteAgentctlReady(
 	}
 	tail, _, _ := runSSHCommand(ctx, client,
 		"tail -n 50 "+shellQuote(sessionDir+"/agentctl.log")+" 2>/dev/null")
-	// The loop above only reaches the deadline by way of an isRemoteAgentctlAlive
-	// probe that returned true on its last iteration — otherwise the "exited
-	// before becoming ready" branch would already have returned. So the process
-	// is provably still running; return its pid (not 0) so the caller can tear
-	// it down instead of leaking it.
+	// The loop above only reaches the deadline after a liveness probe reported
+	// the process alive. That probe is not a permanent guarantee, so describe
+	// it as alive on the last probe before the deadline. Return its pid so the
+	// caller can tear it down instead of leaking it.
 	return pid, fmt.Errorf("ssh: agentctl did not become ready within %v; log tail:\n%s",
 		timeout, tail)
 }
@@ -837,13 +842,15 @@ const sshAgentctlHandshakeRetryDelay = 15 * time.Second
 // stale process left on the picked port). Any other failure (bind
 // exhaustion, transport, a malformed response) is terminal and returned
 // immediately after tearing down anything attempt already started (pid > 0).
+// A teardown error is terminal too, because the next attempt would reuse the
+// same session directory while the old process may still own its pid and log.
 // delay is called between attempts (not after the last one) and is injectable
 // so tests can run the retry loop without waiting on the real backoff; ctx
 // cancellation during the wait aborts the retry immediately.
 func retryAgentctlHandshake(
 	ctx context.Context,
 	attempt func() (port, pid int, token string, err error),
-	teardown func(port, pid int),
+	teardown func(port, pid int) error,
 	delay func(ctx context.Context, d time.Duration) error,
 ) (port, pid int, token string, err error) {
 	var lastErr error
@@ -853,8 +860,14 @@ func retryAgentctlHandshake(
 			return port, pid, token, nil
 		}
 		if pid > 0 {
-			teardown(port, pid)
+			if teardownErr := teardown(port, pid); teardownErr != nil {
+				return 0, 0, "", fmt.Errorf(
+					"ssh: agentctl teardown after attempt %d: %w",
+					i+1, errors.Join(teardownErr, err))
+			}
 		}
+		// teardown removes sessionDir. startRemoteAgentctl recreates it before
+		// each new pid/log pair, so every retry starts with a clean directory.
 		if !errors.Is(err, errSSHAgentctlHandshakeRejected) {
 			return 0, 0, "", err
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -739,6 +739,13 @@ func setSSHControlAuthorization(req *http.Request, token string) {
 	}
 }
 
+// errSSHAgentctlHandshakeRejected marks a handshake that reached a listener —
+// this launch's own freshly-started agentctl or a stale one left on the same
+// port — that rejected the nonce. Mirrors the errSSHAgentctlPortInUse idiom:
+// the caller uses errors.Is to decide whether a fresh instance is worth
+// retrying, as opposed to a transport failure or a malformed response.
+var errSSHAgentctlHandshakeRejected = errors.New("ssh: agentctl handshake rejected")
+
 func remoteControlHandshake(ctx context.Context, client *ssh.Client, controlPort int, nonce string) (string, error) {
 	body, err := json.Marshal(map[string]string{"nonce": nonce})
 	if err != nil {
@@ -757,7 +764,7 @@ func remoteControlHandshake(ctx context.Context, client *ssh.Client, controlPort
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("ssh: agentctl handshake returned %d", resp.StatusCode)
+		return "", fmt.Errorf("%w: status %d", errSSHAgentctlHandshakeRejected, resp.StatusCode)
 	}
 	var result struct {
 		Token string `json:"token"`
@@ -766,6 +773,48 @@ func remoteControlHandshake(ctx context.Context, client *ssh.Client, controlPort
 		return "", errors.New("ssh: agentctl handshake returned no token")
 	}
 	return result.Token, nil
+}
+
+// readRemoteAgentctlLogTail best-effort reads the tail of the current
+// session's agentctl.log, for attaching to a diagnosable error. Errors are
+// swallowed — a missing or unreadable log must not mask the real failure.
+func readRemoteAgentctlLogTail(ctx context.Context, client *ssh.Client, sessionDir string) string {
+	tail, _, _ := runSSHCommand(ctx, client,
+		"tail -n "+strconv.Itoa(sshAgentctlLogTailLines)+" "+shellQuote(sessionDir+"/agentctl.log")+" 2>/dev/null")
+	return tail
+}
+
+const sshAgentctlHandshakeAttempts = 3
+
+// retryAgentctlHandshake calls attempt up to sshAgentctlHandshakeAttempts
+// times, tearing down and retrying only when attempt fails with
+// errSSHAgentctlHandshakeRejected — the observed shape when a handshake
+// reaches a listener other than the agentctl this launch just started (a
+// stale process left on the picked port). Any other failure (bind
+// exhaustion, transport, a malformed response) is terminal and returned
+// immediately after tearing down anything attempt already started (pid > 0).
+func retryAgentctlHandshake(
+	attempt func() (port, pid int, token string, err error),
+	teardown func(port, pid int),
+) (port, pid int, token string, err error) {
+	var lastErr error
+	for range sshAgentctlHandshakeAttempts {
+		port, pid, token, err = attempt()
+		if err == nil {
+			return port, pid, token, nil
+		}
+		if pid > 0 {
+			teardown(port, pid)
+		}
+		if !errors.Is(err, errSSHAgentctlHandshakeRejected) {
+			return 0, 0, "", err
+		}
+		lastErr = err
+	}
+	return 0, 0, "", fmt.Errorf(
+		"ssh: agentctl exhausted %d handshake attempts: %w",
+		sshAgentctlHandshakeAttempts, lastErr,
+	)
 }
 
 func remoteControlHTTPClient(client *ssh.Client, controlPort int) *http.Client {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -542,7 +542,10 @@ func retryRemoteAgentctlPort(
 		}
 		lastErr = err
 		if !errors.Is(err, errSSHAgentctlPortInUse) {
-			return 0, 0, err
+			// Preserve whatever start() reported (e.g. a live pid on a
+			// ready-timeout) so the caller can still tear down a process that
+			// did start, instead of leaking it.
+			return port, pid, err
 		}
 	}
 	return 0, 0, fmt.Errorf(
@@ -597,9 +600,25 @@ echo "$AGENTCTL_PID"
 		return 0, fmt.Errorf("ssh: agentctl wrapper returned non-numeric pid %q", out)
 	}
 
-	// Poll the on-disk log for the "bound successfully" line; until then the
-	// process is starting up and a port-forward connect would race the bind.
-	deadline := time.Now().Add(sshAgentctlReadyTimeout)
+	return awaitRemoteAgentctlReady(
+		ctx, client, sessionDir, port, pid, sshAgentctlReadyTimeout, sshAgentctlReadyPoll, log,
+	)
+}
+
+// awaitRemoteAgentctlReady polls the on-disk log for the "bound successfully"
+// line; until then the process is starting up and a port-forward connect
+// would race the bind. timeout/poll are parameters (rather than reading the
+// package constants directly) so tests can exercise the timeout path without
+// waiting on the real 30s budget.
+func awaitRemoteAgentctlReady(
+	ctx context.Context,
+	client *ssh.Client,
+	sessionDir string,
+	port, pid int,
+	timeout, poll time.Duration,
+	log *logger.Logger,
+) (int, error) {
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		logOut, _, _ := runSSHCommand(ctx, client,
 			"cat "+shellQuote(sessionDir+"/agentctl.log")+" 2>/dev/null")
@@ -622,12 +641,17 @@ echo "$AGENTCTL_PID"
 				"ssh: agentctl exited before becoming ready; log tail:\n%s",
 				lastLines(logOut, sshAgentctlLogTailLines))
 		}
-		time.Sleep(sshAgentctlReadyPoll)
+		time.Sleep(poll)
 	}
 	tail, _, _ := runSSHCommand(ctx, client,
 		"tail -n 50 "+shellQuote(sessionDir+"/agentctl.log")+" 2>/dev/null")
-	return 0, fmt.Errorf("ssh: agentctl did not become ready within %v; log tail:\n%s",
-		sshAgentctlReadyTimeout, tail)
+	// The loop above only reaches the deadline by way of an isRemoteAgentctlAlive
+	// probe that returned true on its last iteration — otherwise the "exited
+	// before becoming ready" branch would already have returned. So the process
+	// is provably still running; return its pid (not 0) so the caller can tear
+	// it down instead of leaking it.
+	return pid, fmt.Errorf("ssh: agentctl did not become ready within %v; log tail:\n%s",
+		timeout, tail)
 }
 
 const sshAgentctlLogTailLines = 25
@@ -763,8 +787,17 @@ func remoteControlHandshake(ctx context.Context, client *ssh.Client, controlPort
 		return "", fmt.Errorf("ssh: agentctl handshake: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode == http.StatusForbidden {
+		// 403 is exactly ConsumeNonce rejecting the nonce (control_server.go) —
+		// the one case worth a fresh instance and a retry.
 		return "", fmt.Errorf("%w: status %d", errSSHAgentctlHandshakeRejected, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Any other non-200 (400/404/500/...) is not the nonce rejection and
+		// must not trigger retryAgentctlHandshake's retry — that would cost
+		// up to sshAgentctlHandshakeAttempts full start-agentctl-and-tear-down
+		// cycles for a failure a fresh instance can't fix.
+		return "", fmt.Errorf("ssh: agentctl handshake: unexpected status %d", resp.StatusCode)
 	}
 	var result struct {
 		Token string `json:"token"`
@@ -786,6 +819,17 @@ func readRemoteAgentctlLogTail(ctx context.Context, client *ssh.Client, sessionD
 
 const sshAgentctlHandshakeAttempts = 3
 
+// sshAgentctlHandshakeRetryDelay is the pause between handshake retry
+// attempts. Sized against the operator-measured trigger on the SSH remote:
+// two independent launches within ~15-30s of each other race the picked
+// port's bootstrap nonce, and the loser gets rejected. The prior zero-delay
+// retry burned all sshAgentctlHandshakeAttempts in under a second — well
+// inside that window — so it could not durably escape the race it exists to
+// recover from. Waiting this long between attempts gives a concurrently
+// launching sibling time to finish (or fail) and vacate the port before the
+// next attempt.
+const sshAgentctlHandshakeRetryDelay = 15 * time.Second
+
 // retryAgentctlHandshake calls attempt up to sshAgentctlHandshakeAttempts
 // times, tearing down and retrying only when attempt fails with
 // errSSHAgentctlHandshakeRejected — the observed shape when a handshake
@@ -793,12 +837,17 @@ const sshAgentctlHandshakeAttempts = 3
 // stale process left on the picked port). Any other failure (bind
 // exhaustion, transport, a malformed response) is terminal and returned
 // immediately after tearing down anything attempt already started (pid > 0).
+// delay is called between attempts (not after the last one) and is injectable
+// so tests can run the retry loop without waiting on the real backoff; ctx
+// cancellation during the wait aborts the retry immediately.
 func retryAgentctlHandshake(
+	ctx context.Context,
 	attempt func() (port, pid int, token string, err error),
 	teardown func(port, pid int),
+	delay func(ctx context.Context, d time.Duration) error,
 ) (port, pid int, token string, err error) {
 	var lastErr error
-	for range sshAgentctlHandshakeAttempts {
+	for i := range sshAgentctlHandshakeAttempts {
 		port, pid, token, err = attempt()
 		if err == nil {
 			return port, pid, token, nil
@@ -810,11 +859,29 @@ func retryAgentctlHandshake(
 			return 0, 0, "", err
 		}
 		lastErr = err
+		if i < sshAgentctlHandshakeAttempts-1 {
+			if derr := delay(ctx, sshAgentctlHandshakeRetryDelay); derr != nil {
+				return 0, 0, "", fmt.Errorf("ssh: agentctl handshake retry cancelled: %w", derr)
+			}
+		}
 	}
 	return 0, 0, "", fmt.Errorf(
 		"ssh: agentctl exhausted %d handshake attempts: %w",
 		sshAgentctlHandshakeAttempts, lastErr,
 	)
+}
+
+// sleepOrContextDone blocks for d or until ctx is cancelled, whichever comes
+// first. Shared delay primitive for retryAgentctlHandshake's production caller.
+func sleepOrContextDone(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func remoteControlHTTPClient(client *ssh.Client, controlPort int) *http.Client {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_ready_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_ready_test.go
@@ -38,6 +38,26 @@ func TestAwaitRemoteAgentctlReadyTimeoutReturnsLivePid(t *testing.T) {
 	}
 }
 
+func TestAwaitRemoteAgentctlReadyPreservesPidWhenLivenessIsUnknown(t *testing.T) {
+	server := newFakeSSHServer(t, func(command, _ string) sshExecResult {
+		if strings.Contains(command, "kill -0") {
+			return sshFail("Operation not permitted")
+		}
+		return sshOut("agentctl: still starting up\n")
+	})
+
+	pid, err := awaitRemoteAgentctlReady(
+		context.Background(), server.dial(t), "/remote/session", 45000, 4242,
+		50*time.Millisecond, 10*time.Millisecond, newTestLogger(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "readiness probe failed") {
+		t.Fatalf("error = %v, want an unknown-liveness probe error", err)
+	}
+	if pid != 4242 {
+		t.Fatalf("pid = %d, want the pid preserved for teardown", pid)
+	}
+}
+
 func TestRetryRemoteAgentctlPortPreservesPidOnTerminalError(t *testing.T) {
 	wantErr := errors.New("ssh: agentctl did not become ready within 30s")
 	port, pid, err := retryRemoteAgentctlPort(

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_ready_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_ready_test.go
@@ -1,0 +1,66 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAwaitRemoteAgentctlReadyTimeoutReturnsLivePid covers the orphan leak a
+// ready-timeout used to cause: the remote process never logged "bound
+// successfully" (or "failed to bind") within the budget, but every liveness
+// probe up to the deadline said it was still running. The caller needs the
+// real pid back to tear it down; returning 0 here made the caller's "if
+// pid > 0" teardown a no-op and leaked the process.
+func TestAwaitRemoteAgentctlReadyTimeoutReturnsLivePid(t *testing.T) {
+	server := newFakeSSHServer(t, func(command, _ string) sshExecResult {
+		switch {
+		case strings.Contains(command, "kill -0"):
+			return sshOK // always alive
+		case strings.Contains(command, "cat ") || strings.Contains(command, "tail "):
+			return sshOut("agentctl: still starting up\n")
+		default:
+			return sshOK
+		}
+	})
+
+	pid, err := awaitRemoteAgentctlReady(
+		context.Background(), server.dial(t), "/remote/session", 45000, 4242,
+		50*time.Millisecond, 10*time.Millisecond, newTestLogger(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("error = %v, want a ready-timeout error", err)
+	}
+	if pid != 4242 {
+		t.Fatalf("pid = %d, want the live pid 4242 preserved for teardown", pid)
+	}
+}
+
+func TestRetryRemoteAgentctlPortPreservesPidOnTerminalError(t *testing.T) {
+	wantErr := errors.New("ssh: agentctl did not become ready within 30s")
+	port, pid, err := retryRemoteAgentctlPort(
+		func() int { return 45000 },
+		func(int) (int, error) { return 4242, wantErr },
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if port != 45000 || pid != 4242 {
+		t.Fatalf("port/pid = %d/%d, want 45000/4242 preserved so the caller can tear down the live process", port, pid)
+	}
+}
+
+func TestRetryRemoteAgentctlPortZeroesPidAfterExhaustingPortAttempts(t *testing.T) {
+	port, pid, err := retryRemoteAgentctlPort(
+		func() int { return 45000 },
+		func(int) (int, error) { return 0, errSSHAgentctlPortInUse },
+	)
+	if !errors.Is(err, errSSHAgentctlPortInUse) {
+		t.Fatalf("error = %v, want errSSHAgentctlPortInUse", err)
+	}
+	if port != 0 || pid != 0 {
+		t.Fatalf("port/pid = %d/%d, want 0/0 — every attempt reported no live process", port, pid)
+	}
+}

--- a/apps/backend/internal/agentctl/server/api/control_server.go
+++ b/apps/backend/internal/agentctl/server/api/control_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 	"github.com/kandev/kandev/internal/agentctl/server/instance"
+	commonconfig "github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/httpmw"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/common/subproc"
@@ -89,12 +90,22 @@ func (m *ControlServer) handleHandshake(c *gin.Context) {
 
 	token := m.cfg.ConsumeNonce(req.Nonce)
 	if token == "" {
-		m.logger.Warn("handshake failed: invalid or already-consumed nonce")
+		// A rejected handshake has three distinct causes that otherwise look
+		// identical from the outside: bootstrap nonce mode was never
+		// configured, the received nonce doesn't match what agentctl started
+		// with, or the configured nonce was already burned by an earlier
+		// handshake. Logging both fingerprints lets a field 403 be attributed
+		// to one of the three instead of guessed at.
+		m.logger.Warn("handshake failed: invalid or already-consumed nonce",
+			zap.Bool("bootstrap_nonce_configured", m.cfg.BootstrapNonceConfigured()),
+			zap.String("configured_nonce_fingerprint", m.cfg.BootstrapNonceFingerprint()),
+			zap.String("received_nonce_fingerprint", commonconfig.NonceFingerprint(req.Nonce)))
 		c.JSON(http.StatusForbidden, gin.H{"error": "invalid or already-consumed nonce"})
 		return
 	}
 
-	m.logger.Info("bootstrap handshake completed, auth token issued")
+	m.logger.Info("bootstrap handshake completed, auth token issued",
+		zap.String("nonce_fingerprint", commonconfig.NonceFingerprint(req.Nonce)))
 	c.JSON(http.StatusOK, gin.H{"token": token})
 }
 

--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -78,6 +78,20 @@ type Config struct {
 	// The nonce is burned after a single successful handshake.
 	BootstrapNonce string
 
+	// bootstrapNonceConfigured records whether AGENTCTL_BOOTSTRAP_NONCE was set
+	// at startup. Unlike BootstrapNonce, it stays true after the nonce is
+	// burned, so handshake-failure diagnostics can tell "bootstrap nonce mode
+	// was never on" apart from "the configured nonce was already consumed" —
+	// both otherwise look identical once BootstrapNonce reads empty.
+	bootstrapNonceConfigured bool
+
+	// bootstrapNonceFingerprint is the diagnostic fingerprint (see
+	// commonconfig.NonceFingerprint) of whichever nonce was configured at
+	// startup. Survives the nonce being burned so a later rejected handshake
+	// can still be attributed to a mismatch against this value, an
+	// already-burned nonce, or bootstrap mode never having been configured.
+	bootstrapNonceFingerprint string
+
 	// IdleTimeout is the duration after which an instance with no in-flight
 	// requests and no recent HTTP activity is reaped by the instance
 	// manager. Sourced from KANDEV_ACP_IDLE_TIMEOUT (default 1h).
@@ -380,9 +394,29 @@ func load(startup *commonconfig.AgentctlStartupConfig) *Config {
 	if nonce := os.Getenv("AGENTCTL_BOOTSTRAP_NONCE"); nonce != "" {
 		cfg.BootstrapNonce = nonce
 		cfg.AuthToken = generateSelfToken()
+		cfg.bootstrapNonceConfigured = true
+		cfg.bootstrapNonceFingerprint = commonconfig.NonceFingerprint(nonce)
 	}
 
 	return cfg
+}
+
+// BootstrapNonceConfigured reports whether AGENTCTL_BOOTSTRAP_NONCE was set at
+// startup, independent of whether the nonce has since been burned by a
+// successful handshake.
+func (c *Config) BootstrapNonceConfigured() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bootstrapNonceConfigured
+}
+
+// BootstrapNonceFingerprint returns the diagnostic fingerprint of the nonce
+// configured at startup, or empty if bootstrap nonce mode was never
+// configured. Unlike BootstrapNonce, it survives the nonce being burned.
+func (c *Config) BootstrapNonceFingerprint() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bootstrapNonceFingerprint
 }
 
 // ListenHost returns the interface agentctl should bind its HTTP listeners to.

--- a/apps/backend/internal/agentctl/server/config/config_test.go
+++ b/apps/backend/internal/agentctl/server/config/config_test.go
@@ -554,6 +554,7 @@ func TestBootstrapNonceDiagnosticsSurviveNonceBurn(t *testing.T) {
 }
 
 func TestBootstrapNonceDiagnosticsUnconfigured(t *testing.T) {
+	t.Setenv("AGENTCTL_BOOTSTRAP_NONCE", "")
 	cfg, err := LoadWithStartup(commonconfig.AgentctlStartupConfig{
 		Configured:                true,
 		IdleTimeout:               time.Hour,

--- a/apps/backend/internal/agentctl/server/config/config_test.go
+++ b/apps/backend/internal/agentctl/server/config/config_test.go
@@ -517,6 +517,61 @@ func TestConsumeNonce(t *testing.T) {
 	})
 }
 
+func TestBootstrapNonceDiagnosticsSurviveNonceBurn(t *testing.T) {
+	t.Setenv("AGENTCTL_BOOTSTRAP_NONCE", "nonce-abc123")
+
+	cfg, err := LoadWithStartup(commonconfig.AgentctlStartupConfig{
+		Configured:                true,
+		IdleTimeout:               time.Hour,
+		IdleReaperInterval:        time.Minute,
+		NotificationQueueCapacity: 4096,
+	})
+	if err != nil {
+		t.Fatalf("LoadWithStartup: %v", err)
+	}
+
+	if !cfg.BootstrapNonceConfigured() {
+		t.Fatal("BootstrapNonceConfigured() = false, want true when AGENTCTL_BOOTSTRAP_NONCE is set")
+	}
+	wantFingerprint := commonconfig.NonceFingerprint("nonce-abc123")
+	if got := cfg.BootstrapNonceFingerprint(); got != wantFingerprint {
+		t.Fatalf("BootstrapNonceFingerprint() = %q, want %q", got, wantFingerprint)
+	}
+
+	if token := cfg.ConsumeNonce("nonce-abc123"); token == "" {
+		t.Fatal("ConsumeNonce() with the correct nonce returned empty")
+	}
+
+	// The whole point of tracking these separately from BootstrapNonce: a
+	// rejected handshake after the nonce was burned must still be able to
+	// report that bootstrap mode was configured, and with which fingerprint.
+	if !cfg.BootstrapNonceConfigured() {
+		t.Fatal("BootstrapNonceConfigured() = false after nonce burn, want true (must survive burning)")
+	}
+	if got := cfg.BootstrapNonceFingerprint(); got != wantFingerprint {
+		t.Fatalf("BootstrapNonceFingerprint() after nonce burn = %q, want %q (must survive burning)", got, wantFingerprint)
+	}
+}
+
+func TestBootstrapNonceDiagnosticsUnconfigured(t *testing.T) {
+	cfg, err := LoadWithStartup(commonconfig.AgentctlStartupConfig{
+		Configured:                true,
+		IdleTimeout:               time.Hour,
+		IdleReaperInterval:        time.Minute,
+		NotificationQueueCapacity: 4096,
+	})
+	if err != nil {
+		t.Fatalf("LoadWithStartup: %v", err)
+	}
+
+	if cfg.BootstrapNonceConfigured() {
+		t.Fatal("BootstrapNonceConfigured() = true, want false when AGENTCTL_BOOTSTRAP_NONCE is unset")
+	}
+	if got := cfg.BootstrapNonceFingerprint(); got != "" {
+		t.Fatalf("BootstrapNonceFingerprint() = %q, want empty when bootstrap nonce mode was never configured", got)
+	}
+}
+
 func TestGenerateSelfToken(t *testing.T) {
 	token := generateSelfToken()
 	if len(token) != 64 { // 32 bytes hex-encoded = 64 chars

--- a/apps/backend/internal/common/config/nonce.go
+++ b/apps/backend/internal/common/config/nonce.go
@@ -1,0 +1,19 @@
+package config
+
+// nonceFingerprintLength is the number of leading hex characters of a
+// bootstrap nonce kept for diagnostics. Long enough to distinguish nonces
+// across a handful of concurrent launches, short enough that logging it never
+// exposes anything close to the full secret.
+const nonceFingerprintLength = 8
+
+// NonceFingerprint returns the first nonceFingerprintLength hex characters of
+// a hex-encoded bootstrap nonce, safe to log on both the backend launcher and
+// the agentctl control server. It lets a rejected handshake be correlated
+// against the nonce each side actually used without ever logging the nonce
+// itself.
+func NonceFingerprint(nonce string) string {
+	if len(nonce) <= nonceFingerprintLength {
+		return nonce
+	}
+	return nonce[:nonceFingerprintLength]
+}

--- a/apps/backend/internal/common/config/nonce.go
+++ b/apps/backend/internal/common/config/nonce.go
@@ -1,19 +1,23 @@
 package config
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
 // nonceFingerprintLength is the number of leading hex characters of a
-// bootstrap nonce kept for diagnostics. Long enough to distinguish nonces
-// across a handful of concurrent launches, short enough that logging it never
-// exposes anything close to the full secret.
+// SHA-256 digest kept for diagnostics.
 const nonceFingerprintLength = 8
 
-// NonceFingerprint returns the first nonceFingerprintLength hex characters of
-// a hex-encoded bootstrap nonce, safe to log on both the backend launcher and
-// the agentctl control server. It lets a rejected handshake be correlated
-// against the nonce each side actually used without ever logging the nonce
-// itself.
+// NonceFingerprint returns a short SHA-256 digest of the bootstrap nonce,
+// safe to log on both the backend launcher and the agentctl control server.
+// It lets a rejected handshake be correlated against the nonce each side used
+// without logging any characters from the nonce itself.
 func NonceFingerprint(nonce string) string {
-	if len(nonce) <= nonceFingerprintLength {
-		return nonce
+	if nonce == "" {
+		return ""
 	}
-	return nonce[:nonceFingerprintLength]
+	digest := sha256.Sum256([]byte(nonce))
+	encoded := hex.EncodeToString(digest[:])
+	return encoded[:nonceFingerprintLength]
 }

--- a/apps/backend/internal/common/config/nonce_test.go
+++ b/apps/backend/internal/common/config/nonce_test.go
@@ -9,19 +9,19 @@ func TestNonceFingerprint(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "32-byte hex nonce keeps only the first 8 characters",
+			name:  "32-byte hex nonce hashes to a short digest",
 			nonce: "0123456789abcdef0123456789abcdef",
-			want:  "01234567",
+			want:  "3eb1bd43",
 		},
 		{
-			name:  "nonce shorter than the fingerprint length is returned unchanged",
+			name:  "nonce shorter than the fingerprint length is hashed",
 			nonce: "abc123",
-			want:  "abc123",
+			want:  "6ca13d52",
 		},
 		{
-			name:  "nonce exactly the fingerprint length is returned unchanged",
+			name:  "nonce exactly the fingerprint length is hashed",
 			nonce: "abcdef01",
-			want:  "abcdef01",
+			want:  "aa280d2e",
 		},
 		{
 			name:  "empty nonce fingerprints to empty",
@@ -39,19 +39,13 @@ func TestNonceFingerprint(t *testing.T) {
 	}
 }
 
-// TestNonceFingerprintNeverExposesFullSecret pins the truncation itself: two
-// nonces that only differ after the fingerprint length must fingerprint
-// identically, proving the fingerprint cannot be used to reconstruct or
-// distinguish the full secret.
-func TestNonceFingerprintNeverExposesFullSecret(t *testing.T) {
-	a := "deadbeef0000000000000000000000000000000000000000000000000000"
-	b := "deadbeefffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-
-	fa, fb := NonceFingerprint(a), NonceFingerprint(b)
-	if fa != fb {
-		t.Fatalf("fingerprints diverged past the truncation point: %q vs %q", fa, fb)
+func TestNonceFingerprintDoesNotExposeNoncePrefix(t *testing.T) {
+	nonce := "deadbeef0000000000000000000000000000000000000000000000000000"
+	got := NonceFingerprint(nonce)
+	if got == nonce[:nonceFingerprintLength] {
+		t.Fatalf("fingerprint %q exposes the nonce prefix", got)
 	}
-	if len(fa) != nonceFingerprintLength {
-		t.Fatalf("fingerprint length = %d, want %d", len(fa), nonceFingerprintLength)
+	if len(got) != nonceFingerprintLength {
+		t.Fatalf("fingerprint length = %d, want %d", len(got), nonceFingerprintLength)
 	}
 }

--- a/apps/backend/internal/common/config/nonce_test.go
+++ b/apps/backend/internal/common/config/nonce_test.go
@@ -1,0 +1,57 @@
+package config
+
+import "testing"
+
+func TestNonceFingerprint(t *testing.T) {
+	cases := []struct {
+		name  string
+		nonce string
+		want  string
+	}{
+		{
+			name:  "32-byte hex nonce keeps only the first 8 characters",
+			nonce: "0123456789abcdef0123456789abcdef",
+			want:  "01234567",
+		},
+		{
+			name:  "nonce shorter than the fingerprint length is returned unchanged",
+			nonce: "abc123",
+			want:  "abc123",
+		},
+		{
+			name:  "nonce exactly the fingerprint length is returned unchanged",
+			nonce: "abcdef01",
+			want:  "abcdef01",
+		},
+		{
+			name:  "empty nonce fingerprints to empty",
+			nonce: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NonceFingerprint(tc.nonce); got != tc.want {
+				t.Fatalf("NonceFingerprint(%q) = %q, want %q", tc.nonce, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNonceFingerprintNeverExposesFullSecret pins the truncation itself: two
+// nonces that only differ after the fingerprint length must fingerprint
+// identically, proving the fingerprint cannot be used to reconstruct or
+// distinguish the full secret.
+func TestNonceFingerprintNeverExposesFullSecret(t *testing.T) {
+	a := "deadbeef0000000000000000000000000000000000000000000000000000"
+	b := "deadbeefffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	fa, fb := NonceFingerprint(a), NonceFingerprint(b)
+	if fa != fb {
+		t.Fatalf("fingerprints diverged past the truncation point: %q vs %q", fa, fb)
+	}
+	if len(fa) != nonceFingerprintLength {
+		t.Fatalf("fingerprint length = %d, want %d", len(fa), nonceFingerprintLength)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -140,10 +140,16 @@ func (e *Executor) stopWithSession(ctx context.Context, session *models.TaskSess
 	if e.onExecutionStopOwnerRegistration != nil {
 		e.onExecutionStopOwnerRegistration(session.ID, executionID, force)
 	}
-	if dbErr := e.updateSessionState(ctx, session.TaskID, session.ID, models.TaskSessionStateCancelled, reason); dbErr != nil {
-		e.logger.Error("failed to update agent session status",
-			zap.String("session_id", session.ID),
-			zap.Error(dbErr))
+	// A session already in a terminal state carries its own outcome (e.g. a
+	// launch failure's error_message); a runtime that outlived it in the
+	// in-memory execution store must still be torn down, but the DB row is
+	// not touched. Mirrors the terminal-state guard in transitionSessionState.
+	if !isStopTerminalSessionState(session.State) {
+		if dbErr := e.updateSessionState(ctx, session.TaskID, session.ID, models.TaskSessionStateCancelled, reason); dbErr != nil {
+			e.logger.Error("failed to update agent session status",
+				zap.String("session_id", session.ID),
+				zap.Error(dbErr))
+		}
 	}
 	e.scheduleStop(ctx, session.ID, executionID, reason, force)
 	return nil

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -143,13 +143,14 @@ func (e *Executor) stopWithSession(ctx context.Context, session *models.TaskSess
 	// A session already in a terminal state carries its own outcome (e.g. a
 	// launch failure's error_message); a runtime that outlived it in the
 	// in-memory execution store must still be torn down, but the DB row is
-	// not touched. Mirrors the terminal-state guard in transitionSessionState.
-	if !isStopTerminalSessionState(session.State) {
-		if dbErr := e.updateSessionState(ctx, session.TaskID, session.ID, models.TaskSessionStateCancelled, reason); dbErr != nil {
-			e.logger.Error("failed to update agent session status",
-				zap.String("session_id", session.ID),
-				zap.Error(dbErr))
-		}
+	// not touched. transitionSessionState re-reads the session's current
+	// state itself rather than trusting the caller-supplied snapshot, so a
+	// session that turned terminal between the caller's read and this call
+	// (e.g. StopByTaskID iterating a list read once) can't be clobbered.
+	if _, _, err := e.transitionSessionState(ctx, session.TaskID, session.ID, models.TaskSessionStateCancelled, reason); err != nil {
+		e.logger.Error("failed to update agent session status",
+			zap.String("session_id", session.ID),
+			zap.Error(err))
 	}
 	e.scheduleStop(ctx, session.ID, executionID, reason, force)
 	return nil

--- a/apps/backend/internal/orchestrator/executor/executor_stop_terminal_guard_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_stop_terminal_guard_test.go
@@ -59,3 +59,58 @@ func TestStopWithSession_DoesNotOverwriteTerminalSession(t *testing.T) {
 		t.Fatalf("session error_message = %q, want the original diagnosis preserved", got.ErrorMessage)
 	}
 }
+
+// TestStopWithSession_DoesNotOverwriteTerminalSession_StaleCallerSnapshot
+// covers the freshness gap the guard above doesn't exercise: the caller's
+// in-hand *models.TaskSession still shows RUNNING (read before a concurrent
+// launch failure landed), but the DB row has already moved to FAILED by the
+// time stopWithSession runs. A guard that trusts the caller-supplied
+// snapshot instead of re-reading current state would see "not terminal" and
+// clobber the FAILED row anyway.
+func TestStopWithSession_DoesNotOverwriteTerminalSession_StaleCallerSnapshot(t *testing.T) {
+	repo := newMockRepository()
+	repo.sessions["session-1"] = &models.TaskSession{
+		ID:           "session-1",
+		TaskID:       "task-1",
+		State:        models.TaskSessionStateFailed,
+		ErrorMessage: "ssh: agentctl handshake returned 403",
+	}
+	staleSnapshot := &models.TaskSession{
+		ID:     "session-1",
+		TaskID: "task-1",
+		State:  models.TaskSessionStateRunning,
+	}
+
+	stopCalls := make(chan string, 1)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return "execution-leaked", nil
+		},
+		stopAgentWithReasonFunc: func(_ context.Context, executionID, _ string, _ bool) error {
+			stopCalls <- executionID
+			return nil
+		},
+	}
+	exec := newTestExecutor(t, manager, repo)
+
+	if err := exec.stopWithSession(context.Background(), staleSnapshot, "task archived", true); err != nil {
+		t.Fatalf("stopWithSession: %v", err)
+	}
+
+	select {
+	case executionID := <-stopCalls:
+		if executionID != "execution-leaked" {
+			t.Fatalf("stopped execution = %q, want execution-leaked", executionID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for leaked execution teardown")
+	}
+
+	got := repo.sessions["session-1"]
+	if got.State != models.TaskSessionStateFailed {
+		t.Fatalf("session state = %q, want FAILED to survive the stop despite a stale RUNNING caller snapshot", got.State)
+	}
+	if got.ErrorMessage != "ssh: agentctl handshake returned 403" {
+		t.Fatalf("session error_message = %q, want the original diagnosis preserved", got.ErrorMessage)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_stop_terminal_guard_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_stop_terminal_guard_test.go
@@ -1,0 +1,61 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// TestStopWithSession_DoesNotOverwriteTerminalSession covers a session whose
+// DB row already reached a terminal state (e.g. FAILED with a diagnostic
+// error_message) while the lifecycle manager still reports a live execution
+// for it — the shape observed when an SSH launch fails at the agentctl
+// handshake after the in-memory execution was registered. The legacy
+// stopWithSession path (used by orchestrator.Service.StopSession, including
+// the async archive-cleanup stop) must not clobber that terminal row with
+// CANCELLED / the stop reason; it must still tear down the leaked runtime.
+func TestStopWithSession_DoesNotOverwriteTerminalSession(t *testing.T) {
+	repo := newMockRepository()
+	session := &models.TaskSession{
+		ID:           "session-1",
+		TaskID:       "task-1",
+		State:        models.TaskSessionStateFailed,
+		ErrorMessage: "ssh: agentctl handshake returned 403",
+	}
+	repo.sessions[session.ID] = session
+
+	stopCalls := make(chan string, 1)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return "execution-leaked", nil
+		},
+		stopAgentWithReasonFunc: func(_ context.Context, executionID, _ string, _ bool) error {
+			stopCalls <- executionID
+			return nil
+		},
+	}
+	exec := newTestExecutor(t, manager, repo)
+
+	if err := exec.stopWithSession(context.Background(), session, "task archived", true); err != nil {
+		t.Fatalf("stopWithSession: %v", err)
+	}
+
+	select {
+	case executionID := <-stopCalls:
+		if executionID != "execution-leaked" {
+			t.Fatalf("stopped execution = %q, want execution-leaked", executionID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for leaked execution teardown")
+	}
+
+	got := repo.sessions[session.ID]
+	if got.State != models.TaskSessionStateFailed {
+		t.Fatalf("session state = %q, want FAILED to survive the stop", got.State)
+	}
+	if got.ErrorMessage != "ssh: agentctl handshake returned 403" {
+		t.Fatalf("session error_message = %q, want the original diagnosis preserved", got.ErrorMessage)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -1594,10 +1594,11 @@ func (r *Repository) UpdateTaskSessionDynamicRouteIfCurrent(
 	return rows > 0, now, nil
 }
 
-// CancelActiveTaskSession atomically transitions one active session to
-// CANCELLED. A false result means the row exists in a non-active state or was
-// concurrently changed before this conditional write; callers re-read to
-// distinguish those cases from a missing row. The returned timestamp belongs
+// CancelActiveTaskSession atomically transitions one active session, including
+// a parked IDLE session, to CANCELLED. A false result means the row exists in
+// a non-active state, or it was concurrently changed before this conditional
+// write; callers re-read to distinguish those cases from a missing row. The
+// returned timestamp belongs
 // to the committed cancellation, so accepting callers never need a fallible
 // post-write read before scheduling teardown.
 func (r *Repository) CancelActiveTaskSession(ctx context.Context, id, reason string) (bool, time.Time, error) {
@@ -1606,7 +1607,7 @@ func (r *Repository) CancelActiveTaskSession(ctx context.Context, id, reason str
 		UPDATE task_sessions
 		SET state = ?, error_message = ?, completed_at = ?, updated_at = ?
 		WHERE id = ?
-			AND state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
+			AND state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT', 'IDLE')
 	`), string(models.TaskSessionStateCancelled), reason, now, now, id)
 	if err != nil {
 		return false, time.Time{}, err

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -1478,6 +1478,7 @@ func TestCancelActiveTaskSessionIsTerminalSafe(t *testing.T) {
 		t.Fatalf("seed running state: %v", err)
 	}
 	insertSession(t, repo, "session-completed", "task-cas", string(models.TaskSessionStateCompleted))
+	insertSession(t, repo, "session-idle", "task-cas", string(models.TaskSessionStateIdle))
 
 	changed, cancelledAt, err := repo.CancelActiveTaskSession(ctx, "session-running", "coordinator stop")
 	if err != nil {
@@ -1488,6 +1489,16 @@ func TestCancelActiveTaskSessionIsTerminalSafe(t *testing.T) {
 	}
 	if got := sessionState(t, repo, "session-running"); got != string(models.TaskSessionStateCancelled) {
 		t.Fatalf("running session state = %q, want CANCELLED", got)
+	}
+	changed, _, err = repo.CancelActiveTaskSession(ctx, "session-idle", "coordinator stop")
+	if err != nil {
+		t.Fatalf("cancel idle session: %v", err)
+	}
+	if !changed {
+		t.Fatal("idle session was not cancelled")
+	}
+	if got := sessionState(t, repo, "session-idle"); got != string(models.TaskSessionStateCancelled) {
+		t.Fatalf("idle session state = %q, want CANCELLED", got)
 	}
 	cancelled, err := repo.GetTaskSession(ctx, "session-running")
 	if err != nil {


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3511/5535bb5f27a4.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** Two SSH task launches racing on the same runner can collide on the same bootstrap nonce; the losing launch gets an unretried 403 at handshake and the task fails immediately, with a leaked agentctl process on a ready-timeout and no diagnostics to tell one 403 cause from another.
**After this:** The losing launch retries the handshake (three attempts, 15s apart) and succeeds without any user action; a live agentctl process is never leaked on timeout, and a fresh 403 is self-attributing via a startup-time bootstrap-nonce fingerprint log line on both the launcher and agentctl sides.
**Who hits this:** Anyone launching two or more SSH-executor tasks against the same remote runner within roughly a 15-30 second window.
**Scope:** `apps/backend` only (handshake retry/backoff, session-stop state read, pid propagation on ready-timeout, retry classification, nonce diagnostics). No `apps/web/` changes.
**Not here:** Serializing concurrent SSH launches against the same runner (the race's underlying interference mechanism), and reaping orphaned agentctl processes left by prior failed launches — both filed as follow-up work, not fixed in this PR.

SSH task launches occasionally failed immediately when two launches raced a runner's bootstrap nonce, with no retry and a leaked agentctl process on ready-timeout. The handshake now retries with a 15s backoff, only treats a 403 as retryable, always propagates the live pid, and reads fresh session state before refusing a stop.

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/orchestrator/executor/... ./internal/agentctl/server/config/... ./internal/agentctl/server/api/... ./internal/common/config/... ./internal/agent/runtime/lifecycle/...` (the 5 packages this diff touches) — only pre-existing failures (proven against a merge-base scratch worktree during Verify; confirmed unchanged after rebase, including one that was simply renamed upstream)
- `golangci-lint run ./... --new-from-rev=77e3cfc97` (from `apps/backend`) — 0 issues
- `make fmt`, `make typecheck`, `make lint`, `make lint-format` — all clean
- `pnpm run i18n:ratchet` (from `apps/web`) — clean; this diff touches no `apps/web/` files
- `pnpm --filter kandev test` — 5/5 pass
- `pnpm --filter @kandev/web test` (full local suite) — 16054/16067 passing; the 9 failures are unrelated to this diff (this diff touches zero `apps/web/` files) and reproduce a different set of unrelated files each run, consistent with local-suite flake under host load
- `make test-scripts` — one pre-existing failure (`dev-prod-db-path.test.sh`'s `Make variable home` subtest), unrelated to this diff
- No E2E run: this diff has zero `apps/web/` paths, so the allowlist exempts it
- No screenshots: backend-only change with no UI-visible effect

## Possible Improvements

Low risk: the fix only adds a bounded retry, a delay, and diagnostics to an existing code path. The actual race (why two launches interfere on the same host at all) is not eliminated here by design — see "Not here" above; a follow-up card tracks orphaned-process reaping.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->