### PR TITLE
fix(backend): stop orphaned agentctl processes from piling up on SSH runners

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -671,14 +671,19 @@ func sshRemoteCleanupContext(ctx context.Context) (context.Context, context.Canc
 // lifetime — every other stop reuses the SSH client opened at CreateInstance
 // or ResumeRemoteInstance.
 func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance *ExecutorInstance, force bool) error {
-	pid, sessionDir, ok := persistedSSHAgentctlTarget(instance.Metadata)
-	if !ok {
-		r.logger.Debug("stop: no tracked SSH session state for instance",
-			zap.String("instance_id", instance.InstanceID))
-		return nil
-	}
 	if !sshShouldStopRemoteAgentctl(instance, force) {
 		return nil
+	}
+	if instance == nil || len(instance.Metadata) == 0 {
+		return fmt.Errorf("ssh: persisted agentctl metadata is missing for instance %q", instanceID(instance))
+	}
+	pid, sessionDir, ok := persistedSSHAgentctlTarget(instance.Metadata)
+	if !ok {
+		return fmt.Errorf("ssh: persisted agentctl metadata is incomplete for instance %q", instance.InstanceID)
+	}
+	taskDir := strings.TrimSpace(getMetadataString(instance.Metadata, MetadataKeySSHRemoteTaskDir))
+	if taskDir == "" {
+		return fmt.Errorf("ssh: no persisted remote task dir for instance %q: agentctl identity is unprovable", instance.InstanceID)
 	}
 	target, err := r.targetFromMetadata(instance.Metadata)
 	if err != nil {
@@ -696,7 +701,6 @@ func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance 
 	if verifyIdentity == nil {
 		verifyIdentity = verifyRemoteAgentctlIdentity
 	}
-	taskDir := getMetadataString(instance.Metadata, MetadataKeySSHRemoteTaskDir)
 	isOurs, err := verifyIdentity(cleanupCtx, client, pid, sessionDir, taskDir)
 	if err != nil {
 		return fmt.Errorf("ssh: verify persisted agentctl identity for instance %q: %w", instance.InstanceID, err)
@@ -728,7 +732,7 @@ func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance 
 // non-positive means there is nothing durable to act on — never build a
 // kill/rm-rf command from an empty or zero value.
 func persistedSSHAgentctlTarget(metadata map[string]interface{}) (pid int, sessionDir string, ok bool) {
-	pidStr := getMetadataString(metadata, MetadataKeySSHRemoteAgentctlPID)
+	pidStr := strings.TrimSpace(getMetadataString(metadata, MetadataKeySSHRemoteAgentctlPID))
 	sessionDir = strings.TrimSpace(getMetadataString(metadata, MetadataKeySSHRemoteSessionDir))
 	if pidStr == "" || sessionDir == "" {
 		return 0, "", false
@@ -738,6 +742,13 @@ func persistedSSHAgentctlTarget(metadata map[string]interface{}) (pid int, sessi
 		return 0, "", false
 	}
 	return parsedPID, sessionDir, true
+}
+
+func instanceID(instance *ExecutorInstance) string {
+	if instance == nil {
+		return "<nil>"
+	}
+	return instance.InstanceID
 }
 
 // RecoverInstances re-opens SSH connections for sessions that were live before

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -613,9 +613,7 @@ func (r *SSHExecutor) StopInstance(ctx context.Context, instance *ExecutorInstan
 	delete(r.sessions, instance.InstanceID)
 	r.mu.Unlock()
 	if state == nil {
-		r.logger.Debug("stop: no tracked SSH session state for instance",
-			zap.String("instance_id", instance.InstanceID))
-		return nil
+		return r.stopPersistedRemoteAgentctl(ctx, instance, force)
 	}
 	if state.forwarder != nil {
 		_ = state.forwarder.Close()
@@ -661,6 +659,63 @@ func sshShouldStopRemoteAgentctl(instance *ExecutorInstance, force bool) bool {
 
 func sshRemoteCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), sshAgentctlCleanupTimeout)
+}
+
+// stopPersistedRemoteAgentctl reaps a remote agentctl process whose in-memory
+// session state did not survive a backend restart, dialing fresh from the
+// pid, session directory, and connection details persisted in
+// executors_running.metadata (see persistentMetadataKeys). It is the only
+// path that can stop a session the executor never tracked in this process
+// lifetime — every other stop reuses the SSH client opened at CreateInstance
+// or ResumeRemoteInstance.
+func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance *ExecutorInstance, force bool) error {
+	pid, sessionDir, ok := persistedSSHAgentctlTarget(instance.Metadata)
+	if !ok {
+		r.logger.Debug("stop: no tracked SSH session state for instance",
+			zap.String("instance_id", instance.InstanceID))
+		return nil
+	}
+	if !sshShouldStopRemoteAgentctl(instance, force) {
+		return nil
+	}
+	target, err := r.targetFromMetadata(instance.Metadata)
+	if err != nil {
+		return fmt.Errorf("ssh: resolve persisted target for instance %q: %w", instance.InstanceID, err)
+	}
+	cleanupCtx, cancel := sshRemoteCleanupContext(ctx)
+	defer cancel()
+	client, err := dialSSH(cleanupCtx, target)
+	if err != nil {
+		return fmt.Errorf("ssh: dial persisted target for instance %q: %w", instance.InstanceID, err)
+	}
+	defer func() { _ = r.closeSSHClient(client) }()
+
+	stopRemote := r.stopRemote
+	if stopRemote == nil {
+		stopRemote = stopRemoteAgentctl
+	}
+	if err := stopRemote(cleanupCtx, client, sessionDir, pid); err != nil {
+		r.logger.Warn("failed to stop persisted remote agentctl",
+			zap.String("instance_id", instance.InstanceID), zap.Error(err))
+	}
+	return nil
+}
+
+// persistedSSHAgentctlTarget extracts the remote pid and session directory a
+// persisted-metadata stop needs. Either being missing or the pid being
+// non-positive means there is nothing durable to act on — never build a
+// kill/rm-rf command from an empty or zero value.
+func persistedSSHAgentctlTarget(metadata map[string]interface{}) (pid int, sessionDir string, ok bool) {
+	pidStr := getMetadataString(metadata, MetadataKeySSHRemoteAgentctlPID)
+	sessionDir = strings.TrimSpace(getMetadataString(metadata, MetadataKeySSHRemoteSessionDir))
+	if pidStr == "" || sessionDir == "" {
+		return 0, "", false
+	}
+	parsedPID, err := strconv.Atoi(pidStr)
+	if err != nil || parsedPID <= 0 {
+		return 0, "", false
+	}
+	return parsedPID, sessionDir, true
 }
 
 // RecoverInstances re-opens SSH connections for sessions that were live before

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -61,14 +61,15 @@ type sshSessionState struct {
 // the client — at the cost of an extra TCP+handshake per session on the same
 // host. See docs/specs/executors/requirements/ssh-executor.md for the full design.
 type SSHExecutor struct {
-	agentctlResolver *AgentctlResolver
-	secretStore      secrets.SecretStore
-	agentList        RemoteAuthAgentLister
-	logger           *logger.Logger
-	brokerPreflight  func(context.Context, *ssh.Client, *ExecutorCreateRequest, SSHRemotePlatform) error
-	stopRemote       func(context.Context, *ssh.Client, string, int) error
-	closeClient      func(*ssh.Client) error
-	cleanupScript    func(context.Context, *ssh.Client, string, map[string]interface{}, map[string]string, SSHRemotePlatform, string, string) error
+	agentctlResolver     *AgentctlResolver
+	secretStore          secrets.SecretStore
+	agentList            RemoteAuthAgentLister
+	logger               *logger.Logger
+	brokerPreflight      func(context.Context, *ssh.Client, *ExecutorCreateRequest, SSHRemotePlatform) error
+	stopRemote           func(context.Context, *ssh.Client, string, int) error
+	verifyRemoteIdentity func(ctx context.Context, client *ssh.Client, pid int, sessionDir, taskDir string) (bool, error)
+	closeClient          func(*ssh.Client) error
+	cleanupScript        func(context.Context, *ssh.Client, string, map[string]interface{}, map[string]string, SSHRemotePlatform, string, string) error
 
 	mu       sync.Mutex
 	sessions map[string]*sshSessionState // keyed by ExecutorInstance.InstanceID
@@ -91,6 +92,7 @@ func NewSSHExecutor(
 	}
 	executor.brokerPreflight = executor.preflightGitHubCredentialBroker
 	executor.stopRemote = stopRemoteAgentctl
+	executor.verifyRemoteIdentity = verifyRemoteAgentctlIdentity
 	executor.closeClient = func(client *ssh.Client) error { return client.Close() }
 	executor.cleanupScript = executor.runCleanupScript
 	return executor
@@ -690,13 +692,33 @@ func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance 
 	}
 	defer func() { _ = r.closeSSHClient(client) }()
 
+	verifyIdentity := r.verifyRemoteIdentity
+	if verifyIdentity == nil {
+		verifyIdentity = verifyRemoteAgentctlIdentity
+	}
+	taskDir := getMetadataString(instance.Metadata, MetadataKeySSHRemoteTaskDir)
+	isOurs, err := verifyIdentity(cleanupCtx, client, pid, sessionDir, taskDir)
+	if err != nil {
+		return fmt.Errorf("ssh: verify persisted agentctl identity for instance %q: %w", instance.InstanceID, err)
+	}
+	if !isOurs {
+		// The pid is gone or has been recycled by an unrelated process since
+		// this row was persisted (a stale row can outlive a remote reboot) —
+		// signalling it would risk killing something we don't own. The
+		// session directory is still ours to reclaim.
+		if _, _, err := runSSHCommand(cleanupCtx, client, removeRemoteDirCommand(sessionDir)); err != nil {
+			r.logger.Warn("failed to remove persisted SSH session dir for unmatched pid",
+				zap.String("instance_id", instance.InstanceID), zap.Error(err))
+		}
+		return nil
+	}
+
 	stopRemote := r.stopRemote
 	if stopRemote == nil {
 		stopRemote = stopRemoteAgentctl
 	}
 	if err := stopRemote(cleanupCtx, client, sessionDir, pid); err != nil {
-		r.logger.Warn("failed to stop persisted remote agentctl",
-			zap.String("instance_id", instance.InstanceID), zap.Error(err))
+		return fmt.Errorf("ssh: stop persisted remote agentctl for instance %q: %w", instance.InstanceID, err)
 	}
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -707,8 +707,7 @@ func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance 
 		// signalling it would risk killing something we don't own. The
 		// session directory is still ours to reclaim.
 		if _, _, err := runSSHCommand(cleanupCtx, client, removeRemoteDirCommand(sessionDir)); err != nil {
-			r.logger.Warn("failed to remove persisted SSH session dir for unmatched pid",
-				zap.String("instance_id", instance.InstanceID), zap.Error(err))
+			return fmt.Errorf("ssh: remove persisted session dir for unmatched pid on instance %q: %w", instance.InstanceID, err)
 		}
 		return nil
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh.go
@@ -702,10 +702,11 @@ func (r *SSHExecutor) stopPersistedRemoteAgentctl(ctx context.Context, instance 
 		return fmt.Errorf("ssh: verify persisted agentctl identity for instance %q: %w", instance.InstanceID, err)
 	}
 	if !isOurs {
-		// The pid is gone or has been recycled by an unrelated process since
-		// this row was persisted (a stale row can outlive a remote reboot) —
-		// signalling it would risk killing something we don't own. The
-		// session directory is still ours to reclaim.
+		// Reached only for a *proven* abandoned row: the pid is gone, or it
+		// is held by something that is not an agentctl under this row's
+		// taskDir. Unproven identity arrives as an error above and never
+		// here, which is what makes reclaiming the directory safe — a
+		// directory is only removed once nothing is known to be using it.
 		if _, _, err := runSSHCommand(cleanupCtx, client, removeRemoteDirCommand(sessionDir)); err != nil {
 			return fmt.Errorf("ssh: remove persisted session dir for unmatched pid on instance %q: %w", instance.InstanceID, err)
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
@@ -270,9 +270,10 @@ func TestRemoteAgentctlStopCommandWaitsAndEscalatesBeforeCleanup(t *testing.T) {
 	command := remoteAgentctlStopCommand("/tmp/session with space", 1234)
 
 	wantOrder := []string{
-		"kill 1234 2>/dev/null || true",
+		"if kill 1234 2>/dev/null; then",
 		"while kill -0 1234",
 		"kill -9 1234",
+		"remote agentctl pid 1234 is still running",
 		"rm -rf '/tmp/session with space'",
 	}
 	previous := -1
@@ -282,6 +283,9 @@ func TestRemoteAgentctlStopCommandWaitsAndEscalatesBeforeCleanup(t *testing.T) {
 			t.Fatalf("command fragment %q is missing or out of order:\n%s", fragment, command)
 		}
 		previous = index
+	}
+	if strings.Contains(command, "kill 1234 2>/dev/null || true") || strings.Contains(command, "kill -9 1234 2>/dev/null || true") {
+		t.Fatalf("stop command must not suppress kill failures:\n%s", command)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
@@ -64,11 +64,11 @@ func TestProbeRemoteAgentctlLiveness(t *testing.T) {
 // probe failure (missing/unsupported ps, a permission fault, an SSH-level
 // fault) must be reported as an error rather than folded into "no match".
 //
-// It also covers R3-F2: the `ps` argv match alone only proves "some agentctl
-// for this taskDir" — sibling sessions of the same task share taskDir in
-// their launch argv — so identity additionally requires the per-session
-// pidfile the launch wrapper writes at <sessionDir>/agentctl.pid to name the
-// same pid.
+// The pidfile leg has the same discipline: <sessionDir>/agentctl.pid must
+// name the pid about to be signalled, and a pidfile that cannot be read or
+// disagrees is an error rather than a mismatch verdict — the caller reclaims
+// the session directory on a mismatch, and that directory may belong to a
+// live process.
 func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
 	t.Run("matching command line and pidfile reports identity", func(t *testing.T) {
 		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
@@ -93,31 +93,50 @@ func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
 		}
 	})
 
-	// R3-F2: a stale row's pid was recycled by a live sibling session's
-	// agentctl on the same taskDir — the argv matches, but this row's own
-	// sessionDir pidfile still names the pid its own (now-dead) launch
-	// recorded, which differs from the pid actually being probed.
-	t.Run("command line matches but pidfile names a different pid reports no identity", func(t *testing.T) {
+	// A pidfile that names a different pid means the session directory
+	// belongs to a launch other than the one this row describes — most
+	// plausibly a newer, live one. Identity is unproven, so the verdict is an
+	// error: a plain "not ours" would authorise the caller to remove that
+	// live launch's directory.
+	t.Run("command line matches but pidfile names a different pid leaves identity unproven", func(t *testing.T) {
 		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("9999")},
 		).handle)
 
 		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
-		if err != nil || ours {
-			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+		if err == nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, error)", ours, err)
+		}
+		if !strings.Contains(err.Error(), "names pid 9999") {
+			t.Fatalf("error = %v, want the disagreeing pid in the detail", err)
 		}
 	})
 
-	t.Run("missing pidfile reports no identity", func(t *testing.T) {
-		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
-			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshFail("No such file or directory")},
-		).handle)
+	// The pid is alive and the argv already matches this row's agentctl, so
+	// an unreadable pidfile cannot be read as absence. Reporting "not ours"
+	// here would leave a live agentctl running while deleting the very
+	// pidfile and log that identify it.
+	t.Run("unreadable pidfile leaves identity unproven", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			result sshExecResult
+		}{
+			{name: "missing file", result: sshFail("No such file or directory")},
+			{name: "channel fault under load", result: sshFail("ssh: unable to open channel")},
+			{name: "non-numeric content", result: sshOut("not-a-pid")},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+					sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+					sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: tc.result},
+				).handle)
 
-		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
-		if err != nil || ours {
-			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+				ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+				if err == nil || ours {
+					t.Fatalf("verify = (%v, %v), want (false, error)", ours, err)
+				}
+			})
 		}
 	})
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
@@ -57,3 +57,67 @@ func TestProbeRemoteAgentctlLiveness(t *testing.T) {
 		}
 	})
 }
