### PR TITLE
docs(agents): correct the reason a blocking MCP question survives 5 minutes

### DIFF
--- a/apps/backend/internal/agent/agents/claude_acp.go
+++ b/apps/backend/internal/agent/agents/claude_acp.go
@@ -123,14 +123,12 @@ func (a *ClaudeACP) Runtime() *RuntimeConfig {
 		WorkingDir:  "{workspace}",
 		RequiredEnv: []string{}, // Auth via ANTHROPIC_API_KEY or OAuth credentials file (see RemoteAuth)
 		Env: map[string]string{
-			// MCP_TIMEOUT also governs the CLI's first-turn MCP prewait, so
-			// it must stay at the CLI's own default; MCP_TOOL_TIMEOUT bounds
-			// total call duration for Kandev's blocking MCP tool calls, but
-			// is not by itself sufficient: the CLI's separate per-tool-call
-			// idle watchdog aborts a silent call after ~300s at this budget,
-			// so the long wait survives on the keepalive that
-			// internal/mcp/server/handlers.go streams, not on this value.
-			// See docs/specs/agents/system-design/mcp-timeout-budgets.md.
+			// MCP_TIMEOUT must stay at the CLI's own default: it also governs
+			// the first-turn MCP prewait. MCP_TOOL_TIMEOUT bounds call
+			// duration, but the keepalive in
+			// internal/mcp/server/handlers.go, not this value, is what keeps
+			// a blocking tool call alive. See
+			// docs/specs/agents/system-design/mcp-timeout-budgets.md.
 			"MCP_TIMEOUT":      "30000",
 			"MCP_TOOL_TIMEOUT": "7200000",
 		},

--- a/apps/backend/internal/agent/agents/claude_acp.go
+++ b/apps/backend/internal/agent/agents/claude_acp.go
@@ -124,8 +124,13 @@ func (a *ClaudeACP) Runtime() *RuntimeConfig {
 		RequiredEnv: []string{}, // Auth via ANTHROPIC_API_KEY or OAuth credentials file (see RemoteAuth)
 		Env: map[string]string{
 			// MCP_TIMEOUT also governs the CLI's first-turn MCP prewait, so
-			// it must stay at the CLI's own default; MCP_TOOL_TIMEOUT holds
-			// the long budget Kandev's blocking MCP tool calls need.
+			// it must stay at the CLI's own default; MCP_TOOL_TIMEOUT bounds
+			// total call duration for Kandev's blocking MCP tool calls, but
+			// is not by itself sufficient: the CLI's separate per-tool-call
+			// idle watchdog aborts a silent call after ~300s regardless of
+			// this budget, so the long wait survives on the keepalive that
+			// internal/mcp/server/handlers.go streams, not on this value.
+			// See docs/specs/agents/system-design/mcp-timeout-budgets.md.
 			"MCP_TIMEOUT":      "30000",
 			"MCP_TOOL_TIMEOUT": "7200000",
 		},

--- a/apps/backend/internal/agent/agents/claude_acp.go
+++ b/apps/backend/internal/agent/agents/claude_acp.go
@@ -127,8 +127,8 @@ func (a *ClaudeACP) Runtime() *RuntimeConfig {
 			// it must stay at the CLI's own default; MCP_TOOL_TIMEOUT bounds
 			// total call duration for Kandev's blocking MCP tool calls, but
 			// is not by itself sufficient: the CLI's separate per-tool-call
-			// idle watchdog aborts a silent call after ~300s regardless of
-			// this budget, so the long wait survives on the keepalive that
+			// idle watchdog aborts a silent call after ~300s at this budget,
+			// so the long wait survives on the keepalive that
 			// internal/mcp/server/handlers.go streams, not on this value.
 			// See docs/specs/agents/system-design/mcp-timeout-budgets.md.
 			"MCP_TIMEOUT":      "30000",

--- a/apps/backend/internal/agent/agents/claude_acp.go
+++ b/apps/backend/internal/agent/agents/claude_acp.go
@@ -123,11 +123,10 @@ func (a *ClaudeACP) Runtime() *RuntimeConfig {
 		WorkingDir:  "{workspace}",
 		RequiredEnv: []string{}, // Auth via ANTHROPIC_API_KEY or OAuth credentials file (see RemoteAuth)
 		Env: map[string]string{
-			// MCP_TIMEOUT must stay at the CLI's own default: it also governs
-			// the first-turn MCP prewait. MCP_TOOL_TIMEOUT bounds call
-			// duration, but the keepalive in
-			// internal/mcp/server/handlers.go, not this value, is what keeps
-			// a blocking tool call alive. See
+			// MCP_TIMEOUT remains at the CLI default because it also controls the
+			// first-turn MCP wait. MCP_TOOL_TIMEOUT provides the long budget for
+			// blocking calls. ask_user_question stays active through the MCP
+			// server's progress keepalive. See
 			// docs/specs/agents/system-design/mcp-timeout-budgets.md.
 			"MCP_TIMEOUT":      "30000",
 			"MCP_TOOL_TIMEOUT": "7200000",

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -3916,13 +3916,10 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		zap.String("session_id", req.SessionID),
 		zap.String("task_id", taskID))
 
-	// Block until user responds or context is cancelled (agent MCP timeout).
-	// This survives the CLI's per-tool-call idle watchdog only because
-	// internal/mcp/server/handlers.go's askQuestionKeepAliveInterval streams
-	// a progress notification well inside that watchdog's window; see
-	// docs/specs/agents/system-design/mcp-timeout-budgets.md. If the agent
-	// times out, the entry is cleaned up and the event-based fallback in the
-	// orchestrator handles resuming with a new turn.
+	// WaitForResponse can outlast the agent client's idle watchdog because the
+	// MCP server emits progress while this call is blocked. If the agent
+	// cancels, cleanup and the event fallback resume the interaction on a new
+	// turn.
 	resp, err := h.clarificationSvc.WaitForResponse(ctx, pendingID)
 	if err != nil {
 		if h.inputPauser != nil {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -3917,14 +3917,12 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		zap.String("task_id", taskID))
 
 	// Block until user responds or context is cancelled (agent MCP timeout).
-	// MCP_TOOL_TIMEOUT alone is not enough: Claude Code's CLI also runs a
-	// per-tool-call idle watchdog on non-stdio MCP transports (which Kandev
-	// uses) that aborts a call after ~300s of silence at Kandev's managed
-	// MCP_TOOL_TIMEOUT. This wait survives because internal/mcp/server/handlers.go's
-	// askQuestionKeepAliveInterval streams a progress notification well
-	// inside that window. See docs/specs/agents/system-design/mcp-timeout-budgets.md.
-	// If the agent times out, the entry is cleaned up and the event-based
-	// fallback in the orchestrator handles resuming with a new turn.
+	// This survives the CLI's per-tool-call idle watchdog only because
+	// internal/mcp/server/handlers.go's askQuestionKeepAliveInterval streams
+	// a progress notification well inside that watchdog's window; see
+	// docs/specs/agents/system-design/mcp-timeout-budgets.md. If the agent
+	// times out, the entry is cleaned up and the event-based fallback in the
+	// orchestrator handles resuming with a new turn.
 	resp, err := h.clarificationSvc.WaitForResponse(ctx, pendingID)
 	if err != nil {
 		if h.inputPauser != nil {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -3919,8 +3919,8 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 	// Block until user responds or context is cancelled (agent MCP timeout).
 	// MCP_TOOL_TIMEOUT alone is not enough: Claude Code's CLI also runs a
 	// per-tool-call idle watchdog on non-stdio MCP transports (which Kandev
-	// uses) that aborts a call after ~300s of silence regardless of that
-	// budget. This wait survives because internal/mcp/server/handlers.go's
+	// uses) that aborts a call after ~300s of silence at Kandev's managed
+	// MCP_TOOL_TIMEOUT. This wait survives because internal/mcp/server/handlers.go's
 	// askQuestionKeepAliveInterval streams a progress notification well
 	// inside that window. See docs/specs/agents/system-design/mcp-timeout-budgets.md.
 	// If the agent times out, the entry is cleaned up and the event-based

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -3917,7 +3917,12 @@ func (h *Handlers) handleAskUserQuestion(ctx context.Context, msg *ws.Message) (
 		zap.String("task_id", taskID))
 
 	// Block until user responds or context is cancelled (agent MCP timeout).
-	// With MCP_TOOL_TIMEOUT set to 2h for Claude Code, this will wait long enough.
+	// MCP_TOOL_TIMEOUT alone is not enough: Claude Code's CLI also runs a
+	// per-tool-call idle watchdog on non-stdio MCP transports (which Kandev
+	// uses) that aborts a call after ~300s of silence regardless of that
+	// budget. This wait survives because internal/mcp/server/handlers.go's
+	// askQuestionKeepAliveInterval streams a progress notification well
+	// inside that window. See docs/specs/agents/system-design/mcp-timeout-budgets.md.
 	// If the agent times out, the entry is cleaned up and the event-based
 	// fallback in the orchestrator handles resuming with a new turn.
 	resp, err := h.clarificationSvc.WaitForResponse(ctx, pendingID)

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -469,3 +469,14 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 	assert.GreaterOrEqual(t, progressSeen, 1, "expected at least one keepalive progress notification")
 	assert.True(t, finalSeen, "expected the final tool result to be delivered")
 }
+
+// TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor pins
+// askQuestionKeepAliveInterval comfortably below the measured 300000ms idle
+// watchdog floor that Claude Code's CLI applies to non-stdio MCP transports
+// (see docs/specs/agents/system-design/mcp-timeout-budgets.md). Raising the
+// production constant above that floor would silently break every question
+// that outlives it, and TestAskUserQuestion_StreamsKeepAliveDuringWait
+// wouldn't catch it because it overrides the interval before running.
+func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor(t *testing.T) {
+	assert.LessOrEqual(t, askQuestionKeepAliveInterval, 60*time.Second)
+}

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -478,5 +478,6 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 // that outlives it, and TestAskUserQuestion_StreamsKeepAliveDuringWait
 // wouldn't catch it because it overrides the interval before running.
 func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor(t *testing.T) {
+	assert.Greater(t, askQuestionKeepAliveInterval, time.Duration(0), "a non-positive interval disables emitKeepAlivePings entirely")
 	assert.LessOrEqual(t, askQuestionKeepAliveInterval, 60*time.Second)
 }

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -470,16 +470,17 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 	assert.True(t, finalSeen, "expected the final tool result to be delivered")
 }
 
-// TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor pins
+// TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline pins
 // askQuestionKeepAliveInterval comfortably below the measured 300000ms idle
 // watchdog default that Claude Code's CLI applies to non-stdio MCP transports
 // at Kandev's managed MCP_TOOL_TIMEOUT (see
-// docs/specs/agents/system-design/mcp-timeout-budgets.md). The <= 60s bound
-// is a chosen safety margin, not a value derived from that 300s default:
-// raising the production constant past it would silently break every
-// question that outlives it, and TestAskUserQuestion_StreamsKeepAliveDuringWait
-// wouldn't catch it because it overrides the interval before running.
-func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor(t *testing.T) {
+// docs/specs/agents/system-design/mcp-timeout-budgets.md). The <= 60s bound is
+// a chosen safety margin, not a value derived from that 300s default: crossing
+// it does not by itself abort a call at the managed default, it spends the
+// margin that also covers a lowered MCP_TOOL_TIMEOUT shrinking the idle
+// deadline. TestAskUserQuestion_StreamsKeepAliveDuringWait cannot catch a
+// regression here because it overrides the interval before running.
+func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline(t *testing.T) {
 	assert.Greater(t, askQuestionKeepAliveInterval, time.Duration(0), "a non-positive interval disables emitKeepAlivePings entirely")
 	assert.LessOrEqual(t, askQuestionKeepAliveInterval, 60*time.Second)
 }

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -472,10 +472,12 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 
 // TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor pins
 // askQuestionKeepAliveInterval comfortably below the measured 300000ms idle
-// watchdog floor that Claude Code's CLI applies to non-stdio MCP transports
-// (see docs/specs/agents/system-design/mcp-timeout-budgets.md). Raising the
-// production constant above that floor would silently break every question
-// that outlives it, and TestAskUserQuestion_StreamsKeepAliveDuringWait
+// watchdog default that Claude Code's CLI applies to non-stdio MCP transports
+// at Kandev's managed MCP_TOOL_TIMEOUT (see
+// docs/specs/agents/system-design/mcp-timeout-budgets.md). The <= 60s bound
+// is a chosen safety margin, not a value derived from that 300s default:
+// raising the production constant past it would silently break every
+// question that outlives it, and TestAskUserQuestion_StreamsKeepAliveDuringWait
 // wouldn't catch it because it overrides the interval before running.
 func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleFloor(t *testing.T) {
 	assert.Greater(t, askQuestionKeepAliveInterval, time.Duration(0), "a non-positive interval disables emitKeepAlivePings entirely")

--- a/apps/backend/internal/mcp/server/ask_user_question_test.go
+++ b/apps/backend/internal/mcp/server/ask_user_question_test.go
@@ -470,16 +470,12 @@ func TestAskUserQuestion_StreamsKeepAliveDuringWait(t *testing.T) {
 	assert.True(t, finalSeen, "expected the final tool result to be delivered")
 }
 
-// TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline pins
-// askQuestionKeepAliveInterval comfortably below the measured 300000ms idle
-// watchdog default that Claude Code's CLI applies to non-stdio MCP transports
-// at Kandev's managed MCP_TOOL_TIMEOUT (see
-// docs/specs/agents/system-design/mcp-timeout-budgets.md). The <= 60s bound is
-// a chosen safety margin, not a value derived from that 300s default: crossing
-// it does not by itself abort a call at the managed default, it spends the
-// margin that also covers a lowered MCP_TOOL_TIMEOUT shrinking the idle
-// deadline. TestAskUserQuestion_StreamsKeepAliveDuringWait cannot catch a
-// regression here because it overrides the interval before running.
+// TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline protects the
+// managed-default safety margin described in the timeout design record. The
+// <= 60s bound targets the managed 300s watchdog, not every accepted
+// MCP_TOOL_TIMEOUT override. An override below this interval remains a
+// documented configuration edge. TestAskUserQuestion_StreamsKeepAliveDuringWait
+// cannot catch a default-value regression because it overrides the interval.
 func TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline(t *testing.T) {
 	assert.Greater(t, askQuestionKeepAliveInterval, time.Duration(0), "a non-positive interval disables emitKeepAlivePings entirely")
 	assert.LessOrEqual(t, askQuestionKeepAliveInterval, 60*time.Second)

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -15,15 +15,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// askQuestionKeepAliveInterval is how often ask_user_question streams a progress
-// notification to the agent while waiting for the user's answer. Two independent
-// clients enforce a ~300s idle ceiling on the in-flight tool-call request if no
-// bytes arrive: auggie runs on Node, whose fetch/undici applies a 300s idle
-// timeout and aborts with "fetch failed"; Claude Code's CLI runs its own
-// per-tool-call idle watchdog on non-stdio MCP transports and aborts with "sent
-// no response or progress for 300s; aborting". Emitting a progress notification
-// well inside that window keeps the streamed POST/SSE response alive so the call
-// survives until the user responds. Declared as a var so tests can shorten it.
+// askQuestionKeepAliveInterval controls progress notifications during the
+// blocking ask_user_question call. Managed defaults keep it below client idle
+// deadlines. Tests can shorten it for fast transport tests.
 var askQuestionKeepAliveInterval = 20 * time.Second
 
 // Argument-name constants used across the ask_user_question_kandev handler.

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -16,12 +16,14 @@ import (
 )
 
 // askQuestionKeepAliveInterval is how often ask_user_question streams a progress
-// notification to the agent while waiting for the user's answer. The agent's MCP
-// client (auggie runs on Node, whose fetch/undici applies a 300s idle timeout to
-// the in-flight tool-call request) aborts the call with "fetch failed" if no bytes
-// arrive for that long. Emitting a progress notification well inside that window
-// keeps the streamed POST/SSE response alive so the call survives until the user
-// responds. Declared as a var so tests can shorten it.
+// notification to the agent while waiting for the user's answer. Two independent
+// clients enforce a ~300s idle ceiling on the in-flight tool-call request if no
+// bytes arrive: auggie runs on Node, whose fetch/undici applies a 300s idle
+// timeout and aborts with "fetch failed"; Claude Code's CLI runs its own
+// per-tool-call idle watchdog on non-stdio MCP transports and aborts with "sent
+// no response or progress for 300s; aborting". Emitting a progress notification
+// well inside that window keeps the streamed POST/SSE response alive so the call
+// survives until the user responds. Declared as a var so tests can shorten it.
 var askQuestionKeepAliveInterval = 20 * time.Second
 
 // Argument-name constants used across the ask_user_question_kandev handler.

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -52,7 +52,7 @@ read by the CLI but not currently set by Kandev (see
 | --- | --- | --- |
 | `MCP_TIMEOUT` | MCP connect deadline, and the deadline of the CLI's first-turn wait on the `subscriptions/listen` stream. CLI default is 30000 ms, clamped to at most 2147483647. | `30000` |
 | `MCP_TOOL_TIMEOUT` | Per-call tool budget, clamped to `[1000, 2147483647]` by the idle watchdog's `toolTimeoutMs` helper (see [Idle watchdog](#idle-watchdog)); separately floors the per-request fetch deadline at `[60000, 2147483647]` (see below). | `7200000` |
-| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long, independent of `MCP_TOOL_TIMEOUT`. | Not set by Kandev. |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long. A separate mechanism from `MCP_TOOL_TIMEOUT`, but capped by the effective tool-call timeout (see [Idle watchdog](#idle-watchdog)). | Not set by Kandev. |
 
 Verified against the shipped CLI (version 2.1.258):
 
@@ -103,7 +103,9 @@ function idleTimeoutMs(server) {
     ?? (transport === "stdio" ? 1800000 : 300000);
   if (idle <= 0) return 0;
   const perServerTimeout = server?.timeout >= 1000 ? server.timeout : 0;
-  // toolTimeoutMs(server) = clamp(perServerTimeout ?? MCP_TOOL_TIMEOUT ?? 1e8, 1000, 2147483647)
+  // toolTimeoutMs(server) = clamp(
+  //   server?.timeout >= 1000 ? server.timeout : (MCP_TOOL_TIMEOUT ?? 1e8),
+  //   1000, 2147483647)
   return Math.min(Math.max(idle, perServerTimeout, 1000), toolTimeoutMs(server));
 }
 ```
@@ -121,7 +123,7 @@ below 300000 ms — e.g. `MCP_TOOL_TIMEOUT=10000` yields a 10s idle deadline. A
 tool call that goes past its idle deadline without emitting a response or a
 `notifications/progress` frame is aborted by the CLI with "sent no response or
 progress for <n>s; aborting". Kandev's managed default keeps the 20s keepalive
-below comfortably inside the deadline, but an override under roughly 20000 ms
+comfortably inside the deadline, but an override under roughly 20000 ms
 drives the idle deadline below the keepalive interval and would abort a
 blocking `ask_user_question_kandev` call outright: this is a real edge in the
 supported override path, not just a record-accuracy nit.
@@ -131,7 +133,7 @@ is the only Kandev MCP tool that blocks on a person, so it is the only one
 this watchdog can plausibly hit. It survives because
 `apps/backend/internal/mcp/server/handlers.go` streams a
 `notifications/progress` frame every `askQuestionKeepAliveInterval` (20s),
-comfortably inside the 300s floor.
+comfortably inside that 300000 ms default.
 
 Four throwaway experiments against that binary (`claude -p --mcp-config
 --allowedTools`, a minimal streamable-HTTP MCP server whose tool never
@@ -139,17 +141,17 @@ returns) confirmed the formula and ruled out the obvious alternative fix:
 
 | Config | Server-observed lifetime | Outcome |
 | --- | --- | --- |
-| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000` (10s), silent | ~35s | aborted at the overridden floor, not at 300s — confirms the CLI reads this env var |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000` (10s), silent | ~35s | aborted at the overridden idle deadline, not at 300s — confirms the CLI reads this env var |
 | Default env, `MCP_TOOL_TIMEOUT=7200000`, silent (no progress) | 304.0s | aborted: "sent no response or progress for 300s; aborting" |
 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=7200000`, `MCP_TOOL_TIMEOUT=7200000`, silent | 358.1s (reproduced twice) | `The operation timed out.` — a second, lower client-side ceiling the env var does not lift |
 | Default env, SSE + `notifications/progress` every 20s | 535.1s, still alive | ended only by the harness's own external kill |
 
 Setting `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` alongside `MCP_TOOL_TIMEOUT` is
-**not** a viable fix on its own: it raises the floor from 300s to only
-~358s, not to two hours, because of the second ceiling above. The progress
+**not** a viable fix on its own: it raises the idle deadline from 300s to
+only ~358s, not to two hours, because of the second ceiling above. The progress
 keepalive is what actually delivers the two-hour budget, and it already
 ships. There is no per-server `timeout` field on the ACP wire
-(`types.McpServer`, `jsonrpc.McpServer`) to raise the idle floor from
+(`types.McpServer`, `jsonrpc.McpServer`) to raise the idle deadline from
 Kandev's side either.
 
 ## Control flow

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -146,6 +146,11 @@ returns) confirmed the formula and ruled out the obvious alternative fix:
 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=7200000`, `MCP_TOOL_TIMEOUT=7200000`, silent | 358.1s (reproduced twice) | `The operation timed out.` — a second, lower client-side ceiling the env var does not lift |
 | Default env, SSE + `notifications/progress` every 20s | 535.1s, still alive | ended only by the harness's own external kill |
 
+The first row's ~35s lifetime is longer than its 10s idle timeout because it
+includes the ~25s `subscriptions/listen` first-turn wait (`MCP_TIMEOUT -
+5000 = 25000ms`) that precedes the idle timer starting on the actual tool
+call: 25s preamble + 10s idle ≈ 35s.
+
 Setting `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` alongside `MCP_TOOL_TIMEOUT` is
 **not** a viable fix on its own: it raises the idle deadline from 300s to
 only ~358s, not to two hours, because of the second ceiling above. The progress

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -52,7 +52,7 @@ read by the CLI but not currently set by Kandev (see
 | --- | --- | --- |
 | `MCP_TIMEOUT` | MCP connect deadline, and the deadline of the CLI's first-turn wait on the `subscriptions/listen` stream. CLI default is 30000 ms, clamped to at most 2147483647. | `30000` |
 | `MCP_TOOL_TIMEOUT` | Per-call tool budget and the per-request fetch deadline floor, clamped to `[60000, 2147483647]`. | `7200000` |
-| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long, independent of `MCP_TOOL_TIMEOUT`. Unset. |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long, independent of `MCP_TOOL_TIMEOUT`. | Not set by Kandev. |
 
 Verified against the shipped CLI (version 2.1.258):
 
@@ -84,17 +84,24 @@ depend on the CLI keeping 30000 as its own default.
 ### Idle watchdog
 
 `MCP_TOOL_TIMEOUT` bounds total call duration; it does not bound silence.
-Separately, the CLI runs a per-tool-call idle watchdog, extracted verbatim
-from the shipped binary:
+Separately, the CLI runs a per-tool-call idle watchdog. This section and its
+experiments were verified against a different binary than the CLI version
+above: `node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`,
+bundled by `@agentclientprotocol/claude-agent-acp@0.75.1` as
+`claude-agent-sdk@0.3.257` (the binary Kandev's ACP adapter actually launches),
+not `~/.local/share/claude/versions/*`. The watchdog function is rewritten
+below with descriptive names from that binary's minified source (logic and
+constants unchanged; the minified identifiers are not):
 
 ```js
 function idleTimeoutMs(server) {
   const transport = server?.type ?? "stdio";
-  if (["sse-ide", "ws-ide", "sdk"].has(transport)) return 0; // disabled
+  if (new Set(["sse-ide", "ws-ide", "sdk"]).has(transport)) return 0; // disabled
   const idle = process.env.CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT
     ?? (transport === "stdio" ? 1800000 : 300000);
   if (idle <= 0) return 0;
   const perServerTimeout = server?.timeout >= 1000 ? server.timeout : 0;
+  // toolTimeoutMs(server) = clamp(MCP_TOOL_TIMEOUT, 60000, 2147483647)
   return Math.min(Math.max(idle, perServerTimeout, 1000), toolTimeoutMs(server));
 }
 ```
@@ -114,12 +121,13 @@ this watchdog can plausibly hit. It survives because
 `notifications/progress` frame every `askQuestionKeepAliveInterval` (20s),
 comfortably inside the 300s floor.
 
-Four throwaway experiments against the real CLI (`claude -p --mcp-config
+Four throwaway experiments against that binary (`claude -p --mcp-config
 --allowedTools`, a minimal streamable-HTTP MCP server whose tool never
 returns) confirmed the formula and ruled out the obvious alternative fix:
 
 | Config | Server-observed lifetime | Outcome |
 | --- | --- | --- |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000` (10s), silent | ~35s | aborted at the overridden floor, not at 300s — confirms the CLI reads this env var |
 | Default env, `MCP_TOOL_TIMEOUT=7200000`, silent (no progress) | 304.0s | aborted: "sent no response or progress for 300s; aborting" |
 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=7200000`, `MCP_TOOL_TIMEOUT=7200000`, silent | 358.1s (reproduced twice) | `The operation timed out.` — a second, lower client-side ceiling the env var does not lift |
 | Default env, SSE + `notifications/progress` every 20s | 535.1s, still alive | ended only by the harness's own external kill |

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -51,7 +51,7 @@ read by the CLI but not currently set by Kandev (see
 | Key | Meaning in the CLI | Kandev managed default |
 | --- | --- | --- |
 | `MCP_TIMEOUT` | MCP connect deadline, and the deadline of the CLI's first-turn wait on the `subscriptions/listen` stream. CLI default is 30000 ms, clamped to at most 2147483647. | `30000` |
-| `MCP_TOOL_TIMEOUT` | Per-call tool budget and the per-request fetch deadline floor, clamped to `[60000, 2147483647]`. | `7200000` |
+| `MCP_TOOL_TIMEOUT` | Per-call tool budget, clamped to `[1000, 2147483647]` by the idle watchdog's `toolTimeoutMs` helper (see [Idle watchdog](#idle-watchdog)); separately floors the per-request fetch deadline at `[60000, 2147483647]` (see below). | `7200000` |
 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long, independent of `MCP_TOOL_TIMEOUT`. | Not set by Kandev. |
 
 Verified against the shipped CLI (version 2.1.258):
@@ -103,7 +103,7 @@ function idleTimeoutMs(server) {
     ?? (transport === "stdio" ? 1800000 : 300000);
   if (idle <= 0) return 0;
   const perServerTimeout = server?.timeout >= 1000 ? server.timeout : 0;
-  // toolTimeoutMs(server) = clamp(MCP_TOOL_TIMEOUT, 60000, 2147483647)
+  // toolTimeoutMs(server) = clamp(perServerTimeout ?? MCP_TOOL_TIMEOUT ?? 1e8, 1000, 2147483647)
   return Math.min(Math.max(idle, perServerTimeout, 1000), toolTimeoutMs(server));
 }
 ```
@@ -112,15 +112,19 @@ Kandev injects its MCP server as `type: "http"` (with an `"sse"` fallback;
 see `apps/backend/internal/agentctl/server/api/agent.go`), which is neither
 `stdio` nor in the disabled set, so the idle default is **300000 ms (300s)**.
 The outer `Math.min` in the formula above means `MCP_TOOL_TIMEOUT` can only
-lower that floor, never raise it: at Kandev's managed `MCP_TOOL_TIMEOUT=7200000`
-the clamp is a no-op and the effective idle deadline stays 300000 ms, but a
-profile override (clamped to a 60000 floor by the CLI) can shrink it, e.g.
-`MCP_TOOL_TIMEOUT=60000` yields a 60s idle deadline, not 300s. A tool call
-that goes past its idle deadline without emitting a response or a
-`notifications/progress` frame is aborted by the CLI with "sent no response
-or progress for <n>s; aborting". The 20s keepalive below survives either way,
-so this qualification has no production consequence today — it only affects
-the accuracy of this record.
+lower that default, never raise it: at Kandev's managed `MCP_TOOL_TIMEOUT=7200000`
+the clamp is a no-op and the effective idle deadline stays 300000 ms. But
+`toolTimeoutMs`'s own floor is 1000 ms, not 60000, so an agent-profile or
+executor-profile override of `MCP_TOOL_TIMEOUT` (see
+[Failure and recovery](#failure-and-recovery)) can shrink the idle deadline far
+below 300000 ms — e.g. `MCP_TOOL_TIMEOUT=10000` yields a 10s idle deadline. A
+tool call that goes past its idle deadline without emitting a response or a
+`notifications/progress` frame is aborted by the CLI with "sent no response or
+progress for <n>s; aborting". Kandev's managed default keeps the 20s keepalive
+below comfortably inside the deadline, but an override under roughly 20000 ms
+drives the idle deadline below the keepalive interval and would abort a
+blocking `ask_user_question_kandev` call outright: this is a real edge in the
+supported override path, not just a record-accuracy nit.
 
 `ask_user_question_kandev` (`apps/backend/internal/mcp/handlers/handlers.go`)
 is the only Kandev MCP tool that blocks on a person, so it is the only one
@@ -167,8 +171,9 @@ paid once per launch; at the previous value of 7200000 it was 1h 59m 55s. The
 degraded outcome is a bounded delay before the first token, after which the
 session proceeds normally with all tools available. A blocking Kandev MCP tool
 call is not, by itself, governed by `MCP_TOOL_TIMEOUT`: the CLI's idle
-watchdog (see [Idle watchdog](#idle-watchdog)) would abort it at 300s
-regardless of that budget. It survives because the server streams a
+watchdog (see [Idle watchdog](#idle-watchdog)) would abort it at 300s under
+Kandev's managed `MCP_TOOL_TIMEOUT=7200000`. It survives because the server
+streams a
 `notifications/progress` keepalive well inside that window.
 
 `MCP_TIMEOUT` remains the connect deadline, so it cannot be reduced to an

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -43,12 +43,16 @@ and the blocking behavior of Kandev's own MCP handlers.
 
 ## Data and contracts
 
-The Claude Code CLI reads two independent environment values.
+The Claude Code CLI reads three independent environment values. Two are
+Kandev-managed defaults; the third, `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`, is
+read by the CLI but not currently set by Kandev (see
+[Idle watchdog](#idle-watchdog) below).
 
 | Key | Meaning in the CLI | Kandev managed default |
 | --- | --- | --- |
 | `MCP_TIMEOUT` | MCP connect deadline, and the deadline of the CLI's first-turn wait on the `subscriptions/listen` stream. CLI default is 30000 ms, clamped to at most 2147483647. | `30000` |
 | `MCP_TOOL_TIMEOUT` | Per-call tool budget and the per-request fetch deadline floor, clamped to `[60000, 2147483647]`. | `7200000` |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | Per-tool-call idle watchdog: aborts a call if no bytes (response or `notifications/progress`) arrive for this long, independent of `MCP_TOOL_TIMEOUT`. Unset. |
 
 Verified against the shipped CLI (version 2.1.258):
 
@@ -77,6 +81,57 @@ contract is to bound its cost, not to work around it.
 intended bound at the declaration site, keeps AC-002 testable, and does not
 depend on the CLI keeping 30000 as its own default.
 
+### Idle watchdog
+
+`MCP_TOOL_TIMEOUT` bounds total call duration; it does not bound silence.
+Separately, the CLI runs a per-tool-call idle watchdog, extracted verbatim
+from the shipped binary:
+
+```js
+function idleTimeoutMs(server) {
+  const transport = server?.type ?? "stdio";
+  if (["sse-ide", "ws-ide", "sdk"].has(transport)) return 0; // disabled
+  const idle = process.env.CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT
+    ?? (transport === "stdio" ? 1800000 : 300000);
+  if (idle <= 0) return 0;
+  const perServerTimeout = server?.timeout >= 1000 ? server.timeout : 0;
+  return Math.min(Math.max(idle, perServerTimeout, 1000), toolTimeoutMs(server));
+}
+```
+
+Kandev injects its MCP server as `type: "http"` (with an `"sse"` fallback;
+see `apps/backend/internal/agentctl/server/api/agent.go`), which is neither
+`stdio` nor in the disabled set, so the idle floor is **300000 ms (300s)**
+regardless of `MCP_TOOL_TIMEOUT`. A tool call that goes 300s without emitting
+a response or a `notifications/progress` frame is aborted by the CLI with
+"sent no response or progress for 300s; aborting" — independent of the
+7200000 ms `MCP_TOOL_TIMEOUT` budget.
+
+`ask_user_question_kandev` (`apps/backend/internal/mcp/handlers/handlers.go`)
+is the only Kandev MCP tool that blocks on a person, so it is the only one
+this watchdog can plausibly hit. It survives because
+`apps/backend/internal/mcp/server/handlers.go` streams a
+`notifications/progress` frame every `askQuestionKeepAliveInterval` (20s),
+comfortably inside the 300s floor.
+
+Four throwaway experiments against the real CLI (`claude -p --mcp-config
+--allowedTools`, a minimal streamable-HTTP MCP server whose tool never
+returns) confirmed the formula and ruled out the obvious alternative fix:
+
+| Config | Server-observed lifetime | Outcome |
+| --- | --- | --- |
+| Default env, `MCP_TOOL_TIMEOUT=7200000`, silent (no progress) | 304.0s | aborted: "sent no response or progress for 300s; aborting" |
+| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=7200000`, `MCP_TOOL_TIMEOUT=7200000`, silent | 358.1s (reproduced twice) | `The operation timed out.` — a second, lower client-side ceiling the env var does not lift |
+| Default env, SSE + `notifications/progress` every 20s | 535.1s, still alive | ended only by the harness's own external kill |
+
+Setting `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` alongside `MCP_TOOL_TIMEOUT` is
+**not** a viable fix on its own: it raises the floor from 300s to only
+~358s, not to two hours, because of the second ceiling above. The progress
+keepalive is what actually delivers the two-hour budget, and it already
+ships. There is no per-server `timeout` field on the ACP wire
+(`types.McpServer`, `jsonrpc.McpServer`) to raise the idle floor from
+Kandev's side either.
+
 ## Control flow
 
 1. `ClaudeACP.Runtime` returns `Env` containing both keys.
@@ -95,7 +150,10 @@ With any MCP server configured, the CLI delays its first turn by
 paid once per launch; at the previous value of 7200000 it was 1h 59m 55s. The
 degraded outcome is a bounded delay before the first token, after which the
 session proceeds normally with all tools available. A blocking Kandev MCP tool
-call is unaffected because it is governed by `MCP_TOOL_TIMEOUT`.
+call is not, by itself, governed by `MCP_TOOL_TIMEOUT`: the CLI's idle
+watchdog (see [Idle watchdog](#idle-watchdog)) would abort it at 300s
+regardless of that budget. It survives because the server streams a
+`notifications/progress` keepalive well inside that window.
 
 `MCP_TIMEOUT` remains the connect deadline, so it cannot be reduced to an
 arbitrarily small value purely to shrink the first-turn wait without also

--- a/docs/specs/agents/system-design/mcp-timeout-budgets.md
+++ b/docs/specs/agents/system-design/mcp-timeout-budgets.md
@@ -88,8 +88,10 @@ Separately, the CLI runs a per-tool-call idle watchdog. This section and its
 experiments were verified against a different binary than the CLI version
 above: `node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`,
 bundled by `@agentclientprotocol/claude-agent-acp@0.75.1` as
-`claude-agent-sdk@0.3.257` (the binary Kandev's ACP adapter actually launches),
-not `~/.local/share/claude/versions/*`. The watchdog function is rewritten
+`claude-agent-sdk@0.3.257` (the managed default Claude ACP runtime pinned at
+this commit; an operator selection can launch a different version — see
+`apps/backend/internal/agent/agents/ACP_BRIDGE_VERSIONS.md`), not
+`~/.local/share/claude/versions/*`. The watchdog function is rewritten
 below with descriptive names from that binary's minified source (logic and
 constants unchanged; the minified identifiers are not):
 
@@ -108,11 +110,17 @@ function idleTimeoutMs(server) {
 
 Kandev injects its MCP server as `type: "http"` (with an `"sse"` fallback;
 see `apps/backend/internal/agentctl/server/api/agent.go`), which is neither
-`stdio` nor in the disabled set, so the idle floor is **300000 ms (300s)**
-regardless of `MCP_TOOL_TIMEOUT`. A tool call that goes 300s without emitting
-a response or a `notifications/progress` frame is aborted by the CLI with
-"sent no response or progress for 300s; aborting" — independent of the
-7200000 ms `MCP_TOOL_TIMEOUT` budget.
+`stdio` nor in the disabled set, so the idle default is **300000 ms (300s)**.
+The outer `Math.min` in the formula above means `MCP_TOOL_TIMEOUT` can only
+lower that floor, never raise it: at Kandev's managed `MCP_TOOL_TIMEOUT=7200000`
+the clamp is a no-op and the effective idle deadline stays 300000 ms, but a
+profile override (clamped to a 60000 floor by the CLI) can shrink it, e.g.
+`MCP_TOOL_TIMEOUT=60000` yields a 60s idle deadline, not 300s. A tool call
+that goes past its idle deadline without emitting a response or a
+`notifications/progress` frame is aborted by the CLI with "sent no response
+or progress for <n>s; aborting". The 20s keepalive below survives either way,
+so this qualification has no production consequence today — it only affects
+the accuracy of this record.
 
 `ask_user_question_kandev` (`apps/backend/internal/mcp/handlers/handlers.go`)
 is the only Kandev MCP tool that blocks on a person, so it is the only one


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3523/ac022573b186.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** a code comment and this repo's own spec doc say Kandev's blocking `ask_user_question_kandev` MCP tool survives because `MCP_TOOL_TIMEOUT` is set to two hours. That's wrong, and the wrong reason invites the wrong fix (e.g. tuning `MCP_TOOL_TIMEOUT` or the unset `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`) the next time someone touches this path.
**After this:** the comment and the doc name the real mechanism — Claude Code's CLI runs a separate per-tool-call idle watchdog (300s default on Kandev's non-stdio MCP transport) that `MCP_TOOL_TIMEOUT` does not bound; the call survives because Kandev already streams a `notifications/progress` keepalive every 20s, well inside that window. A new regression test pins the keepalive interval below the measured deadline so a future change to either value can't silently reopen the gap.
**Who hits this:** whoever next debugs or modifies the ask-user-question timeout path — without this correction they inherit an inaccurate mental model and a plausible-but-wrong fix.
**Scope:** standalone doc/comment correction plus one guard test; no behavior change. Deferred from the Review step of #split-mcp-timeout-2h-iux ("Split the Claude ACP MCP startup and tool-call budgets"), which flagged this as a risk to verify separately rather than widen that PR.
**Not here:** setting `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`. Measured against the shipped CLI binary, it only raises the idle deadline to ~358s (a second, lower client-side ceiling the env var doesn't lift), not to two hours — the progress keepalive is what actually delivers the two-hour budget, and it already ships.

A reported defect ("a blocking question might get torn down after 5 minutes because the idle watchdog binds before `MCP_TOOL_TIMEOUT`") did not reproduce, once the keepalive was accounted for. Fixing the record is the deliverable, not a behavior change.

## Validation

- `go build ./...` — exit 0
- `go test ./internal/mcp/... ./internal/agent/agents/...` — all pass
- `go test ./internal/mcp/server/... -run TestAskUserQuestion -v` — 13/13 pass, including the new `TestAskUserQuestion_KeepAliveIntervalBelowClientIdleDeadline`
- Mutation check: temporarily widened `askQuestionKeepAliveInterval` from 20s to 90s — the new guard test failed as expected (`"1m30s" is not less than or equal to "1m0s"`); reverted
- `gofmt -l` — clean (pre-existing drift in one unrelated file, `internal/backendapp/canvas_edit_test.go`, reproduces identically at the merge-base and was left untouched)
- `golangci-lint run ./... --new-from-rev=origin/main` — 0 issues
- `python3 scripts/lint-spec-files.py --all` — all specification files passed
- `make typecheck test lint`, `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — all green
- Broad `make test` surfaces ~13 unrelated packages (`internal/worktree`, `internal/task/service`, `internal/launcher`, etc.) failing with sandbox-specific errors (`unsafe worktree path: not a directory`, `nats unavailable`, `turn table unavailable`). Reproduced identically against a scratch worktree at the merge-base (`origin/main`), confirming they're pre-existing/environmental, not introduced by this change. One additional flaky test (`TestMigrate_PriorityIdempotent`) passed 3/3 in isolation on both branch and baseline.
- E2E not required: no files under `apps/web/` changed.

## Design docs

- [`docs/specs/agents/system-design/mcp-timeout-budgets.md`](https://github.com/kdlbs/kandev/blob/main/docs/specs/agents/system-design/mcp-timeout-budgets.md) — corrected "Idle watchdog" section and data/contracts table.

## Checklist

- [x] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->