### PR TITLE
fix(backend): prevent duplicate or stranded launches when tasks auto-start on create

### DIFF
--- a/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
+++ b/apps/backend/internal/orchestrator/deferred_launch_consume_test.go
@@ -564,7 +564,7 @@ func TestQueuePromotionOfBlockedWIPOverflowDoesNotLaunch(t *testing.T) {
 	// resume the still-pending promotion lifecycle rather than leave the token
 	// stranded after launching directly.
 	dependencies.blocked = false
-	svc.autoStartTaskForStep(ctx, deferredChainTaskID, "step-limited", "task.dependencies_resolved", 0)
+	svc.autoStartTaskForStep(ctx, deferredChainTaskID, "step-limited", "task.dependencies_resolved", 0, false)
 	require.True(t, counter.awaitLaunch(0), "resolved dependency did not launch the promoted task")
 	awaitLaunchedSession(t, repo, deferredChainTaskID)
 	started, err := repo.GetTask(ctx, deferredChainTaskID)

--- a/apps/backend/internal/orchestrator/event_handlers_dependencies.go
+++ b/apps/backend/internal/orchestrator/event_handlers_dependencies.go
@@ -116,7 +116,7 @@ func (s *Service) evaluateDependentAfterPredecessorChange(
 			zap.String("task_id", task.ID))
 		return
 	}
-	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskDependenciesResolved, 0)
+	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskDependenciesResolved, 0, false)
 }
 
 // publishDependenciesResolved announces that a task's last unresolved
@@ -185,6 +185,6 @@ func (s *Service) reconcileDependencyLaunchesOnStartup(ctx context.Context) {
 		}
 		s.logger.Info("startup: launching task whose dependencies resolved while down",
 			zap.String("task_id", candidate.TaskID))
-		s.autoStartTaskForStep(ctx, candidate.TaskID, candidate.WorkflowStepID, "startup.dependencies_resolved", 0)
+		s.autoStartTaskForStep(ctx, candidate.TaskID, candidate.WorkflowStepID, "startup.dependencies_resolved", 0, false)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_dependencies.go
+++ b/apps/backend/internal/orchestrator/event_handlers_dependencies.go
@@ -31,26 +31,33 @@ func (s *Service) SetTaskDependencyReader(reader TaskDependencyReader) {
 }
 
 // dependencyBlocksAutoStart reports whether taskID has an unresolved dependency
-// and therefore must not be launched by an automated path.
+// and therefore must not be launched by an automated path. gateErrored reports
+// whether the block came from a failed read rather than a genuine dependency
+// block: a genuine block is already covered by dependency-resolution launch
+// paths (evaluateDependentAfterPredecessorChange, reconcileDependencyLaunchesOnStartup),
+// but a read failure is not, so a caller holding a one-shot launch token must
+// restore it only in that case — restoring on every genuine block would burn
+// recoverTaskLifecycleAttempt's bounded retry budget on every startup for as
+// long as the task stays blocked.
 //
