### PR TITLE
fix(office): stop agents showing idle while a successor run works

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -30,14 +30,9 @@ import (
 //
 // Takes the transition from either "idle", or from "working" when the
 // recorded owner (working_run_id) is a different run that is no longer
-// in-flight (not 'claimed'). The second branch closes the DR-14 successor
-// window: handleAgentCompleted leaves a run's own clearAgentWorking call
-// running after the run has already left 'claimed', so a same-agent
-// successor run can be claimed and launched before that clear executes. A
-// launching run taking ownership here means the abandoned owner's later
-// clear no-ops (its runID no longer matches), instead of clobbering the
-// successor's live "working" status. It never takes ownership from a
-// still-claimed owner, so a genuinely in-flight run is never stolen from.
+// in-flight (not 'claimed'). The launching run then owns the status, so the
+// predecessor's later run-scoped clear becomes a no-op. It never takes
+// ownership from a still-claimed owner, so an in-flight run is not stolen.
 //
 // Scoped to status IN ('idle', 'working') so it can never overwrite a
 // status a concurrent writer set between the scheduler's isAgentActive

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status.go
@@ -8,9 +8,13 @@
 // writer — most dangerously autoPauseAgent (office/service/failure.go),
 // which pauses an agent after consecutive failures on the very same code
 // path that clears "working". A CAS makes each write a no-op unless the
-// agent is still in the exact state the caller observed, so the reset can
-// be called redundantly from any terminal path without resurrecting a
-// paused, stopped, or pending-approval agent back to idle.
+// agent is still in a state the caller is entitled to transition from, so
+// the reset can be called redundantly from any terminal path without
+// resurrecting a paused, stopped, or pending-approval agent back to idle.
+// MarkAgentWorking's CAS additionally allows one extra state: a launching
+// run may take ownership from a same-agent predecessor that is still
+// recorded "working" but whose run is no longer in-flight — see its own
+// doc comment for why.
 
 package sqlite
 
@@ -20,21 +24,42 @@ import (
 	"time"
 )
 
-// MarkAgentWorking transitions an agent from "idle" to "working" and records
-// runID as the run that owns the transition. Returns true when this call
-// performed the transition.
+// MarkAgentWorking transitions an agent to "working" and records runID as
+// the run that owns the transition. Returns true when this call performed
+// the transition.
 //
-// Scoped to status = 'idle' so it cannot overwrite a status a concurrent
-// writer set between the scheduler's isAgentActive check and the launch
-// (a user pausing the agent, a budget pause, an approval gate). A false
-// return therefore means "the agent was not idle" and is not an error: the
-// run still launches, exactly as it did before this status existed.
+// Takes the transition from either "idle", or from "working" when the
+// recorded owner (working_run_id) is a different run that is no longer
+// in-flight (not 'claimed'). The second branch closes the DR-14 successor
+// window: handleAgentCompleted leaves a run's own clearAgentWorking call
+// running after the run has already left 'claimed', so a same-agent
+// successor run can be claimed and launched before that clear executes. A
+// launching run taking ownership here means the abandoned owner's later
+// clear no-ops (its runID no longer matches), instead of clobbering the
+// successor's live "working" status. It never takes ownership from a
+// still-claimed owner, so a genuinely in-flight run is never stolen from.
+//
+// Scoped to status IN ('idle', 'working') so it can never overwrite a
+// status a concurrent writer set between the scheduler's isAgentActive
+// check and the launch (a user pausing the agent, a budget pause, an
+// approval gate) — a paused, stopped, or pending-approval agent is never
+// resurrected. A false return means the agent was not idle and had no
+// abandoned owner to take over from; it is not an error, and the run still
+// launches exactly as it did before this status existed.
 func (r *Repository) MarkAgentWorking(ctx context.Context, id, runID string) (bool, error) {
 	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE agent_profiles
 		SET status = 'working', working_run_id = ?, updated_at = ?
-		WHERE id = ? AND status = 'idle' AND `+agentInstanceFilter+`
-	`), runID, time.Now().UTC(), id)
+		WHERE id = ? AND `+agentInstanceFilter+` AND (
+			status = 'idle'
+			OR (status = 'working' AND working_run_id <> ?
+				AND NOT EXISTS (
+					SELECT 1 FROM runs
+					WHERE runs.id = agent_profiles.working_run_id
+					  AND runs.status = 'claimed'
+				))
+		)
+	`), runID, time.Now().UTC(), id, runID)
 	if err != nil {
 		return false, err
 	}

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
@@ -205,3 +205,135 @@ func TestClearAgentWorking_IsIdempotent(t *testing.T) {
 		t.Fatalf("status = %q, want idle", got)
 	}
 }
