### PR TITLE
fix(office): stop the stuck-parent wake sweep from failing every tick on Postgres

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/wake_receipts.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts.go
@@ -268,13 +268,10 @@ func (r *Repository) GetChildSetKeyTx(
 	return formatChildSetKey(rows), nil
 }
 
-// childSetKeyAggregate renders the "id:state" concatenation ListStuckParents
-// compares against a stored receipt. Its output must match formatChildSetKey
-// byte for byte: receipts are written from the Go form and compared against
-// this SQL form, so any difference in separator or ordering makes every
-// receipt look stale and re-wakes the parent on every tick. Postgres does not
-// inherit input ordering from the subquery's ORDER BY, so the ordering is
-// restated inside the aggregate.
+// childSetKeyAggregate renders the deterministic child-set key used by
+// ListStuckParents. Its output must match formatChildSetKey byte for byte.
+// Postgres requires ORDER BY inside STRING_AGG because subquery ordering does
+// not define aggregate input order.
 func childSetKeyAggregate(driver string) string {
 	if dialect.IsPostgres(driver) {
 		return `STRING_AGG(c.id || ':' || c.state, ',' ORDER BY c.id)`

--- a/apps/backend/internal/office/repository/sqlite/wake_receipts.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/kandev/kandev/internal/db/dialect"
 	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 )
 
@@ -99,6 +100,7 @@ type StuckParentCandidate struct {
 // later (guardAgentStatus in the caller is exactly that — a cheap,
 // redundant closing of that race window, not the primary filter).
 func (r *Repository) ListStuckParents(ctx context.Context, reason string, limit int) ([]StuckParentCandidate, error) {
+	driver := r.ro.DriverName()
 	var rows []StuckParentCandidate
 	err := r.ro.SelectContext(ctx, &rows, r.ro.Rebind(`
 		WITH stuck AS (
@@ -107,7 +109,7 @@ func (r *Repository) ListStuckParents(ctx context.Context, reason string, limit 
 				`+RunnerProjection("p")+` AS assignee_agent_profile_id,
 				p.workflow_step_id AS workflow_step_id,
 				COALESCE((
-					SELECT GROUP_CONCAT(c.id || ':' || c.state, ',')
+					SELECT `+childSetKeyAggregate(driver)+`
 					FROM (
 						SELECT id, state FROM tasks
 						WHERE parent_id = p.id AND archived_at IS NULL
@@ -141,7 +143,7 @@ func (r *Repository) ListStuckParents(ctx context.Context, reason string, limit 
 		WHERE s.assignee_agent_profile_id != ''
 		  AND ap.status NOT IN ('paused', 'stopped', 'pending_approval')
 		  AND (
-		      r.child_set_key IS NOT s.child_set_key
+		      r.child_set_key IS DISTINCT FROM s.child_set_key
 		      OR (
 		          NOT EXISTS (
 		              SELECT 1 FROM runs delivered
@@ -152,7 +154,7 @@ func (r *Repository) ListStuckParents(ctx context.Context, reason string, limit 
 		  )
 		  AND NOT EXISTS (
 		      SELECT 1 FROM runs w
-		      WHERE json_extract(w.payload, '$.task_id') = s.parent_task_id
+		      WHERE `+dialect.JSONExtract(driver, "w.payload", "task_id")+` = s.parent_task_id
 		        AND w.reason = ?
 		        AND (
 		            w.status IN ('queued', 'claimed')
@@ -264,6 +266,20 @@ func (r *Repository) GetChildSetKeyTx(
 		return "", err
 	}
 	return formatChildSetKey(rows), nil
+}
+
+// childSetKeyAggregate renders the "id:state" concatenation ListStuckParents
+// compares against a stored receipt. Its output must match formatChildSetKey
+// byte for byte: receipts are written from the Go form and compared against
+// this SQL form, so any difference in separator or ordering makes every
+// receipt look stale and re-wakes the parent on every tick. Postgres does not
+// inherit input ordering from the subquery's ORDER BY, so the ordering is
+// restated inside the aggregate.
+func childSetKeyAggregate(driver string) string {
+	if dialect.IsPostgres(driver) {
+		return `STRING_AGG(c.id || ':' || c.state, ',' ORDER BY c.id)`
+	}
+	return `GROUP_CONCAT(c.id || ':' || c.state, ',')`
 }
 
 func formatChildSetKey(rows []childSetKeyRow) string {

--- a/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
@@ -1,0 +1,194 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// TestPostgresListStuckParents is the PostgreSQL twin of the SQLite
+// ListStuckParents suite. The query carried three SQLite-only constructs —
+// GROUP_CONCAT, json_extract(...), and IS NOT with a column right-hand side —
+// each a parse error on Postgres, so ParentWakeReconciler's backing query
+// could not run there at all and the reconciler recovered nothing. Postgres
+// rejects the whole statement at parse time, so this fails on the first
+// construct rather than returning wrong rows.
+// Skips unless KANDEV_TEST_POSTGRES_DSN is set.
+func TestPostgresListStuckParents(t *testing.T) {
+	repo, ctx := newPostgresWakeRepo(t)
+
+	wantKey := seedPostgresStuckParent(t, ctx, repo, "pg-parent-1", "pg-ws-1")
+
+	rows, err := repo.ListStuckParents(ctx, "task_children_completed", 5)
+	if err != nil {
+		t.Fatalf("ListStuckParents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].ParentTaskID != "pg-parent-1" {
+		t.Errorf("ParentTaskID = %q, want %q", rows[0].ParentTaskID, "pg-parent-1")
+	}
+	if rows[0].AssigneeAgentProfileID != "pg-parent-1-agent" {
+		t.Errorf("AssigneeAgentProfileID = %q, want %q", rows[0].AssigneeAgentProfileID, "pg-parent-1-agent")
+	}
+	if rows[0].ChildSetKey != wantKey {
+		t.Errorf("ChildSetKey = %q, want %q", rows[0].ChildSetKey, wantKey)
+	}
+}
+
+// TestPostgresListStuckParentsChildSetKeyMatchesGo pins the aggregate against
+// GetChildSetKey, which builds the same key in Go. The two must agree byte for
+// byte across engines: a receipt is recorded with the Go form and compared
+// against the SQL form, so a separator or ordering difference would make every
+// receipt look stale and wake each parent forever. Postgres does not guarantee
+// aggregate input order without an explicit ORDER BY inside the aggregate,
+// which is what makes this worth asserting on more than one child.
+func TestPostgresListStuckParentsChildSetKeyMatchesGo(t *testing.T) {
+	repo, ctx := newPostgresWakeRepo(t)
+
+	// Insert the children out of id order so an unordered aggregate produces a
+	// different string than GetChildSetKey's ORDER BY id read.
+	seedPostgresTask(t, ctx, repo, "pg-parent-2", "pg-ws-2")
+	execPostgres(t, ctx, repo,
+		`UPDATE tasks SET project_id = 'office-project' WHERE id = ?`, "pg-parent-2")
+	for _, childID := range []string{"pg-parent-2-child-c", "pg-parent-2-child-a", "pg-parent-2-child-b"} {
+		seedPostgresTask(t, ctx, repo, childID, "pg-ws-2")
+		execPostgres(t, ctx, repo,
+			`UPDATE tasks SET parent_id = ?, state = 'COMPLETED' WHERE id = ?`, "pg-parent-2", childID)
+	}
+	seedPostgresRunner(t, ctx, repo, "pg-parent-2")
+
+	goKey, err := repo.GetChildSetKey(ctx, "pg-parent-2")
+	if err != nil {
+		t.Fatalf("GetChildSetKey: %v", err)
+	}
+
+	rows, err := repo.ListStuckParents(ctx, "task_children_completed", 5)
+	if err != nil {
+		t.Fatalf("ListStuckParents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].ChildSetKey != goKey {
+		t.Errorf("ChildSetKey = %q, want %q (GetChildSetKey)", rows[0].ChildSetKey, goKey)
+	}
+}
+
+// TestPostgresListStuckParentsExcludesCoveredParent drives the two predicates
+// that the remaining dialect-sensitive constructs sit inside: the receipt
+// comparison (IS DISTINCT FROM) and the in-flight-run check (JSON extraction).
+// A parent whose receipt already matches its child set, and which has a queued
+// wake run, must not come back.
+func TestPostgresListStuckParentsExcludesCoveredParent(t *testing.T) {
+	repo, ctx := newPostgresWakeRepo(t)
+
+	key := seedPostgresStuckParent(t, ctx, repo, "pg-parent-3", "pg-ws-3")
+	execPostgres(t, ctx, repo, `
+		INSERT INTO parent_child_wake_receipts (parent_task_id, child_set_key, delivery_operation_id, delivered_at)
+		VALUES (?, ?, 'op-1', ?)
+	`, "pg-parent-3", key, time.Now().UTC())
+
+	rows, err := repo.ListStuckParents(ctx, "task_children_completed", 5)
+	if err != nil {
+		t.Fatalf("ListStuckParents: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("len(rows) = %d, want 0 — receipt already covers this child set", len(rows))
+	}
+
+	// A queued wake run must also exclude the parent once the receipt no longer
+	// matches, which is the json_extract/->> arm.
+	execPostgres(t, ctx, repo,
+		`UPDATE parent_child_wake_receipts SET child_set_key = 'stale' WHERE parent_task_id = ?`, "pg-parent-3")
+	execPostgres(t, ctx, repo, `
+		INSERT INTO runs (id, agent_profile_id, reason, payload, status, requested_at)
+		VALUES ('pg-run-3', 'agent-x', 'task_children_completed', ?, 'queued', ?)
+	`, `{"task_id":"pg-parent-3"}`, time.Now().UTC())
+
+	rows, err = repo.ListStuckParents(ctx, "task_children_completed", 5)
+	if err != nil {
+		t.Fatalf("ListStuckParents (queued run): %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("len(rows) = %d, want 0 — a queued wake run already covers this parent", len(rows))
+	}
+}
+
+// newPostgresWakeRepo opens an isolated Postgres schema and initialises the
+// task repository before the office one, mirroring production boot order (the
+// tasks and runs tables belong to the task repository's schema init).
+func newPostgresWakeRepo(t *testing.T) (*sqlite.Repository, context.Context) {
+	t.Helper()
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init office repo: %v", err)
+	}
+	return repo, context.Background()
+}
+
+// seedPostgresStuckParent builds the minimal parent that satisfies every
+// ListStuckParents predicate — an Office-owned parent, one non-archived
+// COMPLETED child, and a runner resolvable through an agent_profiles row —
+// and returns the child_set_key the query should compute for it.
+func seedPostgresStuckParent(
+	t *testing.T, ctx context.Context, repo *sqlite.Repository, parentID, wsID string,
+) string {
+	t.Helper()
+	seedPostgresTask(t, ctx, repo, parentID, wsID)
+	execPostgres(t, ctx, repo,
+		`UPDATE tasks SET project_id = 'office-project' WHERE id = ?`, parentID)
+
+	childID := parentID + "-child-0"
+	seedPostgresTask(t, ctx, repo, childID, wsID)
+	execPostgres(t, ctx, repo,
+		`UPDATE tasks SET parent_id = ?, state = 'COMPLETED' WHERE id = ?`, parentID, childID)
+
+	seedPostgresRunner(t, ctx, repo, parentID)
+	return childID + ":COMPLETED"
+}
+
+// seedPostgresRunner inserts the agent_profiles row and the
+// workflow_step_participants runner row that RunnerProjection resolves through.
+func seedPostgresRunner(t *testing.T, ctx context.Context, repo *sqlite.Repository, parentID string) {
+	t.Helper()
+	agentID := parentID + "-agent"
+	now := time.Now().UTC()
+	execPostgres(t, ctx, repo, `
+		INSERT INTO agent_profiles (id, agent_id, name, agent_display_name, status, created_at, updated_at)
+		VALUES (?, '', ?, ?, 'idle', ?, ?)
+	`, agentID, agentID, agentID, now, now)
+	execPostgres(t, ctx, repo, `
+		INSERT INTO workflow_step_participants (id, step_id, task_id, role, agent_profile_id)
+		VALUES (?, '', ?, 'runner', ?)
+	`, "p-runner-"+parentID, parentID, agentID)
+}
+
+// seedPostgresTask inserts a tasks row with bound timestamps, since the SQLite
+// helpers in this package use datetime('now').
+func seedPostgresTask(t *testing.T, ctx context.Context, repo *sqlite.Repository, id, wsID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	execPostgres(t, ctx, repo, `
+		INSERT INTO tasks (id, workspace_id, title, description, identifier, created_at, updated_at)
+		VALUES (?, ?, 'Task', '', '', ?, ?)
+	`, id, wsID, now, now)
+}
+
+func execPostgres(
+	t *testing.T, ctx context.Context, repo *sqlite.Repository, query string, args ...any,
+) {
+	t.Helper()
+	if _, err := repo.ExecRaw(ctx, query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
+	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
 	"github.com/kandev/kandev/internal/office/repository/sqlite"
 	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	"github.com/kandev/kandev/internal/testutil"
+	workflowrepo "github.com/kandev/kandev/internal/workflow/repository"
 )
 
 // TestPostgresListStuckParents is the PostgreSQL twin of the SQLite
@@ -121,13 +123,24 @@ func TestPostgresListStuckParentsExcludesCoveredParent(t *testing.T) {
 }
 
 // newPostgresWakeRepo opens an isolated Postgres schema and initialises the
-// task repository before the office one, mirroring production boot order (the
-// tasks and runs tables belong to the task repository's schema init).
+// settings, task, and workflow repositories before the office one, mirroring
+// production boot order: agent_profiles belongs to the settings store schema,
+// tasks and runs belong to the task repository's schema init, and
+// workflow_step_participants.created_at (which RunnerProjection's third
+// COALESCE arm orders by) is added by the workflow repository's migration —
+// see participant_claim_postgres_test.go's newPostgresWakeRepo-equivalent
+// setup for the same ordering contract.
 func newPostgresWakeRepo(t *testing.T) (*sqlite.Repository, context.Context) {
 	t.Helper()
 	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	if _, _, err := settingsstore.Provide(db, db, nil); err != nil {
+		t.Fatalf("init settings store: %v", err)
+	}
 	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
 		t.Fatalf("init task repo: %v", err)
+	}
+	if _, err := workflowrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init workflow repo: %v", err)
 	}
 	repo, err := sqlite.NewWithDB(db, db, nil)
 	if err != nil {
@@ -157,16 +170,23 @@ func seedPostgresStuckParent(
 	return childID + ":COMPLETED"
 }
 
-// seedPostgresRunner inserts the agent_profiles row and the
-// workflow_step_participants runner row that RunnerProjection resolves through.
+// seedPostgresRunner inserts the backing agents row, the agent_profiles row,
+// and the workflow_step_participants runner row that RunnerProjection
+// resolves through. The agents row is required because Postgres enforces
+// agent_profiles.agent_id's foreign key, unlike the SQLite test harness's
+// default connection.
 func seedPostgresRunner(t *testing.T, ctx context.Context, repo *sqlite.Repository, parentID string) {
 	t.Helper()
 	agentID := parentID + "-agent"
 	now := time.Now().UTC()
 	execPostgres(t, ctx, repo, `
+		INSERT INTO agents (id, name, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, agentID, agentID, now, now)
+	execPostgres(t, ctx, repo, `
 		INSERT INTO agent_profiles (id, agent_id, name, agent_display_name, status, created_at, updated_at)
-		VALUES (?, '', ?, ?, 'idle', ?, ?)
-	`, agentID, agentID, agentID, now, now)
+		VALUES (?, ?, ?, ?, 'idle', ?, ?)
+	`, agentID, agentID, agentID, agentID, now, now)
 	execPostgres(t, ctx, repo, `
 		INSERT INTO workflow_step_participants (id, step_id, task_id, role, agent_profile_id)
 		VALUES (?, '', ?, 'runner', ?)

--- a/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
@@ -123,14 +123,10 @@ func TestPostgresListStuckParentsExcludesCoveredParent(t *testing.T) {
 	}
 }
 
-// newPostgresWakeRepo opens an isolated Postgres schema and initialises the
-// settings, task, and workflow repositories before the office one, mirroring
-// production boot order: agent_profiles belongs to the settings store schema,
-// tasks and runs belong to the task repository's schema init, and
-// workflow_step_participants.created_at (which RunnerProjection's third
-// COALESCE arm orders by) is added by the workflow repository's migration —
-// see participant_claim_postgres_test.go's newPostgresWakeRepo-equivalent
-// setup for the same ordering contract.
+// newPostgresWakeRepo opens an isolated Postgres schema and initializes the
+// settings, task, and workflow repositories before the office one. These
+// repositories provide the schema dependencies that ListStuckParents reads:
+// agent_profiles, tasks, runs, and workflow_step_participants.created_at.
 func newPostgresWakeRepo(t *testing.T) (*sqlite.Repository, context.Context) {
 	t.Helper()
 	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))

--- a/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/wake_receipts_postgres_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 // TestPostgresListStuckParents is the PostgreSQL twin of the SQLite
-// ListStuckParents suite. The query carried three SQLite-only constructs —
-// GROUP_CONCAT, json_extract(...), and IS NOT with a column right-hand side —
+// ListStuckParents suite. The query carried several SQLite-only constructs —
+// GROUP_CONCAT, json_extract(...), and IS NOT with a column right-hand side
+// are the three fixed here; a fourth, wsp.rowid, was already fixed in #3459 —
 // each a parse error on Postgres, so ParentWakeReconciler's backing query
 // could not run there at all and the reconciler recovered nothing. Postgres
 // rejects the whole statement at parse time, so this fails on the first


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3525/65717b5890de.html)
<!-- kandev-pr-walkthrough-end -->

**Today:** On PostgreSQL, the parent-wake reconciler's `ListStuckParents` query fails at parse time (`syntax error at or near "'b'"`), so `ParentWakeReconciler` — the level-triggered backstop that recovers stuck parent tasks — logs an error on every tick and never recovers anything. SQLite is unaffected, which is why CI stayed green.
**After this:** The query parses and runs correctly on both engines; the reconciler backstop works on Postgres exactly as it already does on SQLite.
**Who hits this:** Anyone running Office on Postgres — every tick of the reconciler, silently, until a parent gets permanently stuck with no automatic recovery.
**Scope:** Standalone. This PR fixes three of four related dialect issues in this query: `IS NOT` → `IS DISTINCT FROM`, `GROUP_CONCAT`, and `json_extract`. The `wsp.rowid` fallback was fixed via #3459.
**Not here:** A `sqlguard` rule to catch this class of dialect leak (GROUP_CONCAT / json_extract / `IS NOT <column>`) at CI time before it merges — filed as a follow-up (task `01218dab`), not this PR, to keep this change a pure bugfix.

The parent-wake backstop query used two SQLite-only SQL constructs Postgres rejects outright:

- `GROUP_CONCAT(...)` (no Postgres equivalent) → new `childSetKeyAggregate(driver)` picks `STRING_AGG(c.id || ':' || c.state, ',' ORDER BY c.id)` on Postgres, and the byte-identical unchanged `GROUP_CONCAT` form on SQLite.
- `json_extract(w.payload, '$.task_id')` → `dialect.JSONExtract(driver, "w.payload", "task_id")`, the existing helper already used for this exact pattern elsewhere in the repo (`failure.go`, `runs_inflight.go`, `participants.go`).

A new Postgres-gated test file (`wake_receipts_postgres_test.go`, `KANDEV_TEST_POSTGRES_DSN`-gated per `apps/backend/AGENTS.md`) exercises `ListStuckParents` and the `STRING_AGG` aggregate against a real PostgreSQL instance. It runs in CI's `postgres-boot` job (PostgreSQL 16) — `internal/office/repository/sqlite` is in that job's explicit `POSTGRES_PACKAGES` list.

## Validation

- `go build ./...` — clean
- `go vet ./internal/office/repository/sqlite/...` — clean
- `go test -tags fts5 ./internal/office/repository/sqlite/ -run 'StuckParent|WakeReceipt|ChildSetKey' -count=1 -v` — 9 SQLite tests pass; 3 Postgres tests skip locally (no `KANDEV_TEST_POSTGRES_DSN`), run against real Postgres 16 in CI's `postgres-boot` job
- `go run ./cmd/sqlguard ./internal` — clean (this class of dialect leak isn't yet covered — see follow-up above)
- `gofmt -l` on both changed files — clean
- `make typecheck test lint` — clean, other than pre-existing failures proven identical against `origin/main` in a scratch worktree (macOS-runner-specific `internal/worktree`/`agentctl`/`launcher`/etc. TMPDIR path-safety failures, and `TestMigrate_PriorityIdempotent` under `-tags fts5`) — none touch the changed files or packages
- `make lint-format` — clean
- `pnpm run i18n:ratchet` — no UI source added or modified
- E2E not required: diff is two Go files under `apps/backend/internal/office/repository/sqlite/`, zero `apps/web/` paths

## Possible Improvements

Low risk. One residual, non-blocking: the new `STRING_AGG` regression test pins ordering via the derived table's own `ORDER BY id` as much as via `STRING_AGG(... ORDER BY c.id)` itself, so it's a slightly weaker regression pin than it looks (analysis-level observation, not verified against a live Postgres in this environment).

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