-// Fails CLOSED: a read error returns true. Failing open would launch work whose
-// predecessor may never have run, which is the single outcome task dependencies
-// exist to prevent.
-func (s *Service) dependencyBlocksAutoStart(ctx context.Context, taskID, eventName string) bool {
+// Fails CLOSED: a read error returns blocked=true. Failing open would launch
+// work whose predecessor may never have run, which is the single outcome task
+// dependencies exist to prevent.
+func (s *Service) dependencyBlocksAutoStart(ctx context.Context, taskID, eventName string) (blocked, gateErrored bool) {
 	if s.dependencyReader == nil {
-		return false
+		return false, false
 	}
-	blocked, reason, err := s.dependencyReader.DependencyGate(ctx, taskID)
+	isBlocked, reason, err := s.dependencyReader.DependencyGate(ctx, taskID)
 	if err != nil {
 		s.logger.Warn(eventName+": dependency lookup failed; skipping auto-start",
 			zap.String("task_id", taskID), zap.Error(err))
-		return true
+		return true, true
 	}
-	if blocked {
+	if isBlocked {
 		s.logger.Debug(eventName+": task has unresolved dependencies; skipping auto-start",
 			zap.String("task_id", taskID), zap.String("blocked_reason", reason))
 	}
-	return blocked
+	return isBlocked, false
 }
 
 // handleTaskDependenciesForTerminalState reacts to a task reaching a terminal

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -644,6 +644,7 @@ func (s *Service) autoStartReviewTask(
 	if s.shouldSkipTerminalPRAutoStart(ctx, task) {
 		return
 	}
+	createAutoStartOwned := s.ownsAutoStartOnCreateInFlight(task.ID)
 	// Compete for the one-shot auto-start token set at task creation.
 	// The promotion that ran inside CreateTask may have already triggered
 	// autoStartTaskForStep (Path A) asynchronously; only the first claimer
@@ -673,8 +674,16 @@ func (s *Service) autoStartReviewTask(
 			zap.String("task_id", task.ID),
 			zap.Error(err))
 		s.restoreAutoStartClaim(ctx, task.ID, "review.auto_start")
+		if createAutoStartOwned || s.ownsAutoStartOnCreateInFlight(task.ID) {
+			s.restoreAutoStartOnCreate(ctx, task.ID, "review.auto_start")
+		}
 		return
 	}
+	// The watcher path can win the permanent review guard while the
+	// create-time path is still preparing its detached launch. A successful
+	// watcher launch satisfies that intent too, so clear the durable marker
+	// owned by the other path.
+	s.completeAutoStartOnCreate(ctx, task.ID, "review.auto_start")
 	s.logger.Info("auto-started review task",
 		zap.String("task_id", task.ID),
 		zap.Int("pr_number", evt.PR.Number))

--- a/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
@@ -405,7 +405,7 @@ func TestAutoStart_BothPathsFireExactlyOnce(t *testing.T) {
 
 	// Path A: promotion event-driven auto-start on the same task.
 	// autoStartTaskForStep spawns a goroutine — we synchronise via the launched channel.
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.queue_promoted", 0)
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.queue_promoted", 0, false)
 
 	// Wait for exactly one launch. Allow 2 seconds for the async goroutine.
 	deadline := time.After(2 * time.Second)
@@ -568,7 +568,7 @@ func TestAutoStart_NoTokenDoesNotBlock(t *testing.T) {
 	}
 	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
 
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0)
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0, false)
 
 	select {
 	case <-launched:
@@ -627,7 +627,7 @@ func TestAutoStart_FailedLaunchWithoutGuardDoesNotStampClaimed(t *testing.T) {
 	}
 	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
 
-	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0)
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved", 0, false)
 
 	select {
 	case <-attempted:

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -805,14 +805,23 @@ func (s *Service) loadQueuePromotedTaskAndTargetStep(ctx context.Context, taskID
 // already claimed carries through promotion instead of being silently
 // dropped; every other caller goes through handleTaskQueuePromoted and passes
 // false.
+//
+//nolint:cyclop // queue promotion has independent task, dependency, session, and token recovery states
 func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx context.Context, data watcher.TaskEventData, autoStartOnCreateClaimed bool) {
+	restoreCreateIntent := func() {
+		if autoStartOnCreateClaimed {
+			s.restoreAutoStartOnCreate(ctx, data.TaskID, "task.queue_promoted")
+		}
+	}
 	task, targetStep, ok := s.loadQueuePromotedTaskAndTargetStep(ctx, data.TaskID)
 	if !ok {
+		restoreCreateIntent()
 		return
 	}
 	if err := s.syncTaskStateForQueuePromotion(ctx, task, targetStep); err != nil {
 		s.logger.Warn("task.queue_promoted: failed to synchronize task state",
 			zap.String("task_id", task.ID), zap.Error(err))
+		restoreCreateIntent()
 		return
 	}
 	session, sessionErr := s.repo.GetActiveTaskSessionByTaskID(ctx, task.ID)
@@ -825,6 +834,7 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 	if sessionErr != nil {
 		s.logger.Warn("task.queue_promoted: failed to load active session",
 			zap.String("task_id", task.ID), zap.Error(sessionErr))
+		restoreCreateIntent()
 		return
 	}
 	if session == nil {
@@ -832,6 +842,9 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 			// Promotion controls WIP admission, not dependency readiness. Keep both
 			// the promotion lifecycle token and deferred launch intent intact so the
 			// dependency-resolution path can start the task once its blockers clear.
+			if autoStartOnCreateClaimed {
+				s.discardAutoStartOnCreate(ctx, task.ID, "task.queue_promoted")
+			}
 			return
 		}
 	}
@@ -843,10 +856,12 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 	if sourceErr != nil {
 		s.logger.Warn("task.queue_promoted: failed to load source step",
 			zap.String("task_id", task.ID), zap.Error(sourceErr))
+		restoreCreateIntent()
 		return
 	}
 	queuePromotionToken := queuePromotionLifecycleToken(task)
 	if !s.claimTaskEventMetadata(ctx, task, models.MetaKeyQueuePromotionPending) {
+		restoreCreateIntent()
 		return
 	}
 	if remover, ok := s.repo.(taskMetadataKeyRemover); ok {
@@ -857,7 +872,13 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 		go func() {
 			if err := s.finalizeStepEnter(context.WithoutCancel(ctx), task.ID, session.ID, targetStep, task.Description, targetStep.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent), sourceStep); err != nil {
 				s.restoreTaskLifecycleToken(context.WithoutCancel(ctx), task.ID, models.MetaKeyQueuePromotionPending, queuePromotionToken, "task.queue_promoted")
+				if autoStartOnCreateClaimed {
+					s.restoreAutoStartOnCreate(context.WithoutCancel(ctx), task.ID, "task.queue_promoted")
+				}
 				return
+			}
+			if autoStartOnCreateClaimed {
+				s.completeAutoStartOnCreate(context.WithoutCancel(ctx), task.ID, "task.queue_promoted")
 			}
 			if s.onTaskQueuePromotionEntryComplete != nil {
 				s.onTaskQueuePromotionEntryComplete()
@@ -903,11 +924,11 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 // anything with it. Either way the key can never change this handler's
 // outcome, so checking it here would be dead code.
 //
-// The opt-in itself is claimed via claimTaskEventMetadata before launching,
-// the same one-shot-token pattern used for MetaKeyQueuePromotionPending: a
-// duplicate task.created delivery for the same task would otherwise see the
-// key still present and launch a second time. Only the delivery that wins
-// the atomic RemoveTaskMetadataKey proceeds.
+// The opt-in itself is claimed before launching, the same one-shot-token
+// pattern used for MetaKeyQueuePromotionPending. The claim also writes a
+// durable in-flight marker before removing the intent, so a process exit
+// cannot erase the last recovery signal. Only the delivery that wins the
+// local and database ownership hand-off proceeds.
 func (s *Service) handleTaskCreated(ctx context.Context, data watcher.TaskEventData) {
 	task, err := s.repo.GetTask(ctx, data.TaskID)
 	if err != nil || task == nil {
@@ -919,13 +940,21 @@ func (s *Service) handleTaskCreated(ctx context.Context, data watcher.TaskEventD
 	if !autoStartOnCreateActionable(task) {
 		return
 	}
-	if !s.claimTaskEventMetadata(ctx, task, models.MetaKeyAutoStartOnCreate) {
+	sessions, err := s.repo.ListTaskSessions(ctx, task.ID)
+	if err != nil {
+		s.logger.Warn("task.created: failed to check existing sessions", zap.String("task_id", task.ID), zap.Error(err))
 		return
 	}
-	// The claim above already removed the key; carry that ownership into the
-	// launch attempt (autoStartOnCreateClaimed=true) so a StartTask failure
-	// before a durable session exists can restore it instead of stranding the
-	// task with no marker (see handleAutoStartFailure).
+	if len(sessions) > 0 {
+		s.completeAutoStartOnCreate(ctx, task.ID, events.TaskCreated)
+		return
+	}
+	if result := s.claimAutoStartOnCreateForLaunch(ctx, task, false); result != autoStartOnCreateClaimOwned {
+		return
+	}
+	// Carry ownership into the launch attempt so a StartTask failure before a
+	// durable session exists can restore the intent (see
+	// handleAutoStartFailure).
 	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskCreated, data.StepTransitionID, true)
 }
 
@@ -1072,8 +1101,13 @@ func (s *Service) reconcileTaskLifecycleTokens(ctx context.Context) {
 		s.logger.Warn("failed to list auto-start-on-create tokens for recovery", zap.Error(err))
 		return
 	}
-	// autoStarts is the raw, pre-filter list; only entries that pass
-	// autoStartOnCreateActionable below are added to jobs, so it is left out
+	autoStartsInFlight, err := lister.ListTasksWithMetadataKey(ctx, models.MetaKeyAutoStartOnCreateInFlight)
+	if err != nil {
+		s.logger.Warn("failed to list in-flight auto-start-on-create tokens for recovery", zap.Error(err))
+		return
+	}
+	// The auto-start lists are raw, pre-filter lists; only entries that pass
+	// autoStartOnCreateActionable below are added to jobs, so they are left out
 	// of this capacity hint rather than causing routine over-allocation.
 	jobs := make(map[string]struct{}, len(pending)+len(promotions)+len(manualPending)+len(manualCompleted))
 	for _, task := range pending {
@@ -1096,7 +1130,7 @@ func (s *Service) reconcileTaskLifecycleTokens(ctx context.Context) {
 			jobs[task.ID] = struct{}{}
 		}
 	}
-	for _, task := range autoStarts {
+	for _, task := range append(autoStarts, autoStartsInFlight...) {
 		// ListTasksWithMetadataKey matches key EXISTENCE, which is broader
 		// than what handleTaskCreated will act on. Rows it refuses keep their
 		// key forever, so admitting them would schedule work that can never
@@ -1432,7 +1466,8 @@ func autoStartOnCreateActionable(task *models.Task) bool {
 	if task == nil || task.IsFromOffice {
 		return false
 	}
-	return models.HasAutoStartOnCreateIntent(task.Metadata)
+	return models.HasAutoStartOnCreateIntent(task.Metadata) ||
+		models.HasAutoStartOnCreateInFlight(task.Metadata)
 }
 
 // recoverAutoStartOnCreate replays a lost task.created delivery for a task that
@@ -1442,13 +1477,11 @@ func autoStartOnCreateActionable(task *models.Task) bool {
 // without ever touching this key, so an operator starting the task by hand
 // after a lost delivery leaves the token behind. Every automated auto-start
 // path (task.moved, dependency resolution, handleTaskQueuePromoted) now claims
-// this key itself via claimAutoStartOnCreateForLaunch before it launches, but
-// claiming the key and producing a durable session are not the same instant:
-// a launch attempt already in flight may have claimed the key without yet
-// having created a session. Replaying here without checking would launch a
+// this key itself via claimAutoStartOnCreateForLaunch before it launches. The
+// durable in-flight marker remains until a session or run is created, while
+// the local ownership map prevents this process from reclaiming it during the
+// detached launch. Replaying here without the session check would launch a
 // second agent onto a task that is already running or already finished.
-// Neither autoStartTaskForStep nor startTask has an existing-session guard, so
-// that launch would go all the way through.
 func (s *Service) recoverAutoStartOnCreate(ctx context.Context, task *models.Task) {
 	sessions, err := s.repo.ListTaskSessions(ctx, task.ID)
 	if err != nil {
@@ -1459,13 +1492,13 @@ func (s *Service) recoverAutoStartOnCreate(ctx context.Context, task *models.Tas
 		return
 	}
 	if len(sessions) > 0 {
-		// The task was started by one of those other paths, so this one-shot
-		// token is spent. Claim it rather than merely skipping, so the row
-		// converges instead of being re-scanned on every future startup.
-		if s.claimTaskEventMetadata(ctx, task, models.MetaKeyAutoStartOnCreate) {
-			s.logger.Info("discarded spent auto-start-on-create token: task already has a session",
-				zap.String("task_id", task.ID), zap.Int("session_count", len(sessions)))
-		}
+		// The task was started by one of those other paths, so both the
+		// intent and any in-flight hand-off are spent. Clear them rather than
+		// merely skipping, so the row converges instead of being re-scanned on
+		// every future startup.
+		s.completeAutoStartOnCreate(ctx, task.ID, "auto-start-on-create recovery")
+		s.logger.Info("discarded spent auto-start-on-create token: task already has a session",
+			zap.String("task_id", task.ID), zap.Int("session_count", len(sessions)))
 		return
 	}
 	// Re-enter handleTaskCreated exactly like a live delivery would, so the
@@ -1529,22 +1562,33 @@ func (s *Service) syncTaskStateForQueuePromotion(ctx context.Context, task *mode
 
 // autoStartTaskForStep evaluates a target step's on_enter auto-start action
 // for a task with no session yet. autoStartOnCreateClaimed is true only when
-// the caller (handleTaskCreated) already removed MetaKeyAutoStartOnCreate
-// before dispatching here; every other caller passes false and lets
+// the caller (handleTaskCreated) already reserved the create-time launch
+// marker before dispatching here. Every other caller passes false and lets
 // autoStartTaskForLoadedStep claim the key itself if the task still carries
 // it, so a concurrent launch attempt cannot observe the token as if nobody
 // had scheduled a launch for it (see claimAutoStartOnCreateForLaunch).
+//
+//nolint:cyclop // the single auto-start chokepoint evaluates each lifecycle gate before dispatch
 func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, eventName string, stepTransitionID int64, autoStartOnCreateClaimed bool) {
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
 		s.logger.Warn(eventName+": failed to load task for auto-start",
 			zap.String("task_id", taskID), zap.Error(err))
 		if autoStartOnCreateClaimed {
-			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+			s.restoreAutoStartOnCreate(ctx, taskID, eventName)
 		}
 		return
 	}
-	if task == nil || task.QueuedForStepID != "" {
+	if task == nil {
+		if autoStartOnCreateClaimed {
+			s.restoreAutoStartOnCreate(ctx, taskID, eventName)
+		}
+		return
+	}
+	if task.QueuedForStepID != "" {
+		if autoStartOnCreateClaimed {
+			s.restoreAutoStartOnCreate(ctx, taskID, eventName)
+		}
 		return
 	}
 	// Dependency gate. Sits here — the single automated-launch chokepoint — so
@@ -1557,7 +1601,9 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 	// so it restores the token instead of stranding it.
 	if blocked, gateErrored := s.dependencyBlocksAutoStart(ctx, taskID, eventName); blocked {
 		if gateErrored && autoStartOnCreateClaimed {
-			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+			s.restoreAutoStartOnCreate(ctx, taskID, eventName)
+		} else if autoStartOnCreateClaimed {
+			s.discardAutoStartOnCreate(ctx, taskID, eventName)
 		}
 		return
 	}
@@ -1575,9 +1621,12 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 		return
 	}
 	if task != nil && s.shouldSkipTerminalPRAutoStart(ctx, task) {
+		if autoStartOnCreateClaimed {
+			s.discardAutoStartOnCreate(ctx, taskID, eventName)
+		}
 		return
 	}
-	if s.launchDeferredTask(ctx, task, eventName, false) {
+	if s.launchDeferredTask(ctx, task, eventName, false, autoStartOnCreateClaimed) {
 		return
 	}
 
@@ -1589,7 +1638,7 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 			zap.String("to_step_id", stepID),
 			zap.Error(err))
 		if autoStartOnCreateClaimed {
-			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+			s.restoreAutoStartOnCreate(ctx, taskID, eventName)
 		}
 		return
 	}
@@ -1607,45 +1656,208 @@ type autoStartLaunchTokens struct {
 	restoreAutoStartOnCreate bool
 }
 
-// claimAutoStartOnCreateForLaunch decides whether this launch attempt owns
-// restoring MetaKeyAutoStartOnCreate on failure. When alreadyClaimed is true
-// (handleTaskCreated already removed the key before dispatching here), that
-// ownership is simply carried forward. Otherwise the key is claimed now,
-// synchronously and before any launch goroutine starts — so a concurrent
-// lifecycle-recovery read of this task never observes the token next to an
-// in-flight launch it did not itself schedule (see autoStartOnCreateActionable).
-// It does not gate the launch: on_enter's auto_start_agent action already
-// decided to launch, and consuming this key is a side effect of that, not a
-// precondition for it. recoverAutoStartOnCreate's session-existence check is
-// the safety net against a duplicate launch when this claim write itself fails.
-func (s *Service) claimAutoStartOnCreateForLaunch(ctx context.Context, task *models.Task, alreadyClaimed bool) bool {
+type autoStartOnCreateClaimResult uint8
+
+const (
+	autoStartOnCreateNoIntent autoStartOnCreateClaimResult = iota
+	autoStartOnCreateClaimOwned
+	autoStartOnCreateClaimLost
+	autoStartOnCreateClaimError
+)
+
+// claimAutoStartOnCreateForLaunch reserves the create-time launch intent
+// before a detached launch starts. The original intent is removed only after
+// the durable in-flight marker is written. A second caller therefore sees a
+// lost claim, while a process restart can recover the in-flight marker.
+//
+//nolint:cyclop // durable claim/recovery ordering has separate stale, write, and ownership outcomes
+func (s *Service) claimAutoStartOnCreateForLaunch(ctx context.Context, task *models.Task, alreadyClaimed bool) autoStartOnCreateClaimResult {
+	if task == nil {
+		return autoStartOnCreateClaimError
+	}
 	if alreadyClaimed {
-		return true
+		s.autoStartOnCreateMu.Lock()
+		if s.autoStartOnCreateInFlight == nil {
+			s.autoStartOnCreateInFlight = make(map[string]struct{})
+		}
+		s.autoStartOnCreateInFlight[task.ID] = struct{}{}
+		s.autoStartOnCreateMu.Unlock()
+		return autoStartOnCreateClaimOwned
 	}
-	if !models.HasAutoStartOnCreateIntent(task.Metadata) {
-		return false
+
+	s.autoStartOnCreateMu.Lock()
+	defer s.autoStartOnCreateMu.Unlock()
+	if s.autoStartOnCreateInFlight == nil {
+		s.autoStartOnCreateInFlight = make(map[string]struct{})
 	}
-	return s.claimTaskEventMetadata(ctx, task, models.MetaKeyAutoStartOnCreate)
+	if _, inFlight := s.autoStartOnCreateInFlight[task.ID]; inFlight {
+		return autoStartOnCreateClaimLost
+	}
+
+	intent := models.HasAutoStartOnCreateIntent(task.Metadata)
+	staleInFlight := models.HasAutoStartOnCreateInFlight(task.Metadata)
+	if !intent && !staleInFlight {
+		return autoStartOnCreateNoIntent
+	}
+	setter, setterOK := s.repo.(taskMetadataKeySetter)
+	remover, removerOK := s.repo.(taskMetadataKeyRemover)
+	if !setterOK || !removerOK {
+		s.logger.Warn("auto-start-on-create claim unavailable: repository lacks metadata primitives",
+			zap.String("task_id", task.ID))
+		return autoStartOnCreateClaimError
+	}
+	if staleInFlight {
+		// An in-flight marker without a local owner belongs to a previous
+		// process, or to a claim that crashed between its two writes. Rebuild
+		// the original intent before taking a fresh reservation.
+		if !intent {
+			if err := setter.SetTaskMetadataKey(ctx, task.ID, models.MetaKeyAutoStartOnCreate, true); err != nil {
+				s.logger.Warn("failed to restore stale auto-start-on-create intent",
+					zap.String("task_id", task.ID), zap.Error(err))
+				return autoStartOnCreateClaimError
+			}
+		}
+		if _, err := remover.RemoveTaskMetadataKey(ctx, task.ID, models.MetaKeyAutoStartOnCreateInFlight); err != nil {
+			s.logger.Warn("failed to clear stale auto-start-on-create marker",
+				zap.String("task_id", task.ID), zap.Error(err))
+			return autoStartOnCreateClaimError
+		}
+	}
+	if err := setter.SetTaskMetadataKey(ctx, task.ID, models.MetaKeyAutoStartOnCreateInFlight, true); err != nil {
+		s.logger.Warn("failed to persist auto-start-on-create in-flight marker",
+			zap.String("task_id", task.ID), zap.Error(err))
+		return autoStartOnCreateClaimError
+	}
+	claimed, err := remover.RemoveTaskMetadataKey(ctx, task.ID, models.MetaKeyAutoStartOnCreate)
+	if err != nil {
+		s.logger.Warn("failed to claim auto-start-on-create intent",
+			zap.String("task_id", task.ID), zap.Error(err))
+		return autoStartOnCreateClaimError
+	}
+	if !claimed {
+		_, _ = remover.RemoveTaskMetadataKey(ctx, task.ID, models.MetaKeyAutoStartOnCreateInFlight)
+		return autoStartOnCreateClaimLost
+	}
+	s.autoStartOnCreateInFlight[task.ID] = struct{}{}
+	return autoStartOnCreateClaimOwned
 }
 
+func (s *Service) clearAutoStartOnCreateInFlight(taskID string) {
+	s.autoStartOnCreateMu.Lock()
+	delete(s.autoStartOnCreateInFlight, taskID)
+	s.autoStartOnCreateMu.Unlock()
+}
+
+func (s *Service) ownsAutoStartOnCreateInFlight(taskID string) bool {
+	s.autoStartOnCreateMu.Lock()
+	defer s.autoStartOnCreateMu.Unlock()
+	_, owned := s.autoStartOnCreateInFlight[taskID]
+	return owned
+}
+
+// restoreAutoStartOnCreate restores a failed reservation and leaves a
+// durable intent for the next lifecycle sweep. The original intent is
+// written before the in-flight marker is removed, so either write ordering
+// still leaves recovery work after a process exit.
+func (s *Service) restoreAutoStartOnCreate(ctx context.Context, taskID, eventName string) {
+	setter, setterOK := s.repo.(taskMetadataKeySetter)
+	remover, removerOK := s.repo.(taskMetadataKeyRemover)
+	if !setterOK || !removerOK {
+		s.logger.Warn(eventName+": repository cannot restore auto-start-on-create reservation",
+			zap.String("task_id", taskID))
+		s.clearAutoStartOnCreateInFlight(taskID)
+		return
+	}
+	if err := setter.SetTaskMetadataKey(ctx, taskID, models.MetaKeyAutoStartOnCreate, true); err != nil {
+		s.logger.Warn(eventName+": failed to restore auto-start-on-create intent",
+			zap.String("task_id", taskID), zap.Error(err))
+		s.clearAutoStartOnCreateInFlight(taskID)
+		return
+	}
+	if _, err := remover.RemoveTaskMetadataKey(ctx, taskID, models.MetaKeyAutoStartOnCreateInFlight); err != nil {
+		s.logger.Warn(eventName+": failed to clear auto-start-on-create in-flight marker",
+			zap.String("task_id", taskID), zap.Error(err))
+	}
+	s.clearAutoStartOnCreateInFlight(taskID)
+}
+
+// discardAutoStartOnCreate consumes a reservation when the task no longer
+// needs a create-time launch (for example, a terminal PR or a step without
+// auto-start). It is intentionally separate from restoreAutoStartOnCreate.
+func (s *Service) discardAutoStartOnCreate(ctx context.Context, taskID, eventName string) {
+	if remover, ok := s.repo.(taskMetadataKeyRemover); ok {
+		if _, err := remover.RemoveTaskMetadataKey(ctx, taskID, models.MetaKeyAutoStartOnCreateInFlight); err != nil {
+			s.logger.Warn(eventName+": failed to clear auto-start-on-create in-flight marker",
+				zap.String("task_id", taskID), zap.Error(err))
+		}
+	}
+	s.clearAutoStartOnCreateInFlight(taskID)
+}
+
+// completeAutoStartOnCreate clears both lifecycle markers after a session or
+// run is durable. A session-existence check in startup recovery also calls
+// this helper, which makes cleanup idempotent after a process restart.
+func (s *Service) completeAutoStartOnCreate(ctx context.Context, taskID, eventName string) {
+	if remover, ok := s.repo.(taskMetadataKeyRemover); ok {
+		for _, key := range []string{models.MetaKeyAutoStartOnCreate, models.MetaKeyAutoStartOnCreateInFlight} {
+			if _, err := remover.RemoveTaskMetadataKey(ctx, taskID, key); err != nil {
+				s.logger.Warn(eventName+": failed to clear auto-start-on-create marker",
+					zap.String("task_id", taskID), zap.String("metadata_key", key), zap.Error(err))
+			}
+		}
+	}
+	s.clearAutoStartOnCreateInFlight(taskID)
+}
+
+//nolint:cyclop,gocognit,funlen // launch dispatch combines existing workflow gates with durable token ownership
 func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64, autoStartOnCreateClaimed bool) {
 	if task == nil || task.QueuedForStepID != "" || step == nil {
+		if autoStartOnCreateClaimed && task != nil {
+			s.restoreAutoStartOnCreate(ctx, task.ID, eventName)
+		}
 		return
+	}
+	if models.HasAutoStartOnCreateIntent(task.Metadata) || models.HasAutoStartOnCreateInFlight(task.Metadata) || autoStartOnCreateClaimed {
+		sessions, err := s.repo.ListTaskSessions(ctx, task.ID)
+		if err != nil {
+			s.logger.Warn(eventName+": failed to check existing sessions before auto-start-on-create claim",
+				zap.String("task_id", task.ID), zap.Error(err))
+			if autoStartOnCreateClaimed {
+				s.restoreAutoStartOnCreate(ctx, task.ID, eventName)
+			}
+			return
+		}
+		if len(sessions) > 0 {
+			s.completeAutoStartOnCreate(ctx, task.ID, eventName)
+			return
+		}
 	}
 	if s.shouldSkipTerminalPRAutoStart(ctx, task) {
+		if autoStartOnCreateClaimed {
+			s.discardAutoStartOnCreate(ctx, task.ID, eventName)
+		}
 		return
 	}
-	if s.launchDeferredTask(ctx, task, eventName, restoreQueuePromotion) {
+	if s.launchDeferredTask(ctx, task, eventName, restoreQueuePromotion, autoStartOnCreateClaimed) {
 		return
 	}
 	if step == nil || !step.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent) {
 		s.logger.Debug(eventName+": target step has no auto-start",
 			zap.String("task_id", task.ID),
 			zap.String("to_step_id", step.ID))
+		if autoStartOnCreateClaimed {
+			s.discardAutoStartOnCreate(ctx, task.ID, eventName)
+		}
 		return
 	}
 
-	restoreAutoStartOnCreate := s.claimAutoStartOnCreateForLaunch(ctx, task, autoStartOnCreateClaimed)
+	claimResult := s.claimAutoStartOnCreateForLaunch(ctx, task, autoStartOnCreateClaimed)
+	if claimResult == autoStartOnCreateClaimLost || claimResult == autoStartOnCreateClaimError {
+		s.logger.Debug(eventName+": auto-start-on-create claim did not win",
+			zap.String("task_id", task.ID), zap.Uint8("claim_result", uint8(claimResult)))
+		return
+	}
+	restoreAutoStartOnCreate := claimResult == autoStartOnCreateClaimOwned
 
 	if s.isOfficeTask(ctx, task.ID) {
 		s.autoStartOfficeTaskForLoadedStep(ctx, task, step, eventName, restoreQueuePromotion, stepTransitionID, restoreAutoStartOnCreate)
@@ -1703,6 +1915,10 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 				queuePromotionToken:      queuePromotionToken,
 				restoreAutoStartOnCreate: restoreAutoStartOnCreate,
 			})
+			return
+		}
+		if restoreAutoStartOnCreate {
+			s.completeAutoStartOnCreate(asyncCtx, task.ID, eventName)
 		}
 	}()
 }
@@ -1755,12 +1971,18 @@ func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *mo
 			s.logger.Info(eventName+": queued office run (no session, auto-start step)",
 				zap.String("task_id", task.ID),
 				zap.String("to_step_id", step.ID))
+			if restoreAutoStartOnCreate {
+				s.completeAutoStartOnCreate(asyncCtx, task.ID, eventName)
+			}
 			return
 		}
 		s.logger.Debug(eventName+": office auto-start run not queued",
 			zap.String("task_id", task.ID),
 			zap.String("to_step_id", step.ID),
 			zap.String("outcome", string(outcome)))
+		if restoreAutoStartOnCreate {
+			s.completeAutoStartOnCreate(asyncCtx, task.ID, eventName)
+		}
 	}()
 }
 
@@ -1833,12 +2055,13 @@ func (s *Service) handleAutoStartFailure(ctx context.Context, taskID, eventName 
 		s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyQueuePromotionPending, tokens.queuePromotionToken, eventName)
 	}
 	if tokens.restoreAutoStartOnCreate {
-		s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+		s.restoreAutoStartOnCreate(ctx, taskID, eventName)
 	}
 	s.setTaskAutoStartFailedMarker(ctx, taskID, eventName)
 }
 
-func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eventName string, restoreQueuePromotion bool) bool {
+//nolint:cyclop,gocognit,funlen // deferred launches coordinate two durable tokens and async success/failure cleanup
+func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eventName string, restoreQueuePromotion bool, autoStartOnCreateClaimed ...bool) bool {
 	if task.Metadata == nil {
 		return false
 	}
@@ -1848,6 +2071,9 @@ func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eve
 	}
 	encoded, err := json.Marshal(raw)
 	if err != nil {
+		if len(autoStartOnCreateClaimed) > 0 && autoStartOnCreateClaimed[0] {
+			s.restoreAutoStartOnCreate(ctx, task.ID, eventName)
+		}
 		return false
 	}
 	var intent struct {
@@ -1863,7 +2089,25 @@ func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eve
 	}
 	if err := json.Unmarshal(encoded, &intent); err != nil || intent.AgentProfileID == "" {
 		s.logger.Warn(eventName+": invalid deferred launch intent", zap.String("task_id", task.ID), zap.Error(err))
+		if len(autoStartOnCreateClaimed) > 0 && autoStartOnCreateClaimed[0] {
+			s.restoreAutoStartOnCreate(ctx, task.ID, eventName)
+		}
 		return true
+	}
+	createClaimed := false
+	requestedCreateClaim := len(autoStartOnCreateClaimed) > 0 && autoStartOnCreateClaimed[0]
+	if requestedCreateClaim || models.HasAutoStartOnCreateIntent(task.Metadata) || models.HasAutoStartOnCreateInFlight(task.Metadata) {
+		claimResult := s.claimAutoStartOnCreateForLaunch(ctx, task, requestedCreateClaim)
+		switch claimResult {
+		case autoStartOnCreateClaimOwned:
+			createClaimed = true
+		case autoStartOnCreateNoIntent:
+			if requestedCreateClaim {
+				return true
+			}
+		default:
+			return true
+		}
 	}
 	launchIntent := IntentStart
 	if intent.Intent == "prepare" {
@@ -1873,6 +2117,9 @@ func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eve
 		launchCtx := context.WithoutCancel(ctx)
 		metadataClaimed, claimOK := s.claimDeferredLaunch(launchCtx, task.ID, eventName)
 		if !claimOK {
+			if createClaimed {
+				s.restoreAutoStartOnCreate(launchCtx, task.ID, eventName)
+			}
 			return
 		}
 		launchResp, launchErr := s.LaunchSession(launchCtx, &LaunchSessionRequest{
@@ -1890,7 +2137,13 @@ func (s *Service) launchDeferredTask(ctx context.Context, task *models.Task, eve
 			if restoreQueuePromotion {
 				s.restoreTaskLifecycleToken(launchCtx, task.ID, models.MetaKeyQueuePromotionPending, queuePromotionLifecycleToken(task), eventName)
 			}
+			if createClaimed {
+				s.restoreAutoStartOnCreate(launchCtx, task.ID, eventName)
+			}
 			return
+		}
+		if createClaimed {
+			s.completeAutoStartOnCreate(launchCtx, task.ID, eventName)
 		}
 		if intent.RecordRecentUse {
 			s.recordSuccessfulDeferredTaskProfileAsync(launchCtx, intent.UserID, launchResp.AgentProfileID)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -827,11 +827,13 @@ func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx contex
 			zap.String("task_id", task.ID), zap.Error(sessionErr))
 		return
 	}
-	if session == nil && s.dependencyBlocksAutoStart(ctx, task.ID, "task.queue_promoted") {
-		// Promotion controls WIP admission, not dependency readiness. Keep both
-		// the promotion lifecycle token and deferred launch intent intact so the
-		// dependency-resolution path can start the task once its blockers clear.
-		return
+	if session == nil {
+		if blocked, _ := s.dependencyBlocksAutoStart(ctx, task.ID, "task.queue_promoted"); blocked {
+			// Promotion controls WIP admission, not dependency readiness. Keep both
+			// the promotion lifecycle token and deferred launch intent intact so the
+			// dependency-resolution path can start the task once its blockers clear.
+			return
+		}
 	}
 	// Read the source descriptor before claiming the one-shot promotion token.
 	// The claim removes the marker durably and a repository implementation may
@@ -1542,8 +1544,15 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 	// Dependency gate. Sits here — the single automated-launch chokepoint — so
 	// one check covers task.moved, task.queue_promoted, watcher auto-start and
 	// dependency resolution itself. Placed BEFORE launchDeferredTask so a
-	// blocked task neither starts a session nor consumes its launch intent.
-	if s.dependencyBlocksAutoStart(ctx, taskID, eventName) {
+	// blocked task never starts a session. A genuine block still consumes the
+	// caller's launch intent: evaluateDependentAfterPredecessorChange and
+	// reconcileDependencyLaunchesOnStartup independently launch this task once
+	// its dependency resolves. A failed dependency read has no such fallback,
+	// so it restores the token instead of stranding it.
+	if blocked, gateErrored := s.dependencyBlocksAutoStart(ctx, taskID, eventName); blocked {
+		if gateErrored && autoStartOnCreateClaimed {
+			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+		}
 		return
 	}
 	if hasQueuePromotionPending(task) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -680,7 +680,7 @@ func (s *Service) handleTaskMoved(ctx context.Context, data watcher.TaskMovedEve
 			return
 		}
 		if prerequisites != nil && prerequisites.targetStep != nil {
-			s.autoStartTaskForLoadedStep(ctx, task, prerequisites.targetStep, "task.moved", data.QueuePromotion, data.StepTransitionID)
+			s.autoStartTaskForLoadedStep(ctx, task, prerequisites.targetStep, "task.moved", data.QueuePromotion, data.StepTransitionID, false)
 		} else {
 			s.handleTaskMovedNoSession(ctx, data)
 		}
@@ -762,7 +762,7 @@ func (s *Service) loadTaskMovedSessionPrerequisites(
 // If the target step has auto_start_agent, it creates a session and starts the agent
 // using agent/executor profile IDs from the task's metadata.
 func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.TaskMovedEventData) {
-	s.autoStartTaskForStep(ctx, data.TaskID, data.ToStepID, "task.moved", data.StepTransitionID)
+	s.autoStartTaskForStep(ctx, data.TaskID, data.ToStepID, "task.moved", data.StepTransitionID, false)
 }
 
 func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.TaskEventData) {
@@ -839,7 +839,7 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 		}()
 		return
 	}
-	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true, data.StepTransitionID)
+	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true, data.StepTransitionID, false)
 }
 
 // handleTaskCreated lets a task that is created directly onto a step whose
@@ -896,7 +896,11 @@ func (s *Service) handleTaskCreated(ctx context.Context, data watcher.TaskEventD
 	if !s.claimTaskEventMetadata(ctx, task, models.MetaKeyAutoStartOnCreate) {
 		return
 	}
-	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskCreated, data.StepTransitionID)
+	// The claim above already removed the key; carry that ownership into the
+	// launch attempt (autoStartOnCreateClaimed=true) so a StartTask failure
+	// before a durable session exists can restore it instead of stranding the
+	// task with no marker (see handleAutoStartFailure).
+	s.autoStartTaskForStep(ctx, task.ID, task.WorkflowStepID, events.TaskCreated, data.StepTransitionID, true)
 }
 
 func (s *Service) claimTaskEventMetadata(ctx context.Context, task *models.Task, key string) bool {
@@ -1245,9 +1249,24 @@ func (s *Service) recoverTaskLifecycleAttempt(ctx context.Context, taskID string
 		if _, err := s.clearManualMoveLifecycleMarkersIfCompleted(ctx, taskID, completedAt); err != nil {
 			return true
 		}
+		task, err = s.repo.GetTask(ctx, taskID)
+		if err != nil || task == nil {
+			return false
+		}
 	}
 	if _, pending := task.Metadata[models.MetaKeyQueuePromotionPending]; pending {
 		s.handleTaskQueuePromoted(ctx, watcher.TaskEventData{TaskID: taskID})
+		// handleTaskQueuePromoted's no-session branch schedules a launch via
+		// autoStartTaskForLoadedStep, which synchronously claims
+		// MetaKeyAutoStartOnCreate when the task still carries it (see
+		// claimAutoStartOnCreateForLaunch) before this call returns. Re-fetch
+		// so the actionability check below observes that claim instead of the
+		// stale in-memory task, which would otherwise report the token as
+		// still pending and schedule a second, redundant launch attempt.
+		task, err = s.repo.GetTask(ctx, taskID)
+		if err != nil || task == nil {
+			return false
+		}
 	}
 	if autoStartOnCreateActionable(task) {
 		s.recoverAutoStartOnCreate(ctx, task)
@@ -1473,7 +1492,14 @@ func (s *Service) syncTaskStateForQueuePromotion(ctx context.Context, task *mode
 	return nil
 }
 
-func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, eventName string, stepTransitionID int64) {
+// autoStartTaskForStep evaluates a target step's on_enter auto-start action
+// for a task with no session yet. autoStartOnCreateClaimed is true only when
+// the caller (handleTaskCreated) already removed MetaKeyAutoStartOnCreate
+// before dispatching here; every other caller passes false and lets
+// autoStartTaskForLoadedStep claim the key itself if the task still carries
+// it, so a concurrent launch attempt cannot observe the token as if nobody
+// had scheduled a launch for it (see claimAutoStartOnCreateForLaunch).
+func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, eventName string, stepTransitionID int64, autoStartOnCreateClaimed bool) {
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
 		s.logger.Warn(eventName+": failed to load task for auto-start",
@@ -1515,10 +1541,41 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 			zap.Error(err))
 		return
 	}
-	s.autoStartTaskForLoadedStep(ctx, task, step, eventName, false, stepTransitionID)
+	s.autoStartTaskForLoadedStep(ctx, task, step, eventName, false, stepTransitionID, autoStartOnCreateClaimed)
 }
 