+
+// TestMarkAgentWorking_SuccessorTakeover is the DR-14 follow-up regression.
+// Run A finishes (leaves 'claimed', making the agent claimable again) before
+// its own clearAgentWorking runs. In that window, run B is claimed and
+// launched for the same agent: B's MarkAgentWorking must take ownership from
+// A instead of no-oping, so A's later clear (scoped to A's own runID) cannot
+// touch B's ownership and strand the agent showing "idle" while B is in
+// flight.
+func TestMarkAgentWorking_SuccessorTakeover(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	agent := workingStatusAgent(t, repo, "agent-successor", "idle")
+
+	runA := &models.Run{ID: "run-a", AgentProfileID: agent.ID, Reason: "test", Payload: "{}"}
+	if err := repo.CreateRun(ctx, runA); err != nil {
+		t.Fatalf("create run A: %v", err)
+	}
+	claimedA, err := repo.ClaimRun(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("claim run A: %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, agent.ID, claimedA.ID); err != nil {
+		t.Fatalf("mark working (run A): %v", err)
+	}
+
+	// Run A leaves 'claimed' (finishes) but its own clearAgentWorking has not
+	// run yet — the un-transacted window handleAgentCompleted leaves open.
+	if err := repo.FinishRun(ctx, claimedA.ID, string(models.RunStatusFinished), nil); err != nil {
+		t.Fatalf("finish run A: %v", err)
+	}
+
+	// Run B is claimed and launched for the same agent inside that window.
+	runB := &models.Run{ID: "run-b", AgentProfileID: agent.ID, Reason: "test", Payload: "{}"}
+	if err := repo.CreateRun(ctx, runB); err != nil {
+		t.Fatalf("create run B: %v", err)
+	}
+	claimedB, err := repo.ClaimRun(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("claim run B: %v", err)
+	}
+	changed, err := repo.MarkAgentWorking(ctx, agent.ID, claimedB.ID)
+	if err != nil {
+		t.Fatalf("mark working (run B): %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true: run B must take ownership from a finished run A")
+	}
+
+	// Run A's own clearAgentWorking now runs, scoped to A's runID.
+	clearedByA, err := repo.ClearAgentWorking(ctx, agent.ID, claimedA.ID)
+	if err != nil {
+		t.Fatalf("clear working (run A): %v", err)
+	}
+	if clearedByA {
+		t.Fatal("run A's clear reported a change: it must no-op once run B owns \"working\"")
+	}
+	if got := statusOf(t, repo, agent.ID); got != models.AgentStatusWorking {
+		t.Fatalf("status after run A's clear = %q, want %q (run B still in flight)", got, models.AgentStatusWorking)
+	}
+
+	// Run B's own terminal clear correctly resets the agent.
+	clearedByB, err := repo.ClearAgentWorking(ctx, agent.ID, claimedB.ID)
+	if err != nil {
+		t.Fatalf("clear working (run B): %v", err)
+	}
+	if !clearedByB {
+		t.Fatal("run B's own clear should have changed the status")
+	}
+	if got := statusOf(t, repo, agent.ID); got != models.AgentStatusIdle {
+		t.Fatalf("status after run B clear = %q, want %q", got, models.AgentStatusIdle)
+	}
+}
+
+// TestMarkAgentWorking_NoTheftFromLiveOwner is the inverse of the takeover
+// case: while the recorded owner run is still 'claimed' (genuinely in
+// flight), a second MarkAgentWorking call for a different run must not steal
+// ownership.
+func TestMarkAgentWorking_NoTheftFromLiveOwner(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	agent := workingStatusAgent(t, repo, "agent-live-owner", "idle")
+
+	runA := &models.Run{ID: "run-live-a", AgentProfileID: agent.ID, Reason: "test", Payload: "{}"}
+	if err := repo.CreateRun(ctx, runA); err != nil {
+		t.Fatalf("create run A: %v", err)
+	}
+	claimedA, err := repo.ClaimRun(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("claim run A: %v", err)
+	}
+	if _, err := repo.MarkAgentWorking(ctx, agent.ID, claimedA.ID); err != nil {
+		t.Fatalf("mark working (run A): %v", err)
+	}
+
+	// Run A is still 'claimed' — no finish, no clear. A second run's mark
+	// attempt (e.g. a duplicate/misrouted event) must not take ownership.
+	changed, err := repo.MarkAgentWorking(ctx, agent.ID, "run-live-b")
+	if err != nil {
+		t.Fatalf("mark working (run B attempt): %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false: run A is still claimed and in flight")
+	}
+	if got := statusOf(t, repo, agent.ID); got != models.AgentStatusWorking {
+		t.Fatalf("status = %q, want working (unchanged)", got)
+	}
+}
+
+// TestMarkAgentWorking_DoesNotResurrectPausedAgent guards the widened
+// predicate's status scope: it must still only ever transition an idle or
+// (abandoned-owner) working agent, never a paused/stopped/pending-approval
+// one.
+func TestMarkAgentWorking_DoesNotResurrectPausedAgent(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	for _, status := range []string{"paused", "stopped", "pending_approval"} {
+		id := "agent-mark-guard-" + status
+		workingStatusAgent(t, repo, id, status)
+
+		changed, err := repo.MarkAgentWorking(ctx, id, "run-1")
+		if err != nil {
+			t.Fatalf("%s: mark working: %v", status, err)
+		}
+		if changed {
+			t.Fatalf("%s: changed = true, want false: only idle/abandoned-working agents may be marked", status)
+		}
+		if got := statusOf(t, repo, id); string(got) != status {
+			t.Fatalf("%s: status = %q, want it left untouched", status, got)
+		}
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
+++ b/apps/backend/internal/office/repository/sqlite/agent_working_status_test.go
@@ -45,8 +45,7 @@ func setWorkingRunID(t *testing.T, db *sqlx.DB, agentID, runID string) {
 	}
 }
 
-// TestMarkAgentWorking_FromIdle is the core DR-14 write: before this method
-// existed, no production code path could ever produce this status.
+// TestMarkAgentWorking_FromIdle covers the core working-status write.
 func TestMarkAgentWorking_FromIdle(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
@@ -84,10 +83,7 @@ func TestClearAgentWorking_ReturnsToIdle(t *testing.T) {
 
 // TestClearAgentWorking_MismatchedRunID_DoesNotClobberSuccessor is the
 // interleaving regression: a stale or duplicate terminal event for a run
-// that has already finished must not be able to reset an agent a SUCCESSOR
-// run has since marked working. Before working_run_id existed, this exact
-// sequence flipped a live run's agent back to "idle" — reintroducing DR-14's
-// invisibility bug in a narrower window.
+// that has already finished must not reset an agent a successor run owns.
 func TestClearAgentWorking_MismatchedRunID_DoesNotClobberSuccessor(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
@@ -137,11 +133,9 @@ func TestClearAgentWorking_MismatchedRunID_DoesNotClobberSuccessor(t *testing.T)
 	}
 }
 
-// TestClearAgentWorking_DoesNotResurrectPausedAgent guards the highest-risk
-// interaction in DR-14. HandleAgentFailure clears "working" on the same code
-// path that auto-pauses an agent after consecutive failures. If the reset
-// were an unconditional UPDATE rather than a CAS, a paused agent would be
-// silently flipped back to idle and would resume picking up runs.
+// TestClearAgentWorking_DoesNotResurrectPausedAgent guards the interaction
+// between failure cleanup and automatic pausing. The clear must not turn a
+// paused agent back to idle.
 func TestClearAgentWorking_DoesNotResurrectPausedAgent(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()
@@ -206,7 +200,7 @@ func TestClearAgentWorking_IsIdempotent(t *testing.T) {
 	}
 }
 
-// TestMarkAgentWorking_SuccessorTakeover is the DR-14 follow-up regression.
+// TestMarkAgentWorking_SuccessorTakeover covers successor ownership.
 // Run A finishes (leaves 'claimed', making the agent claimable again) before
 // its own clearAgentWorking runs. In that window, run B is claimed and
 // launched for the same agent: B's MarkAgentWorking must take ownership from

--- a/apps/backend/internal/office/service/agent_working_status.go
+++ b/apps/backend/internal/office/service/agent_working_status.go
@@ -28,22 +28,14 @@ const (
 )
 
 // markAgentWorking flips an agent to "working" as its run is handed to the
-// adapter, recording runID as the owning run. This also takes ownership from
-// a same-agent predecessor run that is still recorded "working" but is no
-// longer in-flight (repo.MarkAgentWorking's CAS) — the handoff between two
-// back-to-back runs on one agent, where the predecessor's own clear has not
-// executed yet. So changed = false no longer means "the agent was not
-// idle": it means the agent was neither idle nor holding an abandoned
-// "working" owner, i.e. it was genuinely busy or in a non-launchable status
-// (paused, stopped, pending approval).
+// adapter, recording runID as the owning run. It also takes ownership from
+// a predecessor that is still recorded "working" but is no longer in-flight.
+// A false result means the agent was neither idle nor holding an abandoned
+// owner, so it was genuinely busy or in a non-launchable status.
 //
-// Called BEFORE the launch rather than after it: the completion event for a
-// fast run can be processed as soon as the adapter is invoked, and a
-// mark-after-launch would race that reset and strand the agent showing
-// "working" forever — the exact failure this feature must not introduce,
-// since a stuck "working" reads as progress that is not happening.
-// The caller clears the status when the launch turns out not to have
-// happened.
+// Called BEFORE the launch so a completion event cannot clear a status that
+// the launch has not marked. The caller clears the status when launch does
+// not happen.
 //
 // runID must be non-empty: it is the only way a later clearAgentWorking call
 // can tell this run's own reset apart from a stale one belonging to a

--- a/apps/backend/internal/office/service/agent_working_status.go
+++ b/apps/backend/internal/office/service/agent_working_status.go
@@ -27,8 +27,15 @@ const (
 	eventKeyWorkspaceID    = "workspace_id"
 )
 
-// markAgentWorking flips an idle agent to "working" as its run is handed to
-// the adapter, recording runID as the owning run.
+// markAgentWorking flips an agent to "working" as its run is handed to the
+// adapter, recording runID as the owning run. This also takes ownership from
+// a same-agent predecessor run that is still recorded "working" but is no
+// longer in-flight (repo.MarkAgentWorking's CAS) — the handoff between two
+// back-to-back runs on one agent, where the predecessor's own clear has not
+// executed yet. So changed = false no longer means "the agent was not
+// idle": it means the agent was neither idle nor holding an abandoned
+// "working" owner, i.e. it was genuinely busy or in a non-launchable status
+// (paused, stopped, pending approval).
 //
 // Called BEFORE the launch rather than after it: the completion event for a
 // fast run can be processed as soon as the adapter is invoked, and a

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -311,6 +311,44 @@ func TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate(t *testing.T)
 		"after the requeued run was terminated at a pre-launch gate")
 }
 
+// TestAgentStatus_TasklessCompletionClearsWorkingWhenNoRunResolves covers the
+// third DR-14 follow-up edit: handleTasklessAgentCompleted's sql.ErrNoRows
+// exit (no resolvable claimed run) must clear "working" like its two
+// siblings in handleAgentCompleted and handleAgentFailed, instead of
+// returning without a clear and stranding the agent's status.
+func TestAgentStatus_TasklessCompletionClearsWorkingWhenNoRunResolves(t *testing.T) {
+	svc := newTestService(t)
+	svc.SetSyncHandlers(true)
+	ctx := context.Background()
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	agent := makeAgent("worker-taskless-no-run", models.AgentRoleWorker)
+	if err := svc.CreateAgentInstance(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	// Seed "working" directly rather than via a real launch: the run this
+	// status nominally belongs to has already left "claimed" via another
+	// path (mirroring the ErrNoRows condition resolveLifecycleRun hits),
+	// so no claimed run resolves for the event below.
+	svc.ExecSQL(t, `UPDATE agent_profiles SET status = 'working', working_run_id = 'ghost-run' WHERE id = ?`, agent.ID)
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusWorking, "before the taskless event")
+
+	event := bus.NewEvent(events.AgentCompleted, "test", map[string]string{
+		"run_id":           "ghost-run",
+		"agent_profile_id": agent.ID,
+		"session_id":       "session-" + agent.ID,
+	})
+	if err := eb.Publish(ctx, events.AgentCompleted, event); err != nil {
+		t.Fatalf("publish agent completed: %v", err)
+	}
+
+	assertAgentStatus(t, svc, ctx, agent.ID, models.AgentStatusIdle,
+		"after a taskless AgentCompleted whose run no longer resolves as claimed")
+}
+
 func publishLifecycle(
 	t *testing.T, ctx context.Context, eb bus.EventBus,
 	topic, taskID, agentID string,

--- a/apps/backend/internal/office/service/agent_working_status_test.go
+++ b/apps/backend/internal/office/service/agent_working_status_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/kandev/kandev/internal/office/service"
 )
 
-// DR-14: "working" is a defined agent status that nothing ever assigned, so
-// every Office agent read "idle" permanently — including while a run was in
-// flight. These tests cover the write at the launch boundary and the reset
-// on all three terminal paths (success, failure, cancellation).
+// These tests cover the working-status write at the launch boundary and the
+// reset on all three terminal paths (success, failure, cancellation).
 
 // launchedWorkingAgent seeds an agent + task, ticks the scheduler so the run
 // is actually handed to the adapter, and returns the agent. On return the
@@ -64,10 +62,7 @@ func assertAgentStatus(
 	}
 }
 
