### PR TITLE
fix(e2e): parse run-e2e.sh options after a leading -- and bound the docker info probe

### DIFF
--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -79,7 +79,7 @@ pnpm e2e:run                                   # auto: docker if daemon + CI ima
 pnpm e2e:run tests/task/my-test.spec.ts        # single file (extra args pass through to Playwright)
 pnpm e2e:run tests/path/spec.ts -- --grep "exact test name"  # exact CI failure with a fresh build
 pnpm e2e:run --shards 3                          # 3 shards concurrently on this machine (isolated)
-pnpm e2e:run --no-build -- --grep "task creation"  # skip rebuild; forward flags after --
+pnpm e2e:run --no-build -- --grep "task creation"  # options before --, not after (pnpm forwards -- verbatim)
 pnpm e2e:run --no-build --project mobile-chrome tests/layout/mobile-spa-resilience.spec.ts
 pnpm e2e:docker                                # force the docker CI image (full isolation from a host dev instance)
 pnpm e2e:clean                                 # remove build/test artifacts, incl. root-owned ones from prior docker runs

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -79,7 +79,7 @@ pnpm e2e:run                                   # auto: docker if daemon + CI ima
 pnpm e2e:run tests/task/my-test.spec.ts        # single file (extra args pass through to Playwright)
 pnpm e2e:run tests/path/spec.ts -- --grep "exact test name"  # exact CI failure with a fresh build
 pnpm e2e:run --shards 3                          # 3 shards concurrently on this machine (isolated)
-pnpm e2e:run --no-build -- --grep "task creation"  # options before --, not after (pnpm forwards -- verbatim)
+pnpm e2e:run --no-build -- --grep "task creation"  # runner options before --; Playwright options after
 pnpm e2e:run --no-build --project mobile-chrome tests/layout/mobile-spa-resilience.spec.ts
 pnpm e2e:docker                                # force the docker CI image (full isolation from a host dev instance)
 pnpm e2e:clean                                 # remove build/test artifacts, incl. root-owned ones from prior docker runs

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -62,6 +62,13 @@ DOCKER_PROBE_TIMEOUT="${KANDEV_E2E_DOCKER_PROBE_TIMEOUT:-10}"
 log() { printf '\033[36m[e2e]\033[0m %s\n' "$*" >&2; }
 die() { printf '\033[31m[e2e] %s\033[0m\n' "$*" >&2; exit 1; }
 
+# Validated eagerly: it feeds arithmetic in docker_up below, and an unbounded
+# value there (non-numeric, fractional, or padded with whitespace) is exactly
+# the silent-zero-signal failure this script exists to eliminate. 0 is
+# accepted — it means "skip the probe, treat Docker as unavailable".
+[[ "$DOCKER_PROBE_TIMEOUT" =~ ^[0-9]+$ ]] \
+  || die "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer (got '$DOCKER_PROBE_TIMEOUT')"
+
 # Bounded in pure bash (no `timeout`/`gtimeout` dependency — bare macOS has
 # neither). Backgrounds the probe and kills it if it outlives the budget, so a
 # hung daemon degrades to host mode with a visible reason instead of hanging

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -62,13 +62,10 @@ DOCKER_PROBE_TIMEOUT="${KANDEV_E2E_DOCKER_PROBE_TIMEOUT:-10}"
 log() { printf '\033[36m[e2e]\033[0m %s\n' "$*" >&2; }
 die() { printf '\033[31m[e2e] %s\033[0m\n' "$*" >&2; exit 1; }
 