-func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64) {
+// autoStartLaunchTokens carries the one-shot lifecycle tokens a launch
+// attempt must restore if it fails before producing a durable session or
+// run, so the next startup sweep retries instead of the task silently
+// losing its opt-in.
+type autoStartLaunchTokens struct {
+	hasGuard                 bool
+	restoreQueuePromotion    bool
+	queuePromotionToken      interface{}
+	restoreAutoStartOnCreate bool
+}
+
+// claimAutoStartOnCreateForLaunch decides whether this launch attempt owns
+// restoring MetaKeyAutoStartOnCreate on failure. When alreadyClaimed is true
+// (handleTaskCreated already removed the key before dispatching here), that
+// ownership is simply carried forward. Otherwise the key is claimed now,
+// synchronously and before any launch goroutine starts — so a concurrent
+// lifecycle-recovery read of this task never observes the token next to an
+// in-flight launch it did not itself schedule (see autoStartOnCreateActionable).
+// It does not gate the launch: on_enter's auto_start_agent action already
+// decided to launch, and consuming this key is a side effect of that, not a
+// precondition for it.
+func (s *Service) claimAutoStartOnCreateForLaunch(ctx context.Context, task *models.Task, alreadyClaimed bool) bool {
+	if alreadyClaimed {
+		return true
+	}
+	if !models.HasAutoStartOnCreateIntent(task.Metadata) {
+		return false
+	}
+	return s.claimTaskEventMetadata(ctx, task, models.MetaKeyAutoStartOnCreate)
+}
+
+func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64, autoStartOnCreateClaimed bool) {
 	if task == nil || task.QueuedForStepID != "" || step == nil {
 		return
 	}
@@ -1535,8 +1592,10 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 		return
 	}
 