+
+// TestVerifyRemoteAgentctlIdentity covers R2-F1: verifyRemoteAgentctlIdentity
+// must mirror probeRemoteAgentctlLiveness's discipline for a nonzero `ps`
+// exit — only a confirmed-absent process is a safe "not ours", any other
+// probe failure (missing/unsupported ps, a permission fault, an SSH-level
+// fault) must be reported as an error rather than folded into "no match".
+func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
+	t.Run("matching command line reports identity", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		).handle)
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err != nil || !ours {
+			t.Fatalf("verify = (%v, %v), want (true, nil)", ours, err)
+		}
+	})
+
+	t.Run("non-matching command line reports no identity", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/other-task")},
+		).handle)
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err != nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+		}
+	})
+
+	t.Run("completed remote probe reports absence as no identity", func(t *testing.T) {
+		server := newFakeSSHServer(t, func(string, string) sshExecResult {
+			return sshFail("no such process")
+		})
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err != nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+		}
+	})
+
+	t.Run("unsupported ps command leaves identity unknown", func(t *testing.T) {
+		server := newFakeSSHServer(t, func(string, string) sshExecResult {
+			return sshFail("ps: unrecognized option '-o'")
+		})
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err == nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, error)", ours, err)
+		}
+	})
+
+	t.Run("closed SSH connection leaves identity unknown", func(t *testing.T) {
+		server := newFakeSSHServer(t, nil)
+		client := server.dial(t)
+		if err := client.Close(); err != nil {
+			t.Fatalf("close client: %v", err)
+		}
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), client, 4242, "/remote/session", "/remote/task")
+		if err == nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, error)", ours, err)
+		}
+	})
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
@@ -58,6 +58,19 @@ func TestProbeRemoteAgentctlLiveness(t *testing.T) {
 	})
 }
 
+func TestRemoteProcessCommandLineCommandSupportsBusyboxFallback(t *testing.T) {
+	command := remoteProcessCommandLineCommand(4242)
+	for _, want := range []string{
+		"ps -p 4242 -o command=",
+		"/proc/4242/cmdline",
+		"tr",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("remote process command = %q, want it to contain %q", command, want)
+		}
+	}
+}
+
 // TestVerifyRemoteAgentctlIdentity covers R2-F1: verifyRemoteAgentctlIdentity
 // must mirror probeRemoteAgentctlLiveness's discipline for a nonzero `ps`
 // exit — only a confirmed-absent process is a safe "not ours", any other

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
@@ -63,10 +63,17 @@ func TestProbeRemoteAgentctlLiveness(t *testing.T) {
 // exit — only a confirmed-absent process is a safe "not ours", any other
 // probe failure (missing/unsupported ps, a permission fault, an SSH-level
 // fault) must be reported as an error rather than folded into "no match".
+//
+// It also covers R3-F2: the `ps` argv match alone only proves "some agentctl
+// for this taskDir" — sibling sessions of the same task share taskDir in
+// their launch argv — so identity additionally requires the per-session
+// pidfile the launch wrapper writes at <sessionDir>/agentctl.pid to name the
+// same pid.
 func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
-	t.Run("matching command line reports identity", func(t *testing.T) {
+	t.Run("matching command line and pidfile reports identity", func(t *testing.T) {
 		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		).handle)
 
 		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
@@ -86,9 +93,42 @@ func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
 		}
 	})
 