-// TestAgentStatus_WorkingWhileRunInFlight is the core DR-14 regression pin:
-// before this change the assertion below read "idle" for an agent whose run
-// had just been handed to the adapter, making a busy workspace and a stalled
-// one indistinguishable.
+// TestAgentStatus_WorkingWhileRunInFlight covers the launch-boundary status.
 func TestAgentStatus_WorkingWhileRunInFlight(t *testing.T) {
 	mock := &mockTaskStarter{}
 	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
@@ -171,10 +166,9 @@ func TestAgentStatus_NotLeftWorkingWhenLaunchNeverHappened(t *testing.T) {
 		"after a run that never reached the adapter")
 }
 
-// TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves is the regression
-// test for DR-14 review round 1 Finding 3: resolveLifecycleRun only ever
-// looks up claimed runs, so a cancellation that already marked the run
-// terminal, or a late/duplicate delivery, makes it resolve to sql.ErrNoRows.
+// TestAgentStatus_ReturnsToIdleWhenNoClaimedRunResolves covers the case where
+// resolveLifecycleRun only finds claimed runs. A terminal or duplicate event
+// can therefore return sql.ErrNoRows.
 // handleAgentCompleted (shared by AgentCompleted and AgentStopped) must
 // still clear "working" on that exit — it never reaches stampRunFinished.
 // The event carries the run's own id so the run-scoped clear (see