+	restoreAutoStartOnCreate := s.claimAutoStartOnCreateForLaunch(ctx, task, autoStartOnCreateClaimed)
+
 	if s.isOfficeTask(ctx, task.ID) {
-		s.autoStartOfficeTaskForLoadedStep(ctx, task, step, eventName, restoreQueuePromotion, stepTransitionID)
+		s.autoStartOfficeTaskForLoadedStep(ctx, task, step, eventName, restoreQueuePromotion, stepTransitionID, restoreAutoStartOnCreate)
 		return
 	}
 
@@ -1585,7 +1644,12 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 			s.logger.Error(eventName+": failed to auto-start task",
 				zap.String("task_id", task.ID),
 				zap.Error(err))
-			s.handleAutoStartFailure(asyncCtx, task.ID, eventName, hasGuard, restoreQueuePromotion, queuePromotionToken)
+			s.handleAutoStartFailure(asyncCtx, task.ID, eventName, autoStartLaunchTokens{
+				hasGuard:                 hasGuard,
+				restoreQueuePromotion:    restoreQueuePromotion,
+				queuePromotionToken:      queuePromotionToken,
+				restoreAutoStartOnCreate: restoreAutoStartOnCreate,
+			})
 		}
 	}()
 }
@@ -1597,7 +1661,7 @@ func (s *Service) autoStartTaskForLoadedStep(ctx context.Context, task *models.T
 // a run through the engine's Office adapters instead, the same mechanism the
 // scheduler's recovery sweep and the "assign task" flow already use to start
 // Office work (internal/office/service/scheduler_recovery.go).
-func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64) {
+func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *models.Task, step *wfmodels.WorkflowStep, eventName string, restoreQueuePromotion bool, stepTransitionID int64, restoreAutoStartOnCreate bool) {
 	queuePromotionToken := queuePromotionLifecycleToken(task)
 	// Async for the same reason as the kanban path above: the event bus
 	// delivers synchronously and blocking here would stall the HTTP handler
@@ -1619,7 +1683,12 @@ func (s *Service) autoStartOfficeTaskForLoadedStep(ctx context.Context, task *mo
 			s.logger.Error(eventName+": failed to queue office auto-start run",
 				zap.String("task_id", task.ID),
 				zap.Error(err))
-			s.handleAutoStartFailure(asyncCtx, task.ID, eventName, hasGuard, restoreQueuePromotion, queuePromotionToken)
+			s.handleAutoStartFailure(asyncCtx, task.ID, eventName, autoStartLaunchTokens{
+				hasGuard:                 hasGuard,
+				restoreQueuePromotion:    restoreQueuePromotion,
+				queuePromotionToken:      queuePromotionToken,
+				restoreAutoStartOnCreate: restoreAutoStartOnCreate,
+			})
 			return
 		}
 		// Log the outcome only after the attempt actually resolves — the log
@@ -1697,15 +1766,21 @@ func officeAutoStartIdempotencyKey(task *models.Task, agentProfileID, stepID str
 // only ever called (and the token only ever taken) when the task carries
 // MetaKeyAutoStartGuard, so restoring it unconditionally stamps
 // auto_start_claimed onto tasks that never carried the guard, corrupting the
-// invariant documented at MetaKeyAutoStartGuard. It also stamps
-// MetaKeyAutoStartFailed so the failure surfaces on the task card instead of
-// only in backend logs.
-func (s *Service) handleAutoStartFailure(ctx context.Context, taskID, eventName string, hasGuard, restoreQueuePromotion bool, queuePromotionToken interface{}) {
-	if hasGuard {
+// invariant documented at MetaKeyAutoStartGuard. It also restores
+// MetaKeyAutoStartOnCreate when this attempt claimed it, so a StartTask/queue
+// failure before a durable session or run exists leaves the task retryable by
+// the next startup sweep instead of stranded with no marker at all. It also
+// stamps MetaKeyAutoStartFailed so the failure surfaces on the task card
+// instead of only in backend logs.
+func (s *Service) handleAutoStartFailure(ctx context.Context, taskID, eventName string, tokens autoStartLaunchTokens) {
+	if tokens.hasGuard {
 		s.restoreAutoStartClaim(ctx, taskID, eventName)
 	}
-	if restoreQueuePromotion {
-		s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyQueuePromotionPending, queuePromotionToken, eventName)
+	if tokens.restoreQueuePromotion {
+		s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyQueuePromotionPending, tokens.queuePromotionToken, eventName)
+	}
+	if tokens.restoreAutoStartOnCreate {
+		s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
 	}
 	s.setTaskAutoStartFailedMarker(ctx, taskID, eventName)
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1277,6 +1277,9 @@ func (s *Service) recoverTaskLifecycleAttempt(ctx context.Context, taskID string
 		}
 		task, err = s.repo.GetTask(ctx, taskID)
 		if err != nil || task == nil {
+			// A transient failure here only ends this attempt; it leaves any
+			// surviving lifecycle marker untouched, so the next startup sweep
+			// re-lists and retries the task.
 			return false
 		}
 	}
@@ -1291,6 +1294,9 @@ func (s *Service) recoverTaskLifecycleAttempt(ctx context.Context, taskID string
 		// still pending and schedule a second, redundant launch attempt.
 		task, err = s.repo.GetTask(ctx, taskID)
 		if err != nil || task == nil {
+			// A transient failure here only ends this attempt; it leaves any
+			// surviving lifecycle marker untouched, so the next startup sweep
+			// re-lists and retries the task.
 			return false
 		}
 	}
@@ -1610,7 +1616,8 @@ type autoStartLaunchTokens struct {
 // in-flight launch it did not itself schedule (see autoStartOnCreateActionable).
 // It does not gate the launch: on_enter's auto_start_agent action already
 // decided to launch, and consuming this key is a side effect of that, not a
-// precondition for it.
+// precondition for it. recoverAutoStartOnCreate's session-existence check is
+// the safety net against a duplicate launch when this claim write itself fails.
 func (s *Service) claimAutoStartOnCreateForLaunch(ctx context.Context, task *models.Task, alreadyClaimed bool) bool {
 	if alreadyClaimed {
 		return true

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -766,24 +766,48 @@ func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.Tas
 }
 
 func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.TaskEventData) {
-	task, err := s.repo.GetTask(ctx, data.TaskID)
+	s.handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx, data, false)
+}
+
+// loadQueuePromotedTaskAndTargetStep loads and validates the task and its
+// current workflow step for a task.queue_promoted delivery, returning
+// ok=false for every condition under which the event should be dropped
+// (load failure, no longer queued/admitted, or a manual move still mid-flight).
+func (s *Service) loadQueuePromotedTaskAndTargetStep(ctx context.Context, taskID string) (*models.Task, *wfmodels.WorkflowStep, bool) {
+	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
-		s.logger.Warn("task.queue_promoted: failed to load task", zap.String("task_id", data.TaskID), zap.Error(err))
-		return
+		s.logger.Warn("task.queue_promoted: failed to load task", zap.String("task_id", taskID), zap.Error(err))
+		return nil, nil, false
 	}
 	if task.QueuedForStepID != "" || !task.WIPAdmitted {
-		return
+		return nil, nil, false
 	}
 	if queuedMoveExitPending(task) || manualMoveLifecyclePending(task) {
 		// A manual move has not finished its lifecycle yet.
 		// Keep the promotion token durable; source-exit completion will trigger
 		// queue reconciliation and retry destination entry.
-		return
+		return nil, nil, false
 	}
 	targetStep, err := s.workflowStepGetter.GetStep(ctx, task.WorkflowStepID)
 	if err != nil || targetStep == nil {
 		s.logger.Warn("task.queue_promoted: failed to load target step",
 			zap.String("task_id", task.ID), zap.String("step_id", task.WorkflowStepID), zap.Error(err))
+		return nil, nil, false
+	}
+	return task, targetStep, true
+}
+
+// handleTaskQueuePromotedWithAutoStartOnCreateClaimed is handleTaskQueuePromoted's
+// implementation, parameterized by whether the caller already claimed
+// MetaKeyAutoStartOnCreate for this launch attempt (see
+// claimAutoStartOnCreateForLaunch). autoStartTaskForStep's queue-promotion
+// redirect calls this directly so a create-time opt-in that handleTaskCreated
+// already claimed carries through promotion instead of being silently
+// dropped; every other caller goes through handleTaskQueuePromoted and passes
+// false.
+func (s *Service) handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx context.Context, data watcher.TaskEventData, autoStartOnCreateClaimed bool) {
+	task, targetStep, ok := s.loadQueuePromotedTaskAndTargetStep(ctx, data.TaskID)
+	if !ok {
 		return
 	}
 	if err := s.syncTaskStateForQueuePromotion(ctx, task, targetStep); err != nil {
@@ -839,7 +863,7 @@ func (s *Service) handleTaskQueuePromoted(ctx context.Context, data watcher.Task
 		}()
 		return
 	}
-	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true, data.StepTransitionID, false)
+	s.autoStartTaskForLoadedStep(ctx, task, targetStep, "task.queue_promoted", true, data.StepTransitionID, autoStartOnCreateClaimed)
 }
 
 // handleTaskCreated lets a task that is created directly onto a step whose