-	t.Run("completed remote probe reports absence as no identity", func(t *testing.T) {
+	// R3-F2: a stale row's pid was recycled by a live sibling session's
+	// agentctl on the same taskDir — the argv matches, but this row's own
+	// sessionDir pidfile still names the pid its own (now-dead) launch
+	// recorded, which differs from the pid actually being probed.
+	t.Run("command line matches but pidfile names a different pid reports no identity", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("9999")},
+		).handle)
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err != nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+		}
+	})
+
+	t.Run("missing pidfile reports no identity", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshFail("No such file or directory")},
+		).handle)
+
+		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
+		if err != nil || ours {
+			t.Fatalf("verify = (%v, %v), want (false, nil)", ours, err)
+		}
+	})
+
+	// R3-F1: real `ps -p <absent-pid> -o command=` exits non-zero with both
+	// stdout and stderr empty — it never writes a "no such process" message
+	// the way `kill -0` does. sshFail("") reproduces that shape; a fixture
+	// using sshFail("no such process") here would fabricate a shape `ps`
+	// never actually produces and let the dead-pid case regress silently.
+	t.Run("completed remote probe with empty stderr reports absence as no identity", func(t *testing.T) {
 		server := newFakeSSHServer(t, func(string, string) sshExecResult {
-			return sshFail("no such process")
+			return sshFail("")
 		})
 
 		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_liveness_test.go
@@ -85,6 +85,7 @@ func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
 	t.Run("non-matching command line reports no identity", func(t *testing.T) {
 		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 			sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/other-task")},
+			sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		).handle)
 
 		ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
@@ -127,10 +128,17 @@ func TestVerifyRemoteAgentctlIdentity(t *testing.T) {
 			{name: "non-numeric content", result: sshOut("not-a-pid")},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-					sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
-					sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: tc.result},
-				).handle)
+				rules := []sshScriptRule{
+					{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+					{match: "cat -- '/remote/session/agentctl.pid'", result: tc.result},
+				}
+				switch tc.name {
+				case "missing file":
+					rules = append(rules, sshScriptRule{match: "test -d '/remote/session'", result: sshOK})
+				case "channel fault under load":
+					rules = append(rules, sshScriptRule{match: "test -d '/remote/session'", result: sshFail("ssh: unable to open channel")})
+				}
+				server := newFakeSSHServer(t, newSSHScriptedHandler(t, rules...).handle)
 
 				ours, err := verifyRemoteAgentctlIdentity(context.Background(), server.dial(t), 4242, "/remote/session", "/remote/task")
 				if err == nil || ours {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1136,7 +1136,23 @@ func verifyAbandonedRemoteAgentctlDirectory(ctx context.Context, client *ssh.Cli
 }
 
 func remoteProcessCommandLineCommand(pid int) string {
-	return fmt.Sprintf("ps -p %d -o command=", pid)
+	// BusyBox ps (used by Alpine-based SSH targets) does not support the
+	// procps/macOS `-p` selector. Prefer the precise selector when available,
+	// then read Linux's per-process argv as a portable fallback. Keep an absent
+	// PID as an empty, non-zero result so remotePsProbeConfirmsAbsence can still
+	// distinguish it from a probe error. If neither mechanism is available,
+	// return stderr and fail closed rather than treating the process as absent.
+	return fmt.Sprintf(`ps -p %[1]d -o command= 2>/dev/null || {
+  if [ ! -d /proc ]; then
+    echo "process identity probe unavailable: ps does not support -p and /proc is absent" >&2
+    exit 2
+  fi
+  if [ -e /proc/%[1]d/cmdline ]; then
+    tr '\000' ' ' < /proc/%[1]d/cmdline
+  else
+    exit 1
+  fi
+}`, pid)
 }
 
 func remoteAgentctlCommandLineMatches(commandLine, taskDir string) bool {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1031,19 +1031,33 @@ func stopRemoteAgentctl(ctx context.Context, client *ssh.Client, sessionDir stri
 	return err
 }
 
+//nolint:dupword // shell branches contain repeated `fi` tokens.
 func remoteAgentctlStopCommand(sessionDir string, pid int) string {
 	removeSessionDir := removeRemoteDirCommand(sessionDir)
 	if pid <= 0 {
 		return removeSessionDir
 	}
-	return fmt.Sprintf(`kill %[1]d 2>/dev/null || true
-attempt=0
-while kill -0 %[1]d 2>/dev/null && [ "$attempt" -lt %[2]d ]; do
-  sleep 0.1
-  attempt=$((attempt + 1))
-done
+	return fmt.Sprintf(`if kill %[1]d 2>/dev/null; then
+  attempt=0
+  while kill -0 %[1]d 2>/dev/null && [ "$attempt" -lt %[2]d ]; do
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+  if kill -0 %[1]d 2>/dev/null; then
+    if ! kill -9 %[1]d 2>/dev/null && kill -0 %[1]d 2>/dev/null; then
+      echo "failed to terminate remote agentctl pid %[1]d" >&2
+      exit 1
+    fi
+  fi
+else
+  if kill -0 %[1]d 2>/dev/null; then
+    echo "failed to signal remote agentctl pid %[1]d" >&2
+    exit 1
+  fi
+fi
 if kill -0 %[1]d 2>/dev/null; then
-  kill -9 %[1]d 2>/dev/null || true
+  echo "remote agentctl pid %[1]d is still running" >&2
+  exit 1
 fi
 %[3]s`, pid, sshAgentctlStopPollAttempts, removeSessionDir)
 }
@@ -1096,15 +1110,29 @@ func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid i
 		if !remotePsProbeConfirmsAbsence(stdout, stderr) {
 			return false, remoteProcessProbeError("ps -p", pid, err, stderr)
 		}
-		return false, nil
+		return verifyAbandonedRemoteAgentctlDirectory(ctx, client, pid, sessionDir)
 	}
 	if !remoteAgentctlCommandLineMatches(stdout, taskDir) {
-		return false, nil
+		return verifyAbandonedRemoteAgentctlDirectory(ctx, client, pid, sessionDir)
 	}
 	if err := remoteAgentctlPidFileConfirms(ctx, client, sessionDir, pid); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func verifyAbandonedRemoteAgentctlDirectory(ctx context.Context, client *ssh.Client, pid int, sessionDir string) (bool, error) {
+	filePID, present, err := readRemoteAgentctlPidFile(ctx, client, sessionDir)
+	if err != nil {
+		return false, err
+	}
+	if !present {
+		return false, nil
+	}
+	if filePID != pid {
+		return false, fmt.Errorf("remote pidfile %s/agentctl.pid names pid %d, not %d", sessionDir, filePID, pid)
+	}
+	return false, nil
 }
 
 func remoteProcessCommandLineCommand(pid int) string {
@@ -1149,26 +1177,62 @@ func commandLineHasFlagValue(line, flag, value string) bool {
 // because the caller reclaims the session directory on a mismatch and that
 // directory may belong to a live process.
 func remoteAgentctlPidFileConfirms(ctx context.Context, client *ssh.Client, sessionDir string, pid int) error {
+	filePID, present, err := readRemoteAgentctlPidFile(ctx, client, sessionDir)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return fmt.Errorf("remote agentctl session directory %s disappeared before pidfile verification", sessionDir)
+	}
+	if filePID != pid {
+		return fmt.Errorf("remote pidfile %s/agentctl.pid names pid %d, not %d", sessionDir, filePID, pid)
+	}
+	return nil
+}
+
+func readRemoteAgentctlPidFile(ctx context.Context, client *ssh.Client, sessionDir string) (int, bool, error) {
 	if strings.TrimSpace(sessionDir) == "" {
-		return fmt.Errorf("remote agentctl pidfile check for pid %d: no session directory", pid)
+		return 0, false, errors.New("remote agentctl pidfile check: no session directory")
 	}
 	path := sessionDir + "/agentctl.pid"
 	stdout, stderr, err := runSSHCommand(ctx, client, "cat -- "+shellQuote(path))
 	if err != nil {
-		if detail := strings.TrimSpace(stderr); detail != "" {
-			return fmt.Errorf("remote cat %s failed: %w (stderr: %s)", path, err, detail)
+		exists, existsErr := remoteSessionDirExists(ctx, client, sessionDir)
+		if existsErr != nil {
+			return 0, false, existsErr
 		}
-		return fmt.Errorf("remote cat %s failed: %w", path, err)
+		if !exists {
+			return 0, false, nil
+		}
+		if detail := strings.TrimSpace(stderr); detail != "" {
+			return 0, false, fmt.Errorf("remote cat %s failed: %w (stderr: %s)", path, err, detail)
+		}
+		return 0, false, fmt.Errorf("remote cat %s failed: %w", path, err)
 	}
 	content := strings.TrimSpace(stdout)
 	filePID, err := strconv.Atoi(content)
 	if err != nil {
-		return fmt.Errorf("remote pidfile %s does not name a pid: %q", path, content)
+		return 0, false, fmt.Errorf("remote pidfile %s does not name a pid: %q", path, content)
 	}
-	if filePID != pid {
-		return fmt.Errorf("remote pidfile %s names pid %d, not %d", path, filePID, pid)
+	if filePID <= 0 {
+		return 0, false, fmt.Errorf("remote pidfile %s contains non-positive pid %d", path, filePID)
 	}
-	return nil
+	return filePID, true, nil
+}
+
+func remoteSessionDirExists(ctx context.Context, client *ssh.Client, sessionDir string) (bool, error) {
+	_, stderr, err := runSSHCommand(ctx, client, "test -d "+shellQuote(sessionDir))
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) && strings.TrimSpace(stderr) == "" {
+		return false, nil
+	}
+	if detail := strings.TrimSpace(stderr); detail != "" {
+		return false, fmt.Errorf("remote test -d %s failed: %w (stderr: %s)", sessionDir, err, detail)
+	}
+	return false, fmt.Errorf("remote test -d %s failed: %w", sessionDir, err)
 }
 
 // probeRemoteAgentctlLiveness distinguishes a completed remote process probe

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1057,23 +1057,32 @@ func removeRemoteDirCommand(dir string) string {
 // verifyRemoteAgentctlIdentity confirms that a pid recovered from persisted
 // executors_running metadata still belongs to the agentctl this row
 // describes, before that pid is signalled. A persisted row can outlive a
-// remote host reboot, at which point the pid is guaranteed stale and PID
+// remote host reboot, at which point the pid is guaranteed stale, and PID
 // reuse by an unrelated process owned by the same SSH user is a real risk on
 // a shared runner — probeRemoteAgentctlLiveness alone only proves *some*
-// process holds the pid, not that it is ours. The remote launch command line
-// always includes "agentctl" and the persisted taskDir, but taskDir is
-// shared by every sibling session of the same task (workspace reuse), so a
-// `ps` match only proves "some agentctl for this task" — not this row's own
-// session. remoteAgentctlPidFileMatches supplies the missing per-session
-// evidence via the launch wrapper's own pidfile.
+// process holds the pid, not that it is ours.
 //
-// Returns false (no error) when the pid is gone, belongs to something else,
-// or fails the pidfile cross-check — all "safe to skip the kill" outcomes
-// for the caller. An error return means the identity probe itself failed
-// (e.g. an SSH-level fault, not merely "no such process"), and the caller
-// should treat this the same as a failed stop: preserve the row rather than
-// risk either signalling an unverified pid or reporting an orphan as
-// reaped.
+// There are exactly two proven outcomes; everything else is an error.
+//
+//   - (false, nil) — proven abandoned: the pid is gone, or it is held by
+//     something that is not an agentctl under this row's taskDir. Nothing to
+//     signal, and this row's session directory is the caller's to reclaim.
+//   - (true, nil) — proven ours: the remote command line names agentctl with
+//     this row's taskDir as its --workdir, and the session directory's own
+//     pidfile names the same pid. Safe to signal.
+//
+// An error means identity is unproven: an SSH-level fault, a `ps` that failed
+// for any reason other than the pid being absent, or a pidfile that could not
+// be read or disagreed. Unproven is not abandoned — it is equally consistent
+// with "our live agentctl whose directory we cannot read" and with "a
+// directory that now belongs to a newer launch". The caller must therefore
+// signal nothing, remove nothing, and preserve the row, exactly as it would
+// for a failed stop.
+//
+// Note the limit of the pidfile leg: it bounds divergence between the row and
+// its session directory, but it cannot detect PID reuse where the recycled
+// pid equals this row's own persisted pid, because the pidfile and the
+// persisted pid are both written from the same launch.
 func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid int, sessionDir, taskDir string) (bool, error) {
 	if pid <= 0 {
 		return false, nil
@@ -1092,7 +1101,10 @@ func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid i
 	if !remoteAgentctlCommandLineMatches(stdout, taskDir) {
 		return false, nil
 	}
-	return remoteAgentctlPidFileMatches(ctx, client, sessionDir, pid), nil
+	if err := remoteAgentctlPidFileConfirms(ctx, client, sessionDir, pid); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func remoteProcessCommandLineCommand(pid int) string {
@@ -1101,32 +1113,62 @@ func remoteProcessCommandLineCommand(pid int) string {
 
 func remoteAgentctlCommandLineMatches(commandLine, taskDir string) bool {
 	line := strings.TrimSpace(commandLine)
-	if line == "" || !strings.Contains(line, "agentctl") {
+	if line == "" || taskDir == "" || !strings.Contains(line, "agentctl") {
 		return false
 	}
-	return taskDir != "" && strings.Contains(line, taskDir)
+	return commandLineHasFlagValue(line, "--workdir", taskDir)
 }
 
-// remoteAgentctlPidFileMatches supplies the per-session identity evidence a
-// `ps` argv match cannot: it reads the pidfile the launch wrapper writes at
-// <sessionDir>/agentctl.pid (see startRemoteAgentctlOnPort) and compares its
-// content to the pid about to be signalled. Any failure to confirm a
-// match — the file is gone, unreadable, or names a different pid — returns
-// false so the caller skips the kill; the row's own session directory is
-// still safe to reclaim regardless of pid identity.
-func remoteAgentctlPidFileMatches(ctx context.Context, client *ssh.Client, sessionDir string, pid int) bool {
+// commandLineHasFlagValue reports whether a `ps` command line passes value as
+// the whole value of flag. The value must end at a word boundary: a plain
+// substring test would also accept a sibling directory that merely starts
+// with this row's taskDir, and signalling on that evidence would kill another
+// task's agentctl.
+func commandLineHasFlagValue(line, flag, value string) bool {
+	for _, needle := range []string{flag + " " + value, flag + "=" + value} {
+		for offset := 0; ; {
+			index := strings.Index(line[offset:], needle)
+			if index < 0 {
+				break
+			}
+			end := offset + index + len(needle)
+			if end == len(line) || line[end] == ' ' || line[end] == '\t' {
+				return true
+			}
+			offset = end
+		}
+	}
+	return false
+}
+
+// remoteAgentctlPidFileConfirms requires the session directory's own pidfile,
+// written by the launch wrapper at <sessionDir>/agentctl.pid (see
+// startRemoteAgentctlOnPort), to name the pid that is about to be signalled.
+// Only a confirmed match returns nil. A pidfile that cannot be read, does not
+// parse, or names a different pid is an error and never a mismatch verdict,
+// because the caller reclaims the session directory on a mismatch and that
+// directory may belong to a live process.
+func remoteAgentctlPidFileConfirms(ctx context.Context, client *ssh.Client, sessionDir string, pid int) error {
 	if strings.TrimSpace(sessionDir) == "" {
-		return false
+		return fmt.Errorf("remote agentctl pidfile check for pid %d: no session directory", pid)
 	}
-	stdout, _, err := runSSHCommand(ctx, client, "cat -- "+shellQuote(sessionDir+"/agentctl.pid"))
+	path := sessionDir + "/agentctl.pid"
+	stdout, stderr, err := runSSHCommand(ctx, client, "cat -- "+shellQuote(path))
 	if err != nil {
-		return false
+		if detail := strings.TrimSpace(stderr); detail != "" {
+			return fmt.Errorf("remote cat %s failed: %w (stderr: %s)", path, err, detail)
+		}
+		return fmt.Errorf("remote cat %s failed: %w", path, err)
 	}
-	filePID, err := strconv.Atoi(strings.TrimSpace(stdout))
+	content := strings.TrimSpace(stdout)
+	filePID, err := strconv.Atoi(content)
 	if err != nil {
-		return false
+		return fmt.Errorf("remote pidfile %s does not name a pid: %q", path, content)
 	}
-	return filePID == pid
+	if filePID != pid {
+		return fmt.Errorf("remote pidfile %s names pid %d, not %d", path, filePID, pid)
+	}
+	return nil
 }
 
 // probeRemoteAgentctlLiveness distinguishes a completed remote process probe

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1061,15 +1061,19 @@ func removeRemoteDirCommand(dir string) string {
 // reuse by an unrelated process owned by the same SSH user is a real risk on
 // a shared runner — probeRemoteAgentctlLiveness alone only proves *some*
 // process holds the pid, not that it is ours. The remote launch command line
-// always includes "agentctl" and the persisted workdir (sessionDir or
-// taskDir), so a `ps` command-line match is sufficient identity evidence.
+// always includes "agentctl" and the persisted taskDir, but taskDir is
+// shared by every sibling session of the same task (workspace reuse), so a
+// `ps` match only proves "some agentctl for this task" — not this row's own
+// session. remoteAgentctlPidFileMatches supplies the missing per-session
+// evidence via the launch wrapper's own pidfile.
 //
-// Returns false (no error) when the pid is gone or belongs to something
-// else — both are "safe to skip the kill" outcomes for the caller. An error
-// return means the identity probe itself failed (e.g. an SSH-level fault,
-// not merely "no such process"), and the caller should treat this the same
-// as a failed stop: preserve the row rather than risk either signalling an
-// unverified pid or reporting an orphan as reaped.
+// Returns false (no error) when the pid is gone, belongs to something else,
+// or fails the pidfile cross-check — all "safe to skip the kill" outcomes
+// for the caller. An error return means the identity probe itself failed
+// (e.g. an SSH-level fault, not merely "no such process"), and the caller
+// should treat this the same as a failed stop: preserve the row rather than
+// risk either signalling an unverified pid or reporting an orphan as
+// reaped.
 func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid int, sessionDir, taskDir string) (bool, error) {
 	if pid <= 0 {
 		return false, nil
@@ -1080,25 +1084,49 @@ func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid i
 		if !errors.As(err, &exitErr) {
 			return false, remoteProcessProbeError("ps -p", pid, err, stderr)
 		}
-		if !remoteProcessProbeConfirmsAbsence(stderr) {
+		if !remotePsProbeConfirmsAbsence(stdout, stderr) {
 			return false, remoteProcessProbeError("ps -p", pid, err, stderr)
 		}
 		return false, nil
 	}
-	return remoteAgentctlCommandLineMatches(stdout, sessionDir, taskDir), nil
+	if !remoteAgentctlCommandLineMatches(stdout, taskDir) {
+		return false, nil
+	}
+	return remoteAgentctlPidFileMatches(ctx, client, sessionDir, pid), nil
 }
 
 func remoteProcessCommandLineCommand(pid int) string {
 	return fmt.Sprintf("ps -p %d -o command=", pid)
 }
 
-func remoteAgentctlCommandLineMatches(commandLine, sessionDir, taskDir string) bool {
+func remoteAgentctlCommandLineMatches(commandLine, taskDir string) bool {
 	line := strings.TrimSpace(commandLine)
 	if line == "" || !strings.Contains(line, "agentctl") {
 		return false
 	}
-	return (sessionDir != "" && strings.Contains(line, sessionDir)) ||
-		(taskDir != "" && strings.Contains(line, taskDir))
+	return taskDir != "" && strings.Contains(line, taskDir)
+}
+
+// remoteAgentctlPidFileMatches supplies the per-session identity evidence a
+// `ps` argv match cannot: it reads the pidfile the launch wrapper writes at
+// <sessionDir>/agentctl.pid (see startRemoteAgentctlOnPort) and compares its
+// content to the pid about to be signalled. Any failure to confirm a
+// match — the file is gone, unreadable, or names a different pid — returns
+// false so the caller skips the kill; the row's own session directory is
+// still safe to reclaim regardless of pid identity.
+func remoteAgentctlPidFileMatches(ctx context.Context, client *ssh.Client, sessionDir string, pid int) bool {
+	if strings.TrimSpace(sessionDir) == "" {
+		return false
+	}
+	stdout, _, err := runSSHCommand(ctx, client, "cat -- "+shellQuote(sessionDir+"/agentctl.pid"))
+	if err != nil {
+		return false
+	}
+	filePID, err := strconv.Atoi(strings.TrimSpace(stdout))
+	if err != nil {
+		return false
+	}
+	return filePID == pid
 }
 
 // probeRemoteAgentctlLiveness distinguishes a completed remote process probe
@@ -1126,6 +1154,21 @@ func remoteProcessProbeConfirmsAbsence(stderr string) bool {
 	return strings.Contains(message, "no such process") ||
 		strings.Contains(message, "no such pid") ||
 		strings.Contains(message, "esrch")
+}
+
+// remotePsProbeConfirmsAbsence distinguishes a `ps -p <pid>` selection miss
+// from a genuine probe fault. Unlike `kill -0`, `ps -p <absent-pid> -o
+// command=` never writes a "no such process" style message — on every
+// observed platform (macOS, procps/Linux) it exits non-zero with both
+// stdout and stderr empty. Treating that shape as confirmed absence keeps
+// this fail-closed: any real stderr content (a busybox/unsupported flag, a
+// permission fault, an SSH-level error) still falls through to an error
+// instead of being read as "process gone".
+func remotePsProbeConfirmsAbsence(stdout, stderr string) bool {
+	if remoteProcessProbeConfirmsAbsence(stderr) {
+		return true
+	}
+	return strings.TrimSpace(stdout) == "" && strings.TrimSpace(stderr) == ""
 }
 
 func remoteProcessProbeError(command string, pid int, err error, stderr string) error {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1078,10 +1078,12 @@ func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid i
 	if err != nil {
 		var exitErr *ssh.ExitError
 		if !errors.As(err, &exitErr) {
-			return false, remoteProcessProbeError(pid, err, stderr)
+			return false, remoteProcessProbeError("ps -p", pid, err, stderr)
 		}
-		// A nonzero ps exit (e.g. no matching process) is evaluated below
-		// like any other result: empty output never matches.
+		if !remoteProcessProbeConfirmsAbsence(stderr) {
+			return false, remoteProcessProbeError("ps -p", pid, err, stderr)
+		}
+		return false, nil
 	}
 	return remoteAgentctlCommandLineMatches(stdout, sessionDir, taskDir), nil
 }
@@ -1114,7 +1116,7 @@ func probeRemoteAgentctlLiveness(ctx context.Context, client *ssh.Client, pid in
 		if remoteProcessProbeConfirmsAbsence(stderr) {
 			return false, nil
 		}
-		return false, remoteProcessProbeError(pid, err, stderr)
+		return false, remoteProcessProbeError("kill -0", pid, err, stderr)
 	}
 	return false, err
 }
@@ -1126,12 +1128,12 @@ func remoteProcessProbeConfirmsAbsence(stderr string) bool {
 		strings.Contains(message, "esrch")
 }
 
-func remoteProcessProbeError(pid int, err error, stderr string) error {
+func remoteProcessProbeError(command string, pid int, err error, stderr string) error {
 	detail := strings.TrimSpace(stderr)
 	if detail == "" {
-		return fmt.Errorf("remote kill -0 %d failed: %w", pid, err)
+		return fmt.Errorf("remote %s %d failed: %w", command, pid, err)
 	}
-	return fmt.Errorf("remote kill -0 %d failed: %w (stderr: %s)", pid, err, detail)
+	return fmt.Errorf("remote %s %d failed: %w (stderr: %s)", command, pid, err, detail)
 }
 
 // isRemoteAgentctlAlive is the best-effort boolean form used by status and

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -1032,7 +1032,7 @@ func stopRemoteAgentctl(ctx context.Context, client *ssh.Client, sessionDir stri
 }
 
 func remoteAgentctlStopCommand(sessionDir string, pid int) string {
-	removeSessionDir := "rm -rf " + shellQuote(sessionDir)
+	removeSessionDir := removeRemoteDirCommand(sessionDir)
 	if pid <= 0 {
 		return removeSessionDir
 	}
@@ -1046,6 +1046,57 @@ if kill -0 %[1]d 2>/dev/null; then
   kill -9 %[1]d 2>/dev/null || true
 fi
 %[3]s`, pid, sshAgentctlStopPollAttempts, removeSessionDir)
+}
+
+// removeRemoteDirCommand builds the shell command that reclaims a remote
+// session directory on its own, independent of whether a process is stopped.
+func removeRemoteDirCommand(dir string) string {
+	return "rm -rf " + shellQuote(dir)
+}
+
+// verifyRemoteAgentctlIdentity confirms that a pid recovered from persisted
+// executors_running metadata still belongs to the agentctl this row
+// describes, before that pid is signalled. A persisted row can outlive a
+// remote host reboot, at which point the pid is guaranteed stale and PID
+// reuse by an unrelated process owned by the same SSH user is a real risk on
+// a shared runner — probeRemoteAgentctlLiveness alone only proves *some*
+// process holds the pid, not that it is ours. The remote launch command line
+// always includes "agentctl" and the persisted workdir (sessionDir or
+// taskDir), so a `ps` command-line match is sufficient identity evidence.
+//
+// Returns false (no error) when the pid is gone or belongs to something
+// else — both are "safe to skip the kill" outcomes for the caller. An error
+// return means the identity probe itself failed (e.g. an SSH-level fault,
+// not merely "no such process"), and the caller should treat this the same
+// as a failed stop: preserve the row rather than risk either signalling an
+// unverified pid or reporting an orphan as reaped.
+func verifyRemoteAgentctlIdentity(ctx context.Context, client *ssh.Client, pid int, sessionDir, taskDir string) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	stdout, stderr, err := runSSHCommand(ctx, client, remoteProcessCommandLineCommand(pid))
+	if err != nil {
+		var exitErr *ssh.ExitError
+		if !errors.As(err, &exitErr) {
+			return false, remoteProcessProbeError(pid, err, stderr)
+		}
+		// A nonzero ps exit (e.g. no matching process) is evaluated below
+		// like any other result: empty output never matches.
+	}
+	return remoteAgentctlCommandLineMatches(stdout, sessionDir, taskDir), nil
+}
+
+func remoteProcessCommandLineCommand(pid int) string {
+	return fmt.Sprintf("ps -p %d -o command=", pid)
+}
+
+func remoteAgentctlCommandLineMatches(commandLine, sessionDir, taskDir string) bool {
+	line := strings.TrimSpace(commandLine)
+	if line == "" || !strings.Contains(line, "agentctl") {
+		return false
+	}
+	return (sessionDir != "" && strings.Contains(line, sessionDir)) ||
+		(taskDir != "" && strings.Contains(line, taskDir))
 }
 
 // probeRemoteAgentctlLiveness distinguishes a completed remote process probe

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -1,0 +1,119 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+)
+
+// Tests for reaping a remote agentctl whose in-memory session state did not
+// survive a backend restart, driven only by persisted executors_running
+// metadata (ssh_remote_agentctl_pid / ssh_remote_session_dir plus the SSH
+// connection keys read by targetFromMetadata).
+
+func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
+	server := newFakeSSHServer(t, nil)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	if _, ok := server.lastCommandContaining("kill 4242"); !ok {
+		t.Fatalf("expected the persisted pid to be killed, commands: %v", server.commands())
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); !ok {
+		t.Fatalf("expected the persisted session dir to be removed, commands: %v", server.commands())
+	}
+	if len(exec.sessions) != 0 {
+		t.Fatal("a persisted-metadata stop must not leave tracked session state behind")
+	}
+}
+
+func TestSSHExecutorStopInstancePersistedMetadataPreservesOnBackendShutdown(t *testing.T) {
+	server := newFakeSSHServer(t, nil)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: StopReasonBackendShutdown,
+		Metadata:   metadata,
+	}, false)
+	if err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	if len(server.commands()) != 0 {
+		t.Fatalf("a non-forced graceful shutdown must not touch the remote host, commands: %v", server.commands())
+	}
+}
+
+func TestSSHExecutorStopInstanceNoPersistedMetadataIsNoOp(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]interface{}
+	}{
+		{name: "nil metadata", metadata: nil},
+		{name: "no pid", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteSessionDir: "/remote/session",
+		}},
+		{name: "no session dir", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "4242",
+		}},
+		{name: "zero pid", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "0",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+		}},
+		{name: "negative pid", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "-1",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+		}},
+		{name: "non-numeric pid", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "not-a-pid",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+		}},
+		{name: "blank session dir", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "4242",
+			MetadataKeySSHRemoteSessionDir:  "   ",
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+			err := exec.StopInstance(context.Background(), &ExecutorInstance{
+				InstanceID: "orphaned-instance",
+				StopReason: "startup terminal session cleanup",
+				Metadata:   tc.metadata,
+			}, true)
+			if err != nil {
+				t.Fatalf("StopInstance: %v", err)
+			}
+		})
+	}
+}
+
+func TestSSHExecutorStopInstancePersistedMetadataUnresolvableTargetErrors(t *testing.T) {
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "4242",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+			// No host, host_alias, or fingerprint: targetFromMetadata must fail.
+		},
+	}, true)
+	if err == nil {
+		t.Fatal("expected an error resolving an SSH target with no host information")
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -14,8 +14,12 @@ import (
 // connection keys read by targetFromMetadata).
 
 func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
+	// The remote launch command line is always "<agentctlBin> --workdir
+	// <taskDir>" (startRemoteAgentctlOnPort) — sessionDir never appears in
+	// the argv. The fake server's ps output mirrors that shape so this test
+	// exercises the identity branch that actually fires in production.
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 		sshScriptRule{match: "kill 4242", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -23,6 +27,7 @@ func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 
 	err := exec.StopInstance(context.Background(), &ExecutorInstance{
 		InstanceID: "orphaned-instance",
@@ -74,6 +79,65 @@ func TestSSHExecutorStopInstanceIdentityMismatchSkipsKill(t *testing.T) {
 	}
 }
 
+// TestSSHExecutorStopInstanceIdentityMismatchDirRemovalFailurePropagatesError
+// covers R2-F3: when the pid doesn't belong to our agentctl and the session
+// dir can't be reclaimed, StopInstance must error instead of warning and
+// returning nil — otherwise the caller prunes the executors_running row and
+// the session dir leaks with nothing left to retry it.
+func TestSSHExecutorStopInstanceIdentityMismatchDirRemovalFailurePropagatesError(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/usr/bin/some-other-process --unrelated")},
+		sshScriptRule{match: "rm -rf '/remote/session'", result: sshFail("permission denied")},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err == nil {
+		t.Fatal("expected StopInstance to propagate a failing session dir removal for an unmatched pid")
+	}
+}
+
+// TestSSHExecutorStopInstanceIdentityTaskDirMismatchSkipsKill covers the arm
+// of remoteAgentctlCommandLineMatches that actually fires in production: the
+// remote command line has "agentctl" and a --workdir, but it names a
+// different taskDir than the one persisted for this row (e.g. a stale row
+// whose pid was reused by another task's agentctl). That must not match.
+func TestSSHExecutorStopInstanceIdentityTaskDirMismatchSkipsKill(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task-other")},
+		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task-abc"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	if _, ok := server.lastCommandContaining("kill 4242"); ok {
+		t.Fatalf("expected no kill when the remote command line's taskDir doesn't match, commands: %v", server.commands())
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); !ok {
+		t.Fatalf("expected the session dir to still be reclaimed, commands: %v", server.commands())
+	}
+}
+
 // TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow covers F2's
 // other branch: when the identity probe itself can't be answered (an
 // SSH-level fault, not merely "no such process"), StopInstance must error so
@@ -109,7 +173,7 @@ func TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow(t *testing.T) {
 // deleting it out from under a still-live orphan.
 func TestSSHExecutorStopInstanceStopCommandFailurePropagatesError(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -117,6 +181,7 @@ func TestSSHExecutorStopInstanceStopCommandFailurePropagatesError(t *testing.T) 
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 
 	err := exec.StopInstance(context.Background(), &ExecutorInstance{
 		InstanceID: "orphaned-instance",

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -84,14 +84,14 @@ func TestSSHExecutorStopInstanceDeadPidEmptyStderrReapsCleanly(t *testing.T) {
 	}
 }
 
-// TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile covers R3-F2:
-// taskDir is shared by every sibling session of the same task (workspace
-// reuse), so a `ps` argv match alone only proves "some agentctl for this
-// task" — a stale row's persisted pid can be recycled by a live sibling
-// session's agentctl on the same taskDir. The per-session pidfile at
-// <sessionDir>/agentctl.pid must also name the same pid before a kill is
-// sent. Two rows share taskDir here — only the row whose own sessionDir
-// pidfile matches its persisted pid may be signalled.
+// TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile pins the
+// pidfile leg of identity. taskDir is shared by every sibling session of the
+// same task (workspace reuse), so a `ps` argv match alone only proves "some
+// agentctl for this task"; the per-session pidfile at
+// <sessionDir>/agentctl.pid must name the same pid before a kill is sent.
+// When the two disagree, the session directory demonstrably belongs to some
+// other launch, so the stop must neither signal the pid nor remove the
+// directory — it must fail so the row survives for a later attempt.
 func TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile(t *testing.T) {
 	sharedArgv := sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")
 
@@ -124,11 +124,11 @@ func TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile(t *testing.T) {
 		}
 	})
 
-	t.Run("row whose metadata pid was corrupted to a sibling's live pid is not signalled", func(t *testing.T) {
+	t.Run("row whose pidfile disagrees is neither signalled nor reclaimed", func(t *testing.T) {
 		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 			sshScriptRule{match: "ps -p 4242 -o command=", result: sharedArgv},
-			// session-b's own launch recorded a different pid (9999); its
-			// persisted metadata pid of 4242 does not belong to it.
+			// The directory's pidfile names 9999, so /remote/session-b is
+			// owned by a launch other than the one this row describes.
 			sshScriptRule{match: "cat -- '/remote/session-b/agentctl.pid'", result: sshOut("9999")},
 			sshScriptRule{match: "rm -rf '/remote/session-b'", result: sshOK},
 		).handle)
@@ -144,14 +144,14 @@ func TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile(t *testing.T) {
 			StopReason: "startup terminal session cleanup",
 			Metadata:   metadata,
 		}, true)
-		if err != nil {
-			t.Fatalf("StopInstance: %v", err)
+		if err == nil {
+			t.Fatal("expected StopInstance to fail when the session dir's pidfile names a different pid")
 		}
 		if _, ok := server.lastCommandContaining("kill 4242"); ok {
 			t.Fatalf("expected no kill when the pidfile names a different pid, commands: %v", server.commands())
 		}
-		if _, ok := server.lastCommandContaining("rm -rf '/remote/session-b'"); !ok {
-			t.Fatalf("expected session-b's own session dir to still be reclaimed, commands: %v", server.commands())
+		if _, ok := server.lastCommandContaining("rm -rf '/remote/session-b'"); ok {
+			t.Fatalf("expected no removal of a session dir owned by another launch, commands: %v", server.commands())
 		}
 	})
 }
@@ -380,5 +380,71 @@ func TestSSHExecutorStopInstancePersistedMetadataUnresolvableTargetErrors(t *tes
 	}, true)
 	if err == nil {
 		t.Fatal("expected an error resolving an SSH target with no host information")
+	}
+}
+
+// TestSSHExecutorStopInstanceUnreadablePidfilePreservesLiveAgentctl pins the
+// most damaging way this path can fail: the pid is alive and its argv already
+// identifies it as this row's agentctl, but the session directory's pidfile
+// cannot be read (remote housekeeping reclaimed the directory, or an SSH
+// session channel could not be opened on a loaded runner). Treating that as
+// "not ours" would leave the agentctl running forever while deleting the
+// pidfile and log that identify it, and would report success so the caller
+// prunes the only row that could retry the reap.
+func TestSSHExecutorStopInstanceUnreadablePidfilePreservesLiveAgentctl(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshFail("ssh: unable to open channel")},
+		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err == nil {
+		t.Fatal("expected StopInstance to fail when the pidfile of a live, argv-matching agentctl cannot be read")
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); ok {
+		t.Fatalf("expected no removal while identity is unproven, commands: %v", server.commands())
+	}
+	if _, ok := server.lastCommandContaining("kill 4242"); ok {
+		t.Fatalf("expected no kill while identity is unproven, commands: %v", server.commands())
+	}
+}
+
+// TestRemoteAgentctlCommandLineMatchesRequiresWholeWorkdirValue pins the
+// --workdir comparison to a whole argument. A substring test also accepts a
+// sibling task directory that merely starts with this row's taskDir, which
+// would signal another task's agentctl.
+func TestRemoteAgentctlCommandLineMatchesRequiresWholeWorkdirValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandLine string
+		taskDir     string
+		want        bool
+	}{
+		{name: "exact value", commandLine: "/opt/kandev/bin/agentctl --workdir /remote/task", taskDir: "/remote/task", want: true},
+		{name: "exact value with trailing flag", commandLine: "/opt/kandev/bin/agentctl --workdir /remote/task --verbose", taskDir: "/remote/task", want: true},
+		{name: "equals form", commandLine: "/opt/kandev/bin/agentctl --workdir=/remote/task", taskDir: "/remote/task", want: true},
+		{name: "sibling dir sharing the prefix", commandLine: "/opt/kandev/bin/agentctl --workdir /remote/task-other", taskDir: "/remote/task", want: false},
+		{name: "prefix then the real value", commandLine: "/opt/kandev/bin/agentctl --workdir /remote/task-other --workdir /remote/task", taskDir: "/remote/task", want: true},
+		{name: "value present but not as --workdir", commandLine: "/opt/kandev/bin/agentctl --log /remote/task", taskDir: "/remote/task", want: false},
+		{name: "not agentctl", commandLine: "/usr/bin/tail -f /remote/task", taskDir: "/remote/task", want: false},
+		{name: "empty task dir", commandLine: "/opt/kandev/bin/agentctl --workdir /remote/task", taskDir: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := remoteAgentctlCommandLineMatches(tc.commandLine, tc.taskDir); got != tc.want {
+				t.Fatalf("remoteAgentctlCommandLineMatches(%q, %q) = %v, want %v", tc.commandLine, tc.taskDir, got, tc.want)
+			}
+		})
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -20,6 +20,7 @@ func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
 	// exercises the identity branch that actually fires in production.
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "kill 4242", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -46,6 +47,113 @@ func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
 	if len(exec.sessions) != 0 {
 		t.Fatal("a persisted-metadata stop must not leave tracked session state behind")
 	}
+}
+
+// TestSSHExecutorStopInstanceDeadPidEmptyStderrReapsCleanly covers R3-F1: a
+// dead pid probed via `ps -p <pid> -o command=` exits non-zero with empty
+// stdout and empty stderr on every observed platform — the ordinary shape
+// for the common "the orphan already exited" case, not the exception. That
+// must be read as confirmed absence, not as a probe fault: the stop must
+// succeed without signalling anything, and the session dir must still be
+// reclaimed so the row is prunable.
+func TestSSHExecutorStopInstanceDeadPidEmptyStderrReapsCleanly(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshFail("")},
+		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	if _, ok := server.lastCommandContaining("kill 4242"); ok {
+		t.Fatalf("expected no kill for a confirmed-dead pid, commands: %v", server.commands())
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); !ok {
+		t.Fatalf("expected the session dir to still be reclaimed, commands: %v", server.commands())
+	}
+}
+
+// TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile covers R3-F2:
+// taskDir is shared by every sibling session of the same task (workspace
+// reuse), so a `ps` argv match alone only proves "some agentctl for this
+// task" — a stale row's persisted pid can be recycled by a live sibling
+// session's agentctl on the same taskDir. The per-session pidfile at
+// <sessionDir>/agentctl.pid must also name the same pid before a kill is
+// sent. Two rows share taskDir here — only the row whose own sessionDir
+// pidfile matches its persisted pid may be signalled.
+func TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile(t *testing.T) {
+	sharedArgv := sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")
+
+	t.Run("row whose own pidfile confirms the pid is still killed despite shared taskDir", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sharedArgv},
+			// session-a's own launch recorded pid 4242 in its own pidfile —
+			// the shared taskDir argv match alone would be ambiguous
+			// between the two sibling sessions, but the pidfile disambiguates.
+			sshScriptRule{match: "cat -- '/remote/session-a/agentctl.pid'", result: sshOut("4242")},
+			sshScriptRule{match: "rm -rf '/remote/session-a'", result: sshOK},
+		).handle)
+		exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+		metadata := sshConnectionMetadata(t, server)
+		metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+		metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session-a"
+		metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
+
+		err := exec.StopInstance(context.Background(), &ExecutorInstance{
+			InstanceID: "session-a-instance",
+			StopReason: "startup terminal session cleanup",
+			Metadata:   metadata,
+		}, true)
+		if err != nil {
+			t.Fatalf("StopInstance: %v", err)
+		}
+		if _, ok := server.lastCommandContaining("kill 4242"); !ok {
+			t.Fatalf("expected session-a's own confirmed pid to be killed, commands: %v", server.commands())
+		}
+	})
+
+	t.Run("row whose metadata pid was corrupted to a sibling's live pid is not signalled", func(t *testing.T) {
+		server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+			sshScriptRule{match: "ps -p 4242 -o command=", result: sharedArgv},
+			// session-b's own launch recorded a different pid (9999); its
+			// persisted metadata pid of 4242 does not belong to it.
+			sshScriptRule{match: "cat -- '/remote/session-b/agentctl.pid'", result: sshOut("9999")},
+			sshScriptRule{match: "rm -rf '/remote/session-b'", result: sshOK},
+		).handle)
+		exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+		metadata := sshConnectionMetadata(t, server)
+		metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+		metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session-b"
+		metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
+
+		err := exec.StopInstance(context.Background(), &ExecutorInstance{
+			InstanceID: "session-b-instance",
+			StopReason: "startup terminal session cleanup",
+			Metadata:   metadata,
+		}, true)
+		if err != nil {
+			t.Fatalf("StopInstance: %v", err)
+		}
+		if _, ok := server.lastCommandContaining("kill 4242"); ok {
+			t.Fatalf("expected no kill when the pidfile names a different pid, commands: %v", server.commands())
+		}
+		if _, ok := server.lastCommandContaining("rm -rf '/remote/session-b'"); !ok {
+			t.Fatalf("expected session-b's own session dir to still be reclaimed, commands: %v", server.commands())
+		}
+	})
 }
 
 // TestSSHExecutorStopInstanceIdentityMismatchSkipsKill covers F2: a pid
@@ -174,6 +282,7 @@ func TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow(t *testing.T) {
 func TestSSHExecutorStopInstanceStopCommandFailurePropagatesError(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -59,6 +59,8 @@ func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
 func TestSSHExecutorStopInstanceDeadPidEmptyStderrReapsCleanly(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshFail("")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshFail("")},
+		sshScriptRule{match: "test -d '/remote/session'", result: sshFail("")},
 		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -81,6 +83,31 @@ func TestSSHExecutorStopInstanceDeadPidEmptyStderrReapsCleanly(t *testing.T) {
 	}
 	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); !ok {
 		t.Fatalf("expected the session dir to still be reclaimed, commands: %v", server.commands())
+	}
+}
+
+func TestSSHExecutorStopInstanceDeadPidWithNewerSessionPreservesDirectory(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshFail("")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("9999")},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err == nil {
+		t.Fatal("expected StopInstance to preserve a session directory whose pidfile names a newer pid")
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); ok {
+		t.Fatalf("expected no removal of a session directory owned by another launch, commands: %v", server.commands())
 	}
 }
 
@@ -163,6 +190,7 @@ func TestSSHExecutorStopInstanceSharedTaskDirIdentityUsesPidfile(t *testing.T) {
 func TestSSHExecutorStopInstanceIdentityMismatchSkipsKill(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/usr/bin/some-other-process --unrelated")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -170,6 +198,7 @@ func TestSSHExecutorStopInstanceIdentityMismatchSkipsKill(t *testing.T) {
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 
 	err := exec.StopInstance(context.Background(), &ExecutorInstance{
 		InstanceID: "orphaned-instance",
@@ -195,6 +224,7 @@ func TestSSHExecutorStopInstanceIdentityMismatchSkipsKill(t *testing.T) {
 func TestSSHExecutorStopInstanceIdentityMismatchDirRemovalFailurePropagatesError(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/usr/bin/some-other-process --unrelated")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "rm -rf '/remote/session'", result: sshFail("permission denied")},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -202,6 +232,7 @@ func TestSSHExecutorStopInstanceIdentityMismatchDirRemovalFailurePropagatesError
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 
 	err := exec.StopInstance(context.Background(), &ExecutorInstance{
 		InstanceID: "orphaned-instance",
@@ -221,6 +252,7 @@ func TestSSHExecutorStopInstanceIdentityMismatchDirRemovalFailurePropagatesError
 func TestSSHExecutorStopInstanceIdentityTaskDirMismatchSkipsKill(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task-other")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
@@ -261,6 +293,7 @@ func TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow(t *testing.T) {
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 
 	err := exec.StopInstance(context.Background(), &ExecutorInstance{
 		InstanceID: "orphaned-instance",
@@ -323,7 +356,7 @@ func TestSSHExecutorStopInstancePersistedMetadataPreservesOnBackendShutdown(t *t
 	}
 }
 
-func TestSSHExecutorStopInstanceNoPersistedMetadataIsNoOp(t *testing.T) {
+func TestSSHExecutorStopInstanceIncompletePersistedMetadataErrors(t *testing.T) {
 	tests := []struct {
 		name     string
 		metadata map[string]interface{}
@@ -351,6 +384,15 @@ func TestSSHExecutorStopInstanceNoPersistedMetadataIsNoOp(t *testing.T) {
 			MetadataKeySSHRemoteAgentctlPID: "4242",
 			MetadataKeySSHRemoteSessionDir:  "   ",
 		}},
+		{name: "missing task dir", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "4242",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+		}},
+		{name: "blank task dir", metadata: map[string]interface{}{
+			MetadataKeySSHRemoteAgentctlPID: "4242",
+			MetadataKeySSHRemoteSessionDir:  "/remote/session",
+			MetadataKeySSHRemoteTaskDir:     "   ",
+		}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -360,8 +402,8 @@ func TestSSHExecutorStopInstanceNoPersistedMetadataIsNoOp(t *testing.T) {
 				StopReason: "startup terminal session cleanup",
 				Metadata:   tc.metadata,
 			}, true)
-			if err != nil {
-				t.Fatalf("StopInstance: %v", err)
+			if err == nil {
+				t.Fatal("StopInstance succeeded with incomplete persisted metadata")
 			}
 		})
 	}
@@ -395,6 +437,7 @@ func TestSSHExecutorStopInstanceUnreadablePidfilePreservesLiveAgentctl(t *testin
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshFail("ssh: unable to open channel")},
+		sshScriptRule{match: "test -d '/remote/session'", result: sshFail("ssh: unable to open channel")},
 		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
 	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_persisted_stop_test.go
@@ -2,7 +2,10 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"golang.org/x/crypto/ssh"
 )
 
 // Tests for reaping a remote agentctl whose in-memory session state did not
@@ -11,7 +14,10 @@ import (
 // connection keys read by targetFromMetadata).
 
 func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
-	server := newFakeSSHServer(t, nil)
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "kill 4242", result: sshOK},
+	).handle)
 	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
 
 	metadata := sshConnectionMetadata(t, server)
@@ -34,6 +40,91 @@ func TestSSHExecutorStopInstanceFromPersistedMetadataOnly(t *testing.T) {
 	}
 	if len(exec.sessions) != 0 {
 		t.Fatal("a persisted-metadata stop must not leave tracked session state behind")
+	}
+}
+
+// TestSSHExecutorStopInstanceIdentityMismatchSkipsKill covers F2: a pid
+// recovered from persisted metadata that no longer belongs to our agentctl
+// (reused by an unrelated process, or the command line simply doesn't match)
+// must never be signalled. The session directory is still reclaimed.
+func TestSSHExecutorStopInstanceIdentityMismatchSkipsKill(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/usr/bin/some-other-process --unrelated")},
+		sshScriptRule{match: "rm -rf '/remote/session'", result: sshOK},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	if _, ok := server.lastCommandContaining("kill 4242"); ok {
+		t.Fatalf("expected no kill for a pid that doesn't match our agentctl, commands: %v", server.commands())
+	}
+	if _, ok := server.lastCommandContaining("rm -rf '/remote/session'"); !ok {
+		t.Fatalf("expected the session dir to still be reclaimed, commands: %v", server.commands())
+	}
+}
+
+// TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow covers F2's
+// other branch: when the identity probe itself can't be answered (an
+// SSH-level fault, not merely "no such process"), StopInstance must error so
+// the caller preserves the executors_running row instead of reporting a
+// possibly-live orphan as reaped.
+func TestSSHExecutorStopInstanceIdentityProbeFailurePreservesRow(t *testing.T) {
+	server := newFakeSSHServer(t, nil)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+	exec.verifyRemoteIdentity = func(context.Context, *ssh.Client, int, string, string) (bool, error) {
+		return false, errors.New("ssh: channel closed mid-command")
+	}
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err == nil {
+		t.Fatal("expected StopInstance to error when the identity probe itself fails")
+	}
+	if len(server.commands()) != 0 {
+		t.Fatalf("expected no remote command after a failed identity probe, commands: %v", server.commands())
+	}
+}
+
+// TestSSHExecutorStopInstanceStopCommandFailurePropagatesError covers F1: a
+// failing remote stop command must surface as an error, not be swallowed,
+// so the caller preserves the executors_running row and retries instead of
+// deleting it out from under a still-live orphan.
+func TestSSHExecutorStopInstanceStopCommandFailurePropagatesError(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
+	).handle)
+	exec := NewSSHExecutor(nil, nil, nil, newTestLogger())
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+
+	err := exec.StopInstance(context.Background(), &ExecutorInstance{
+		InstanceID: "orphaned-instance",
+		StopReason: "startup terminal session cleanup",
+		Metadata:   metadata,
+	}, true)
+	if err == nil {
+		t.Fatal("expected StopInstance to propagate a failing remote stop command")
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stop_resume_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_stop_resume_test.go
@@ -146,8 +146,8 @@ func TestSSHExecutorStopInstanceIsSafeWithoutTrackedState(t *testing.T) {
 	if err := exec.StopInstance(context.Background(), nil, false); err != nil {
 		t.Fatalf("StopInstance(nil): %v", err)
 	}
-	if err := exec.StopInstance(context.Background(), &ExecutorInstance{InstanceID: "gone"}, false); err != nil {
-		t.Fatalf("StopInstance(untracked): %v", err)
+	if err := exec.StopInstance(context.Background(), &ExecutorInstance{InstanceID: "gone"}, false); err == nil {
+		t.Fatal("StopInstance(untracked) succeeded without persisted metadata")
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -947,8 +947,10 @@ func (m *Manager) StopAgent(ctx context.Context, executionID string, force bool)
 func (m *Manager) StopAgentWithReason(ctx context.Context, executionID string, reason string, force bool) error {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
-		handled, err := m.stopPersistedKubernetesExecution(ctx, executionID, reason, force)
-		if handled {
+		if handled, err := m.stopPersistedKubernetesExecution(ctx, executionID, reason, force); handled {
+			return err
+		}
+		if handled, err := m.stopPersistedSSHExecution(ctx, executionID, reason, force); handled {
 			return err
 		}
 		return fmt.Errorf("execution %q not found: %w", executionID, ErrExecutionNotFound)

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup.go
@@ -1,0 +1,112 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/agentruntime"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// persistedSSHCleanupStore is intentionally narrower than the task
+// repository. It lets a stop request recover the executors_running row after
+// a backend restart without making ordinary lifecycle code depend on the
+// repository implementation.
+type persistedSSHCleanupStore interface {
+	ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error)
+}
+
+// stopPersistedSSHExecution handles the restart-only case where the
+// authoritative executors_running row survived but process-local lifecycle
+// state (the SSH client, forwarder, and remote pid tracked by SSHExecutor)
+// did not. Unlike Kubernetes, an SSH connection is fully described by the
+// row's own persisted metadata (host, port, user, fingerprint, remote pid,
+// remote session dir — see persistentMetadataKeys), so no reconciliation
+// against a "current" executor config is needed before dispatching the stop.
+// The caller that owns task cleanup remains responsible for deleting the row
+// after this exact remote teardown succeeds.
+func (m *Manager) stopPersistedSSHExecution(
+	ctx context.Context,
+	executionID string,
+	reason string,
+	force bool,
+) (bool, error) {
+	store, ok := m.runningWriter.(persistedSSHCleanupStore)
+	if !ok {
+		return false, nil
+	}
+	row, err := loadPersistedSSHExecution(ctx, store, executionID)
+	if err != nil {
+		return true, err
+	}
+	if row == nil || row.Runtime != agentruntime.RuntimeSSH {
+		return false, nil
+	}
+
+	activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStopping)
+	if err != nil {
+		return true, err
+	}
+	defer activityLease.Release()
+
+	instance := &ExecutorInstance{
+		InstanceID:  row.AgentExecutionID,
+		TaskID:      row.TaskID,
+		SessionID:   row.SessionID,
+		RuntimeName: agentruntime.RuntimeSSH,
+		Metadata:    row.Metadata,
+		StopReason:  reason,
+	}
+	if err := m.stopPersistedSSHBackend(ctx, instance, force); err != nil {
+		return true, fmt.Errorf("stop persisted SSH runtime: %w", err)
+	}
+	return true, nil
+}
+
+func loadPersistedSSHExecution(
+	ctx context.Context,
+	store persistedSSHCleanupStore,
+	executionID string,
+) (*models.ExecutorRunning, error) {
+	rows, err := store.ListExecutorsRunning(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load persisted runtime inventory: %w", err)
+	}
+	return uniquePersistedSSHExecution(rows, executionID)
+}
+
+func (m *Manager) stopPersistedSSHBackend(
+	ctx context.Context,
+	instance *ExecutorInstance,
+	force bool,
+) error {
+	if m.executorRegistry == nil {
+		return errors.New("ssh runtime registry is unavailable")
+	}
+	backend, err := m.executorRegistry.GetBackend(executor.NameSSH)
+	if err != nil {
+		return fmt.Errorf("get SSH runtime: %w", err)
+	}
+	return backend.StopInstance(ctx, instance, force)
+}
+
+func uniquePersistedSSHExecution(
+	rows []*models.ExecutorRunning,
+	executionID string,
+) (*models.ExecutorRunning, error) {
+	var found *models.ExecutorRunning
+	for _, row := range rows {
+		if row == nil || strings.TrimSpace(row.AgentExecutionID) != executionID {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("multiple persisted runtime rows match execution %q", executionID)
+		}
+		found = row
+	}
+	return found, nil
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
@@ -1,0 +1,105 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agentruntime"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// restartSSHInventoryStore is the SSH analogue of restartKubernetesInventoryStore:
+// a fake ExecutorRunningWriter that also lists persisted rows, standing in for
+// the executors_running table after a backend restart that lost in-memory
+// SSHExecutor session state.
+type restartSSHInventoryStore struct {
+	captureExecutorRunningWriter
+	rows []*models.ExecutorRunning
+}
+
+func (s *restartSSHInventoryStore) ListExecutorsRunning(context.Context) ([]*models.ExecutorRunning, error) {
+	return s.rows, nil
+}
+
+func TestStopAgentWithReasonReapsPersistedSSHAgentctlAfterRestart(t *testing.T) {
+	server := newFakeSSHServer(t, nil)
+	log := newTestRegistryLogger()
+	registry := NewExecutorRegistry(log)
+	registry.Register(NewSSHExecutor(nil, nil, nil, log))
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	row := &models.ExecutorRunning{
+		ID: "session-1", SessionID: "session-1", TaskID: "task-1",
+		ExecutorID: "executor-1", AgentExecutionID: "execution-1",
+		Runtime: agentruntime.RuntimeSSH, Metadata: metadata,
+	}
+	store := &restartSSHInventoryStore{rows: []*models.ExecutorRunning{row}}
+
+	mgr := NewManager(nil, &MockEventBus{}, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	mgr.SetExecutorRunningWriter(store)
+
+	// The execution is not in the in-memory store: this exercises exactly the
+	// restart case, where the row survived but SSHExecutor.sessions did not.
+	err := mgr.StopAgentWithReason(context.Background(), "execution-1", "startup terminal session cleanup", true)
+
+	require.NoError(t, err)
+	if _, ok := server.lastCommandContaining("kill 4242"); !ok {
+		t.Fatalf("expected the persisted remote agentctl to be reaped, commands: %v", server.commands())
+	}
+}
+
+func TestStopAgentWithReasonSkipsNonSSHPersistedRows(t *testing.T) {
+	log := newTestRegistryLogger()
+	registry := NewExecutorRegistry(log)
+	store := &restartSSHInventoryStore{rows: []*models.ExecutorRunning{{
+		AgentExecutionID: "execution-1", Runtime: agentruntime.RuntimeDocker,
+	}}}
+	mgr := NewManager(nil, &MockEventBus{}, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	mgr.SetExecutorRunningWriter(store)
+
+	err := mgr.StopAgentWithReason(context.Background(), "execution-1", "startup terminal session cleanup", true)
+
+	require.ErrorIs(t, err, ErrExecutionNotFound)
+}
+
+func TestStopAgentWithReasonNoPersistedRowStillReturnsNotFound(t *testing.T) {
+	log := newTestRegistryLogger()
+	registry := NewExecutorRegistry(log)
+	store := &restartSSHInventoryStore{}
+	mgr := NewManager(nil, &MockEventBus{}, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	mgr.SetExecutorRunningWriter(store)
+
+	err := mgr.StopAgentWithReason(context.Background(), "execution-1", "startup terminal session cleanup", true)
+
+	require.ErrorIs(t, err, ErrExecutionNotFound)
+}
+
+func TestStopAgentWithReasonPersistedSSHBackendShutdownWithoutForcePreservesRemote(t *testing.T) {
+	server := newFakeSSHServer(t, nil)
+	log := newTestRegistryLogger()
+	registry := NewExecutorRegistry(log)
+	registry.Register(NewSSHExecutor(nil, nil, nil, log))
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	row := &models.ExecutorRunning{
+		AgentExecutionID: "execution-1", Runtime: agentruntime.RuntimeSSH, Metadata: metadata,
+	}
+	store := &restartSSHInventoryStore{rows: []*models.ExecutorRunning{row}}
+	mgr := NewManager(nil, &MockEventBus{}, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	mgr.SetExecutorRunningWriter(store)
+
+	err := mgr.StopAgentWithReason(context.Background(), "execution-1", StopReasonBackendShutdown, false)
+
+	require.NoError(t, err)
+	require.Empty(t, server.commands(), "a non-forced graceful shutdown must not touch the remote host")
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
@@ -24,7 +24,10 @@ func (s *restartSSHInventoryStore) ListExecutorsRunning(context.Context) ([]*mod
 }
 
 func TestStopAgentWithReasonReapsPersistedSSHAgentctlAfterRestart(t *testing.T) {
-	server := newFakeSSHServer(t, nil)
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "kill 4242", result: sshOK},
+	).handle)
 	log := newTestRegistryLogger()
 	registry := NewExecutorRegistry(log)
 	registry.Register(NewSSHExecutor(nil, nil, nil, log))
@@ -102,4 +105,37 @@ func TestStopAgentWithReasonPersistedSSHBackendShutdownWithoutForcePreservesRemo
 
 	require.NoError(t, err)
 	require.Empty(t, server.commands(), "a non-forced graceful shutdown must not touch the remote host")
+}
+
+// TestStopAgentWithReasonPropagatesPersistedSSHStopFailure covers F1 at the
+// manager level: a failing remote stop command for a restart-recovered SSH
+// row must surface as an error from StopAgentWithReason, so the caller
+// (startup cleanup) preserves the executors_running row instead of pruning
+// it out from under a still-live orphan.
+func TestStopAgentWithReasonPropagatesPersistedSSHStopFailure(t *testing.T) {
+	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
+	).handle)
+	log := newTestRegistryLogger()
+	registry := NewExecutorRegistry(log)
+	registry.Register(NewSSHExecutor(nil, nil, nil, log))
+
+	metadata := sshConnectionMetadata(t, server)
+	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
+	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	row := &models.ExecutorRunning{
+		ID: "session-1", SessionID: "session-1", TaskID: "task-1",
+		ExecutorID: "executor-1", AgentExecutionID: "execution-1",
+		Runtime: agentruntime.RuntimeSSH, Metadata: metadata,
+	}
+	store := &restartSSHInventoryStore{rows: []*models.ExecutorRunning{row}}
+
+	mgr := NewManager(nil, &MockEventBus{}, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	mgr.SetExecutorRunningWriter(store)
+
+	err := mgr.StopAgentWithReason(context.Background(), "execution-1", "startup terminal session cleanup", true)
+
+	require.Error(t, err)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
@@ -24,8 +24,12 @@ func (s *restartSSHInventoryStore) ListExecutorsRunning(context.Context) ([]*mod
 }
 
 func TestStopAgentWithReasonReapsPersistedSSHAgentctlAfterRestart(t *testing.T) {
+	// The remote launch command line is always "<agentctlBin> --workdir
+	// <taskDir>" (startRemoteAgentctlOnPort) — sessionDir never appears in
+	// the argv. The fake server's ps output mirrors that shape so this test
+	// exercises the identity branch that actually fires in production.
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 		sshScriptRule{match: "kill 4242", result: sshOK},
 	).handle)
 	log := newTestRegistryLogger()
@@ -35,6 +39,7 @@ func TestStopAgentWithReasonReapsPersistedSSHAgentctlAfterRestart(t *testing.T) 
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 	row := &models.ExecutorRunning{
 		ID: "session-1", SessionID: "session-1", TaskID: "task-1",
 		ExecutorID: "executor-1", AgentExecutionID: "execution-1",
@@ -114,7 +119,7 @@ func TestStopAgentWithReasonPersistedSSHBackendShutdownWithoutForcePreservesRemo
 // it out from under a still-live orphan.
 func TestStopAgentWithReasonPropagatesPersistedSSHStopFailure(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
-		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/session")},
+		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
 		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
 	).handle)
 	log := newTestRegistryLogger()
@@ -124,6 +129,7 @@ func TestStopAgentWithReasonPropagatesPersistedSSHStopFailure(t *testing.T) {
 	metadata := sshConnectionMetadata(t, server)
 	metadata[MetadataKeySSHRemoteAgentctlPID] = "4242"
 	metadata[MetadataKeySSHRemoteSessionDir] = "/remote/session"
+	metadata[MetadataKeySSHRemoteTaskDir] = "/remote/task"
 	row := &models.ExecutorRunning{
 		ID: "session-1", SessionID: "session-1", TaskID: "task-1",
 		ExecutorID: "executor-1", AgentExecutionID: "execution-1",

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_ssh_restart_cleanup_test.go
@@ -30,6 +30,7 @@ func TestStopAgentWithReasonReapsPersistedSSHAgentctlAfterRestart(t *testing.T) 
 	// exercises the identity branch that actually fires in production.
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "kill 4242", result: sshOK},
 	).handle)
 	log := newTestRegistryLogger()
@@ -120,6 +121,7 @@ func TestStopAgentWithReasonPersistedSSHBackendShutdownWithoutForcePreservesRemo
 func TestStopAgentWithReasonPropagatesPersistedSSHStopFailure(t *testing.T) {
 	server := newFakeSSHServer(t, newSSHScriptedHandler(t,
 		sshScriptRule{match: "ps -p 4242 -o command=", result: sshOut("/opt/kandev/bin/agentctl --workdir /remote/task")},
+		sshScriptRule{match: "cat -- '/remote/session/agentctl.pid'", result: sshOut("4242")},
 		sshScriptRule{match: "kill 4242", result: sshFail("permission denied")},
 	).handle)
 	log := newTestRegistryLogger()


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3527/6c5e4f809b10.html)
<!-- kandev-pr-walkthrough-end -->

Orphaned `agentctl` processes pile up on SSH runners because a task's teardown never reaches the remote host once the in-memory session record that tracked it is gone.

**Today:** A terminal task session leaves its remote `agentctl` running on the SSH runner, because the stop path only checked `SSHExecutor`'s in-memory session map, which does not survive a backend restart, and the not-found fallback only knew how to handle Kubernetes. On one runner, roughly a day of normal use left 21 orphaned `agentctl` processes and 34 child processes running with Kandev reporting zero live sessions for that executor, holding about half the box's RAM. New launches also scanned past 10+ stale control ports before finding a free one, and that retry noise masked an unrelated launch failure for two separate investigations.
**After this:** Stopping a session now falls back to the pid, port, and session directory already persisted in `executors_running.metadata` when the in-memory session is gone, verifies the remote process identity before signalling it, and only then sends SIGTERM. Startup cleanup already force-stops terminal/missing-session rows, so fixing the stop path is enough for the existing sweep to reap pre-existing orphans too, with no new background job.
**Who hits this:** Anyone running tasks against an SSH executor; the leak accumulates over ordinary use and previously required a manual `kill` on the runner to recover.
**Scope:** standalone fix, no sibling PRs.
**Not here:** remote task-directory cleanup (out of scope for v1 per `docs/specs/ssh-executor/spec.md`), a passthrough agent's own descendants outliving it, and the separate agentctl handshake 403 (killing these orphans looked like it fixed that 403, but launches on a clean machine still 403 when they overlap, so the two are not the same bug).

## Validation

- `go build ./...` (apps/backend) — clean.
- `gofmt -l` over every changed file — clean.
- `golangci-lint run ./internal/agent/runtime/lifecycle/... --timeout=6m` — 0 issues.
- `go test -tags fts5 ./...` (apps/backend, full suite) run at this branch's HEAD and independently at both merge-base commits (`ed50fb05b` and, after rebasing onto current `main`, `401947fd8`) in scratch worktrees. The failing-test set is byte-for-byte identical at merge-base and at HEAD (75 pre-existing failures, same names, same packages) — zero failures newly introduced by this diff. Two additional names seen once during a full-suite run in `internal/orchestrator` (a package this diff does not touch) did not reproduce on a 3x isolated rerun and are pre-existing test flakiness, not a regression.
- Targeted run of every SSH stop / identity / liveness test in the touched package (31 tests, including 3 new) — all pass.
- `make lint`, `make lint-format`, `cd apps/web && pnpm run i18n:ratchet` — all clean. E2E not required: this diff is entirely backend Go under `apps/backend/internal/agent/runtime/lifecycle/`, with zero `apps/(web|cli|packages)` changes.
- Pre-commit hooks (harness lint, architecture lint, gofmt, Go lint on changed code, em-dash guard, commitlint) passed on every commit.

## Possible Improvements

Low risk. Remote process identity is proven by `ps` argv plus the session directory's pidfile; it cannot distinguish PID reuse where the recycled pid happens to equal this row's own persisted pid (a same-session-id sibling race). That gap is unchanged in either direction by this PR and is tracked as a follow-up rather than expanded here, since closing it needs per-session evidence added to the remote launch command.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->