@@ -257,9 +251,8 @@ func TestAgentStatus_StaleEventDoesNotClobberSuccessorRun(t *testing.T) {
 		"after run A's stale event: run B's working status must survive")
 }
 
-// TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate is the
-// regression test for DR-14 review round 2 Finding 1: a launched run that
-// gets requeued (e.g. a post-start provider fallback calling
+// TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate covers a
+// launched run that gets requeued (for example, a post-start provider fallback calling
 // RequeueRunForNextCandidate) sets the run back to "queued" without ever
 // clearing the agent's "working" status, since that clear only happens on
 // the launch/complete cycle the requeue bypassed. The next scheduler pass
@@ -312,8 +305,8 @@ func TestAgentStatus_ReturnsToIdleWhenRequeuedRunHitsPreLaunchGate(t *testing.T)
 }
 
 // TestAgentStatus_TasklessCompletionClearsWorkingWhenNoRunResolves covers the
-// third DR-14 follow-up edit: handleTasklessAgentCompleted's sql.ErrNoRows
-// exit (no resolvable claimed run) must clear "working" like its two
+// handleTasklessAgentCompleted's sql.ErrNoRows exit (no resolvable claimed
+// run) must clear "working" like its two
 // siblings in handleAgentCompleted and handleAgentFailed, instead of
 // returning without a clear and stranding the agent's status.
 func TestAgentStatus_TasklessCompletionClearsWorkingWhenNoRunResolves(t *testing.T) {

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -697,8 +697,10 @@ func (s *Service) handleAgentFailed(ctx context.Context, event *bus.Event) error
 		"session_id":    data.SessionID,
 		"error_message": data.ErrorMessage,
 	})