@@ -1406,14 +1430,17 @@ func autoStartOnCreateActionable(task *models.Task) bool {
 // recoverAutoStartOnCreate replays a lost task.created delivery for a task that
 // still carries an actionable create-time opt-in.
 //
-// The opt-in is NOT proof that no launch happened. handleTaskCreated is the
-// only function that claims this key; a manual StartTask, a task.moved
-// auto-start and handleTaskQueuePromoted all launch without touching it. So
-// after a lost delivery — the very failure this sweep repairs — an operator
-// starting the task by hand leaves the token behind, and replaying it here
-// would launch a second agent onto a task that is already running or already
-// finished. Neither autoStartTaskForStep nor startTask has an existing-session
-// guard, so that launch would go all the way through.
+// The opt-in is NOT proof that no launch happened. A manual StartTask launches
+// without ever touching this key, so an operator starting the task by hand
+// after a lost delivery leaves the token behind. Every automated auto-start
+// path (task.moved, dependency resolution, handleTaskQueuePromoted) now claims
+// this key itself via claimAutoStartOnCreateForLaunch before it launches, but
+// claiming the key and producing a durable session are not the same instant:
+// a launch attempt already in flight may have claimed the key without yet
+// having created a session. Replaying here without checking would launch a
+// second agent onto a task that is already running or already finished.
+// Neither autoStartTaskForStep nor startTask has an existing-session guard, so
+// that launch would go all the way through.
 func (s *Service) recoverAutoStartOnCreate(ctx context.Context, task *models.Task) {
 	sessions, err := s.repo.ListTaskSessions(ctx, task.ID)
 	if err != nil {
@@ -1504,6 +1531,9 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 	if err != nil {
 		s.logger.Warn(eventName+": failed to load task for auto-start",
 			zap.String("task_id", taskID), zap.Error(err))
+		if autoStartOnCreateClaimed {
+			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+		}
 		return
 	}
 	if task == nil || task.QueuedForStepID != "" {
@@ -1520,9 +1550,13 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 		// A dependency may resolve after same-step WIP promotion was admitted.
 		// Resume through the promotion handler so destination-entry lifecycle is
 		// claimed and its token participates in deferred-launch failure recovery.
-		s.handleTaskQueuePromoted(ctx, watcher.TaskEventData{
+		// autoStartOnCreateClaimed carries forward here: if handleTaskCreated
+		// already claimed MetaKeyAutoStartOnCreate for this attempt, the
+		// promotion path must inherit that ownership rather than starting a
+		// fresh, unclaimed one (see claimAutoStartOnCreateForLaunch).
+		s.handleTaskQueuePromotedWithAutoStartOnCreateClaimed(ctx, watcher.TaskEventData{
 			TaskID: task.ID, StepTransitionID: stepTransitionID,
-		})
+		}, autoStartOnCreateClaimed)
 		return
 	}
 	if task != nil && s.shouldSkipTerminalPRAutoStart(ctx, task) {
@@ -1539,6 +1573,9 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 			zap.String("task_id", taskID),
 			zap.String("to_step_id", stepID),
 			zap.Error(err))
+		if autoStartOnCreateClaimed {
+			s.restoreTaskLifecycleToken(ctx, taskID, models.MetaKeyAutoStartOnCreate, true, eventName)
+		}
 		return
 	}
 	s.autoStartTaskForLoadedStep(ctx, task, step, eventName, false, stepTransitionID, autoStartOnCreateClaimed)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_inflight_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_inflight_test.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type failAutoStartOnCreateClaimRepository struct {
+	sessionExecutorStore
+}
+
+func (r *failAutoStartOnCreateClaimRepository) RemoveTaskMetadataKey(ctx context.Context, taskID, key string) (bool, error) {
+	if key == models.MetaKeyAutoStartOnCreate {
+		return false, errors.New("injected auto-start claim failure")
+	}
+	return r.sessionExecutorStore.RemoveTaskMetadataKey(ctx, taskID, key)
+}
+
+func TestAutoStartOnCreateClaimLeavesDurableInFlightMarker(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-inflight", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-inflight", WorkspaceID: "ws-inflight", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "task-inflight", WorkspaceID: "ws-inflight", WorkflowID: "wf-inflight",
+		WorkflowStepID: "step-inflight", State: v1.TaskStateCreated,
+		Metadata:  map[string]interface{}{models.MetaKeyAutoStartOnCreate: true},
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	svc := &Service{repo: repo, logger: testLogger()}
+	task, err := repo.GetTask(ctx, "task-inflight")
+	requireNoError(t, err)
+	if got := svc.claimAutoStartOnCreateForLaunch(ctx, task, false); got != autoStartOnCreateClaimOwned {
+		t.Fatalf("claim result = %d, want owned", got)
+	}
+
+	reloaded, err := repo.GetTask(ctx, task.ID)
+	requireNoError(t, err)
+	if models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("auto-start-on-create intent remained after claim")
+	}
+	if !models.HasAutoStartOnCreateInFlight(reloaded.Metadata) {
+		t.Fatal("in-flight marker was not persisted before launch")
+	}
+	if got := svc.claimAutoStartOnCreateForLaunch(ctx, reloaded, false); got != autoStartOnCreateClaimLost {
+		t.Fatalf("second claim result = %d, want lost", got)
+	}
+
+	svc.completeAutoStartOnCreate(ctx, task.ID, "test")
+	reloaded, err = repo.GetTask(ctx, task.ID)
+	requireNoError(t, err)
+	if models.HasAutoStartOnCreateIntent(reloaded.Metadata) || models.HasAutoStartOnCreateInFlight(reloaded.Metadata) {
+		t.Fatalf("auto-start markers remained after completion: %#v", reloaded.Metadata)
+	}
+}
+
+func TestAutoStartOnCreateClaimReclaimsStaleInFlightMarker(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-stale", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-stale", WorkspaceID: "ws-stale", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "task-stale", WorkspaceID: "ws-stale", WorkflowID: "wf-stale",
+		WorkflowStepID: "step-stale", State: v1.TaskStateCreated,
+		Metadata:  map[string]interface{}{models.MetaKeyAutoStartOnCreateInFlight: true},
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	svc := &Service{repo: repo, logger: testLogger()}
+	task, err := repo.GetTask(ctx, "task-stale")
+	requireNoError(t, err)
+	if got := svc.claimAutoStartOnCreateForLaunch(ctx, task, false); got != autoStartOnCreateClaimOwned {
+		t.Fatalf("stale claim result = %d, want owned", got)
+	}
+
+	reloaded, err := repo.GetTask(ctx, task.ID)
+	requireNoError(t, err)
+	if models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("stale recovery left the rebuilt intent in place")
+	}
+	if !models.HasAutoStartOnCreateInFlight(reloaded.Metadata) {
+		t.Fatal("stale recovery did not create a fresh in-flight marker")
+	}
+}
+
+func TestAutoStartOnCreateClaimFailureSkipsLaunch(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-claim-error", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-claim-error", WorkspaceID: "ws-claim-error", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "task-claim-error", WorkspaceID: "ws-claim-error", WorkflowID: "wf-claim-error",
+		WorkflowStepID: "step-claim-error", State: v1.TaskStateCreated,
+		Metadata:  map[string]interface{}{models.MetaKeyAutoStartOnCreate: true},
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	step := &wfmodels.WorkflowStep{
+		ID: "step-claim-error", WorkflowID: "wf-claim-error", Name: "Start", Position: 0,
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}}},
+	}
+	stepGetter := newMockStepGetter()
+	stepGetter.steps[step.ID] = step
+	failingRepo := &failAutoStartOnCreateClaimRepository{sessionExecutorStore: repo}
+	svc := &Service{repo: failingRepo, workflowStepGetter: stepGetter, logger: testLogger()}
+
+	task, err := repo.GetTask(ctx, "task-claim-error")
+	requireNoError(t, err)
+	// The claim must fail closed before any goroutine or executor call. The
+	// executor field is deliberately unset, so a launch would panic this test.
+	svc.autoStartTaskForLoadedStep(ctx, task, step, "test.claim_error", false, 0, false)
+
+	reloaded, err := repo.GetTask(ctx, task.ID)
+	requireNoError(t, err)
+	if !models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("claim failure removed the original intent")
+	}
+	if !models.HasAutoStartOnCreateInFlight(reloaded.Metadata) {
+		t.Fatal("claim failure did not leave a recoverable in-flight marker")
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
+	taskservice "github.com/kandev/kandev/internal/task/service"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
@@ -416,5 +417,130 @@ func TestHandleTaskCreatedWithQueuePromotionPendingRestoresAutoStartOnCreateOnPr
 	requireNoError(t, err)
 	if len(sessions) != 0 {
 		t.Fatalf("ListTaskSessions = %d, want 0 (the injected failure must happen before session persistence)", len(sessions))
+	}
+}
+
+// erroringDependencyReader models a transient DependencyGate read failure,
+// distinct from a genuine dependency block: DependencyGate itself errors, so
+// dependencyBlocksAutoStart fails closed with gateErrored=true regardless of
+// whether the task has any dependency edges at all.
+type erroringDependencyReader struct {
+	err error
+}
+
+func (r *erroringDependencyReader) DependencyGate(context.Context, string) (bool, string, error) {
+	return false, "", r.err
+}
+
+func (r *erroringDependencyReader) ListDependentTaskIDs(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (r *erroringDependencyReader) ListPendingDependencyLaunches(context.Context) ([]taskservice.PendingDependencyLaunch, error) {
+	return nil, nil
+}
+
+// TestAutoStartTaskForStepRestoresAutoStartOnCreateOnDependencyGateError covers
+// Review Round 2's F4: autoStartTaskForStep's dependency gate is its third
+// early return, and unlike the other two (GetTask, GetStep failures, both
+// already fixed), it did not restore MetaKeyAutoStartOnCreate when
+// autoStartOnCreateClaimed was true. handleTaskCreated already removes the key
+// before dispatching here, and the startup sweep discovers candidates only by
+// that key's existence — so a DependencyGate read failure (not a genuine
+// block) stranded the task permanently: it has no dependency edge for
+// reconcileDependencyLaunchesOnStartup to find, and no other path re-lists it.
+//
+// A genuine block is deliberately NOT covered by this restore (see
+// dependencyBlocksAutoStart's gateErrored split): it is already covered by
+// evaluateDependentAfterPredecessorChange / reconcileDependencyLaunchesOnStartup
+// once the dependency resolves, so restoring there would only burn
+// recoverTaskLifecycleAttempt's bounded retry budget on every startup for as
+// long as the task stays blocked.
+func TestAutoStartTaskForStepRestoresAutoStartOnCreateOnDependencyGateError(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+
+	metadata := map[string]interface{}{
+		models.MetaKeyAutoStartOnCreate: true,
+		models.MetaKeyAgentProfileID:    "routine-assignee",
+	}
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:             "t-dependency-gate-error",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		Title:          "Routine run",
+		Description:    "prompt",
+		State:          v1.TaskStateCreated,
+		Metadata:       metadata,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Routine Start", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{
+				{Type: wfmodels.OnEnterAutoStartAgent},
+			},
+		},
+	}
+
+	launched := make(chan string, 2)
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentProfileID, _ := req.Metadata[models.MetaKeyAgentProfileID].(string)
+			launched <- agentProfileID
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t-dependency-gate-error"] = &v1.Task{
+		ID:          "t-dependency-gate-error",
+		WorkspaceID: "ws1",
+		WorkflowID:  "wf1",
+		Description: "prompt",
+		State:       v1.TaskStateCreated,
+		Metadata:    metadata,
+	}
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+	svc.SetTaskDependencyReader(&erroringDependencyReader{err: errors.New("boom: transient dependency gate failure")})
+
+	svc.handleTaskCreated(ctx, watcher.TaskEventData{TaskID: "t-dependency-gate-error"})
+
+	select {
+	case got := <-launched:
+		t.Fatalf("unexpected launch despite dependency gate error: %q", got)
+	default:
+	}
+
+	reloaded, err := repo.GetTask(ctx, "t-dependency-gate-error")
+	requireNoError(t, err)
+	if !models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("MetaKeyAutoStartOnCreate was not restored after a DependencyGate error; the task is stranded with no dependency edge for reconcileDependencyLaunchesOnStartup to find and no other marker for the next sweep")
+	}
+	sessions, err := repo.ListTaskSessions(ctx, "t-dependency-gate-error")
+	requireNoError(t, err)
+	if len(sessions) != 0 {
+		t.Fatalf("ListTaskSessions = %d, want 0 (the dependency gate must block before any session is created)", len(sessions))
+	}
+
+	// Clear the injected failure and let a subsequent startup sweep retry using
+	// the restored token.
+	svc.SetTaskDependencyReader(&resolvedDependencyReader{})
+
+	svc.reconcileTaskLifecycleTokens(ctx)
+
+	select {
+	case got := <-launched:
+		if got != "routine-assignee" {
+			t.Fatalf("AgentProfileID = %q, want routine-assignee", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the retried auto-start launch")
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
@@ -334,3 +334,87 @@ func TestHandleTaskCreatedRestoresAutoStartOnCreateOnPreSessionFailure(t *testin
 		t.Fatal("timed out waiting for the retried auto-start launch")
 	}
 }
+
+// TestHandleTaskCreatedWithQueuePromotionPendingRestoresAutoStartOnCreateOnPreSessionFailure
+// covers Review Round 1's F1: a task carrying BOTH MetaKeyAutoStartOnCreate and
+// MetaKeyQueuePromotionPending reaches handleTaskCreated (as recoverAutoStartOnCreate's
+// replay does), which claims MetaKeyAutoStartOnCreate and calls autoStartTaskForStep
+// with autoStartOnCreateClaimed=true. autoStartTaskForStep sees the promotion
+// token and redirects into the queue-promotion handler; before the fix that
+// redirect dropped autoStartOnCreateClaimed, so claimAutoStartOnCreateForLaunch
+// saw the (already-removed) key as unclaimed and a pre-session StartTask
+// failure restored MetaKeyQueuePromotionPending but never
+// MetaKeyAutoStartOnCreate, stranding the task on exactly the recovery path
+// this card exists to close.
+func TestHandleTaskCreatedWithQueuePromotionPendingRestoresAutoStartOnCreateOnPreSessionFailure(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+
+	metadata := map[string]interface{}{
+		models.MetaKeyAutoStartOnCreate:     true,
+		models.MetaKeyQueuePromotionPending: true,
+		models.MetaKeyAgentProfileID:        "routine-assignee",
+	}
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:             "t-promotion-and-create",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		WIPAdmitted:    true,
+		Title:          "Promoted routine run",
+		Description:    "prompt",
+		State:          v1.TaskStateTODO,
+		Metadata:       metadata,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Routine Start", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{
+				{Type: wfmodels.OnEnterAutoStartAgent},
+			},
+		},
+	}
+
+	launched := make(chan string, 2)
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentProfileID, _ := req.Metadata[models.MetaKeyAgentProfileID].(string)
+			launched <- agentProfileID
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.getTaskErr = errors.New("boom: transient task lookup failure")
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+
+	svc.handleTaskCreated(ctx, watcher.TaskEventData{TaskID: "t-promotion-and-create"})
+
+	waitForAutoStartFailedMarker(t, repo, ctx, "t-promotion-and-create")
+
+	select {
+	case got := <-launched:
+		t.Fatalf("unexpected launch despite pre-session task lookup failure: %q", got)
+	default:
+	}
+
+	reloaded, err := repo.GetTask(ctx, "t-promotion-and-create")
+	requireNoError(t, err)
+	if !models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("MetaKeyAutoStartOnCreate was not restored after a pre-session StartTask failure reached through the queue-promotion redirect")
+	}
+	if _, pending := reloaded.Metadata[models.MetaKeyQueuePromotionPending]; !pending {
+		t.Fatal("MetaKeyQueuePromotionPending was not restored after the pre-session StartTask failure")
+	}
+	sessions, err := repo.ListTaskSessions(ctx, "t-promotion-and-create")
+	requireNoError(t, err)
+	if len(sessions) != 0 {
+		t.Fatalf("ListTaskSessions = %d, want 0 (the injected failure must happen before session persistence)", len(sessions))
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
@@ -313,7 +313,12 @@ func TestHandleTaskCreatedRestoresAutoStartOnCreateOnPreSessionFailure(t *testin
 	}
 
 	// Clear the injected failure and let a subsequent startup sweep retry
-	// using the restored token.
+	// using the restored token. Locked because the first launch attempt's
+	// detached goroutine (see autoStartTaskForLoadedStep) can still be
+	// finishing unrelated work on taskRepo after waitForAutoStartFailedMarker
+	// observes the marker on the separate repo above; GetTask takes the same
+	// lock on its read side.
+	taskRepo.mu.Lock()
 	taskRepo.getTaskErr = nil
 	taskRepo.tasks["t-pre-session-failure"] = &v1.Task{
 		ID:          "t-pre-session-failure",
@@ -323,6 +328,7 @@ func TestHandleTaskCreatedRestoresAutoStartOnCreateOnPreSessionFailure(t *testin
 		State:       v1.TaskStateCreated,
 		Metadata:    metadata,
 	}
+	taskRepo.mu.Unlock()
 
 	svc.reconcileTaskLifecycleTokens(ctx)
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_auto_start_recovery_test.go
@@ -1,0 +1,336 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// This file covers the two latent auto-start recovery defects filed as a
+// sibling of WO-36.1: a replay double-launch race between the queue-promotion
+// lifecycle token and the create-time auto-start opt-in (Gap A), and a
+// pre-session StartTask failure that stranded the create-time opt-in with no
+// durable marker (Gap B). Both are fixed by the same mechanism: the opt-in
+// is claimed synchronously by the launch attempt itself (autoStartTaskForLoadedStep,
+// via claimAutoStartOnCreateForLaunch), not merely observed, and restored on
+// failure (handleAutoStartFailure) exactly like the existing queue-promotion
+// token.
+
+// TestRecoverTaskLifecycleAttemptConcurrentPromotionAndAutoStartOnCreateLaunchesOnce
+// covers Gap A: recoverTaskLifecycleAttempt used to evaluate
+// autoStartOnCreateActionable against the SAME in-memory task it loaded at
+// the top of the function, without re-fetching after the queue-promotion
+// branch ran. handleTaskQueuePromoted's no-session path schedules a launch
+// through autoStartTaskForLoadedStep, but that launch's actual session
+// creation happens in a detached goroutine — so a stale read could still see
+// MetaKeyAutoStartOnCreate present and schedule a second, redundant launch via
+// recoverAutoStartOnCreate.
+//
+// The fix makes the race structural rather than timing-dependent:
+// autoStartTaskForLoadedStep claims MetaKeyAutoStartOnCreate synchronously,
+// before spawning its launch goroutine, and recoverTaskLifecycleAttempt
+// re-fetches the task after the promotion branch. So by the time
+// autoStartOnCreateActionable evaluates, the token is already gone.
+func TestRecoverTaskLifecycleAttemptConcurrentPromotionAndAutoStartOnCreateLaunchesOnce(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+
+	metadata := map[string]interface{}{
+		models.MetaKeyQueuePromotionPending: true,
+		models.MetaKeyAutoStartOnCreate:     true,
+		models.MetaKeyAgentProfileID:        "routine-assignee",
+	}
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:             "t-race",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		WIPAdmitted:    true,
+		Title:          "Concurrent tokens",
+		Description:    "prompt",
+		State:          v1.TaskStateTODO,
+		Metadata:       metadata,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Auto Start Step", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{
+				{Type: wfmodels.OnEnterAutoStartAgent},
+			},
+		},
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t-race"] = &v1.Task{
+		ID:          "t-race",
+		WorkspaceID: "ws1",
+		WorkflowID:  "wf1",
+		Description: "prompt",
+		State:       v1.TaskStateTODO,
+		Metadata:    metadata,
+	}
+	launched := make(chan string, 4)
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentProfileID, _ := req.Metadata[models.MetaKeyAgentProfileID].(string)
+			launched <- agentProfileID
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+
+	svc.recoverTaskLifecycleAttempt(ctx, "t-race")
+
+	select {
+	case got := <-launched:
+		if got != "routine-assignee" {
+			t.Fatalf("AgentProfileID = %q, want routine-assignee", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the auto-start launch")
+	}
+	// Settle window: prove no second launch follows the first, rather than
+	// just reading one value off the channel and declaring victory.
+	select {
+	case got := <-launched:
+		t.Fatalf("unexpected second launch for agent profile %q", got)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	sessions, err := repo.ListTaskSessions(ctx, "t-race")
+	requireNoError(t, err)
+	if len(sessions) != 1 {
+		t.Fatalf("ListTaskSessions(t-race) = %d sessions, want 1", len(sessions))
+	}
+}
+
+// TestRecoverTaskLifecycleAttemptConcurrentPromotionLaunchesOnceWithoutWorkspaceBindingElection
+// covers the same Gap A race, but on the session-create route that does NOT
+// go through CreateTaskSessionWithWorkspaceBinding's election
+// (executor_execute.go: bindWorkspace && !taskUsesDeferredEnvironmentInheritance).
+// Today that election is what accidentally limits the race to one launch on
+// the ordinary path: the loser's session-create call fails with "workspace is
+// preparing", and handleAutoStartFailure restores the promotion token for the
+// next sweep to converge. A task using workspace.mode=inherit_parent takes the
+// CreateTaskSessionWithInitialRuntimeSeed / plain CreateTaskSession route
+// instead, neither of which enforces per-task session uniqueness — so this is
+// the test that proves the actual fix (the synchronous token claim), not the
+// incidental mitigation.
+func TestRecoverTaskLifecycleAttemptConcurrentPromotionLaunchesOnceWithoutWorkspaceBindingElection(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "t-race-parent", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "step1",
+		Title: "Parent", State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now,
+	}))
+	// ExecutorType intentionally left empty: the child launch below resolves
+	// no executor either (no MetaKeyExecutorID, no default configured in this
+	// test harness), and LaunchPreparedSession rejects an inherited
+	// environment whose non-empty ExecutorType disagrees with the launch's
+	// resolved one (executor_execute.go's workspace-reuse-unsafe guard).
+	requireNoError(t, repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: "env-parent", TaskID: "t-race-parent",
+		Status: models.TaskEnvironmentStatusReady,
+	}))
+	requireNoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "ps1", TaskID: "t-race-parent", State: models.TaskSessionStateRunning,
+		IsPrimary: true, TaskEnvironmentID: "env-parent", StartedAt: now, UpdatedAt: now,
+	}))
+
+	metadata := map[string]interface{}{
+		models.MetaKeyQueuePromotionPending: true,
+		models.MetaKeyAutoStartOnCreate:     true,
+		models.MetaKeyAgentProfileID:        "routine-assignee",
+		"workspace":                         map[string]interface{}{"mode": "inherit_parent"},
+	}
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:             "t-race-child",
+		ParentID:       "t-race-parent",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		WIPAdmitted:    true,
+		Title:          "Concurrent tokens, inherited workspace",
+		Description:    "prompt",
+		State:          v1.TaskStateTODO,
+		Metadata:       metadata,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Auto Start Step", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{
+				{Type: wfmodels.OnEnterAutoStartAgent},
+			},
+		},
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t-race-child"] = &v1.Task{
+		ID:          "t-race-child",
+		ParentID:    "t-race-parent",
+		WorkspaceID: "ws1",
+		WorkflowID:  "wf1",
+		Description: "prompt",
+		State:       v1.TaskStateTODO,
+		Metadata:    metadata,
+	}
+	launched := make(chan string, 4)
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentProfileID, _ := req.Metadata[models.MetaKeyAgentProfileID].(string)
+			launched <- agentProfileID
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+
+	svc.recoverTaskLifecycleAttempt(ctx, "t-race-child")
+
+	select {
+	case got := <-launched:
+		if got != "routine-assignee" {
+			t.Fatalf("AgentProfileID = %q, want routine-assignee", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the auto-start launch")
+	}
+	select {
+	case got := <-launched:
+		t.Fatalf("unexpected second launch for agent profile %q", got)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	sessions, err := repo.ListTaskSessions(ctx, "t-race-child")
+	requireNoError(t, err)
+	if len(sessions) != 1 {
+		t.Fatalf("ListTaskSessions(t-race-child) = %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].TaskEnvironmentID != "env-parent" {
+		t.Fatalf("session TaskEnvironmentID = %q, want env-parent (inherited, non-bindWorkspace route confirms this isn't the workspace-binding election doing the work)", sessions[0].TaskEnvironmentID)
+	}
+}
+
+// TestHandleTaskCreatedRestoresAutoStartOnCreateOnPreSessionFailure covers Gap
+// B: handleTaskCreated claims (removes) MetaKeyAutoStartOnCreate synchronously
+// before handing the launch to autoStartTaskForLoadedStep's detached
+// goroutine. Before this fix, handleAutoStartFailure restored
+// MetaKeyAutoStartGuard and MetaKeyQueuePromotionPending on failure but never
+// MetaKeyAutoStartOnCreate, so a StartTask failure before a session exists
+// stranded the task with no durable marker for the next startup sweep to
+// find.
+//
+// getTaskErr fails scheduler.GetTask, which startTask calls after resolving
+// the target step but before prepareSessionForStart creates any session row
+// — a deterministic pre-session failure, no sleep-and-hope.
+func TestHandleTaskCreatedRestoresAutoStartOnCreateOnPreSessionFailure(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+	requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+
+	metadata := map[string]interface{}{
+		models.MetaKeyAutoStartOnCreate: true,
+		models.MetaKeyAgentProfileID:    "routine-assignee",
+	}
+	requireNoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:             "t-pre-session-failure",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		Title:          "Routine run",
+		Description:    "prompt",
+		State:          v1.TaskStateCreated,
+		Metadata:       metadata,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Routine Start", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{
+				{Type: wfmodels.OnEnterAutoStartAgent},
+			},
+		},
+	}
+
+	launched := make(chan string, 2)
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			agentProfileID, _ := req.Metadata[models.MetaKeyAgentProfileID].(string)
+			launched <- agentProfileID
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.getTaskErr = errors.New("boom: transient task lookup failure")
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+
+	svc.handleTaskCreated(ctx, watcher.TaskEventData{TaskID: "t-pre-session-failure"})
+
+	waitForAutoStartFailedMarker(t, repo, ctx, "t-pre-session-failure")
+
+	select {
+	case got := <-launched:
+		t.Fatalf("unexpected launch despite pre-session task lookup failure: %q", got)
+	default:
+	}
+
+	reloaded, err := repo.GetTask(ctx, "t-pre-session-failure")
+	requireNoError(t, err)
+	if !models.HasAutoStartOnCreateIntent(reloaded.Metadata) {
+		t.Fatal("MetaKeyAutoStartOnCreate was not restored after a pre-session StartTask failure; the task is stranded with no durable marker for the next startup sweep")
+	}
+	sessions, err := repo.ListTaskSessions(ctx, "t-pre-session-failure")
+	requireNoError(t, err)
+	if len(sessions) != 0 {
+		t.Fatalf("ListTaskSessions = %d, want 0 (the injected failure must happen before session persistence)", len(sessions))
+	}
+
+	// Clear the injected failure and let a subsequent startup sweep retry
+	// using the restored token.
+	taskRepo.getTaskErr = nil
+	taskRepo.tasks["t-pre-session-failure"] = &v1.Task{
+		ID:          "t-pre-session-failure",
+		WorkspaceID: "ws1",
+		WorkflowID:  "wf1",
+		Description: "prompt",
+		State:       v1.TaskStateCreated,
+		Metadata:    metadata,
+	}
+
+	svc.reconcileTaskLifecycleTokens(ctx)
+
+	select {
+	case got := <-launched:
+		if got != "routine-assignee" {
+			t.Fatalf("AgentProfileID = %q, want routine-assignee", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the retried auto-start launch")
+	}
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -591,6 +591,13 @@ type Service struct {
 	passthroughDispatchMu sync.Mutex
 	passthroughDispatches map[string]map[*passthroughDispatchToken]struct{}
 
+	// autoStartOnCreateMu serializes the local ownership hand-off for the
+	// durable auto-start-on-create marker. The database marker survives a
+	// process restart; this map prevents recovery and event delivery from
+	// reclaiming the same marker while its detached launch is still running.
+	autoStartOnCreateMu       sync.Mutex
+	autoStartOnCreateInFlight map[string]struct{}
+
 	// Message creator for saving agent responses
 	messageCreator MessageCreator
 
@@ -1500,6 +1507,7 @@ func NewService(
 		executor:                     exec,
 		scheduler:                    sched,
 		messageQueue:                 msgQueue,
+		autoStartOnCreateInFlight:    make(map[string]struct{}),
 		taskLaunchRecoveryRepo:       taskLaunchRecoveryRepo,
 		clarificationWatchdogTimeout: 15 * time.Second,
 		gitSnapshotCache:             newGitSnapshotCache(),

--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -271,14 +271,26 @@ func (s *Service) isPassthroughProfile(ctx context.Context, profileID string) bo
 	return info.CLIPassthrough
 }
 
+// blocksAutoStartLaunch reports whether an auto-start request must be
+// downgraded to a prepare, either because the task's current step does not
+// allow it or because it has an unresolved dependency. The dependency gate's
+// launch-token restore concern does not apply here: this path owns no
+// lifecycle token to restore.
+func (s *Service) blocksAutoStartLaunch(ctx context.Context, req *LaunchSessionRequest) bool {
+	if s.shouldBlockAutoStart(ctx, req) {
+		return true
+	}
+	blocked, _ := s.dependencyBlocksAutoStart(ctx, req.TaskID, "session.launch")
+	return blocked
+}
+
 // launchStart creates a new session and launches the agent.
 // If the request is an auto-start and the task's current workflow step does not
 // have auto_start_agent, or the task has unresolved dependencies, the request
 // is downgraded to a prepare (workspace-only, no agent) to prevent unwanted
 // auto-starts from the frontend's useAutoStartSession hook.
 func (s *Service) launchStart(ctx context.Context, req *LaunchSessionRequest) (*LaunchSessionResponse, error) {
-	if req.AutoStart && (s.shouldBlockAutoStart(ctx, req) ||
-		s.dependencyBlocksAutoStart(ctx, req.TaskID, "session.launch")) {
+	if req.AutoStart && s.blocksAutoStartLaunch(ctx, req) {
 		req.LaunchWorkspace = true
 		return s.launchPrepare(ctx, req)
 	}

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -215,6 +215,12 @@ const (
 	// whose Routine workflow start step has no other transition to carry it
 	// into an auto_start_agent evaluation.
 	MetaKeyAutoStartOnCreate = "auto_start_on_create"
+	// MetaKeyAutoStartOnCreateInFlight is a durable hand-off marker for an
+	// auto-start-on-create launch. The original intent is consumed before the
+	// detached launch starts, but this marker remains until a session or run
+	// is durable. That lets startup recovery retry a process that exits in the
+	// gap instead of losing the last recovery signal.
+	MetaKeyAutoStartOnCreateInFlight = "auto_start_on_create_in_flight"
 	// MetaKeyStepHandoffCarry is a single-slot, task-scoped token carrying one
 	// consuming transition's completion handoff exactly one hop, to the next
 	// step's first dispatched prompt. Its value is a StepHandoffCarryToken.
@@ -261,6 +267,15 @@ func IsAgentTitleOwner(metadata map[string]interface{}, sessionID string) bool {
 func HasAutoStartOnCreateIntent(metadata map[string]interface{}) bool {
 	intent, ok := metadata[MetaKeyAutoStartOnCreate].(bool)
 	return ok && intent
+}
+
+// HasAutoStartOnCreateInFlight reports whether a launch attempt still owns
+// the durable hand-off marker for a create-time auto-start. Only an explicit
+// true value counts; JSON rehydration and in-process callers use the same
+// representation as the other lifecycle markers.
+func HasAutoStartOnCreateInFlight(metadata map[string]interface{}) bool {
+	inFlight, ok := metadata[MetaKeyAutoStartOnCreateInFlight].(bool)
+	return ok && inFlight
 }
 
 // TaskSession.Metadata key that records how the session came into existence.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3529/0e596f4a91bb.html)
<!-- kandev-pr-walkthrough-end -->

A task that opts in to auto-launch the moment it is created leans on the startup-recovery sweep to retry that launch after a crash or restart. Two races in that sweep make the retry unsafe: one can fire the same task's launch twice, the other can drop the auto-start intent for good, leaving the task stuck at zero sessions with no path back.

**Today:** Neither race fires yet — the only producer of the auto-start-on-create marker (`CreateOfficeTaskInWorkflow`, via the Routine workflow) never hits either recovery branch, since that workflow has no WIP limit and disallows manual moves. But the sweep code that would mishandle them already ships.
**After this:** The auto-start marker is claimed atomically by whichever recovery attempt actually launches, and restored if that attempt fails before a session exists — so a retry sweep can no longer double-launch or silently lose the intent.
**Who hits this:** Nobody today. It activates the moment a second producer sets the auto-start-on-create marker, or the Routine workflow gains a WIP limit or manual moves — this closes the gap before either lands.
**Scope:** standalone hardening fix, filed as a sibling of #2967 (`WO-36`, "Heavy routine task never starts") because this platform's task nesting is capped at depth 1.
**Not here:** two smaller residual gaps surfaced during review are deliberately deferred to follow-up cards rather than folded in here (see Possible Improvements) — one is a claim-failure edge case that degrades to the pre-existing timing race rather than regressing anything, the other requires a task shape (`MetaKeyDeferredLaunch` + `MetaKeyAutoStartOnCreate` together) that no producer can create today.

## Important Changes

- Claim the auto-start-on-create marker synchronously, before the launch goroutine starts, instead of after — closing the window where two recovery branches could both decide to launch.
- Restore the marker on a pre-session launch failure, mirroring how the existing queue-promotion token is already restored, so a crash before session creation doesn't strand the task.
- Re-fetch the task inside the lifecycle-recovery sweep after any branch that may have claimed the marker, so a later branch in the same attempt sees current state.
- Thread an explicit "already claimed by this attempt" flag through the call chain so only the original launch path can restore its own token, never a different caller's.

## Validation

- `go build ./...` — clean.
- `go test ./internal/orchestrator/... -count=1 -timeout 20m` — full package green, run twice after rebase onto current `main` (169s, plus an earlier 432s run under heavy shared-machine load); an additional `-race` run over the 7 new/changed tests also passed with no data race.
- `golangci-lint run ./internal/orchestrator/...` and full-repo `make lint` — both `0 issues`.
- `gofmt -l` over changed files — clean.
- `make lint-format` and `cd apps/web && pnpm run i18n:ratchet` — clean (backend-only diff, no UI source touched).
- Two review rounds (this platform's own review skill plus an independent cross-vendor pass) verified the fix against the code; both flagged findings were either not reproducible or explicitly deferred (see Possible Improvements).
- `make typecheck test lint`'s full-repo `go test ./...` surfaced dozens of unrelated failures (`internal/worktree`, `internal/launcher`, `internal/task/service`, etc. — none in the package this PR touches). Reproduced the same failures against this branch's merge-base in a separate scratch worktree, confirming they're pre-existing environmental flakiness on this shared machine, not caused by this change.

## Possible Improvements

Low risk: the change only narrows an already-unreachable race window and adds no new production code paths. Two smaller latent gaps found while reviewing this fix are intentionally out of scope and tracked as follow-up cards: (1) the synchronous claim's own metadata write can itself fail, which degrades back to the pre-existing timing race rather than introducing a new failure mode; (2) a deferred-launch task carrying the auto-start marker would skip the claim entirely, but no code path can currently produce that task shape.

Screenshots do not apply — this is a backend-only change with no UI-visible surface (`apps/web/` is untouched).

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->