### PR TITLE
fix(backend): don't flag healthy sessions as orphaned after upgrading

### DIFF
--- a/apps/backend/internal/orchestrator/dynamic_policy_recovery.go
+++ b/apps/backend/internal/orchestrator/dynamic_policy_recovery.go
@@ -58,9 +58,12 @@ func (s *Service) startDynamicPolicyRecovery(ctx context.Context) {
 // LaunchDynamicRouteAction) can strand a route this way, and no timer or
 // event fires for a durable status that is not a pending wait. A route that
 // reached MarkActive is no longer "starting", so this sweep cannot demote a
-// healthy idling dynamic session.
+// healthy idling dynamic session. Dynamic routing disabled means any
+// recovery action this sweep produces is guaranteed to fail
+// (LaunchDynamicRouteAction returns ErrDynamicRoutingDisabled), so it must
+// stay a no-op exactly like startDynamicPolicyRecovery.
 func (s *Service) reconcileOrphanedDynamicStartingRoutes(ctx context.Context) {
-	if s.profileExecutionResolver == nil {
+	if s.profileExecutionResolver == nil || !s.profileExecutionResolver.Enabled() {
 		return
 	}
 	lister, ok := s.repo.(dynamicStartingRouteLister)

--- a/apps/backend/internal/orchestrator/dynamic_route_recovery_test.go
+++ b/apps/backend/internal/orchestrator/dynamic_route_recovery_test.go
@@ -236,6 +236,56 @@ func TestReconcileOrphanedDynamicStartingRoutes_SweepsInFlightLaunchStates(t *te
 	}
 }
 
+// TestReconcileOrphanedDynamicStartingRoutes_SkipsWhenRoutingDisabled is the
+// regression test for the PR #3362 review follow-up (thread r3931855722):
+// profileExecutionResolver is always constructed and wired regardless of the
+// feature flag (backendapp/services.go, main.go), so the old nil-only guard
+// let this sweep run - and write action_required - even with dynamic routing
+// disabled, which is the flag's value in every shipped profile. A disabled
+// resolver's recovery action always fails
+// (LaunchDynamicRouteAction/ErrDynamicRoutingDisabled), so the resulting
+// banner could never be cleared except by a manual DB fix.
+func TestReconcileOrphanedDynamicStartingRoutes_SkipsWhenRoutingDisabled(t *testing.T) {
+	ctx := context.Background()
+	const (
+		taskID      = "task-dynamic-orphan-sweep-disabled"
+		sessionID   = "session-dynamic-orphan-sweep-disabled"
+		executionID = "execution-dynamic-orphan-sweep-disabled"
+	)
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateIdle)
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, &mockAgentManager{})
+
+	seedEngine := dynamicruntime.NewEngine(dynamicruntime.WithPersistence(repo))
+	svc.SetProfileExecutionResolver(agentruntime.NewProfileExecutionResolver(nil, seedEngine, true))
+	seedClaimedDynamicRoute(t, ctx, repo, seedEngine, sessionID, executionID)
+
+	recoveryEngine := dynamicruntime.NewEngine(
+		dynamicruntime.WithPersistence(repo),
+		dynamicruntime.WithStateLoader(repo),
+	)
+	svc.SetProfileExecutionResolver(agentruntime.NewProfileExecutionResolver(nil, recoveryEngine, false))
+
+	svc.reconcileOrphanedDynamicStartingRoutes(ctx)
+
+	routeState, err := repo.LoadRouteState(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadRouteState: %v", err)
+	}
+	if routeState == nil || routeState.Status != "starting" {
+		t.Fatalf("durable route state = %#v, want untouched 'starting' with routing disabled", routeState)
+	}
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if session.RouteState != "starting" {
+		t.Fatalf("task session route_state = %q, want untouched 'starting' with routing disabled", session.RouteState)
+	}
+}
+
 // TestReconcileOrphanedDynamicStartingRoutes_PrecedesGeneralStartupReconciliation
 // is the regression test for the CodeRabbit finding on Create PR review
 // (service.go#L2580): Service.Start runs reconcileExecutorSessionsOnStartup

--- a/apps/backend/internal/persistence/storeconformance/upgrade_test.go
+++ b/apps/backend/internal/persistence/storeconformance/upgrade_test.go
@@ -186,6 +186,80 @@ func TestPreviousStableUpgrade(t *testing.T) {
 	}
 }
 