+	// Clear before routing can make the run claimable again. This prevents
+	// cleanup from this attempt from matching a relaunch that reuses its run ID.
+	s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 	if s.tryPostStartFallback(ctx, run, data.ErrorMessage, data.ProviderError) {
-		s.clearAgentWorking(ctx, run.AgentProfileID, run.ID)
 		return nil
 	}
 	// Office failure path (v1): every agent error is terminal. The

--- a/apps/backend/internal/office/service/event_subscribers.go
+++ b/apps/backend/internal/office/service/event_subscribers.go
@@ -526,6 +526,16 @@ func (s *Service) handleTasklessAgentCompleted(
 	run, err := s.resolveLifecycleRun(ctx, *data)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// Same reasoning as handleAgentCompleted's and handleAgentFailed's
+			// ErrNoRows exits: no claimed run resolves, so nothing reaches
+			// this function's own clear below, but the agent may still be
+			// "working" from the launch. Scoped to data.RunID for the same
+			// reason.
+			agentProfileID := data.AgentProfileID
+			if agentProfileID == "" {
+				agentProfileID = data.AgentID
+			}
+			s.clearAgentWorking(ctx, agentProfileID, data.RunID)
 			return nil
 		}
 		return err

--- a/apps/backend/internal/office/service/event_subscribers_engine_test.go
+++ b/apps/backend/internal/office/service/event_subscribers_engine_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/office/models"
@@ -284,6 +286,34 @@ func (fallbackHandledRoutingDispatcher) MarkRunSuccessHealth(
 ) {
 }
 