-# Validated eagerly: it feeds arithmetic in docker_up below, and an unbounded
-# value there (non-numeric, fractional, or padded with whitespace) is exactly
-# the silent-zero-signal failure this script exists to eliminate. 0 is
-# accepted — it means "skip the probe, treat Docker as unavailable". No
-# leading zeros: bash arithmetic reads a leading-zero literal as octal, which
-# rejects valid-looking values like "08" (or silently means something else
-# for "010") one line below in docker_up.
+# Feeds arithmetic in docker_up; validated to reject fractional, suffixed, and
+# whitespace-padded values. 0 is accepted — it means "skip the probe, treat
+# Docker as unavailable". No leading zeros: bash arithmetic reads them as octal,
+# so "08" is a parse error and "010" silently means 8.
 [[ "$DOCKER_PROBE_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] \
   || die "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer (got '$DOCKER_PROBE_TIMEOUT')"
 
@@ -78,6 +75,10 @@ die() { printf '\033[31m[e2e] %s\033[0m\n' "$*" >&2; exit 1; }
 # the whole runner forever.
 docker_up() {
   command -v docker >/dev/null 2>&1 || return 1
+  if (( DOCKER_PROBE_TIMEOUT == 0 )); then
+    log "docker info did not respond within 0s; treating Docker as unavailable (pass --host to skip this probe)"
+    return 1
+  fi
   docker info >/dev/null 2>&1 &
   local pid=$! max_ticks=$(( DOCKER_PROBE_TIMEOUT * 10 )) tick=0
   while kill -0 "$pid" 2>/dev/null; do

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -26,11 +26,12 @@
 #            run-e2e.sh clean                                    # remove build/test artifacts (incl. root-owned)
 #   Via pnpm: pnpm e2e:run [options] [-- <playwright args>]
 #   pnpm/npm forward a caller-supplied `--` verbatim, so `pnpm e2e:run -- --host`
-#   reaches this script as `-- --host`. A leading bare `--` is therefore dropped
-#   before option parsing and carries no meaning — write script options directly
-#   after `e2e:run` (`pnpm e2e:run --host --no-build -- --grep foo`), not before
-#   a leading `--`. A `--` anywhere else still ends option parsing and forwards
-#   everything after it straight to Playwright.
+#   reaches this script as `-- --host`. The package entry point drops that leading
+#   artifact before option parsing; direct script calls preserve `--` as the
+#   documented Playwright separator. For package calls, write script options
+#   directly after `e2e:run` (`pnpm e2e:run --host --no-build -- --grep foo`).
+#   A `--` anywhere else still ends option parsing and forwards everything after it
+#   straight to Playwright.
 #
 # Options:
 #   --docker | --host     Force runner (default: auto-detect)
@@ -79,14 +80,20 @@ docker_up() {
     log "docker info did not respond within 0s; treating Docker as unavailable (pass --host to skip this probe)"
     return 1
   fi
+  local had_monitor=0
+  case "$-" in
+    *m*) had_monitor=1 ;;
+  esac
+  set -m
   docker info >/dev/null 2>&1 &
   local pid=$! max_ticks=$(( DOCKER_PROBE_TIMEOUT * 10 )) tick=0
+  [[ "$had_monitor" -eq 1 ]] || set +m
   while kill -0 "$pid" 2>/dev/null; do
     if (( tick >= max_ticks )); then
       # SIGKILL, not SIGTERM: a wedged docker client can be blocked in a way
       # that doesn't honor SIGTERM, and `wait` below blocks until it exits.
-      kill -9 "$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null
+      kill -9 -- "-$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
       log "docker info did not respond within ${DOCKER_PROBE_TIMEOUT}s; treating Docker as unavailable (pass --host to skip this probe)"
       return 1
     fi
@@ -214,10 +221,11 @@ STRICT=1
 PROJECT=chromium
 PW_ARGS=()
 # pnpm/npm forward the caller's `--` verbatim, so `pnpm e2e:run -- --host`
-# reaches this script as `-- --host`. A leading `--` therefore carries no
-# information; dropping it keeps script options parseable. A later `--` still
-# ends option parsing (in the loop below).
-[[ "${1:-}" == -- ]] && shift
+# reaches this script as `-- --host`. Only the package entry point drops that
+# artifact. Direct calls keep the documented `-- <playwright args>` separator.
+if [[ "${npm_lifecycle_event:-}" == e2e:run && "${1:-}" == -- ]]; then
+  shift
+fi
 [[ "${1:-}" == clean ]] && { SUBCMD=clean; shift; }
 [[ "${1:-}" == run ]] && shift
 while [[ $# -gt 0 ]]; do

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -65,8 +65,11 @@ die() { printf '\033[31m[e2e] %s\033[0m\n' "$*" >&2; exit 1; }
 # Validated eagerly: it feeds arithmetic in docker_up below, and an unbounded
 # value there (non-numeric, fractional, or padded with whitespace) is exactly
 # the silent-zero-signal failure this script exists to eliminate. 0 is
-# accepted — it means "skip the probe, treat Docker as unavailable".
-[[ "$DOCKER_PROBE_TIMEOUT" =~ ^[0-9]+$ ]] \
+# accepted — it means "skip the probe, treat Docker as unavailable". No
+# leading zeros: bash arithmetic reads a leading-zero literal as octal, which
+# rejects valid-looking values like "08" (or silently means something else
+# for "010") one line below in docker_up.
+[[ "$DOCKER_PROBE_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] \
   || die "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer (got '$DOCKER_PROBE_TIMEOUT')"
 
 # Bounded in pure bash (no `timeout`/`gtimeout` dependency — bare macOS has

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -72,7 +72,9 @@ docker_up() {
   local pid=$! max_ticks=$(( DOCKER_PROBE_TIMEOUT * 10 )) tick=0
   while kill -0 "$pid" 2>/dev/null; do
     if (( tick >= max_ticks )); then
-      kill "$pid" 2>/dev/null
+      # SIGKILL, not SIGTERM: a wedged docker client can be blocked in a way
+      # that doesn't honor SIGTERM, and `wait` below blocks until it exits.
+      kill -9 "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       log "docker info did not respond within ${DOCKER_PROBE_TIMEOUT}s; treating Docker as unavailable (pass --host to skip this probe)"
       return 1

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -22,8 +22,15 @@
 #     container.
 #
 # Usage:
-#   run-e2e.sh [run] [options] [-- <playwright args>]   # default subcommand: run
-#   run-e2e.sh clean                                    # remove build/test artifacts (incl. root-owned)
+#   Direct:  run-e2e.sh [run] [options] [-- <playwright args>]   # default subcommand: run
+#            run-e2e.sh clean                                    # remove build/test artifacts (incl. root-owned)
+#   Via pnpm: pnpm e2e:run [options] [-- <playwright args>]
+#   pnpm/npm forward a caller-supplied `--` verbatim, so `pnpm e2e:run -- --host`
+#   reaches this script as `-- --host`. A leading bare `--` is therefore dropped
+#   before option parsing and carries no meaning — write script options directly
+#   after `e2e:run` (`pnpm e2e:run --host --no-build -- --grep foo`), not before
+#   a leading `--`. A `--` anywhere else still ends option parsing and forwards
+#   everything after it straight to Playwright.
 #
 # Options:
 #   --docker | --host     Force runner (default: auto-detect)
@@ -38,6 +45,8 @@
 #   KANDEV_CI_BUILD_IMAGE   (default: ghcr.io/kdlbs/kandev-ci:build-latest)
 #   KANDEV_CI_RUNTIME_IMAGE (default: kandev-ci:runtime-local, falls back to ghcr…:runtime-latest)
 #   KANDEV_E2E_ALLOW_UNSAFE_PARALLELISM=1  bypass local shard/worker guards for experiments
+#   KANDEV_E2E_DOCKER_PROBE_TIMEOUT (default: 10)  seconds to wait for `docker info`
+#   before treating Docker as unavailable in auto/clean mode
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -48,11 +57,31 @@ WEB_DIR="$REPO_ROOT/apps/web"
 BACKEND_DIR="$REPO_ROOT/apps/backend"
 BUILD_IMAGE="${KANDEV_CI_BUILD_IMAGE:-ghcr.io/kdlbs/kandev-ci:build-latest}"
 RUNTIME_IMAGE="${KANDEV_CI_RUNTIME_IMAGE:-}"
+DOCKER_PROBE_TIMEOUT="${KANDEV_E2E_DOCKER_PROBE_TIMEOUT:-10}"
 
 log() { printf '\033[36m[e2e]\033[0m %s\n' "$*" >&2; }
 die() { printf '\033[31m[e2e] %s\033[0m\n' "$*" >&2; exit 1; }
 
-docker_up() { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; }
+# Bounded in pure bash (no `timeout`/`gtimeout` dependency — bare macOS has
+# neither). Backgrounds the probe and kills it if it outlives the budget, so a
+# hung daemon degrades to host mode with a visible reason instead of hanging
+# the whole runner forever.
+docker_up() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 &
+  local pid=$! max_ticks=$(( DOCKER_PROBE_TIMEOUT * 10 )) tick=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( tick >= max_ticks )); then
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      log "docker info did not respond within ${DOCKER_PROBE_TIMEOUT}s; treating Docker as unavailable (pass --host to skip this probe)"
+      return 1
+    fi
+    sleep 0.1
+    tick=$(( tick + 1 ))
+  done
+  wait "$pid"
+}
 is_container_project() { [[ "$PROJECT" == containers || "$PROJECT" == kubernetes-compat ]]; }
 
 resolve_runtime_image() {
@@ -171,6 +200,11 @@ DO_BUILD=1
 STRICT=1
 PROJECT=chromium
 PW_ARGS=()
+# pnpm/npm forward the caller's `--` verbatim, so `pnpm e2e:run -- --host`
+# reaches this script as `-- --host`. A leading `--` therefore carries no
+# information; dropping it keeps script options parseable. A later `--` still
+# ends option parsing (in the loop below).
+[[ "${1:-}" == -- ]] && shift
 [[ "${1:-}" == clean ]] && { SUBCMD=clean; shift; }
 [[ "${1:-}" == run ]] && shift
 while [[ $# -gt 0 ]]; do

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -435,6 +435,38 @@ describe("run-e2e.sh", () => {
     expect(elapsedMs).toBeLessThan(15_000);
   });
 
+  it("bounds the docker info probe even when the hung process ignores SIGTERM", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const dockerPath = path.join(binDir, "docker");
+    fs.writeFileSync(
+      dockerPath,
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then trap "" TERM; sleep 10; exit 0; fi\nexit 0\n',
+    );
+    fs.chmodSync(dockerPath, 0o755);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const start = Date.now();
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "1" }),
+      },
+    );
+    const elapsedMs = Date.now() - start;
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "docker info did not respond within 1s; treating Docker as unavailable",
+    );
+    expect(result.stderr).toContain("mode=host");
+    expect(elapsedMs).toBeLessThan(5_000);
+  }, 20_000);
+
   it("applies the worker guard to raw Playwright runs", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-raw-"));
     tempDirs.push(binDir);

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -34,6 +34,22 @@ function fakeExecutable(binDir: string, name: string, contents: string): void {
   fs.chmodSync(executablePath, 0o755);
 }
 
+function isRunningProcess(pid: number): boolean {
+  const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+    encoding: "utf8",
+  });
+  if (result.status === 0) {
+    const state = result.stdout.trim();
+    return state !== "" && !state.startsWith("Z");
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("run-e2e.sh", () => {
   it("marks a managed containers run before invoking Playwright", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
@@ -514,7 +530,7 @@ describe("run-e2e.sh", () => {
     expect(result.stderr).toContain("mode=host");
     expect(elapsedMs).toBeLessThan(5_000);
     const childPid = Number(fs.readFileSync(childPidFile, "utf8"));
-    expect(() => process.kill(childPid, 0)).toThrow();
+    expect(isRunningProcess(childPid)).toBe(false);
   }, 20_000);
 
   it.each([

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -338,11 +338,8 @@ describe("run-e2e.sh", () => {
   });
 
   it("parses script options after a leading -- (the natural pnpm invocation)", () => {
-    // pnpm/npm forward a caller's `--` verbatim, so `pnpm e2e:run -- --host`
-    // reaches this script as `-- --host`. Regression test for the bug where
-    // the parser's `--) shift; PW_ARGS+=("$@"); break` case matched that
-    // leading `--` first and dumped every script option into PW_ARGS,
-    // leaving MODE=auto and DO_BUILD=1 no matter what was passed.
+    // pnpm/npm forward `--` verbatim, so `pnpm e2e:run -- --host` reaches the
+    // script as `-- --host`. A leading bare `--` must be dropped before parsing.
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
     tempDirs.push(binDir);
     const pnpmPath = path.join(binDir, "pnpm");

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -467,6 +467,56 @@ describe("run-e2e.sh", () => {
     expect(elapsedMs).toBeLessThan(5_000);
   }, 20_000);
 
+  it.each([
+    ["non-numeric", "abc"],
+    ["fractional", "1.5"],
+    ["a natural but unsupported time suffix", "10s"],
+    ["trailing whitespace, e.g. from a .env file", "10 "],
+  ])("rejects an invalid KANDEV_E2E_DOCKER_PROBE_TIMEOUT (%s)", (_label, value) => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: value }),
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer",
+    );
+    expect(result.stderr).toContain(`got '${value}'`);
+  });
+
+  it("accepts 0 as a valid KANDEV_E2E_DOCKER_PROBE_TIMEOUT (skip the probe)", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--host", "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "0" }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain(
+      "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer",
+    );
+  });
+
   it("applies the worker guard to raw Playwright runs", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-raw-"));
     tempDirs.push(binDir);

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -337,6 +337,104 @@ describe("run-e2e.sh", () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain("Playwright worker limit");
   });
 
+  it("parses script options after a leading -- (the natural pnpm invocation)", () => {
+    // pnpm/npm forward a caller's `--` verbatim, so `pnpm e2e:run -- --host`
+    // reaches this script as `-- --host`. Regression test for the bug where
+    // the parser's `--) shift; PW_ARGS+=("$@"); break` case matched that
+    // leading `--` first and dumped every script option into PW_ARGS,
+    // leaving MODE=auto and DO_BUILD=1 no matter what was passed.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nprintf '%s' \"${KANDEV_E2E_CONTAINERS:-}\"\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--", "--host", "--no-build", "--project", "containers", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("1");
+  });
+
+  it("forwards only the tail after a second -- when the first -- is a leading pnpm artifact", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nprintf '%s' \"$*\"\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--", "--host", "--no-build", "--project", "chromium", "--", "--grep", "foo"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(
+      "exec playwright test --config e2e/playwright.config.ts --project=chromium --workers=1 --grep foo",
+    );
+  });
+
+  it("runs the clean subcommand when it follows a leading pnpm --", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const dockerPath = path.join(binDir, "docker");
+    fs.writeFileSync(
+      dockerPath,
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then exit 1; fi\nexit 0\n',
+    );
+    fs.chmodSync(dockerPath, 0o755);
+
+    const result = spawnSync("bash", [scriptPath, "--", "clean"], {
+      encoding: "utf8",
+      env: runnerEnv(binDir),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("clean done");
+  });
+
+  it("bounds the docker info probe and falls back to host mode on a hung daemon", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    const dockerPath = path.join(binDir, "docker");
+    fs.writeFileSync(
+      dockerPath,
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then sleep 30; exit 0; fi\nexit 0\n',
+    );
+    fs.chmodSync(dockerPath, 0o755);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(pnpmPath, 0o755);
+
+    const start = Date.now();
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "1" }),
+      },
+    );
+    const elapsedMs = Date.now() - start;
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "docker info did not respond within 1s; treating Docker as unavailable",
+    );
+    expect(result.stderr).toContain("mode=host");
+    expect(elapsedMs).toBeLessThan(15_000);
+  });
+
   it("applies the worker guard to raw Playwright runs", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-raw-"));
     tempDirs.push(binDir);

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -472,6 +472,7 @@ describe("run-e2e.sh", () => {
     ["fractional", "1.5"],
     ["a natural but unsupported time suffix", "10s"],
     ["trailing whitespace, e.g. from a .env file", "10 "],
+    ["a leading zero, which bash arithmetic reads as octal", "08"],
   ])("rejects an invalid KANDEV_E2E_DOCKER_PROBE_TIMEOUT (%s)", (_label, value) => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
     tempDirs.push(binDir);
@@ -495,16 +496,19 @@ describe("run-e2e.sh", () => {
     expect(result.stderr).toContain(`got '${value}'`);
   });
 
-  it("accepts 0 as a valid KANDEV_E2E_DOCKER_PROBE_TIMEOUT (skip the probe)", () => {
+  it("accepts 0 as a valid KANDEV_E2E_DOCKER_PROBE_TIMEOUT and skips the probe wait in auto mode", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
     tempDirs.push(binDir);
+    const dockerPath = path.join(binDir, "docker");
+    fs.writeFileSync(dockerPath, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(dockerPath, 0o755);
     const pnpmPath = path.join(binDir, "pnpm");
     fs.writeFileSync(pnpmPath, "#!/usr/bin/env sh\nexit 0\n");
     fs.chmodSync(pnpmPath, 0o755);
 
     const result = spawnSync(
       "bash",
-      [scriptPath, "--host", "--no-build", "--project", "chromium", "--", "--help"],
+      [scriptPath, "--no-build", "--project", "chromium", "--", "--help"],
       {
         encoding: "utf8",
         env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "0" }),
@@ -515,6 +519,10 @@ describe("run-e2e.sh", () => {
     expect(result.stderr).not.toContain(
       "KANDEV_E2E_DOCKER_PROBE_TIMEOUT must be a non-negative integer",
     );
+    expect(result.stderr).toContain(
+      "docker info did not respond within 0s; treating Docker as unavailable",
+    );
+    expect(result.stderr).toContain("mode=host");
   });
 
   it("applies the worker guard to raw Playwright runs", () => {

--- a/apps/web/e2e/scripts/run-e2e.test.ts
+++ b/apps/web/e2e/scripts/run-e2e.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 function runnerEnv(binDir: string, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
   const env = {
     ...process.env,
+    npm_lifecycle_event: "e2e:run",
     KANDEV_E2E_ALLOW_UNSAFE_PARALLELISM: "",
     ...extra,
     PATH: `${binDir}:${process.env.PATH ?? ""}`,
@@ -25,6 +26,12 @@ function runnerEnv(binDir: string, extra: Record<string, string> = {}): NodeJS.P
   delete env.KANDEV_E2E_DOCKER;
   delete env.CAPTURE_PR_ASSETS;
   return env;
+}
+
+function fakeExecutable(binDir: string, name: string, contents: string): void {
+  const executablePath = path.join(binDir, name);
+  fs.writeFileSync(executablePath, contents);
+  fs.chmodSync(executablePath, 0o755);
 }
 
 describe("run-e2e.sh", () => {
@@ -359,6 +366,23 @@ describe("run-e2e.sh", () => {
     expect(result.stdout).toBe("1");
   });
 
+  it("preserves a leading -- for direct script invocations", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    fakeExecutable(binDir, "docker", "#!/usr/bin/env sh\nexit 1\n");
+    fakeExecutable(binDir, "make", "#!/usr/bin/env sh\nexit 0\n");
+    fakeExecutable(binDir, "pnpm", "#!/usr/bin/env sh\nprintf '%s' \"$*\"\n");
+
+    const result = spawnSync("bash", [scriptPath, "--", "clean"], {
+      encoding: "utf8",
+      env: runnerEnv(binDir, { npm_lifecycle_event: "" }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("clean done");
+    expect(result.stdout).toContain("clean");
+  });
+
   it("forwards only the tail after a second -- when the first -- is a leading pnpm artifact", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
     tempDirs.push(binDir);
@@ -432,13 +456,37 @@ describe("run-e2e.sh", () => {
     expect(elapsedMs).toBeLessThan(15_000);
   });
 
+  it("selects Docker mode after a successful bounded probe", () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
+    tempDirs.push(binDir);
+    fakeExecutable(
+      binDir,
+      "docker",
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ] || [ "$1" = "image" ] || [ "$1" = "run" ]; then exit 0; fi\nexit 1\n',
+    );
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "--no-build", "--project", "chromium", "--", "--help"],
+      {
+        encoding: "utf8",
+        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "1" }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("mode=docker");
+    expect(result.stderr).not.toContain("did not respond within");
+  });
+
   it("bounds the docker info probe even when the hung process ignores SIGTERM", () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-e2e-runner-"));
     tempDirs.push(binDir);
+    const childPidFile = path.join(binDir, "child.pid");
     const dockerPath = path.join(binDir, "docker");
     fs.writeFileSync(
       dockerPath,
-      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then trap "" TERM; sleep 10; exit 0; fi\nexit 0\n',
+      '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then trap "" TERM; sleep 10 & child=$!; printf \'%s\' "$child" > "$KANDEV_RUNNER_CHILD_PID_FILE"; wait "$child"; exit 0; fi\nexit 0\n',
     );
     fs.chmodSync(dockerPath, 0o755);
     const pnpmPath = path.join(binDir, "pnpm");
@@ -451,7 +499,10 @@ describe("run-e2e.sh", () => {
       [scriptPath, "--no-build", "--project", "chromium", "--", "--help"],
       {
         encoding: "utf8",
-        env: runnerEnv(binDir, { KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "1" }),
+        env: runnerEnv(binDir, {
+          KANDEV_E2E_DOCKER_PROBE_TIMEOUT: "1",
+          KANDEV_RUNNER_CHILD_PID_FILE: childPidFile,
+        }),
       },
     );
     const elapsedMs = Date.now() - start;
@@ -462,6 +513,8 @@ describe("run-e2e.sh", () => {
     );
     expect(result.stderr).toContain("mode=host");
     expect(elapsedMs).toBeLessThan(5_000);
+    const childPid = Number(fs.readFileSync(childPidFile, "utf8"));
+    expect(() => process.kill(childPid, 0)).toThrow();
   }, 20_000);
 
   it.each([

--- a/docs/public/testing.md
+++ b/docs/public/testing.md
@@ -82,6 +82,8 @@ pnpm e2e:run --project chromium tests/path/to/spec.ts
 
 The managed runner builds what it needs, chooses host or the CI runtime image, enables strict WebSocket assertions, and supports `--shards N`, `--no-build`, and `--project NAME`.
 
+Set `KANDEV_E2E_DOCKER_PROBE_TIMEOUT` to change the Docker availability limit in automatic mode. The default is 10 seconds. Set it to `0` to skip the probe and use host mode.
+
 Playwright uses one worker per process. Each worker fixture starts a real Go backend serving the built SPA with unique ports, a temporary `HOME`, Kandev home, SQLite database, repositories/worktrees, and agentctl port range. Each test receives a fresh browser context and resets seeded application state. Kandev process boundaries are real; external providers and the agent process are mocked unless a project says otherwise.
 
 Projects in `apps/web/e2e/playwright.config.ts` are:


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3518/01c5c6d6594c.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** Running `pnpm e2e:run -- --host --no-build --project chromium --grep foo` silently
ignores every one of those flags. pnpm forwards the literal `--` to the script, so the
argv the script sees is `-- --host --no-build --project chromium --grep foo`. The old
parser's `--)` case matched that leading `--` on the very first iteration, dumped
everything after it into the raw-Playwright-args bucket, and stopped parsing — so
`MODE`, `DO_BUILD`, and `PROJECT` silently kept their defaults. Combined with an
unbounded `docker info` call in the default `auto` mode, a host with a wedged Docker
daemon (installed but unresponsive) makes the runner hang forever with zero output and
zero child processes to inspect — indistinguishable from a general hang until you
`bash -x` trace it. This cost a full round of a Testing phase chasing exactly that.
**After this:** A leading bare `--` is dropped before option parsing starts, so
`pnpm e2e:run -- <script-flags>` parses those flags correctly; a later `--` still ends
option parsing and forwards the remainder to Playwright, unchanged. The `docker info`
probe now runs in the background with a poll loop bounded by
`KANDEV_E2E_DOCKER_PROBE_TIMEOUT` (default 10s, validated as a non-negative integer with
no leading zeros to avoid bash's octal parsing), and is `kill -9`'d and reaped on
timeout — a wedged daemon now fails fast with a clear message instead of hanging.
**Who hits this:** Anyone running the E2E suite locally through the `pnpm` script with
extra flags (the documented, common invocation) on a host where the Docker daemon can
stall — this reproduced on a real dev machine, not a hypothetical.
**Scope:** standalone — local dev tooling only, one script + its test + the invocation
docs.
**Not here:** `run-raw-e2e.sh`, `resource-guard.sh`, `playwright.config.ts`, CI workflows
(this script is not invoked from `.github/workflows/**`), and the pre-existing unguarded
`"${PW_ARGS[@]}"` expansion later in the script.

## Summary
- `run-e2e.sh`: strip a leading bare `--` before option parsing so `pnpm e2e:run -- <opts>`
  reaches the script's own flag parser instead of being swallowed into the raw
  Playwright-args passthrough.
- `run-e2e.sh`: bound the `docker info` availability probe with
  `KANDEV_E2E_DOCKER_PROBE_TIMEOUT` (default 10s) using a pure-bash background-and-poll
  loop (no `timeout`/`gtimeout` dependency, since bare macOS has neither), with the
  timeout value validated against `^(0|[1-9][0-9]*)$` to reject leading zeros before it
  hits bash arithmetic.
- Usage header in `run-e2e.sh` and `.agents/skills/e2e/SKILL.md` now state the
  pnpm-vs-direct invocation distinction explicitly.
- `run-e2e.test.ts`: new coverage for the leading-`--` parsing fix and the bounded probe
  (23 tests total in the file).

## Verification
- `bash -n apps/web/e2e/scripts/run-e2e.sh` — OK.
- `pnpm vitest run e2e/scripts/run-e2e.test.ts` (from `apps/web`) —
  `Test Files 1 passed (1)` / `Tests 23 passed (23)`.
- Old-vs-new executed-set comparison (fake `pnpm` echoing argv, `docker` stub exiting 1,
  old script = pre-fix version from `main`):
  - Pre-existing call form `--host --no-build --project chromium -- --grep foo`: old and
    new produce an identical Playwright invocation (no regression).
  - The bug-triggering call form `-- --host --no-build --project chromium -- --grep foo`
    (what `pnpm e2e:run -- ...` actually sends): old silently ignored `--no-build` and
    hung in a `make` build; new correctly parses `--no-build` and forwards only
    `--grep foo` to Playwright.
- `.github/workflows/**` contains zero references to `run-e2e.sh` or `e2e:run` — this is
  local dev tooling only, so CI blast radius is zero.
- Full gauntlet on the rebased branch: `make fmt`, `make typecheck`, `make lint`,
  `make lint-format`, `pnpm run i18n:ratchet` — all clean.
- `make test` (`test-backend`) has pre-existing failures on this checkout (worktree
  lifecycle, launcher, and agentctl suites) — unrelated to this change: the diff touches
  zero Go files, so it cannot be the cause. Confirmed by diff content, not assumption.

E2E was not run: nothing under `apps/web/src|lib` changed, no Go, no locales, no
rendered surface — Playwright asserts product behavior in a browser, and no product
behavior changed here. The runner's own behavior is covered directly by the vitest suite
above plus the old-vs-new executed-set comparison, which is stronger evidence for this
kind of change than a browser run would be.

## Screenshots
Not applicable — this is a local dev-tooling change (a bash script, its test file, and a
skill doc); there is no rendered UI surface to capture.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->