+// TestPreviousStableUpgrade_BackfillsLegacyActiveDynamicRoutes is the
+// two-dialect regression test for the PR #3362 review follow-up (thread
+// r3931855722): the v0.93.0 fixture predates the durable "active" dynamic
+// route status, so every route a legacy install successfully launched is
+// durably "starting" against an otherwise-healthy IDLE Office session. This
+// seeds that exact legacy shape on top of the unmodified golden fixture (no
+// fixture bytes or checksums change) and proves the one-time backfill
+// migration repairs it identically on SQLite and PostgreSQL, so the startup
+// orphan sweep does not misclassify it as orphaned on first restart after
+// upgrade.
+func TestPreviousStableUpgrade_BackfillsLegacyActiveDynamicRoutes(t *testing.T) {
+	manifest := loadUpgradeManifest(t)
+	for _, engine := range []testconformance.EngineName{testconformance.EngineSQLite, testconformance.EnginePostgres} {
+		engine := engine
+		t.Run(string(engine)+"/"+previousStableTag, func(t *testing.T) {
+			fixture := fixtureForEngine(t, manifest, engine)
+			database := testconformance.OpenEngine(t, engine, "")
+			if err := applyFixture(t, database, fixture); err != nil {
+				t.Fatalf("apply %s fixture: %v", engine, err)
+			}
+			seedLegacyDynamicRouteFixtureRows(t, database)
+			if err := runCurrentInitialization(database); err != nil {
+				t.Fatalf("current initialization: %v", err)
+			}
+			assertLegacyDynamicRouteBackfilled(t, database)
+		})
+	}
+}
+
+// seedLegacyDynamicRouteFixtureRows adds an IDLE session with a "starting"
+// dynamic route on top of the unmodified v0.93.0 fixture, referencing the
+// fixture's own task row so no foreign key is left dangling.
+func seedLegacyDynamicRouteFixtureRows(t *testing.T, engine testconformance.Engine) {
+	t.Helper()
+	ctx := context.Background()
+	now := "2026-01-01 00:00:00"
+	if _, err := engine.DB.ExecContext(ctx, engine.DB.Rebind(`
+		INSERT INTO task_sessions (id, task_id, state, route_generation, route_state, started_at, updated_at)
+		VALUES (?, ?, 'IDLE', 1, 'starting', ?, ?)
+	`), "fixture-v0930-dynamic-session", "fixture-v0930-task", now, now); err != nil {
+		t.Fatalf("seed legacy IDLE dynamic session: %v", err)
+	}
+	if _, err := engine.DB.ExecContext(ctx, engine.DB.Rebind(`
+		INSERT INTO dynamic_route_states (
+			session_id, logical_profile_id, execution_profile_id, route_generation, profile_version, state, updated_at
+		) VALUES (?, 'dynamic-logical', 'candidate-1', 1, 1, 'starting', ?)
+	`), "fixture-v0930-dynamic-session", now); err != nil {
+		t.Fatalf("seed legacy starting dynamic_route_states row: %v", err)
+	}
+}
+
+func assertLegacyDynamicRouteBackfilled(t *testing.T, engine testconformance.Engine) {
+	t.Helper()
+	ctx := context.Background()
+	var routeState string
+	if err := engine.DB.QueryRowxContext(ctx, engine.DB.Rebind(
+		`SELECT state FROM dynamic_route_states WHERE session_id = ?`,
+	), "fixture-v0930-dynamic-session").Scan(&routeState); err != nil {
+		t.Fatalf("read dynamic_route_states.state: %v", err)
+	}
+	if routeState != "active" {
+		t.Fatalf("dynamic_route_states.state = %q, want active", routeState)
+	}
+	var sessionRouteState string
+	if err := engine.DB.QueryRowxContext(ctx, engine.DB.Rebind(
+		`SELECT route_state FROM task_sessions WHERE id = ?`,
+	), "fixture-v0930-dynamic-session").Scan(&sessionRouteState); err != nil {
+		t.Fatalf("read task_sessions.route_state: %v", err)
+	}
+	if sessionRouteState != "active" {
+		t.Fatalf("task_sessions.route_state = %q, want active", sessionRouteState)
+	}
+}
+
 func loadUpgradeManifest(t *testing.T) upgradeManifest {
 	t.Helper()
 	contents, err := os.ReadFile(filepath.Join("testdata", "upgrades", previousStableTag, "manifest.json"))

--- a/apps/backend/internal/persistence/storeconformance/upgrade_test.go
+++ b/apps/backend/internal/persistence/storeconformance/upgrade_test.go
@@ -223,6 +223,12 @@ func seedLegacyDynamicRouteFixtureRows(t *testing.T, engine testconformance.Engi
 	ctx := context.Background()
 	now := "2026-01-01 00:00:00"
 	if _, err := engine.DB.ExecContext(ctx, engine.DB.Rebind(`
+		INSERT INTO kandev_meta (key, value) VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value
+	`), "kandev_version", previousStableTag); err != nil {
+		t.Fatalf("seed legacy database version: %v", err)
+	}
+	if _, err := engine.DB.ExecContext(ctx, engine.DB.Rebind(`
 		INSERT INTO task_sessions (id, task_id, state, route_generation, route_state, started_at, updated_at)
 		VALUES (?, ?, 'IDLE', 1, 'starting', ?, ?)
 	`), "fixture-v0930-dynamic-session", "fixture-v0930-task", now, now); err != nil {

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -75,6 +75,9 @@ func (r *Repository) runMigrations() error {
 	r.migrate.Apply("task_sessions.downstream_acp_session_id", `ALTER TABLE task_sessions ADD COLUMN downstream_acp_session_id TEXT NOT NULL DEFAULT ''`)
 	r.migrate.Apply("dynamic_route_states.continuation_json", `ALTER TABLE dynamic_route_states ADD COLUMN continuation_json TEXT NOT NULL DEFAULT ''`)
 	r.migrate.Apply("dynamic_route_states.policy_state_json", `ALTER TABLE dynamic_route_states ADD COLUMN policy_state_json TEXT NOT NULL DEFAULT ''`)
+	if err := r.backfillLegacyActiveDynamicRoutes(); err != nil {
+		return err
+	}
 	r.migrate.Apply("executors_running.execution_profile_id", `ALTER TABLE executors_running ADD COLUMN execution_profile_id TEXT NOT NULL DEFAULT ''`)
 	r.migrate.Apply("executors_running.last_message_uuid", `ALTER TABLE executors_running ADD COLUMN last_message_uuid TEXT DEFAULT ''`)
 	r.migrate.Apply("executors_running.metadata", `ALTER TABLE executors_running ADD COLUMN metadata TEXT DEFAULT '{}'`)

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -69,6 +69,7 @@ func (r *Repository) initDynamicRoutingSchema() error {
 			state TEXT NOT NULL DEFAULT 'selecting',
 			continuation_json TEXT NOT NULL DEFAULT '',
 			policy_state_json TEXT NOT NULL DEFAULT '',
+			legacy_active_backfill_applied INTEGER NOT NULL DEFAULT 1,
 			updated_at TIMESTAMP NOT NULL,
 			FOREIGN KEY (session_id) REFERENCES task_sessions(id) ON DELETE CASCADE
 		);

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
@@ -1,0 +1,74 @@
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/kandev/kandev/internal/db"
+)
+
+// dynamicRouteLegacyActiveBackfillColumn marks that
+// backfillLegacyActiveDynamicRoutes has already run against this database.
+// Its presence is the marker: a fresh install's dynamic_route_states DDL
+// declares the column inline (see initDynamicRoutingSchema), so a new
+// database never runs the backfill. On an existing database the column is
+// absent until this migration adds it in the same transaction as the
+// backfill, so a partial apply cannot leave the marker present without the
+// backfill having actually run.
+const dynamicRouteLegacyActiveBackfillColumn = "legacy_active_backfill_applied"
+
+// backfillLegacyActiveDynamicRoutes is a one-time migration for databases
+// created before the durable "active" route status existed. Before that
+// status was introduced, a successfully-launched dynamic route was persisted
+// "starting" and never transitioned further, so on such a database every
+// currently-IDLE Office dynamic session's route is durably "starting" only
+// because the marking mechanism did not exist yet - not because anything is
+// stuck. The startup orphan sweep (isOrphanableDynamicSessionState,
+// internal/orchestrator) treats IDLE as orphanable, which is correct for a
+// route that becomes stranded after an upgrade, so without this backfill it
+// would also flip every one of these healthy legacy routes to
+// action_required on the first restart after upgrading.
+//
+// The backfill runs once, gated on the marker column rather than on the
+// "starting"/IDLE row shape itself, because that shape recurs legitimately:
+// a route claimed after this migration has already run can also fail before
+// reaching "active" and be left "starting" against an IDLE session, and that
+// is exactly the orphan the startup sweep exists to catch. Re-running a
+// value-based backfill on every boot would silently swallow it instead.
+func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
+	exists, err := db.ColumnExists(r.db, "dynamic_route_states", dynamicRouteLegacyActiveBackfillColumn)
+	if err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: probe marker column: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	tx, err := r.db.Beginx()
+	if err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`
+		UPDATE dynamic_route_states
+		SET state = 'active'
+		WHERE state = 'starting'
+			AND session_id IN (SELECT id FROM task_sessions WHERE state = 'IDLE')
+	`); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: backfill dynamic_route_states: %w", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE task_sessions
+		SET route_state = 'active'
+		WHERE state = 'IDLE' AND route_state = 'starting'
+	`); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: backfill task_sessions: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE dynamic_route_states ADD COLUMN ` +
+		dynamicRouteLegacyActiveBackfillColumn + ` INTEGER NOT NULL DEFAULT 1`); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: add marker column: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: commit: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
@@ -79,11 +79,11 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 	`); err != nil {
 		return fmt.Errorf("dynamic route legacy backfill: backfill dynamic_route_states: %w", err)
 	}
-	// Scoped to the rows the UPDATE above just backfilled to 'active', not to
-	// every IDLE+starting projection: a session whose authoritative route row
-	// is 'action_required' or 'waiting' (e.g. routeDynamicAgentFailure wrote
-	// the durable row but the projection write failed) must keep its
-	// projection untouched, or this backfill would erase a live Retry banner.
+	// Scoped to sessions whose dynamic_route_states row is now 'active' (whether
+	// just backfilled or already active before this migration ran). A session whose
+	// authoritative route row is 'action_required' or 'waiting' (e.g.
+	// routeDynamicAgentFailure wrote the durable row but the projection write failed)
+	// must keep its projection untouched, or this backfill would erase a live Retry banner.
 	if _, err := tx.Exec(`
 		UPDATE task_sessions
 		SET route_state = 'active'

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
@@ -94,9 +94,6 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE dynamic_route_states ADD COLUMN ` +
 		dynamicRouteLegacyActiveBackfillColumn + ` INTEGER NOT NULL DEFAULT 1`); err != nil {
-		if db.IsAlreadyExistsError(err) {
-			return nil
-		}
 		return fmt.Errorf("dynamic route legacy backfill: add marker column: %w", err)
 	}
 	if err := tx.Commit(); err != nil {

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
@@ -1,8 +1,12 @@
 package sqlite
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/kandev/kandev/internal/db"
@@ -19,6 +23,12 @@ import (
 // backfill having actually run.
 const dynamicRouteLegacyActiveBackfillColumn = "legacy_active_backfill_applied"
 
+// dynamicRouteLegacyActiveBackfillMaxVersion is the first stable release that
+// includes the active-route transition. Prerelease and unknown versions are
+// intentionally rejected because their route lifecycle cannot be proven from
+// the stored version alone.
+const dynamicRouteLegacyActiveBackfillMaxVersion = "0.94.0"
+
 // dynamicRouteLegacyActiveBackfillLockID serializes concurrent PostgreSQL
 // initializers. All instances must derive the same bigint so a second boot
 // waits for the first to finish the backfill instead of racing it.
@@ -27,14 +37,15 @@ const dynamicRouteLegacyActiveBackfillLockID int64 = 0x4B44_4452_4142 // "KDDRAB
 // backfillLegacyActiveDynamicRoutes is a one-time migration for databases
 // created before the durable "active" route status existed. Before that
 // status was introduced, a successfully-launched dynamic route was persisted
-// "starting" and never transitioned further, so on such a database every
-// currently-IDLE Office dynamic session's route is durably "starting" only
-// because the marking mechanism did not exist yet - not because anything is
-// stuck. The startup orphan sweep (isOrphanableDynamicSessionState,
-// internal/orchestrator) treats IDLE as orphanable, which is correct for a
-// route that becomes stranded after an upgrade, so without this backfill it
-// would also flip every one of these healthy legacy routes to
-// action_required on the first restart after upgrading.
+// "starting" and never transitioned further, so on a proven pre-active stable
+// database every currently-IDLE Office dynamic session's route is durably
+// "starting" only because the marking mechanism did not exist yet - not
+// because anything is stuck. The startup orphan sweep
+// (isOrphanableDynamicSessionState, internal/orchestrator) treats IDLE as
+// orphanable, which is correct for a route that becomes stranded after an
+// upgrade, so without this backfill it would also flip every one of these
+// healthy legacy routes to action_required on the first restart after
+// upgrading.
 //
 // The backfill runs once, gated on the marker column rather than on the
 // "starting"/IDLE row shape itself, because that shape recurs legitimately:
@@ -70,27 +81,44 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 	if exists {
 		return nil
 	}
-
-	if _, err := tx.Exec(`
-		UPDATE dynamic_route_states
-		SET state = 'active'
-		WHERE state = 'starting'
-			AND session_id IN (SELECT id FROM task_sessions WHERE state = 'IDLE')
-	`); err != nil {
-		return fmt.Errorf("dynamic route legacy backfill: backfill dynamic_route_states: %w", err)
+	eligible, err := legacyActiveBackfillVersionAllowed(tx)
+	if err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: read stored version: %w", err)
 	}
-	// Scoped to sessions whose dynamic_route_states row is now 'active' (whether
-	// just backfilled or already active before this migration ran). A session whose
-	// authoritative route row is 'action_required' or 'waiting' (e.g.
-	// routeDynamicAgentFailure wrote the durable row but the projection write failed)
-	// must keep its projection untouched, or this backfill would erase a live Retry banner.
-	if _, err := tx.Exec(`
-		UPDATE task_sessions
-		SET route_state = 'active'
-		WHERE state = 'IDLE' AND route_state = 'starting'
-			AND id IN (SELECT session_id FROM dynamic_route_states WHERE state = 'active')
-	`); err != nil {
-		return fmt.Errorf("dynamic route legacy backfill: backfill task_sessions: %w", err)
+
+	if eligible {
+		if _, err := tx.Exec(`
+			UPDATE dynamic_route_states
+			SET state = 'active'
+			WHERE state = 'starting'
+				AND session_id IN (
+					SELECT ts.id
+					FROM task_sessions ts
+					WHERE ts.id = dynamic_route_states.session_id
+						AND ts.state = 'IDLE'
+						AND ts.route_state = 'starting'
+						AND ts.route_generation = dynamic_route_states.route_generation
+				)
+		`); err != nil {
+			return fmt.Errorf("dynamic route legacy backfill: backfill dynamic_route_states: %w", err)
+		}
+		// Scoped to sessions whose dynamic_route_states row is now 'active' and
+		// whose generation still matches. A session whose authoritative route row
+		// or generation differs must keep its projection available for recovery.
+		if _, err := tx.Exec(`
+			UPDATE task_sessions
+			SET route_state = 'active'
+			WHERE state = 'IDLE' AND route_state = 'starting'
+				AND id IN (
+					SELECT drs.session_id
+					FROM dynamic_route_states drs
+					WHERE drs.session_id = task_sessions.id
+						AND drs.state = 'active'
+						AND drs.route_generation = task_sessions.route_generation
+				)
+		`); err != nil {
+			return fmt.Errorf("dynamic route legacy backfill: backfill task_sessions: %w", err)
+		}
 	}
 	if _, err := tx.Exec(`ALTER TABLE dynamic_route_states ADD COLUMN ` +
 		dynamicRouteLegacyActiveBackfillColumn + ` INTEGER NOT NULL DEFAULT 1`); err != nil {
@@ -100,6 +128,42 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 		return fmt.Errorf("dynamic route legacy backfill: commit: %w", err)
 	}
 	return nil
+}
+
+func legacyActiveBackfillVersionAllowed(conn db.SchemaQuerier) (bool, error) {
+	exists, err := db.TableExists(conn, "kandev_meta")
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	var storedVersion string
+	err = conn.QueryRow(conn.Rebind(
+		`SELECT value FROM kandev_meta WHERE key = 'kandev_version'`,
+	)).Scan(&storedVersion)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	storedVersion = strings.TrimSpace(storedVersion)
+	if len(storedVersion) > 0 && (storedVersion[0] == 'v' || storedVersion[0] == 'V') {
+		storedVersion = storedVersion[1:]
+	}
+	if strings.Count(strings.SplitN(storedVersion, "+", 2)[0], ".") != 2 {
+		return false, nil
+	}
+	parsed, err := semver.NewVersion(storedVersion)
+	if err != nil || parsed.Prerelease() != "" {
+		return false, nil
+	}
+	maxVersion, err := semver.NewVersion(dynamicRouteLegacyActiveBackfillMaxVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse migration version boundary: %w", err)
+	}
+	return parsed.LessThan(maxVersion), nil
 }
 
 // acquireDynamicRouteLegacyActiveBackfillLock serializes concurrent

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration.go
@@ -3,7 +3,10 @@ package sqlite
 import (
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/db/dialect"
 )
 
 // dynamicRouteLegacyActiveBackfillColumn marks that
@@ -15,6 +18,11 @@ import (
 // backfill, so a partial apply cannot leave the marker present without the
 // backfill having actually run.
 const dynamicRouteLegacyActiveBackfillColumn = "legacy_active_backfill_applied"
+
+// dynamicRouteLegacyActiveBackfillLockID serializes concurrent PostgreSQL
+// initializers. All instances must derive the same bigint so a second boot
+// waits for the first to finish the backfill instead of racing it.
+const dynamicRouteLegacyActiveBackfillLockID int64 = 0x4B44_4452_4142 // "KDDRAB" marker
 
 // backfillLegacyActiveDynamicRoutes is a one-time migration for databases
 // created before the durable "active" route status existed. Before that
@@ -48,6 +56,21 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := r.acquireDynamicRouteLegacyActiveBackfillLock(tx); err != nil {
+		return err
+	}
+
+	// Re-probe inside the lock: a concurrent PostgreSQL initializer may have
+	// already run and committed the backfill between the cheap probe above
+	// and this transaction acquiring the advisory lock.
+	exists, err = r.columnExists(tx, "dynamic_route_states", dynamicRouteLegacyActiveBackfillColumn)
+	if err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: re-probe marker column: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
 	if _, err := tx.Exec(`
 		UPDATE dynamic_route_states
 		SET state = 'active'
@@ -56,19 +79,45 @@ func (r *Repository) backfillLegacyActiveDynamicRoutes() error {
 	`); err != nil {
 		return fmt.Errorf("dynamic route legacy backfill: backfill dynamic_route_states: %w", err)
 	}
+	// Scoped to the rows the UPDATE above just backfilled to 'active', not to
+	// every IDLE+starting projection: a session whose authoritative route row
+	// is 'action_required' or 'waiting' (e.g. routeDynamicAgentFailure wrote
+	// the durable row but the projection write failed) must keep its
+	// projection untouched, or this backfill would erase a live Retry banner.
 	if _, err := tx.Exec(`
 		UPDATE task_sessions
 		SET route_state = 'active'
 		WHERE state = 'IDLE' AND route_state = 'starting'
+			AND id IN (SELECT session_id FROM dynamic_route_states WHERE state = 'active')
 	`); err != nil {
 		return fmt.Errorf("dynamic route legacy backfill: backfill task_sessions: %w", err)
 	}
 	if _, err := tx.Exec(`ALTER TABLE dynamic_route_states ADD COLUMN ` +
 		dynamicRouteLegacyActiveBackfillColumn + ` INTEGER NOT NULL DEFAULT 1`); err != nil {
+		if db.IsAlreadyExistsError(err) {
+			return nil
+		}
 		return fmt.Errorf("dynamic route legacy backfill: add marker column: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("dynamic route legacy backfill: commit: %w", err)
+	}
+	return nil
+}
+
+// acquireDynamicRouteLegacyActiveBackfillLock serializes concurrent
+// PostgreSQL initializers so the loser waits for the winner's backfill
+// (including the marker ADD COLUMN) to commit instead of racing it. SQLite
+// relies on the transaction becoming the writer lock.
+func (r *Repository) acquireDynamicRouteLegacyActiveBackfillLock(tx *sqlx.Tx) error {
+	if !dialect.IsPostgres(r.db.DriverName()) {
+		return nil
+	}
+	if _, err := tx.Exec(`SET LOCAL lock_timeout = '30s'`); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: set lock timeout: %w", err)
+	}
+	if _, err := tx.Exec(`SELECT pg_advisory_xact_lock($1)`, dynamicRouteLegacyActiveBackfillLockID); err != nil {
+		return fmt.Errorf("dynamic route legacy backfill: acquire migration advisory lock: %w", err)
 	}
 	return nil
 }

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
@@ -164,6 +164,57 @@ func TestBackfillLegacyActiveDynamicRoutes_MigratesLegacyIdleRouteToActive(t *te
 	}
 }
 
+// TestBackfillLegacyActiveDynamicRoutes_NoRouteRowLeavesProjectionUnchanged
+// is the regression test for review round 1 finding F2 (negative case i): an
+// IDLE session whose task_sessions.route_state projection reads 'starting'
+// but has no dynamic_route_states row at all must not be touched. The
+// projection UPDATE is scoped to rows the dynamic_route_states UPDATE just
+// backfilled to 'active', so a session with no route row is never in scope.
+func TestBackfillLegacyActiveDynamicRoutes_NoRouteRowLeavesProjectionUnchanged(t *testing.T) {
+	db := openLegacyDynamicRouteDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-no-route-row", "session-no-route-row", "IDLE", now)
+	// Deliberately no seedLegacyDynamicRouteState call: this session has no
+	// dynamic_route_states row.
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("run legacy backfill migration: %v", err)
+	}
+
+	if got := taskSessionRouteState(t, db, "session-no-route-row"); got != "starting" {
+		t.Fatalf("task_sessions.route_state for session with no route row = %q, want unchanged starting", got)
+	}
+}
+
+// TestBackfillLegacyActiveDynamicRoutes_ActionRequiredRouteLeavesProjectionUnchanged
+// is the regression test for review round 1 finding F2 (negative case ii): an
+// IDLE session whose durable dynamic_route_states row is 'action_required'
+// (a genuinely broken route surfaced by routeDynamicAgentFailure) but whose
+// task_sessions.route_state projection still reads 'starting' - because the
+// projection write that follows the durable write in
+// routeDynamicAgentFailure failed or never ran - must keep that projection
+// untouched. Overwriting it with 'active' would hide a live Retry banner for
+// a route that is actually broken.
+func TestBackfillLegacyActiveDynamicRoutes_ActionRequiredRouteLeavesProjectionUnchanged(t *testing.T) {
+	db := openLegacyDynamicRouteDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-action-required", "session-action-required", "IDLE", now)
+	seedLegacyDynamicRouteState(t, db, "session-action-required", "action_required", now)
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("run legacy backfill migration: %v", err)
+	}
+
+	if got := dynamicRouteState(t, db, "session-action-required"); got != "action_required" {
+		t.Fatalf("dynamic_route_states.state for action_required route = %q, want unchanged action_required", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-action-required"); got != "starting" {
+		t.Fatalf("task_sessions.route_state for action_required route = %q, want unchanged starting (must not hide the Retry banner)", got)
+	}
+}
+
 // TestBackfillLegacyActiveDynamicRoutes_FreshInstallIsNoOp proves a brand new
 // database (whose dynamic_route_states DDL already declares the marker
 // column) never runs the backfill, so a genuinely orphaned starting+IDLE

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
@@ -1,0 +1,202 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	dbutil "github.com/kandev/kandev/internal/db"
+)
+
+// legacyDynamicRouteStatesDDL is the pre-#3362 dynamic_route_states shape:
+// identical to the current fresh-install DDL minus the backfill marker
+// column, so opening a database against it reproduces exactly what the
+// migration must detect and repair.
+const legacyDynamicRouteStatesDDL = `
+	CREATE TABLE dynamic_route_states (
+		session_id TEXT PRIMARY KEY,
+		logical_profile_id TEXT NOT NULL,
+		execution_profile_id TEXT NOT NULL DEFAULT '',
+		route_generation BIGINT NOT NULL DEFAULT 0,
+		profile_version BIGINT NOT NULL DEFAULT 0,
+		state TEXT NOT NULL DEFAULT 'selecting',
+		continuation_json TEXT NOT NULL DEFAULT '',
+		policy_state_json TEXT NOT NULL DEFAULT '',
+		updated_at TIMESTAMP NOT NULL,
+		FOREIGN KEY (session_id) REFERENCES task_sessions(id) ON DELETE CASCADE
+	);`
+
+// openLegacyDynamicRouteDB builds a baseline database with the final schema,
+// then rewinds dynamic_route_states to its pre-marker legacy shape so the
+// backfill migration has something to detect.
+func openLegacyDynamicRouteDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "legacy-dynamic-route.db")
+	dbConn, err := dbutil.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("seed baseline schema: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE dynamic_route_states`); err != nil {
+		t.Fatalf("drop final dynamic_route_states: %v", err)
+	}
+	if _, err := db.Exec(legacyDynamicRouteStatesDDL); err != nil {
+		t.Fatalf("seed legacy dynamic_route_states: %v", err)
+	}
+	return db
+}
+
+func seedLegacyDynamicRouteTaskAndSession(t *testing.T, db *sqlx.DB, taskID, sessionID, sessionState string, startedAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO tasks (id, workspace_id, title, created_at, updated_at)
+		VALUES (?, 'ws-1', 'legacy dynamic route task', ?, ?)`), taskID, startedAt, startedAt); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_sessions (id, task_id, state, route_generation, route_state, started_at, updated_at)
+		VALUES (?, ?, ?, 1, 'starting', ?, ?)`), sessionID, taskID, sessionState, startedAt, startedAt); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+}
+
+func seedLegacyDynamicRouteState(t *testing.T, db *sqlx.DB, sessionID, state string, updatedAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO dynamic_route_states (
+			session_id, logical_profile_id, execution_profile_id, route_generation, profile_version, state, updated_at
+		) VALUES (?, 'dynamic-logical', 'candidate-1', 1, 1, ?, ?)`),
+		sessionID, state, updatedAt); err != nil {
+		t.Fatalf("seed dynamic_route_states: %v", err)
+	}
+}
+
+func dynamicRouteState(t *testing.T, db *sqlx.DB, sessionID string) string {
+	t.Helper()
+	var state string
+	if err := db.QueryRow(db.Rebind(
+		`SELECT state FROM dynamic_route_states WHERE session_id = ?`), sessionID).Scan(&state); err != nil {
+		t.Fatalf("read dynamic_route_states.state: %v", err)
+	}
+	return state
+}
+
+func taskSessionRouteState(t *testing.T, db *sqlx.DB, sessionID string) string {
+	t.Helper()
+	var routeState string
+	if err := db.QueryRow(db.Rebind(
+		`SELECT route_state FROM task_sessions WHERE id = ?`), sessionID).Scan(&routeState); err != nil {
+		t.Fatalf("read task_sessions.route_state: %v", err)
+	}
+	return routeState
+}
+
+// TestBackfillLegacyActiveDynamicRoutes_MigratesLegacyIdleRouteToActive is
+// the regression test for the PR #3362 review follow-up (thread
+// r3931855722): on a database created before the durable "active" route
+// status existed, every currently-IDLE Office dynamic session's route is
+// durably "starting" only because the marking mechanism did not exist yet.
+// Without this backfill, the startup orphan sweep
+// (isOrphanableDynamicSessionState) would misclassify every one of these
+// healthy routes as orphaned on the first restart after upgrading.
+func TestBackfillLegacyActiveDynamicRoutes_MigratesLegacyIdleRouteToActive(t *testing.T) {
+	db := openLegacyDynamicRouteDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-legacy-idle", "session-legacy-idle", "IDLE", now)
+	seedLegacyDynamicRouteState(t, db, "session-legacy-idle", "starting", now)
+
+	// Control: a session still STARTING (a genuine in-flight launch at the
+	// moment of the snapshot) must not be touched by the legacy backfill -
+	// only isOrphanableDynamicSessionState's STARTING branch, evaluated live
+	// at startup, may resolve it.
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-legacy-starting", "session-legacy-starting", "STARTING", now)
+	seedLegacyDynamicRouteState(t, db, "session-legacy-starting", "starting", now)
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("run legacy backfill migration: %v", err)
+	}
+
+	if got := dynamicRouteState(t, db, "session-legacy-idle"); got != "active" {
+		t.Fatalf("dynamic_route_states.state for legacy IDLE route = %q, want active", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-legacy-idle"); got != "active" {
+		t.Fatalf("task_sessions.route_state for legacy IDLE route = %q, want active", got)
+	}
+	if got := dynamicRouteState(t, db, "session-legacy-starting"); got != "starting" {
+		t.Fatalf("dynamic_route_states.state for STARTING session = %q, want unchanged starting", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-legacy-starting"); got != "starting" {
+		t.Fatalf("task_sessions.route_state for STARTING session = %q, want unchanged starting", got)
+	}
+
+	exists, err := dbutil.ColumnExists(db, "dynamic_route_states", dynamicRouteLegacyActiveBackfillColumn)
+	if err != nil {
+		t.Fatalf("probe marker column: %v", err)
+	}
+	if !exists {
+		t.Fatal("marker column missing after migration")
+	}
+
+	// A route claimed after the marker column exists can still fail before
+	// reaching "active" and land on the same starting+IDLE shape. Re-running
+	// initSchema (as every boot does) must not backfill it: the marker gates
+	// the whole migration, not just the value-based shape, so this row must
+	// survive to be caught by the live startup orphan sweep instead.
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-post-upgrade-orphan", "session-post-upgrade-orphan", "IDLE", now)
+	seedLegacyDynamicRouteState(t, db, "session-post-upgrade-orphan", "starting", now)
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("replay initSchema after marker column exists: %v", err)
+	}
+
+	if got := dynamicRouteState(t, db, "session-post-upgrade-orphan"); got != "starting" {
+		t.Fatalf("post-upgrade orphan dynamic_route_states.state = %q, want unchanged starting (must survive to the runtime sweep)", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-post-upgrade-orphan"); got != "starting" {
+		t.Fatalf("post-upgrade orphan task_sessions.route_state = %q, want unchanged starting", got)
+	}
+}
+
+// TestBackfillLegacyActiveDynamicRoutes_FreshInstallIsNoOp proves a brand new
+// database (whose dynamic_route_states DDL already declares the marker
+// column) never runs the backfill, so a genuinely orphaned starting+IDLE
+// route created on a fresh install is never masked.
+func TestBackfillLegacyActiveDynamicRoutes_FreshInstallIsNoOp(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "fresh-dynamic-route.db")
+	dbConn, err := dbutil.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("seed baseline schema: %v", err)
+	}
+
+	exists, err := dbutil.ColumnExists(db, "dynamic_route_states", dynamicRouteLegacyActiveBackfillColumn)
+	if err != nil {
+		t.Fatalf("probe marker column: %v", err)
+	}
+	if !exists {
+		t.Fatal("fresh install is missing the backfill marker column")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-fresh-orphan", "session-fresh-orphan", "IDLE", now)
+	seedLegacyDynamicRouteState(t, db, "session-fresh-orphan", "starting", now)
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("replay initSchema: %v", err)
+	}
+
+	if got := dynamicRouteState(t, db, "session-fresh-orphan"); got != "starting" {
+		t.Fatalf("fresh-install orphan dynamic_route_states.state = %q, want unchanged starting", got)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/dynamic_route_legacy_active_migration_test.go
@@ -49,10 +49,21 @@ func openLegacyDynamicRouteDB(t *testing.T) *sqlx.DB {
 	if _, err := db.Exec(legacyDynamicRouteStatesDDL); err != nil {
 		t.Fatalf("seed legacy dynamic_route_states: %v", err)
 	}
+	setStoredKandevVersion(t, db, "v0.93.0")
 	return db
 }
 
 func seedLegacyDynamicRouteTaskAndSession(t *testing.T, db *sqlx.DB, taskID, sessionID, sessionState string, startedAt time.Time) {
+	seedLegacyDynamicRouteTaskAndSessionAtGeneration(t, db, taskID, sessionID, sessionState, startedAt, 1)
+}
+
+func seedLegacyDynamicRouteTaskAndSessionAtGeneration(
+	t *testing.T,
+	db *sqlx.DB,
+	taskID, sessionID, sessionState string,
+	startedAt time.Time,
+	generation int64,
+) {
 	t.Helper()
 	if _, err := db.Exec(db.Rebind(`
 		INSERT INTO tasks (id, workspace_id, title, created_at, updated_at)
@@ -61,19 +72,52 @@ func seedLegacyDynamicRouteTaskAndSession(t *testing.T, db *sqlx.DB, taskID, ses
 	}
 	if _, err := db.Exec(db.Rebind(`
 		INSERT INTO task_sessions (id, task_id, state, route_generation, route_state, started_at, updated_at)
-		VALUES (?, ?, ?, 1, 'starting', ?, ?)`), sessionID, taskID, sessionState, startedAt, startedAt); err != nil {
+		VALUES (?, ?, ?, ?, 'starting', ?, ?)`), sessionID, taskID, sessionState, generation, startedAt, startedAt); err != nil {
 		t.Fatalf("seed session: %v", err)
 	}
 }
 
 func seedLegacyDynamicRouteState(t *testing.T, db *sqlx.DB, sessionID, state string, updatedAt time.Time) {
+	seedLegacyDynamicRouteStateAtGeneration(t, db, sessionID, state, 1, updatedAt)
+}
+
+func seedLegacyDynamicRouteStateAtGeneration(
+	t *testing.T,
+	db *sqlx.DB,
+	sessionID, state string,
+	generation int64,
+	updatedAt time.Time,
+) {
 	t.Helper()
 	if _, err := db.Exec(db.Rebind(`
 		INSERT INTO dynamic_route_states (
 			session_id, logical_profile_id, execution_profile_id, route_generation, profile_version, state, updated_at
-		) VALUES (?, 'dynamic-logical', 'candidate-1', 1, 1, ?, ?)`),
-		sessionID, state, updatedAt); err != nil {
+		) VALUES (?, 'dynamic-logical', 'candidate-1', ?, 1, ?, ?)`),
+		sessionID, generation, state, updatedAt); err != nil {
 		t.Fatalf("seed dynamic_route_states: %v", err)
+	}
+}
+
+func setStoredKandevVersion(t *testing.T, db *sqlx.DB, version string) {
+	t.Helper()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS kandev_meta (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL DEFAULT ''
+		)`); err != nil {
+		t.Fatalf("ensure kandev_meta: %v", err)
+	}
+	if version == "" {
+		if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key = 'kandev_version'`); err != nil {
+			t.Fatalf("delete kandev_version: %v", err)
+		}
+		return
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO kandev_meta (key, value) VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value
+	`), "kandev_version", version); err != nil {
+		t.Fatalf("set kandev_version: %v", err)
 	}
 }
 
@@ -249,5 +293,81 @@ func TestBackfillLegacyActiveDynamicRoutes_FreshInstallIsNoOp(t *testing.T) {
 
 	if got := dynamicRouteState(t, db, "session-fresh-orphan"); got != "starting" {
 		t.Fatalf("fresh-install orphan dynamic_route_states.state = %q, want unchanged starting", got)
+	}
+}
+
+func TestBackfillLegacyActiveDynamicRoutes_SkipsUnprovenancedRoutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "unknown", version: ""},
+		{name: "newer stable", version: "v0.94.0"},
+		{name: "nightly provenance", version: "0.93.1-nightly.sha123456789abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openLegacyDynamicRouteDB(t)
+			setStoredKandevVersion(t, db, tt.version)
+			now := time.Now().UTC().Truncate(time.Second)
+			seedLegacyDynamicRouteTaskAndSession(t, db, "task-unprovenanced", "session-unprovenanced", "IDLE", now)
+			seedLegacyDynamicRouteState(t, db, "session-unprovenanced", "starting", now)
+
+			if _, err := NewWithDB(db, db, nil); err != nil {
+				t.Fatalf("run legacy backfill migration: %v", err)
+			}
+			if got := dynamicRouteState(t, db, "session-unprovenanced"); got != "starting" {
+				t.Fatalf("dynamic_route_states.state = %q, want unchanged starting", got)
+			}
+			if got := taskSessionRouteState(t, db, "session-unprovenanced"); got != "starting" {
+				t.Fatalf("task_sessions.route_state = %q, want unchanged starting", got)
+			}
+			exists, err := dbutil.ColumnExists(db, "dynamic_route_states", dynamicRouteLegacyActiveBackfillColumn)
+			if err != nil {
+				t.Fatalf("probe marker column: %v", err)
+			}
+			if !exists {
+				t.Fatal("marker column missing after skipped migration")
+			}
+		})
+	}
+}
+
+func TestBackfillLegacyActiveDynamicRoutes_SkipsGenerationMismatch(t *testing.T) {
+	db := openLegacyDynamicRouteDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyDynamicRouteTaskAndSessionAtGeneration(t, db, "task-generation-mismatch", "session-generation-mismatch", "IDLE", now, 2)
+	seedLegacyDynamicRouteStateAtGeneration(t, db, "session-generation-mismatch", "starting", 1, now)
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("run legacy backfill migration: %v", err)
+	}
+	if got := dynamicRouteState(t, db, "session-generation-mismatch"); got != "starting" {
+		t.Fatalf("dynamic_route_states.state = %q, want unchanged starting", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-generation-mismatch"); got != "starting" {
+		t.Fatalf("task_sessions.route_state = %q, want unchanged starting", got)
+	}
+}
+
+func TestBackfillLegacyActiveDynamicRoutes_SkipsNonStartingProjection(t *testing.T) {
+	db := openLegacyDynamicRouteDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyDynamicRouteTaskAndSession(t, db, "task-non-starting-projection", "session-non-starting-projection", "IDLE", now)
+	seedLegacyDynamicRouteState(t, db, "session-non-starting-projection", "starting", now)
+	if _, err := db.Exec(db.Rebind(
+		`UPDATE task_sessions SET route_state = ? WHERE id = ?`,
+	), "active", "session-non-starting-projection"); err != nil {
+		t.Fatalf("set non-starting projection: %v", err)
+	}
+
+	if _, err := NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("run legacy backfill migration: %v", err)
+	}
+	if got := dynamicRouteState(t, db, "session-non-starting-projection"); got != "starting" {
+		t.Fatalf("dynamic_route_states.state = %q, want unchanged starting", got)
+	}
+	if got := taskSessionRouteState(t, db, "session-non-starting-projection"); got != "active" {
+		t.Fatalf("task_sessions.route_state = %q, want unchanged active", got)
 	}
 }


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3524/6f28c098e693.html)
<!-- kandev-pr-walkthrough-end -->

Before PR #3362, a successful dynamic launch never durably advanced past the `starting` route state (there was no `MarkActive`), so on the first backend restart after upgrading to that PR, `reconcileOrphanedDynamicStartingRoutes` misread every pre-existing healthy IDLE dynamic route as orphaned and flipped it to `action_required` — a false-positive Retry banner on otherwise-healthy Office sessions. This adds a one-time backfill so those legacy routes are marked `active` before the sweep ever sees them.

**Today:** On the first restart after upgrading past PR #3362, every pre-existing healthy IDLE dynamic-routed Office session gets a spurious `action_required` Retry banner, because the orphan sweep can't distinguish "never marked active because the marking mechanism didn't exist yet" from "genuinely orphaned mid-launch."
**After this:** A one-time migration backfills `active` onto legacy `starting`+IDLE routes before the orphan sweep runs, so the upgrade is silent for healthy sessions; the sweep still catches genuine post-upgrade orphans.
**Who hits this:** Any existing install with in-flight Office dynamic-routed sessions at the moment it upgrades past PR #3362 — a one-time event on first restart, not a recurring issue.
**Scope:** Standalone follow-up from PR #3362 review (thread `r3931855722`, `dynamic_policy_recovery.go:106`), deliberately deferred out of that PR's scope. No sibling PRs.
**Not here:** The sweep's IDLE-is-orphanable classification itself is unchanged and correct for real post-upgrade orphans — only pre-existing legacy routes are backfilled. Also unchanged: `Engine.MarkActive`/`MarkActionRequired` semantics, the Retry/Try-next recovery UI, and the feature flag default.

Also fixes a second, independent defect found while investigating: `reconcileOrphanedDynamicStartingRoutes` only guarded on `profileExecutionResolver == nil`, but that resolver is always constructed regardless of the feature flag — so the sweep ran (and could write `action_required`) even with dynamic routing disabled, which is every shipped profile's default. The guard now also checks `!resolver.Enabled()`, matching the sibling `startDynamicPolicyRecovery` guard.

## Validation

- `go build ./...`
- `go run ./cmd/sqlguard ./internal`
- `go test ./internal/task/repository/sqlite/... -run TestBackfillLegacyActiveDynamicRoutes -count=1 -v` — 4/4 PASS
- `go test ./internal/orchestrator/... -run TestReconcileOrphanedDynamicStartingRoutes -count=1 -v` — all PASS (in-flight STARTING/IDLE sweep, disabled-flag skip, ordering before general startup reconciliation, 6 non-orphan-state skips)
- `go test ./internal/persistence/storeconformance/... -run TestPreviousStableUpgrade_BackfillsLegacyActiveDynamicRoutes -count=1 -v` — sqlite PASS, pgx self-skips locally (no `KANDEV_TEST_POSTGRES_DSN`); the pgx variant runs in CI's PG16 persistence job (`.github/workflows/backend-tests.yml`, full-package run, no `-run` filter). Note: the PG18 job's `-run` anchor does not match this test name, so PG18 does not additionally exercise it — PG16 does, and that job is unmodified by this PR.
- `go test ./internal/orchestrator/... ./internal/task/repository/sqlite/... ./internal/persistence/storeconformance/...` (full packages, post-rebase) — all green
- `make typecheck`, `make lint` (`golangci-lint run ./...` → 0 issues), `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — all green
- E2E: not required — diff is 7 files, all under `apps/backend/internal/`, none under `apps/web/`
- Rebased onto current `main` (401947fd8); no conflicts, diff scope unchanged (7 files, 506 insertions / 2 deletions)

## Possible Improvements

Low risk: the backfill runs once (gated on a schema marker column, following the existing `worktree_ownership_migration.go` / `git_snapshot_environment_migration.go` pattern), is scoped to IDLE routes still in `starting` state, and cannot make anything worse than the pre-#3362 status quo it preserves. It genuinely cannot distinguish a healthy legacy route from a true pre-upgrade orphan (the two are byte-identical on a legacy DB) — this was raised and rejected during review because the alternative (no backfill) false-positives on the healthy majority instead of the stranded minority, and the session is IDLE so the next prompt claims a new generation regardless.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Related: https://github.com/kdlbs/kandev/pull/3362#discussion_r3931855722


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->