+type blockingPostStartFallbackDispatcher struct {
+	t        *testing.T
+	svc      *service.Service
+	requeued chan struct{}
+	release  chan struct{}
+}
+
+func (d *blockingPostStartFallbackDispatcher) DispatchWithRouting(
+	context.Context, *models.Run, *models.AgentInstance, service.LaunchContext,
+) (bool, bool, error) {
+	return false, false, nil
+}
+
+func (d *blockingPostStartFallbackDispatcher) HandlePostStartFailure(
+	_ context.Context, run *models.Run, _ *models.AgentInstance, _ string, _ *streams.ProviderError,
+) (bool, error) {
+	d.svc.ExecSQL(d.t, `UPDATE runs SET status = 'queued', session_id = '',
+		claimed_at = NULL, finished_at = NULL WHERE id = ?`, run.ID)
+	close(d.requeued)
+	<-d.release
+	return true, nil
+}
+
+func (d *blockingPostStartFallbackDispatcher) MarkRunSuccessHealth(
+	context.Context, *models.Run, *models.AgentInstance,
+) {
+}
+
 // queueTaskAssignedRunForAgentFailedTests queues + claims a run for taskID
 // so an AgentFailed event resolves it via resolveLifecycleRun's
 // task+agent fallback (GetClaimedRunByTaskAndAgent).
@@ -437,6 +467,78 @@ func TestEngineDispatcher_AgentFailed_PostStartFallbackHandled_SkipsDispatch(t *
 	}
 	assertAgentStatus(t, svc, context.Background(), "worker-1", models.AgentStatusIdle,
 		"after a handled post-start fallback")
+}
+
+func TestAgentFailed_PostStartFallback_DelayedCleanupDoesNotIdleRelaunch(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockTaskStarter{}
+	svc := newTestService(t, service.ServiceOptions{TaskStarter: mock})
+	svc.SetSyncHandlers(true)
+	eb := bus.NewMemoryEventBus(logger.Default())
+	if err := svc.RegisterEventSubscribers(eb); err != nil {
+		t.Fatalf("register subscribers: %v", err)
+	}
+
+	createTestAgent(t, svc, "ws-1", "worker-reroute")
+	project := &models.Project{
+		WorkspaceID:    "ws-1",
+		Name:           "Project worker-reroute",
+		ExecutorConfig: `{"type":"local_pc"}`,
+	}
+	if err := svc.CreateProject(ctx, project); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	svc.ExecSQL(t, `INSERT INTO tasks (id, workspace_id, project_id, title, created_at, updated_at)
+		VALUES ('task-reroute', 'ws-1', ?, 'Reroute task', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		project.ID)
+	run := queueTaskAssignedRunForAgentFailedTests(t, svc, "worker-reroute", "task-reroute")
+	svc.ExecSQL(t, `UPDATE runs SET resolved_provider_id = 'test-provider' WHERE id = ?`, run.ID)
+	svc.ExecSQL(t, `UPDATE agent_profiles SET status = 'working', working_run_id = ? WHERE id = ?`,
+		run.ID, "worker-reroute")
+
+	dispatcher := &blockingPostStartFallbackDispatcher{
+		t:        t,
+		svc:      svc,
+		requeued: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	svc.SetRoutingDispatcher(dispatcher)
+	event := bus.NewEvent(events.AgentFailed, "test", map[string]string{
+		"task_id":          "task-reroute",
+		"run_id":           run.ID,
+		"session_id":       "session-reroute",
+		"agent_profile_id": "worker-reroute",
+		"error_message":    "provider unavailable",
+	})
+	publishDone := make(chan error, 1)
+	go func() { publishDone <- eb.Publish(ctx, events.AgentFailed, event) }()
+
+	select {
+	case <-dispatcher.requeued:
+	case <-time.After(5 * time.Second):
+		t.Fatal("post-start fallback did not requeue the run")
+	}
+
+	relaunched, err := svc.ClaimNextRun(ctx)
+	if err != nil {
+		t.Fatalf("claim relaunched run: %v", err)
+	}
+	if relaunched == nil || relaunched.ID != run.ID {
+		t.Fatalf("relaunched run = %v, want run %q", relaunched, run.ID)
+	}
+	service.ProcessRunForTest(svc, ctx, relaunched)
+	if mock.callCount() != 1 {
+		t.Fatalf("StartTask calls = %d, want 1 for the relaunch", mock.callCount())
+	}
+	assertAgentStatus(t, svc, ctx, "worker-reroute", models.AgentStatusWorking,
+		"after the same run relaunches")
+
+	close(dispatcher.release)
+	if err := <-publishDone; err != nil {
+		t.Fatalf("publish agent failed: %v", err)
+	}
+	assertAgentStatus(t, svc, ctx, "worker-reroute", models.AgentStatusWorking,
+		"after the old failure cleanup completes")
 }
 
 // TestEngineDispatcher_PathBEscalation_DoesNotFireAgentErrorTrigger pins


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3516/91c3d9fe4ba3.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** When one queued run for an agent finishes and a second run for the same agent is claimed and launched inside a narrow window (before the first run's own cleanup clears the agent's "working" flag), the agent's status keeps showing "idle" for the entire duration of the second run, even though a run is actively in progress on it.
**After this:** The second run's launch now takes over the "working" status from the abandoned first run, so the agent correctly shows "working" for as long as a run is actually in progress on it.
**Who hits this:** Anyone watching per-agent status in Office when two runs queue back-to-back on the same agent — reachable on any workspace with sequential per-agent scheduling, not tied to a specific integration.
**Scope:** standalone
**Not here:** making the run-finish and agent-status-clear sequence transactional across the runs/office repositories; this widens the ownership check instead, which closes the same window without a cross-repository transaction.

Widens `MarkAgentWorking`'s compare-and-swap so a launching run can take ownership of the "working" status from a same-agent predecessor whose run has already left `claimed`, instead of the successor's mark silently no-oping and the predecessor's later clear mislabeling the agent as idle mid-run. Also clears the agent's working status on the taskless-completion "no run found" exit path, matching its two sibling handlers that already did.

## Validation

- `go test -tags fts5 ./internal/office/... ./internal/runs/...` — green, except `TestMigrate_PriorityIdempotent` (`internal/office/repository/sqlite`), which fails identically at the merge-base in a scratch worktree (`no such column: description` under `-tags fts5`) and is unrelated to this change.
- `make typecheck` — clean.
- `make lint-backend` (`golangci-lint run ./...`) — `0 issues`.
- `make lint-format` — clean.
- `cd apps/web && pnpm run i18n:ratchet` — no-op (backend-only change).
- Rebased onto current `main`; full gauntlet re-run after rebase with the same results.
- No `apps/web/` changes, no migration, no new event-bus subscriber — E2E and Postgres-specific coverage are not required for this diff.

## Possible Improvements

Low risk: this only widens a CAS predicate used at a single call site (`prepareAndLaunch`), reusing the exact in-flight-run check `ReconcileAgentWorkingStatus` already relies on, so it cannot take ownership from a run that is still `claimed`.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->