### PR TITLE
fix(office): keep budget alerts honest when a policy changes mid-check

### DIFF
--- a/apps/backend/internal/office/costs/budget_claim_metrics.go
+++ b/apps/backend/internal/office/costs/budget_claim_metrics.go
@@ -1,0 +1,17 @@
+package costs
+
+import "expvar"
+
+// budgetClaimFailuresTotal counts claim-store failures encountered while
+// evaluating a budget policy, exported through the stdlib expvar surface at
+// /debug/vars in dev mode. Shaped as an expvar.Map, matching
+// cost_events_written_total / cost_events_dropped_total in
+// internal/office/service/cost_metrics.go, rather than a plain Int, so
+// /debug/vars stays consistent. The "op" label has exactly one value,
+// "claim": it covers both a policy's own level claim and its companion
+// alert claim, and does not grow — a failed claim discard during a policy
+// update is a different, already non-silent failure and is deliberately
+// not counted here.
+var budgetClaimFailuresTotal = expvar.NewMap("budget_claim_failures_total")
+
+const budgetClaimFailureLabel = "op=claim"

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -246,6 +246,49 @@ func TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue(t *testing.T) 
 	}
 }
 
+// TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsTwicePerEval
+// extends TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue to the
+// exceeded level: claimAndEmit's afterClaim hook claims the alert-level
+// companion right after the exceeded-level claim, so a broken store fails
+// both claim attempts once per evaluation (AC-OFFICE-COSTS-002.14).
+func TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsTwicePerEval(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-fault-exc")
+	injected := errors.New("injected claim store failure")
+	faulty := &claimFaultRepo{Repository: repo, failLevels: map[string]error{
+		"alert":    injected,
+		"exceeded": injected,
+	}}
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(faulty, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-fault-exc", 500)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-fault-exc", "task-1", 600) // >= limit
+
+	before := claimFailureCount(t)
+	for i := 0; i < 2; i++ {
+		results, err := svc.CheckBudget(ctx, "ws-1", "agent-fault-exc", "proj-1")
+		if err != nil {
+			t.Fatalf("CheckBudget[%d]: %v", i, err)
+		}
+		if !results[0].ExceededSubmitted {
+			t.Fatalf("eval %d: ExceededSubmitted=false, want true (fail-open)", i)
+		}
+	}
+	if got := spy.count("budget.exceeded"); got != 2 {
+		t.Fatalf("budget.exceeded = %d, want 2 (duplicates permitted under broken store)", got)
+	}
+	// exceeded claim + companion alert claim both fail => 2 increments per evaluation.
+	if delta := claimFailureCount(t) - before; delta != 4 {
+		t.Fatalf("budget_claim_failures_total delta = %d, want 4 (2 per exceeded eval)", delta)
+	}
+}
+
 // TestCheckBudget_AlreadyClaimedMiss_NoFailureCounterDelta covers the
 // AC-OFFICE-COSTS-002.14a half of the failure counter: a Claim call
 // returning (claimed=false, err=nil) — whether because an earlier

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -3,6 +3,7 @@ package costs_test
 import (
 	"context"
 	"errors"
+	"expvar"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,31 @@ import (
 	"github.com/kandev/kandev/internal/office/costs"
 	"github.com/kandev/kandev/internal/office/models"
 )
+
+// claimFailureCount reads the current value of budget_claim_failures_total's
+// "op=claim" entry. Tests must compare before/after deltas, never the
+// absolute value: the expvar.Map is process-global and accumulates across
+// every test in this package.
+func claimFailureCount(t *testing.T) int64 {
+	t.Helper()
+	v := expvar.Get("budget_claim_failures_total")
+	if v == nil {
+		return 0
+	}
+	m, ok := v.(*expvar.Map)
+	if !ok {
+		t.Fatalf("budget_claim_failures_total is not an expvar.Map, got %T", v)
+	}
+	kv := m.Get("op=claim")
+	if kv == nil {
+		return 0
+	}
+	iv, ok := kv.(*expvar.Int)
+	if !ok {
+		t.Fatalf("op=claim counter is not an expvar.Int, got %T", kv)
+	}
+	return iv.Value()
+}
 
 // REQ-OFFICE-COSTS-002: budget notifications fire on crossings, not on
 // every evaluation. See docs/specs/office/requirements/costs.md and
@@ -199,6 +225,8 @@ func TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue(t *testing.T) 
 	}
 	insertBudgetTestCostEvent(t, execSQL, "agent-fault", "task-1", 850)
 
+	before := claimFailureCount(t)
+
 	// Two evaluations, both against the always-failing claim store: a
 	// broken store degrades to duplicate notifications, never to silence.
 	for i := 0; i < 2; i++ {
@@ -212,6 +240,130 @@ func TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue(t *testing.T) 
 	}
 	if got := spy.count("budget.alert"); got != 2 {
 		t.Fatalf("budget.alert submissions under a faulted store = %d, want 2 (duplicates permitted)", got)
+	}
+	if delta := claimFailureCount(t) - before; delta != 2 {
+		t.Fatalf("budget_claim_failures_total delta = %d, want 2 (AC-OFFICE-COSTS-002.14: one per faulted evaluation)", delta)
+	}
+}
+
+// TestCheckBudget_AlreadyClaimedMiss_NoFailureCounterDelta covers the
+// AC-OFFICE-COSTS-002.14a half of the failure counter: a Claim call
+// returning (claimed=false, err=nil) — whether because an earlier
+// evaluation already holds it or because the referenced policy was deleted
+// mid-evaluation (a foreign-key violation, classified identically) — is an
+// ordinary miss, not a claim-store failure, and must not move
+// budget_claim_failures_total.
+func TestCheckBudget_AlreadyClaimedMiss_NoFailureCounterDelta(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-miss")
+	missy := &claimFaultRepo{Repository: repo, missLevels: map[string]bool{"alert": true}}
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(missy, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-miss", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-miss", "task-1", 850)
+
+	before := claimFailureCount(t)
+
+	results, err := svc.CheckBudget(ctx, "ws-1", "agent-miss", "proj-1")
+	if err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+	if results[0].AlertSubmitted {
+		t.Fatal("a (claimed=false, err=nil) miss must not submit")
+	}
+	if got := spy.count("budget.alert"); got != 0 {
+		t.Fatalf("budget.alert submissions = %d, want 0", got)
+	}
+	if delta := claimFailureCount(t) - before; delta != 0 {
+		t.Fatalf("budget_claim_failures_total delta = %d, want 0 (AC-OFFICE-COSTS-002.14a: a miss is not a store failure)", delta)
+	}
+}
+
+// TestCheckBudget_ExceededClaimsCompanionBeforeEmit covers AC-OFFICE-COSTS-002.5's
+// claim-then-emit ordering: costs-03.md's Claim-then-emit step 2 records both
+// the exceeded claim and its alert-level companion before the emission
+// decision. Asserting call order (not just eventual outcome) is what proves
+// the ordering — outcome alone cannot distinguish this from a companion claim
+// recorded after the emit.
+func TestCheckBudget_ExceededClaimsCompanionBeforeEmit(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-order")
+	order := &callOrderRecorder{}
+	orderedRepo := &orderRecordingRepo{Repository: repo, order: order}
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(orderedRepo, logger.Default(), &orderRecordingActivity{order: order}, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-order", 500)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-order", "task-1", 600)
+
+	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-order", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+
+	got := order.snapshot()
+	want := []string{"claim:exceeded", "claim:alert", "emit:budget.exceeded"}
+	if len(got) != len(want) {
+		t.Fatalf("call order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("call order = %v, want %v (both claims must precede the emission)", got, want)
+		}
+	}
+}
+
+// TestCheckBudget_PauseAgent_ReArmsDespiteExistingClaim covers
+// AC-OFFICE-COSTS-002.12: suppressing a notification must not suppress
+// enforcement. An evaluation landing on an already-claimed level must still
+// pause an agent the user has since unpaused.
+func TestCheckBudget_PauseAgent_ReArmsDespiteExistingClaim(t *testing.T) {
+	svc, repo, execSQL := newBudgetTestService(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-rearm")
+
+	policy := newIdempotencyTestPolicy("agent-rearm", 500)
+	policy.ActionOnExceed = "pause_agent"
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-rearm", "task-1", 600)
+
+	first, err := svc.CheckBudget(ctx, "ws-1", "agent-rearm", "proj-1")
+	if err != nil {
+		t.Fatalf("first CheckBudget: %v", err)
+	}
+	if !first[0].AgentPaused {
+		t.Fatal("first evaluation should pause the agent")
+	}
+
+	if err := repo.UpdateAgentStatusFields(ctx, "agent-rearm", "idle", ""); err != nil {
+		t.Fatalf("unpause agent: %v", err)
+	}
+
+	second, err := svc.CheckBudget(ctx, "ws-1", "agent-rearm", "proj-1")
+	if err != nil {
+		t.Fatalf("second CheckBudget: %v", err)
+	}
+	if !second[0].AgentPaused {
+		t.Fatal("second evaluation must still pause the agent despite the level already being claimed")
+	}
+
+	agent, err := repo.GetAgentInstance(ctx, "agent-rearm")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if agent.Status != "paused" {
+		t.Fatalf("agent status = %q, want paused", agent.Status)
 	}
 }
 

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -1,0 +1,382 @@
+package costs_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/office/costs"
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// REQ-OFFICE-COSTS-002: budget notifications fire on crossings, not on
+// every evaluation. See docs/specs/office/requirements/costs.md and
+// docs/specs/office/system-design/costs-03.md / costs-04.md.
+
+func newIdempotencyTestPolicy(scopeID string, limit int64) *models.BudgetPolicy {
+	return &models.BudgetPolicy{
+		WorkspaceID:       "ws-1",
+		ScopeType:         "agent",
+		ScopeID:           scopeID,
+		LimitSubcents:     limit,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "notify_only",
+	}
+}
+
+// monthlyPeriodKey mirrors the RFC3339-UTC month-start rendering the
+// service computes internally, for tests that assert on stored claim rows.
+func monthlyPeriodKey() string {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+}
+
+func TestCheckBudget_EvaluateTwice_AlertEmitsOnce(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-alert-twice")
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(repo, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-alert-twice", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-alert-twice", "task-1", 850)
+
+	first, err := svc.CheckBudget(ctx, "ws-1", "agent-alert-twice", "proj-1")
+	if err != nil {
+		t.Fatalf("first CheckBudget: %v", err)
+	}
+	if !first[0].AlertFired || !first[0].AlertSubmitted {
+		t.Fatalf("first evaluation: AlertFired=%v AlertSubmitted=%v, want true/true", first[0].AlertFired, first[0].AlertSubmitted)
+	}
+
+	second, err := svc.CheckBudget(ctx, "ws-1", "agent-alert-twice", "proj-1")
+	if err != nil {
+		t.Fatalf("second CheckBudget: %v", err)
+	}
+	if !second[0].AlertFired {
+		t.Error("second evaluation should still report the level reached")
+	}
+	if second[0].AlertSubmitted {
+		t.Error("second evaluation must not resubmit an already-claimed level")
+	}
+
+	if got := spy.count("budget.alert"); got != 1 {
+		t.Fatalf("budget.alert submissions = %d, want 1", got)
+	}
+}
+
+func TestCheckBudget_EvaluateTwice_ExceededEmitsOnce(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-exceed-twice")
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(repo, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-exceed-twice", 500)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-exceed-twice", "task-1", 600)
+
+	for i := 0; i < 2; i++ {
+		if _, err := svc.CheckBudget(ctx, "ws-1", "agent-exceed-twice", "proj-1"); err != nil {
+			t.Fatalf("CheckBudget[%d]: %v", i, err)
+		}
+	}
+
+	if got := spy.count("budget.exceeded"); got != 1 {
+		t.Fatalf("budget.exceeded submissions = %d, want 1", got)
+	}
+}
+
+// TestCheckBudget_ExceededClaimsCompanionAlert covers AC-OFFICE-COSTS-002.5
+// on a healthy store: spend jumping straight past the limit still holds
+// the alert-level claim, so a later evaluation landing back in the alert
+// band does not emit a budget.alert describing a spend reduction.
+func TestCheckBudget_ExceededClaimsCompanionAlert(t *testing.T) {
+	repo, queryRow, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-companion")
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(repo, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-companion", 500)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	// Jumps straight past the limit; the alert band is never reached on its
+	// own by a rollup query, only inferred via the companion claim.
+	insertBudgetTestCostEvent(t, execSQL, "agent-companion", "task-1", 600)
+
+	results, err := svc.CheckBudget(ctx, "ws-1", "agent-companion", "proj-1")
+	if err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+	if !results[0].ExceededSubmitted {
+		t.Fatal("expected the exceeded row to be submitted")
+	}
+	if results[0].AlertSubmitted {
+		t.Fatal("the alert-level field must be false: only budget.exceeded was emitted (AC-OFFICE-COSTS-002.13)")
+	}
+
+	var count int
+	if err := queryRow(
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ? AND period_key = ? AND level = 'alert'`,
+		policy.ID, monthlyPeriodKey(),
+	).Scan(&count); err != nil {
+		t.Fatalf("count companion claim: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("companion alert-level claim rows = %d, want 1", count)
+	}
+}
+
+// TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded covers the
+// AC-OFFICE-COSTS-002.5 fault-injection carve-out: when the companion
+// alert-level claim errors, the evaluation still submits budget.exceeded
+// (already earned by the exceeded-level claim) and the failure is logged
+// and counted like any other claim-store error. The test deliberately does
+// NOT assert the companion claim was recorded, per the spec's own
+// instruction — that is the failure this test injects.
+func TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-companion-fault")
+	faulty := &claimFaultRepo{Repository: repo, failLevels: map[string]error{
+		"alert": errors.New("injected companion claim failure"),
+	}}
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(faulty, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-companion-fault", 500)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-companion-fault", "task-1", 600)
+
+	results, err := svc.CheckBudget(ctx, "ws-1", "agent-companion-fault", "proj-1")
+	if err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+	if !results[0].ExceededSubmitted {
+		t.Fatal("budget.exceeded must still be submitted despite the companion claim failure")
+	}
+	if got := spy.count("budget.exceeded"); got != 1 {
+		t.Fatalf("budget.exceeded submissions = %d, want 1", got)
+	}
+}
+
+// TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue covers
+// AC-OFFICE-COSTS-002.14: a claim-store error degrades to emit-anyway, and
+// the result's submitted field is true even though no claim was held — the
+// case a "held the claim and submitted" reading gets backwards.
+func TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-fault")
+	injected := errors.New("injected claim store failure")
+	faulty := &claimFaultRepo{Repository: repo, failLevels: map[string]error{
+		"alert": injected,
+	}}
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(faulty, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-fault", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-fault", "task-1", 850)
+
+	// Two evaluations, both against the always-failing claim store: a
+	// broken store degrades to duplicate notifications, never to silence.
+	for i := 0; i < 2; i++ {
+		results, err := svc.CheckBudget(ctx, "ws-1", "agent-fault", "proj-1")
+		if err != nil {
+			t.Fatalf("CheckBudget[%d]: %v", i, err)
+		}
+		if !results[0].AlertSubmitted {
+			t.Fatalf("evaluation %d: AlertSubmitted = false, want true (fail-open emission)", i)
+		}
+	}
+	if got := spy.count("budget.alert"); got != 2 {
+		t.Fatalf("budget.alert submissions under a faulted store = %d, want 2 (duplicates permitted)", got)
+	}
+}
+
+// TestCheckBudget_ConcurrentEvaluation_EmitsOnce covers
+// AC-OFFICE-COSTS-002.10 on a healthy store: the claim table's primary key
+// resolves the race, so concurrent evaluations of the same policy, period
+// and level submit exactly one activity row.
+func TestCheckBudget_ConcurrentEvaluation_EmitsOnce(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-concurrent")
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(repo, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-concurrent", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-concurrent", "task-1", 850)
+
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := svc.CheckBudget(ctx, "ws-1", "agent-concurrent", "proj-1"); err != nil {
+				t.Errorf("CheckBudget: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := spy.count("budget.alert"); got != 1 {
+		t.Fatalf("budget.alert submissions under concurrent evaluation = %d, want 1", got)
+	}
+}
+
+// TestCheckBudget_PeriodKeyMatchesSpendBoundary covers AC-OFFICE-COSTS-002.6a:
+// the claim recorded for a monthly policy is keyed to the same window
+// boundary the spend rollup used, rendered as RFC3339 UTC.
+func TestCheckBudget_PeriodKeyMatchesSpendBoundary(t *testing.T) {
+	repo, queryRow, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-period")
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(repo, logger.Default(), &noopActivity{}, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-period", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-period", "task-1", 850)
+
+	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-period", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+
+	var gotKey string
+	if err := queryRow(
+		`SELECT period_key FROM office_budget_claims WHERE policy_id = ? AND level = 'alert'`, policy.ID,
+	).Scan(&gotKey); err != nil {
+		t.Fatalf("query claim period_key: %v", err)
+	}
+	if gotKey != monthlyPeriodKey() {
+		t.Fatalf("claim period_key = %q, want %q (must match the spend rollup's boundary)", gotKey, monthlyPeriodKey())
+	}
+}
+
+// TestCheckBudget_LifetimePolicyClaimsLifetimeKey covers the "lifetime"
+// literal branch of AC-OFFICE-COSTS-002.6: a policy whose spend window
+// never resets (period "total") gets a claim that never resets either.
+func TestCheckBudget_LifetimePolicyClaimsLifetimeKey(t *testing.T) {
+	repo, queryRow, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-lifetime")
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(repo, logger.Default(), &noopActivity{}, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-lifetime", 1000)
+	policy.Period = "total"
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-lifetime", "task-1", 850)
+
+	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-lifetime", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+
+	var gotKey string
+	if err := queryRow(
+		`SELECT period_key FROM office_budget_claims WHERE policy_id = ? AND level = 'alert'`, policy.ID,
+	).Scan(&gotKey); err != nil {
+		t.Fatalf("query claim period_key: %v", err)
+	}
+	if gotKey != "lifetime" {
+		t.Fatalf("claim period_key = %q, want %q", gotKey, "lifetime")
+	}
+}
+
+// TestCheckBudget_SpendBelowLevelKeepsExistingClaim covers
+// AC-OFFICE-COSTS-002.15: nothing in the evaluation flow ever releases a
+// claim, even when a later evaluation finds spend below the level it
+// claimed.
+func TestCheckBudget_SpendBelowLevelKeepsExistingClaim(t *testing.T) {
+	repo, _, _ := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-keep-claim")
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(repo, logger.Default(), &noopActivity{}, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-keep-claim", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	periodKey := monthlyPeriodKey()
+	if claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert"); err != nil || !claimed {
+		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
+	}
+
+	// No cost events: spend is 0, well below the alert level, so this
+	// evaluation takes the "no claim, no emission" branch entirely.
+	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-keep-claim", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+
+	claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert")
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if claimed {
+		t.Fatal("existing claim must survive an evaluation where spend does not reach the level")
+	}
+}
+
+// TestCheckPreExecutionBudget_StillDeniesAfterAlreadyClaimed covers
+// AC-OFFICE-COSTS-002.12: suppressing a notification must not suppress
+// enforcement. block_new_tasks keeps denying on every subsequent check
+// regardless of whether a claim already exists.
+func TestCheckPreExecutionBudget_StillDeniesAfterAlreadyClaimed(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-enforce")
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(repo, logger.Default(), &noopActivity{}, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-enforce", 500)
+	policy.ActionOnExceed = "block_new_tasks"
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-enforce", "task-1", 600)
+
+	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-enforce", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+
+	allowed, reason, err := svc.CheckPreExecutionBudget(ctx, "agent-enforce", "", "ws-1")
+	if err != nil {
+		t.Fatalf("CheckPreExecutionBudget: %v", err)
+	}
+	if allowed {
+		t.Errorf("block_new_tasks must still deny once the notification is already claimed; reason=%q", reason)
+	}
+}

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -168,12 +168,14 @@ func TestCheckBudget_ExceededClaimsCompanionAlert(t *testing.T) {
 }
 
 // TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded covers the
-// AC-OFFICE-COSTS-002.5 fault-injection carve-out: when the companion
-// alert-level claim errors, the evaluation still submits budget.exceeded
-// (already earned by the exceeded-level claim) and the failure is logged
-// and counted like any other claim-store error. The test deliberately does
-// NOT assert the companion claim was recorded, per the spec's own
-// instruction — that is the failure this test injects.
+// AC-OFFICE-COSTS-003.10 fault-injection case: when the companion
+// alert-level insert errors, the whole atomic pair rolls back — no exceeded
+// claim row survives either — but the evaluation still submits
+// budget.exceeded (already earned by the exceeded-level insert winning
+// before the rollback) and the pair failure is logged and counted exactly
+// once, not once per row. The test deliberately does NOT assert the
+// companion claim was recorded, per the spec's own instruction — that is
+// the failure this test injects.
 func TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded(t *testing.T) {
 	repo, _, execSQL := newBudgetTestRepo(t)
 	ctx := context.Background()
@@ -191,6 +193,7 @@ func TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded(t *testing.T)
 	}
 	insertBudgetTestCostEvent(t, execSQL, "agent-companion-fault", "task-1", 600)
 
+	before := claimFailureCount(t)
 	results, err := svc.CheckBudget(ctx, "ws-1", "agent-companion-fault", "proj-1")
 	if err != nil {
 		t.Fatalf("CheckBudget: %v", err)
@@ -200,6 +203,9 @@ func TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded(t *testing.T)
 	}
 	if got := spy.count("budget.exceeded"); got != 1 {
 		t.Fatalf("budget.exceeded submissions = %d, want 1", got)
+	}
+	if delta := claimFailureCount(t) - before; delta != 1 {
+		t.Fatalf("budget_claim_failures_total delta = %d, want 1 (the pair is one claim attempt)", delta)
 	}
 }
 
@@ -246,12 +252,14 @@ func TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue(t *testing.T) 
 	}
 }
 
-// TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsTwicePerEval
+// TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsOncePerEval
 // extends TestCheckBudget_ClaimStoreFault_EmitsAndReportsSubmittedTrue to the
-// exceeded level: claimAndEmit's afterClaim hook claims the alert-level
-// companion right after the exceeded-level claim, so a broken store fails
-// both claim attempts once per evaluation (AC-OFFICE-COSTS-002.14).
-func TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsTwicePerEval(t *testing.T) {
+// exceeded level: AC-OFFICE-COSTS-003.10 makes the exceeded claim and its
+// alert-level companion one atomic attempt, so a broken store fails the
+// whole pair exactly once per evaluation — one log line, one counter
+// increment (AC-OFFICE-COSTS-003.14 amends AC-OFFICE-COSTS-002.14 to say
+// so), not once per row as it would if the two claims were independent.
+func TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsOncePerEval(t *testing.T) {
 	repo, _, execSQL := newBudgetTestRepo(t)
 	ctx := context.Background()
 	createBudgetTestAgent(t, repo, "ws-1", "agent-fault-exc")
@@ -283,9 +291,8 @@ func TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsTwicePerEval(t *
 	if got := spy.count("budget.exceeded"); got != 2 {
 		t.Fatalf("budget.exceeded = %d, want 2 (duplicates permitted under broken store)", got)
 	}
-	// exceeded claim + companion alert claim both fail => 2 increments per evaluation.
-	if delta := claimFailureCount(t) - before; delta != 4 {
-		t.Fatalf("budget_claim_failures_total delta = %d, want 4 (2 per exceeded eval)", delta)
+	if delta := claimFailureCount(t) - before; delta != 2 {
+		t.Fatalf("budget_claim_failures_total delta = %d, want 2 (1 per exceeded eval, the pair is one claim attempt)", delta)
 	}
 }
 
@@ -526,7 +533,7 @@ func TestCheckBudget_SpendBelowLevelKeepsExistingClaim(t *testing.T) {
 	}
 
 	periodKey := monthlyPeriodKey()
-	if claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert"); err != nil || !claimed {
+	if claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert", policy.Revision); err != nil || !claimed {
 		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
 	}
 
@@ -536,7 +543,7 @@ func TestCheckBudget_SpendBelowLevelKeepsExistingClaim(t *testing.T) {
 		t.Fatalf("CheckBudget: %v", err)
 	}
 
-	claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert")
+	claimed, err := repo.Claim(ctx, policy.ID, periodKey, "alert", policy.Revision)
 	if err != nil {
 		t.Fatalf("re-claim: %v", err)
 	}

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -148,6 +148,10 @@ func TestCheckBudget_ExceededClaimsCompanionAlert(t *testing.T) {
 	// own by a rollup query, only inferred via the companion claim.
 	insertBudgetTestCostEvent(t, execSQL, "agent-companion", "task-1", 600)
 
+	// Captured before CheckBudget so this assertion can't compute a
+	// different month boundary than the evaluation did if the two calls
+	// straddle a UTC month rollover.
+	periodKey := monthlyPeriodKey()
 	results, err := svc.CheckBudget(ctx, "ws-1", "agent-companion", "proj-1")
 	if err != nil {
 		t.Fatalf("CheckBudget: %v", err)
@@ -162,7 +166,7 @@ func TestCheckBudget_ExceededClaimsCompanionAlert(t *testing.T) {
 	var count int
 	if err := queryRow(
 		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ? AND period_key = ? AND level = 'alert'`,
-		policy.ID, monthlyPeriodKey(),
+		policy.ID, periodKey,
 	).Scan(&count); err != nil {
 		t.Fatalf("count companion claim: %v", err)
 	}
@@ -579,6 +583,10 @@ func TestCheckBudget_PeriodKeyMatchesSpendBoundary(t *testing.T) {
 	}
 	insertBudgetTestCostEvent(t, execSQL, "agent-period", "task-1", 850)
 
+	// Captured before CheckBudget so the comparison can't compute a
+	// different month boundary than the evaluation did if the two calls
+	// straddle a UTC month rollover.
+	wantKey := monthlyPeriodKey()
 	if _, err := svc.CheckBudget(ctx, "ws-1", "agent-period", "proj-1"); err != nil {
 		t.Fatalf("CheckBudget: %v", err)
 	}
@@ -589,8 +597,8 @@ func TestCheckBudget_PeriodKeyMatchesSpendBoundary(t *testing.T) {
 	).Scan(&gotKey); err != nil {
 		t.Fatalf("query claim period_key: %v", err)
 	}
-	if gotKey != monthlyPeriodKey() {
-		t.Fatalf("claim period_key = %q, want %q (must match the spend rollup's boundary)", gotKey, monthlyPeriodKey())
+	if gotKey != wantKey {
+		t.Fatalf("claim period_key = %q, want %q (must match the spend rollup's boundary)", gotKey, wantKey)
 	}
 }
 

--- a/apps/backend/internal/office/costs/budget_idempotency_test.go
+++ b/apps/backend/internal/office/costs/budget_idempotency_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/office/costs"
 	"github.com/kandev/kandev/internal/office/models"
@@ -167,6 +171,49 @@ func TestCheckBudget_ExceededClaimsCompanionAlert(t *testing.T) {
 	}
 }
 
+// TestCheckBudget_ExceededClaimHeld_AlertBandEvaluationSuppressed covers
+// AC-OFFICE-COSTS-003.12 directly: while an exceeded-level claim is held
+// for a policy, period and revision, an evaluation whose spend reaches only
+// the alert level must not emit budget.alert for that period and revision.
+// The exceeded claim's companion already holds the alert-level slot, so
+// this follows from the ordinary primary-key conflict on a second
+// alert-level insert, with no separate read of the exceeded claim.
+func TestCheckBudget_ExceededClaimHeld_AlertBandEvaluationSuppressed(t *testing.T) {
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	createBudgetTestAgent(t, repo, "ws-1", "agent-exceeded-then-alert")
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+	svc := costs.NewCostService(repo, logger.Default(), spy, agents, agents)
+
+	policy := newIdempotencyTestPolicy("agent-exceeded-then-alert", 1000)
+	if err := svc.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	periodKey := monthlyPeriodKey()
+	if claimed, err := repo.ClaimExceeded(ctx, policy.ID, periodKey, policy.Revision); err != nil || !claimed {
+		t.Fatalf("seed exceeded+companion claim: claimed=%v err=%v", claimed, err)
+	}
+
+	// Spend in the alert band only: >= 80% of the 1000 limit, below it.
+	insertBudgetTestCostEvent(t, execSQL, "agent-exceeded-then-alert", "task-1", 900)
+
+	results, err := svc.CheckBudget(ctx, "ws-1", "agent-exceeded-then-alert", "proj-1")
+	if err != nil {
+		t.Fatalf("CheckBudget: %v", err)
+	}
+	if !results[0].AlertFired {
+		t.Fatal("expected spend to reach the alert level")
+	}
+	if results[0].AlertSubmitted {
+		t.Fatal("budget.alert must not be submitted while an exceeded-level claim is held for this policy, period and revision")
+	}
+	if got := spy.count("budget.alert"); got != 0 {
+		t.Fatalf("budget.alert emissions = %d, want 0", got)
+	}
+}
+
 // TestCheckBudget_CompanionAlertClaimFault_StillSubmitsExceeded covers the
 // AC-OFFICE-COSTS-003.10 fault-injection case: when the companion
 // alert-level insert errors, the whole atomic pair rolls back — no exceeded
@@ -293,6 +340,69 @@ func TestCheckBudget_ClaimStoreFault_ExceededPath_EmitsAndCountsOncePerEval(t *t
 	}
 	if delta := claimFailureCount(t) - before; delta != 2 {
 		t.Fatalf("budget_claim_failures_total delta = %d, want 2 (1 per exceeded eval, the pair is one claim attempt)", delta)
+	}
+}
+
+// TestCheckBudget_ClaimStoreFault_LogsLevelFieldMatchingEmission covers
+// AC-OFFICE-COSTS-003.14: the claim-store failure log's level field names
+// the level whose emission the failed claim governs — "alert" for a
+// standalone alert-band claim, "exceeded" for the atomic pair — never a
+// sentinel shared by both.
+func TestCheckBudget_ClaimStoreFault_LogsLevelFieldMatchingEmission(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("create observer logger: %v", err)
+	}
+	injected := errors.New("injected claim store failure")
+
+	repo, _, execSQL := newBudgetTestRepo(t)
+	ctx := context.Background()
+	agents := &repoAgents{repo: repo}
+	spy := &budgetActivitySpy{}
+
+	createBudgetTestAgent(t, repo, "ws-1", "agent-log-alert")
+	alertFaulty := &claimFaultRepo{Repository: repo, failLevels: map[string]error{"alert": injected}}
+	alertSvc := costs.NewCostService(alertFaulty, log, spy, agents, agents)
+	alertPolicy := newIdempotencyTestPolicy("agent-log-alert", 1000)
+	if err := alertSvc.CreateBudgetPolicy(ctx, alertPolicy); err != nil {
+		t.Fatalf("create alert policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-log-alert", "task-1", 850)
+	if _, err := alertSvc.CheckBudget(ctx, "ws-1", "agent-log-alert", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget (alert): %v", err)
+	}
+
+	createBudgetTestAgent(t, repo, "ws-1", "agent-log-exceeded")
+	exceededFaulty := &claimFaultRepo{Repository: repo, failLevels: map[string]error{"exceeded": injected}}
+	exceededSvc := costs.NewCostService(exceededFaulty, log, spy, agents, agents)
+	exceededPolicy := newIdempotencyTestPolicy("agent-log-exceeded", 500)
+	if err := exceededSvc.CreateBudgetPolicy(ctx, exceededPolicy); err != nil {
+		t.Fatalf("create exceeded policy: %v", err)
+	}
+	insertBudgetTestCostEvent(t, execSQL, "agent-log-exceeded", "task-1", 600)
+	if _, err := exceededSvc.CheckBudget(ctx, "ws-1", "agent-log-exceeded", "proj-1"); err != nil {
+		t.Fatalf("CheckBudget (exceeded): %v", err)
+	}
+
+	entries := logs.FilterMessage("budget claim store failure").All()
+	if len(entries) != 2 {
+		t.Fatalf("claim-store-failure log entries = %d, want 2", len(entries))
+	}
+	var sawAlert, sawExceeded bool
+	for _, e := range entries {
+		switch e.ContextMap()["level"] {
+		case "alert":
+			sawAlert = true
+		case "exceeded":
+			sawExceeded = true
+		}
+	}
+	if !sawAlert {
+		t.Fatal(`expected a log entry with level="alert" for the standalone alert-band claim failure`)
+	}
+	if !sawExceeded {
+		t.Fatal(`expected a log entry with level="exceeded" for the atomic pair's claim failure`)
 	}
 }
 

--- a/apps/backend/internal/office/costs/budgets.go
+++ b/apps/backend/internal/office/costs/budgets.go
@@ -138,17 +138,19 @@ func (s *CostService) evaluatePolicy(
 		if policy.ActionOnExceed == budgetActionPauseAgent && policy.ScopeType == scopeAgent {
 			result.AgentPaused = s.pauseAgentForBudget(ctx, policy.ScopeID)
 		}
-		result.ExceededSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelExceeded)
-		// A spend that jumps straight from below the alert level to above
-		// the limit must also hold the alert-level claim, so a later
-		// evaluation that lands back in the alert band does not emit a
-		// budget.alert describing a reduction in spend. The outcome is
-		// discarded (claimed or already-claimed are equally fine here); a
-		// claim-store error is still logged and counted like any other.
-		s.claimCompanionAlert(ctx, policy, periodKey)
+		result.ExceededSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelExceeded,
+			// A spend that jumps straight from below the alert level to
+			// above the limit must also hold the alert-level claim before
+			// budget.exceeded is emitted, so a concurrent evaluation
+			// landing in the alert band cannot win that claim in the gap
+			// and emit a budget.alert describing a reduction in spend. The
+			// outcome is discarded (claimed or already-claimed are equally
+			// fine here); a claim-store error is still logged and counted
+			// like any other.
+			func() { s.claimCompanionAlert(ctx, policy, periodKey) })
 	case spent >= threshold:
 		result.AlertFired = true
-		result.AlertSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelAlert)
+		result.AlertSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelAlert, nil)
 	}
 
 	return result, nil
@@ -156,15 +158,23 @@ func (s *CostService) evaluatePolicy(
 
 // claimAndEmit resolves the three outcomes of claiming (policy, periodKey,
 // level) and emits that level's activity row when the claim allows it.
-// Reports whether this evaluation submitted the row.
+// Reports whether this evaluation submitted the row. afterClaim, when
+// non-nil, runs immediately after the claim and before the emission
+// decision, regardless of the claim's outcome — the seam the exceeded
+// level's alert-level companion claim uses so both claims land before
+// either emission is decided.
 func (s *CostService) claimAndEmit(
 	ctx context.Context,
 	workspaceID string,
 	policy *BudgetPolicy,
 	spent int64,
 	periodKey, level string,
+	afterClaim func(),
 ) bool {
 	claimed, err := s.repo.Claim(ctx, policy.ID, periodKey, level)
+	if afterClaim != nil {
+		afterClaim()
+	}
 	if err != nil {
 		s.recordClaimFailure(policy.ID, level, err)
 		s.emitLevel(ctx, workspaceID, policy, spent, level)

--- a/apps/backend/internal/office/costs/budgets.go
+++ b/apps/backend/internal/office/costs/budgets.go
@@ -26,16 +26,36 @@ const (
 	budgetActionBlockNewTasks = "block_new_tasks"
 )
 
+// Claim levels. See docs/specs/office/requirements/costs.md#terminology.
+const (
+	claimLevelAlert    = "alert"
+	claimLevelExceeded = "exceeded"
+)
+
+// claimPeriodLifetime is the period_key for a policy whose spend window
+// never resets (periodCutoff's zero-time "no filter" answer). It is a
+// literal rather than the RFC3339 rendering of the zero time so a future
+// change to periodCutoff's zero value can never collide with it.
+const claimPeriodLifetime = "lifetime"
+
 // BudgetCheckResult describes the outcome of a budget check.
-// SpentSubcents / LimitSubcents are hundredths of a cent.
+// SpentSubcents / LimitSubcents are hundredths of a cent. AlertFired /
+// LimitExceed report whether spend reaches that level *now* (used for
+// gating); AlertSubmitted / ExceededSubmitted report whether *this*
+// evaluation handed that level's row to the activity logger (used for
+// assertions and for callers that want to react only to new crossings).
+// The two pairs are independent: holding a claim does not imply a
+// submission, and a submission does not imply a claim was held.
 type BudgetCheckResult struct {
-	PolicyID       string
-	ActionOnExceed string
-	SpentSubcents  int64
-	LimitSubcents  int64
-	AlertFired     bool
-	LimitExceed    bool
-	AgentPaused    bool
+	PolicyID          string
+	ActionOnExceed    string
+	SpentSubcents     int64
+	LimitSubcents     int64
+	AlertFired        bool
+	LimitExceed       bool
+	AlertSubmitted    bool
+	ExceededSubmitted bool
+	AgentPaused       bool
 }
 
 // CheckBudget evaluates all budget policies for the given agent and project.
@@ -95,7 +115,8 @@ func (s *CostService) evaluatePolicy(
 	workspaceID string,
 	policy *BudgetPolicy,
 ) (BudgetCheckResult, error) {
-	spent, err := s.getSpendForPolicy(ctx, workspaceID, policy)
+	boundary := periodCutoff(string(policy.Period), time.Now())
+	spent, err := s.getSpendForPolicy(ctx, workspaceID, policy, boundary)
 	if err != nil {
 		return BudgetCheckResult{}, err
 	}
@@ -108,21 +129,84 @@ func (s *CostService) evaluatePolicy(
 		LimitSubcents:  limit,
 	}
 
+	periodKey := periodKeyFor(boundary)
 	threshold := limit * int64(policy.AlertThresholdPct) / 100
-	if spent >= threshold && spent < limit {
-		result.AlertFired = true
-		s.logBudgetAlert(ctx, workspaceID, policy, spent)
-	}
 
-	if spent >= limit {
+	switch {
+	case spent >= limit:
 		result.LimitExceed = true
 		if policy.ActionOnExceed == budgetActionPauseAgent && policy.ScopeType == scopeAgent {
 			result.AgentPaused = s.pauseAgentForBudget(ctx, policy.ScopeID)
 		}
-		s.logBudgetExceeded(ctx, workspaceID, policy, spent)
+		result.ExceededSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelExceeded)
+		// A spend that jumps straight from below the alert level to above
+		// the limit must also hold the alert-level claim, so a later
+		// evaluation that lands back in the alert band does not emit a
+		// budget.alert describing a reduction in spend. The outcome is
+		// discarded (claimed or already-claimed are equally fine here); a
+		// claim-store error is still logged and counted like any other.
+		s.claimCompanionAlert(ctx, policy, periodKey)
+	case spent >= threshold:
+		result.AlertFired = true
+		result.AlertSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelAlert)
 	}
 
 	return result, nil
+}
+
+// claimAndEmit resolves the three outcomes of claiming (policy, periodKey,
+// level) and emits that level's activity row when the claim allows it.
+// Reports whether this evaluation submitted the row.
+func (s *CostService) claimAndEmit(
+	ctx context.Context,
+	workspaceID string,
+	policy *BudgetPolicy,
+	spent int64,
+	periodKey, level string,
+) bool {
+	claimed, err := s.repo.Claim(ctx, policy.ID, periodKey, level)
+	if err != nil {
+		s.recordClaimFailure(policy.ID, level, err)
+		s.emitLevel(ctx, workspaceID, policy, spent, level)
+		return true
+	}
+	if !claimed {
+		return false
+	}
+	s.emitLevel(ctx, workspaceID, policy, spent, level)
+	return true
+}
+
+// claimCompanionAlert records the alert-level claim alongside an
+// exceeded-level emission, so a spend that jumps straight past the limit
+// still de-escalates correctly. Its outcome never changes the
+// budget.exceeded emission; only a claim-store error is reported, exactly
+// like any other claim attempt.
+func (s *CostService) claimCompanionAlert(ctx context.Context, policy *BudgetPolicy, periodKey string) {
+	if _, err := s.repo.Claim(ctx, policy.ID, periodKey, claimLevelAlert); err != nil {
+		s.recordClaimFailure(policy.ID, claimLevelAlert, err)
+	}
+}
+
+func (s *CostService) emitLevel(
+	ctx context.Context, workspaceID string, policy *BudgetPolicy, spent int64, level string,
+) {
+	if level == claimLevelExceeded {
+		s.logBudgetExceeded(ctx, workspaceID, policy, spent)
+		return
+	}
+	s.logBudgetAlert(ctx, workspaceID, policy, spent)
+}
+
+// recordClaimFailure logs and counts a claim-store failure encountered
+// while evaluating a policy. Never called for a foreign-key violation (the
+// referenced policy no longer exists, not a store failure) or for a failed
+// claim discard during a policy update, both of which are reported through
+// different channels.
+func (s *CostService) recordClaimFailure(policyID, level string, err error) {
+	budgetClaimFailuresTotal.Add(budgetClaimFailureLabel, 1)
+	s.logger.Error("budget claim store failure",
+		zap.String("policy_id", policyID), zap.String("level", level), zap.Error(err))
 }
 
 // periodCutoff returns the time.Time at which the policy's spend window
@@ -135,12 +219,24 @@ func periodCutoff(period string, now time.Time) time.Time {
 	return time.Time{}
 }
 
+// periodKeyFor renders a period boundary as the claim's stored identity.
+// The layout is contract, not local style: a non-zero boundary is RFC3339 in
+// UTC, and periodCutoff's zero-time "lifetime" answer renders as the
+// literal "lifetime" rather than the RFC3339 zero time, so it can never be
+// mistaken for a real instant.
+func periodKeyFor(boundary time.Time) string {
+	if boundary.IsZero() {
+		return claimPeriodLifetime
+	}
+	return boundary.UTC().Format(time.RFC3339)
+}
+
 func (s *CostService) getSpendForPolicy(
 	ctx context.Context,
 	workspaceID string,
 	policy *BudgetPolicy,
+	since time.Time,
 ) (int64, error) {
-	since := periodCutoff(string(policy.Period), time.Now())
 	switch policy.ScopeType {
 	case scopeAgent:
 		return s.repo.GetCostForAgentSince(ctx, policy.ScopeID, since)

--- a/apps/backend/internal/office/costs/budgets.go
+++ b/apps/backend/internal/office/costs/budgets.go
@@ -138,43 +138,27 @@ func (s *CostService) evaluatePolicy(
 		if policy.ActionOnExceed == budgetActionPauseAgent && policy.ScopeType == scopeAgent {
 			result.AgentPaused = s.pauseAgentForBudget(ctx, policy.ScopeID)
 		}
-		result.ExceededSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelExceeded,
-			// A spend that jumps straight from below the alert level to
-			// above the limit must also hold the alert-level claim before
-			// budget.exceeded is emitted, so a concurrent evaluation
-			// landing in the alert band cannot win that claim in the gap
-			// and emit a budget.alert describing a reduction in spend. The
-			// outcome is discarded (claimed or already-claimed are equally
-			// fine here); a claim-store error is still logged and counted
-			// like any other.
-			func() { s.claimCompanionAlert(ctx, policy, periodKey) })
+		result.ExceededSubmitted = s.claimExceededAndEmit(ctx, workspaceID, policy, spent, periodKey)
 	case spent >= threshold:
 		result.AlertFired = true
-		result.AlertSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelAlert, nil)
+		result.AlertSubmitted = s.claimAndEmit(ctx, workspaceID, policy, spent, periodKey, claimLevelAlert)
 	}
 
 	return result, nil
 }
 
 // claimAndEmit resolves the three outcomes of claiming (policy, periodKey,
-// level) and emits that level's activity row when the claim allows it.
-// Reports whether this evaluation submitted the row. afterClaim, when
-// non-nil, runs immediately after the claim and before the emission
-// decision, regardless of the claim's outcome — the seam the exceeded
-// level's alert-level companion claim uses so both claims land before
-// either emission is decided.
+// level) at the policy's current revision, and emits that level's activity
+// row when the claim allows it. Reports whether this evaluation submitted
+// the row.
 func (s *CostService) claimAndEmit(
 	ctx context.Context,
 	workspaceID string,
 	policy *BudgetPolicy,
 	spent int64,
 	periodKey, level string,
-	afterClaim func(),
 ) bool {
-	claimed, err := s.repo.Claim(ctx, policy.ID, periodKey, level)
-	if afterClaim != nil {
-		afterClaim()
-	}
+	claimed, err := s.repo.Claim(ctx, policy.ID, periodKey, level, policy.Revision)
 	if err != nil {
 		s.recordClaimFailure(policy.ID, level, err)
 		s.emitLevel(ctx, workspaceID, policy, spent, level)
@@ -187,15 +171,29 @@ func (s *CostService) claimAndEmit(
 	return true
 }
 
-// claimCompanionAlert records the alert-level claim alongside an
-// exceeded-level emission, so a spend that jumps straight past the limit
-// still de-escalates correctly. Its outcome never changes the
-// budget.exceeded emission; only a claim-store error is reported, exactly
-// like any other claim attempt.
-func (s *CostService) claimCompanionAlert(ctx context.Context, policy *BudgetPolicy, periodKey string) {
-	if _, err := s.repo.Claim(ctx, policy.ID, periodKey, claimLevelAlert); err != nil {
-		s.recordClaimFailure(policy.ID, claimLevelAlert, err)
+// claimExceededAndEmit resolves the atomic exceeded-plus-companion claim
+// pair at the policy's current revision and emits budget.exceeded when the
+// exceeded-level row was won. A claim-store error anywhere in the pair —
+// including on the companion insert — fails the whole pair open: the error
+// is logged and counted once, and budget.exceeded still emits.
+func (s *CostService) claimExceededAndEmit(
+	ctx context.Context,
+	workspaceID string,
+	policy *BudgetPolicy,
+	spent int64,
+	periodKey string,
+) bool {
+	claimed, err := s.repo.ClaimExceeded(ctx, policy.ID, periodKey, policy.Revision)
+	if err != nil {
+		s.recordClaimFailure(policy.ID, claimLevelExceeded, err)
+		s.emitLevel(ctx, workspaceID, policy, spent, claimLevelExceeded)
+		return true
 	}
+	if !claimed {
+		return false
+	}
+	s.emitLevel(ctx, workspaceID, policy, spent, claimLevelExceeded)
+	return true
 }
 
 func (s *CostService) emitLevel(

--- a/apps/backend/internal/office/costs/budgets_test.go
+++ b/apps/backend/internal/office/costs/budgets_test.go
@@ -61,19 +61,79 @@ func (s *budgetActivitySpy) count(action string) int {
 }
 
 // claimFaultRepo wraps a real *sqlite.Repository and overrides Claim to
-// fail for the named levels, so tests can drive AC-OFFICE-COSTS-002.5's and
-// AC-OFFICE-COSTS-002.14's claim-store-error paths deterministically
-// without a fault-injecting SQL driver.
+// fail (failLevels) or miss without error (missLevels) for the named
+// levels, so tests can drive AC-OFFICE-COSTS-002.5's, .14's and .14a's
+// claim-store outcomes deterministically without a fault-injecting SQL
+// driver. missLevels stands in for either an already-held claim or a
+// foreign-key-violation-as-miss (AC-OFFICE-COSTS-002.14a): both return
+// (false, nil), and the counter under test cannot and should not
+// distinguish them.
 type claimFaultRepo struct {
 	*sqlite.Repository
 	failLevels map[string]error
+	missLevels map[string]bool
 }
 
 func (r *claimFaultRepo) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
 	if err, ok := r.failLevels[level]; ok {
 		return false, err
 	}
+	if r.missLevels[level] {
+		return false, nil
+	}
 	return r.Repository.Claim(ctx, policyID, periodKey, level)
+}
+
+// callOrderRecorder records events in the order they occur, for tests that
+// must prove sequencing rather than just eventual outcome (AC-OFFICE-COSTS-002.5's
+// claim-then-emit ordering).
+type callOrderRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *callOrderRecorder) record(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *callOrderRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// orderRecordingRepo wraps a real *sqlite.Repository and records each
+// Claim call's level into a shared callOrderRecorder.
+type orderRecordingRepo struct {
+	*sqlite.Repository
+	order *callOrderRecorder
+}
+
+func (r *orderRecordingRepo) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
+	claimed, err := r.Repository.Claim(ctx, policyID, periodKey, level)
+	r.order.record("claim:" + level)
+	return claimed, err
+}
+
+// orderRecordingActivity implements shared.ActivityLogger and records each
+// submitted action into the same callOrderRecorder as orderRecordingRepo,
+// so a test can assert the interleaving of claims and emissions.
+type orderRecordingActivity struct {
+	order *callOrderRecorder
+}
+
+func (a *orderRecordingActivity) LogActivity(_ context.Context, _, _, _, action, _, _, _ string) {
+	a.order.record("emit:" + action)
+}
+
+func (a *orderRecordingActivity) LogActivityWithRun(
+	ctx context.Context, wsID, actorType, actorID, action, targetType, targetID, details, _, _ string,
+) {
+	a.LogActivity(ctx, wsID, actorType, actorID, action, targetType, targetID, details)
 }
 
 // repoAgents adapts the office repository to shared.AgentReader +

--- a/apps/backend/internal/office/costs/budgets_test.go
+++ b/apps/backend/internal/office/costs/budgets_test.go
@@ -2,6 +2,8 @@ package costs_test
 
 import (
 	"context"
+	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +18,63 @@ import (
 	"github.com/kandev/kandev/internal/office/repository/sqlite"
 	"github.com/kandev/kandev/internal/office/shared"
 )
+
+// budgetActivitySpy implements shared.ActivityLogger and records every
+// call so tests can assert on *submission* (AC-OFFICE-COSTS-002.2a), never
+// with a SELECT against office_activity_log: LogActivity returns nothing,
+// so the durability of any one row is not something the contract promises.
+// The mutex makes it safe for TestCheckBudget_ConcurrentEvaluation_EmitsOnce,
+// which drives LogActivity from multiple goroutines.
+type budgetActivitySpy struct {
+	mu    sync.Mutex
+	calls []budgetActivityCall
+}
+
+// budgetActivityCall records one LogActivity invocation observed by
+// budgetActivitySpy.
+type budgetActivityCall struct {
+	action, targetType, targetID, details string
+}
+
+func (s *budgetActivitySpy) LogActivity(_ context.Context, _, _, _, action, targetType, targetID, details string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, budgetActivityCall{action, targetType, targetID, details})
+}
+
+func (s *budgetActivitySpy) LogActivityWithRun(
+	ctx context.Context, wsID, actorType, actorID, action, targetType, targetID, details, _, _ string,
+) {
+	s.LogActivity(ctx, wsID, actorType, actorID, action, targetType, targetID, details)
+}
+
+func (s *budgetActivitySpy) count(action string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, c := range s.calls {
+		if c.action == action {
+			n++
+		}
+	}
+	return n
+}
+
+// claimFaultRepo wraps a real *sqlite.Repository and overrides Claim to
+// fail for the named levels, so tests can drive AC-OFFICE-COSTS-002.5's and
+// AC-OFFICE-COSTS-002.14's claim-store-error paths deterministically
+// without a fault-injecting SQL driver.
+type claimFaultRepo struct {
+	*sqlite.Repository
+	failLevels map[string]error
+}
+
+func (r *claimFaultRepo) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
+	if err, ok := r.failLevels[level]; ok {
+		return false, err
+	}
+	return r.Repository.Claim(ctx, policyID, periodKey, level)
+}
 
 // repoAgents adapts the office repository to shared.AgentReader +
 // shared.AgentWriter so budget tests can exercise the real pause-agent
@@ -40,17 +99,13 @@ func (a *repoAgents) UpdateAgentStatusFields(ctx context.Context, agentID, statu
 	return a.repo.UpdateAgentStatusFields(ctx, agentID, status, pauseReason)
 }
 
-func newBudgetTestService(t *testing.T) (*costs.CostService, *sqlite.Repository, func(string, ...interface{})) {
-	t.Helper()
-	return newBudgetTestServiceWithActivity(t, &noopActivity{})
-}
-
-// newBudgetTestServiceWithActivity is the same setup as newBudgetTestService
-// but lets project-scope tests supply a spy activity logger to observe which
-// budget.alert / budget.exceeded rows fire.
-func newBudgetTestServiceWithActivity(
-	t *testing.T, activity shared.ActivityLogger,
-) (*costs.CostService, *sqlite.Repository, func(string, ...interface{})) {
+// newBudgetTestRepo builds the in-memory office repo shared by every budget
+// test, without wiring a CostService, so fault-injection tests can wrap the
+// repo (claimFaultRepo) or swap the activity logger (budgetActivitySpy)
+// before constructing the service. queryRow exposes read-only access to the
+// underlying connection for tests that assert directly on
+// office_budget_claims rather than through the CostService API.
+func newBudgetTestRepo(t *testing.T) (*sqlite.Repository, func(string, ...interface{}) *sql.Row, func(string, ...interface{})) {
 	t.Helper()
 	db, err := sqlx.Open("sqlite3", ":memory:")
 	if err != nil {
@@ -80,16 +135,35 @@ func newBudgetTestServiceWithActivity(
 	if err != nil {
 		t.Fatalf("new repo: %v", err)
 	}
-	log := logger.Default()
-	agents := &repoAgents{repo: repo}
-	svc := costs.NewCostService(repo, log, activity, agents, agents)
-
 	execSQL := func(query string, args ...interface{}) {
 		t.Helper()
 		if _, err := db.Exec(query, args...); err != nil {
 			t.Fatalf("exec sql: %v", err)
 		}
 	}
+	queryRow := func(query string, args ...interface{}) *sql.Row {
+		t.Helper()
+		return db.QueryRow(query, args...)
+	}
+	return repo, queryRow, execSQL
+}
+
+func newBudgetTestService(t *testing.T) (*costs.CostService, *sqlite.Repository, func(string, ...interface{})) {
+	t.Helper()
+	return newBudgetTestServiceWithActivity(t, &noopActivity{})
+}
+
+// newBudgetTestServiceWithActivity is the same setup as newBudgetTestService
+// but lets project-scope tests supply a spy activity logger to observe which
+// budget.alert / budget.exceeded rows fire.
+func newBudgetTestServiceWithActivity(
+	t *testing.T, activity shared.ActivityLogger,
+) (*costs.CostService, *sqlite.Repository, func(string, ...interface{})) {
+	t.Helper()
+	repo, _, execSQL := newBudgetTestRepo(t)
+	log := logger.Default()
+	agents := &repoAgents{repo: repo}
+	svc := costs.NewCostService(repo, log, activity, agents, agents)
 	return svc, repo, execSQL
 }
 
@@ -103,29 +177,6 @@ func insertBudgetTestTask(t *testing.T, execSQL func(string, ...interface{}), ta
 		`INSERT INTO tasks (id, workspace_id, project_id) VALUES (?, ?, ?)`,
 		taskID, workspaceID, projectID,
 	)
-}
-
-// budgetActivityCall records one LogActivity invocation observed by
-// budgetActivitySpy.
-type budgetActivityCall struct {
-	action     string
-	targetType string
-	targetID   string
-}
-
-// budgetActivitySpy implements shared.ActivityLogger and records every call,
-// so project-budget tests can assert exactly which alerts fired without
-// depending on evaluatePolicy's return value (EvaluateProjectBudget only
-// returns an error).
-type budgetActivitySpy struct {
-	calls []budgetActivityCall
-}
-
-func (s *budgetActivitySpy) LogActivity(_ context.Context, _, _, _, action, targetType, targetID, _ string) {
-	s.calls = append(s.calls, budgetActivityCall{action: action, targetType: targetType, targetID: targetID})
-}
-
-func (s *budgetActivitySpy) LogActivityWithRun(_ context.Context, _, _, _, _, _, _, _, _, _ string) {
 }
 
 func createBudgetTestAgent(t *testing.T, repo *sqlite.Repository, wsID, agentID string) {

--- a/apps/backend/internal/office/costs/budgets_test.go
+++ b/apps/backend/internal/office/costs/budgets_test.go
@@ -74,14 +74,34 @@ type claimFaultRepo struct {
 	missLevels map[string]bool
 }
 
-func (r *claimFaultRepo) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
+func (r *claimFaultRepo) Claim(ctx context.Context, policyID, periodKey, level string, revision int64) (bool, error) {
 	if err, ok := r.failLevels[level]; ok {
 		return false, err
 	}
 	if r.missLevels[level] {
 		return false, nil
 	}
-	return r.Repository.Claim(ctx, policyID, periodKey, level)
+	return r.Repository.Claim(ctx, policyID, periodKey, level, revision)
+}
+
+// ClaimExceeded overrides the atomic pair the same way Claim does, keyed by
+// the level whose outcome is being faulted: "exceeded" fails or misses the
+// pair before either insert is attempted (mirroring a fenced exceeded
+// insert refused or store-faulted); "alert" fails or misses only the
+// companion half, after a real exceeded insert has already run for real,
+// mirroring AC-OFFICE-COSTS-003.10's atomic rollback of the whole pair on a
+// companion-side error.
+func (r *claimFaultRepo) ClaimExceeded(ctx context.Context, policyID, periodKey string, revision int64) (bool, error) {
+	if err, ok := r.failLevels["exceeded"]; ok {
+		return false, err
+	}
+	if r.missLevels["exceeded"] {
+		return false, nil
+	}
+	if err, ok := r.failLevels["alert"]; ok {
+		return false, err
+	}
+	return r.Repository.ClaimExceeded(ctx, policyID, periodKey, revision)
 }
 
 // callOrderRecorder records events in the order they occur, for tests that
@@ -113,9 +133,21 @@ type orderRecordingRepo struct {
 	order *callOrderRecorder
 }
 
-func (r *orderRecordingRepo) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
-	claimed, err := r.Repository.Claim(ctx, policyID, periodKey, level)
+func (r *orderRecordingRepo) Claim(ctx context.Context, policyID, periodKey, level string, revision int64) (bool, error) {
+	claimed, err := r.Repository.Claim(ctx, policyID, periodKey, level, revision)
 	r.order.record("claim:" + level)
+	return claimed, err
+}
+
+// ClaimExceeded records both of the atomic pair's levels immediately after
+// the (single) real call returns, preserving the ordering property the test
+// cares about: both claim events precede the emission decision. It cannot
+// observe the two inserts individually from outside the transaction, but it
+// doesn't need to — only their position relative to the emission matters.
+func (r *orderRecordingRepo) ClaimExceeded(ctx context.Context, policyID, periodKey string, revision int64) (bool, error) {
+	claimed, err := r.Repository.ClaimExceeded(ctx, policyID, periodKey, revision)
+	r.order.record("claim:exceeded")
+	r.order.record("claim:alert")
 	return claimed, err
 }
 

--- a/apps/backend/internal/office/costs/handler_budget_revision_test.go
+++ b/apps/backend/internal/office/costs/handler_budget_revision_test.go
@@ -1,0 +1,121 @@
+package costs_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/kandev/kandev/internal/office/costs"
+)
+
+// newBudgetTestRouter mounts the budget routes over a fresh CostService, for
+// tests that need to observe the HTTP-level wire contract rather than the
+// service API directly.
+func newBudgetTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	svc, _, _ := newBudgetTestService(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	costs.NewHandler(svc).RegisterRoutes(router.Group("/api/v1"))
+	return router
+}
+
+func doBudgetRequest(t *testing.T, router *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestCreateBudget_ResponseCarriesServerAssignedRevision covers
+// AC-OFFICE-COSTS-003.2 and .4 on the wire: the 201 response's budget
+// carries "revision": 1, never the column default leaking through as 0,
+// and a client-presented revision in the create body has no effect (the
+// request DTO has no such field, so this is enforced structurally, but the
+// response must still report what the row actually holds).
+func TestCreateBudget_ResponseCarriesServerAssignedRevision(t *testing.T) {
+	router := newBudgetTestRouter(t)
+
+	rec := doBudgetRequest(t, router, http.MethodPost, "/api/v1/workspaces/ws-1/budgets", `{
+		"scope_type": "workspace",
+		"limit_subcents": 1000,
+		"period": "monthly",
+		"alert_threshold_pct": 80,
+		"action_on_exceed": "notify_only",
+		"revision": 999
+	}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Budget struct {
+			ID       string `json:"id"`
+			Revision int64  `json:"revision"`
+		} `json:"budget"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	if body.Budget.Revision != 1 {
+		t.Fatalf("create response revision = %d, want 1 (a presented 999 must not survive)", body.Budget.Revision)
+	}
+	if !strings.Contains(rec.Body.String(), `"revision"`) {
+		t.Fatalf("response body must serialize revision as a visible field, got %s", rec.Body.String())
+	}
+}
+
+// TestUpdateBudget_ClientRevisionFieldHasNoEffect covers
+// AC-OFFICE-COSTS-003.7: the update request body has no revision field, so
+// a client-supplied "revision" in the PATCH JSON is inert, and the response
+// reports the server's own bump (2, after the create's 1) regardless of
+// what the caller sent.
+func TestUpdateBudget_ClientRevisionFieldHasNoEffect(t *testing.T) {
+	router := newBudgetTestRouter(t)
+
+	createRec := doBudgetRequest(t, router, http.MethodPost, "/api/v1/workspaces/ws-1/budgets", `{
+		"scope_type": "workspace",
+		"limit_subcents": 1000,
+		"period": "monthly",
+		"alert_threshold_pct": 80,
+		"action_on_exceed": "notify_only"
+	}`)
+	var created struct {
+		Budget struct {
+			ID string `json:"id"`
+		} `json:"budget"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create body %q: %v", createRec.Body.String(), err)
+	}
+
+	updateRec := doBudgetRequest(t, router, http.MethodPatch, "/api/v1/budgets/"+created.Budget.ID, `{
+		"limit_subcents": 2000,
+		"revision": 999999
+	}`)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", updateRec.Code, updateRec.Body.String())
+	}
+
+	var updated struct {
+		Budget struct {
+			Revision      int64 `json:"revision"`
+			LimitSubcents int64 `json:"limit_subcents"`
+		} `json:"budget"`
+	}
+	if err := json.Unmarshal(updateRec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode update body %q: %v", updateRec.Body.String(), err)
+	}
+	if updated.Budget.Revision != 2 {
+		t.Fatalf("updated revision = %d, want 2 (a presented 999999 must not survive)", updated.Budget.Revision)
+	}
+	if updated.Budget.LimitSubcents != 2000 {
+		t.Fatalf("limit_subcents = %d, want 2000", updated.Budget.LimitSubcents)
+	}
+}

--- a/apps/backend/internal/office/costs/service.go
+++ b/apps/backend/internal/office/costs/service.go
@@ -32,6 +32,9 @@ type Repository interface {
 	UpdateBudgetPolicy(ctx context.Context, policy *BudgetPolicy) error
 	DeleteBudgetPolicy(ctx context.Context, id string) error
 	UpdateAgentStatusFields(ctx context.Context, agentID, status, pauseReason string) error
+	// Claim atomically records that (policyID, periodKey, level) may emit its
+	// budget notification. See docs/specs/office/requirements/costs.md.
+	Claim(ctx context.Context, policyID, periodKey, level string) (bool, error)
 }
 
 // CostService handles cost recording, summaries, and budget evaluation.

--- a/apps/backend/internal/office/costs/service.go
+++ b/apps/backend/internal/office/costs/service.go
@@ -33,8 +33,13 @@ type Repository interface {
 	DeleteBudgetPolicy(ctx context.Context, id string) error
 	UpdateAgentStatusFields(ctx context.Context, agentID, status, pauseReason string) error
 	// Claim atomically records that (policyID, periodKey, level) may emit its
-	// budget notification. See docs/specs/office/requirements/costs.md.
-	Claim(ctx context.Context, policyID, periodKey, level string) (bool, error)
+	// budget notification, fenced to revision. See
+	// docs/specs/budget-claim-revision-fencing/spec.md.
+	Claim(ctx context.Context, policyID, periodKey, level string, revision int64) (bool, error)
+	// ClaimExceeded atomically records the exceeded-level claim and, only
+	// when this call wins it, the alert-level companion claim, both fenced
+	// to revision. See docs/specs/budget-claim-revision-fencing/spec.md.
+	ClaimExceeded(ctx context.Context, policyID, periodKey string, revision int64) (bool, error)
 }
 
 // CostService handles cost recording, summaries, and budget evaluation.

--- a/apps/backend/internal/office/models/models.go
+++ b/apps/backend/internal/office/models/models.go
@@ -375,6 +375,10 @@ type BudgetPolicy struct {
 	ActionOnExceed    BudgetActionOnExceed `json:"action_on_exceed" db:"action_on_exceed"`
 	CreatedAt         time.Time            `json:"created_at" db:"created_at"`
 	UpdatedAt         time.Time            `json:"updated_at" db:"updated_at"`
+	// Revision identifies which immutable set of the fields above a budget
+	// claim was evaluated against (REQ-OFFICE-COSTS-003). Server-assigned:
+	// starts at 1 and increases by exactly 1 on each successful update.
+	Revision int64 `json:"revision" db:"revision"`
 }
 
 // Run represents a run queue entry.

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -70,6 +70,18 @@ type Repository struct {
 	// before the policy row update, so a test can prove the two are
 	// transactional without a fault-injecting driver.
 	failBudgetPolicyUpdateErr error
+
+	// failBudgetClaimsRecreateErr is a test-only failpoint: when set,
+	// recreateBudgetClaimsForRevision returns it instead of touching the
+	// database, so a test can prove initSchema surfaces the error rather
+	// than swallowing it.
+	failBudgetClaimsRecreateErr error
+
+	// failBudgetExceededCompanionErr is a test-only failpoint: when set,
+	// ClaimExceeded returns it after the exceeded-level insert has run but
+	// before the companion alert-level insert, so a test can prove the
+	// pair rolls back together.
+	failBudgetExceededCompanionErr error
 }
 
 // NewWithDB creates a new office repository with existing database connections.
@@ -119,6 +131,12 @@ func (r *Repository) ReaderDB() *sqlx.DB { return r.ro }
 func (r *Repository) initSchema() error {
 	if err := r.createCoreTables(); err != nil {
 		return err
+	}
+	// Runs after createCoreTables (which creates office_budget_claims) so
+	// it probes the real table rather than racing its creation. Its error
+	// is returned, not swallowed: see recreateBudgetClaimsForRevision.
+	if err := r.recreateBudgetClaimsForRevision(); err != nil {
+		return fmt.Errorf("recreate office_budget_claims: %w", err)
 	}
 	if err := r.createExtensionTables(); err != nil {
 		return err
@@ -328,28 +346,37 @@ func (r *Repository) createCostTables() error {
 		alert_threshold_pct INTEGER DEFAULT 80,
 		action_on_exceed TEXT DEFAULT 'notify_only',
 		created_at TIMESTAMP NOT NULL,
-		updated_at TIMESTAMP NOT NULL
+		updated_at TIMESTAMP NOT NULL,
+		revision INTEGER NOT NULL DEFAULT 1
 	);
+	` + budgetClaimsDDL)
+	return err
+}
 
-	-- office_budget_claims must be created after office_budget_policies:
-	-- its foreign key references that table, and PostgreSQL rejects a
-	-- forward reference at CREATE TABLE time even though SQLite tolerates
-	-- it. One row per (policy, evaluation period, level) that has already
-	-- produced its budget.alert / budget.exceeded notification; the
-	-- primary key is the concurrency control for a claim attempt.
-	-- ON DELETE CASCADE removes a policy's claims on every deletion path
-	-- without a matching code change at any of them.
+// budgetClaimsDDL is the final office_budget_claims shape: one row per
+// (policy, evaluation period, level, policy revision) that has already
+// produced its budget.alert / budget.exceeded notification. revision is
+// part of the primary key, not just a fence input, so a claim written
+// against a revision a concurrent update has already superseded can never
+// match a later evaluation's fenced insert. Used both for fresh-database
+// creation here and for the recreate in recreateBudgetClaimsForRevision, so
+// a fresh database and a migrated one converge. office_budget_claims must
+// be created after office_budget_policies: its foreign key references that
+// table, and PostgreSQL rejects a forward reference at CREATE TABLE time
+// even though SQLite tolerates it. ON DELETE CASCADE removes a policy's
+// claims on every deletion path without a matching code change at any of
+// them.
+const budgetClaimsDDL = `
 	CREATE TABLE IF NOT EXISTS office_budget_claims (
 		policy_id TEXT NOT NULL,
 		period_key TEXT NOT NULL,
 		level TEXT NOT NULL,
+		revision INTEGER NOT NULL,
 		claimed_at TIMESTAMP NOT NULL,
-		PRIMARY KEY (policy_id, period_key, level),
+		PRIMARY KEY (policy_id, period_key, level, revision),
 		FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE
 	);
-	`)
-	return err
-}
+`
 
 func (r *Repository) createRunTables() error {
 	_, err := r.db.Exec(`

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -64,6 +64,12 @@ type Repository struct {
 	ro      *sqlx.DB // reader
 	log     *logger.Logger
 	migrate *db.MigrateLogger
+
+	// failBudgetPolicyUpdateErr is a test-only failpoint: when set,
+	// updateBudgetPolicyTx returns it after the claim discard has run but
+	// before the policy row update, so a test can prove the two are
+	// transactional without a fault-injecting driver.
+	failBudgetPolicyUpdateErr error
 }
 
 // NewWithDB creates a new office repository with existing database connections.
@@ -323,6 +329,23 @@ func (r *Repository) createCostTables() error {
 		action_on_exceed TEXT DEFAULT 'notify_only',
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL
+	);
+
+	-- office_budget_claims must be created after office_budget_policies:
+	-- its foreign key references that table, and PostgreSQL rejects a
+	-- forward reference at CREATE TABLE time even though SQLite tolerates
+	-- it. One row per (policy, evaluation period, level) that has already
+	-- produced its budget.alert / budget.exceeded notification; the
+	-- primary key is the concurrency control for a claim attempt.
+	-- ON DELETE CASCADE removes a policy's claims on every deletion path
+	-- without a matching code change at any of them.
+	CREATE TABLE IF NOT EXISTS office_budget_claims (
+		policy_id TEXT NOT NULL,
+		period_key TEXT NOT NULL,
+		level TEXT NOT NULL,
+		claimed_at TIMESTAMP NOT NULL,
+		PRIMARY KEY (policy_id, period_key, level),
+		FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE
 	);
 	`)
 	return err

--- a/apps/backend/internal/office/repository/sqlite/base.go
+++ b/apps/backend/internal/office/repository/sqlite/base.go
@@ -77,6 +77,12 @@ type Repository struct {
 	// than swallowing it.
 	failBudgetClaimsRecreateErr error
 
+	// failBudgetClaimsRecreateAfterDropErr is a test-only failpoint: when
+	// set, recreateBudgetClaimsForRevision returns it after DROP TABLE has
+	// run but before CREATE TABLE, inside the same transaction, so a test
+	// can prove the two are atomic rather than two independent statements.
+	failBudgetClaimsRecreateAfterDropErr error
+
 	// failBudgetExceededCompanionErr is a test-only failpoint: when set,
 	// ClaimExceeded returns it after the exceeded-level insert has run but
 	// before the companion alert-level insert, so a test can prove the

--- a/apps/backend/internal/office/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/office/repository/sqlite/base_migrations.go
@@ -62,10 +62,22 @@ func (r *Repository) runMigrations() error {
 	r.migrateParentWakeReceiptColumns()
 	r.migrate.Apply("task_workspace_groups.ownership_generation",
 		`ALTER TABLE task_workspace_groups ADD COLUMN ownership_generation INTEGER NOT NULL DEFAULT 1`)
+	r.migrateBudgetPolicyRevision()
 	if err := r.migrate.Err(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// migrateBudgetPolicyRevision adds office_budget_policies.revision for
+// databases created before REQ-OFFICE-COSTS-003. The DEFAULT 1 backfills
+// every existing row exactly like createCostTables' inline column, so a
+// fresh database and a migrated one converge. A boot replay is a no-op:
+// db.IsDuplicateColumnError is the only local classifier (ADR 0027), reused
+// via MigrateLogger.Apply rather than adding a new one.
+func (r *Repository) migrateBudgetPolicyRevision() {
+	r.migrate.Apply("office_budget_policies.revision",
+		`ALTER TABLE office_budget_policies ADD COLUMN revision INTEGER NOT NULL DEFAULT 1`)
 }
 
 // migrateContinuationScope adds runs.continuation_scope for databases

--- a/apps/backend/internal/office/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/office/repository/sqlite/base_migrations.go
@@ -76,7 +76,7 @@ func (r *Repository) runMigrations() error {
 // db.IsDuplicateColumnError is the only local classifier (ADR 0027), reused
 // via MigrateLogger.Apply rather than adding a new one.
 func (r *Repository) migrateBudgetPolicyRevision() {
-	r.migrate.Apply("office_budget_policies.revision",
+	_ = r.migrate.Apply("office_budget_policies.revision",
 		`ALTER TABLE office_budget_policies ADD COLUMN revision INTEGER NOT NULL DEFAULT 1`)
 }
 

--- a/apps/backend/internal/office/repository/sqlite/base_test.go
+++ b/apps/backend/internal/office/repository/sqlite/base_test.go
@@ -53,6 +53,7 @@ func TestInitSchema_AllTablesExist(t *testing.T) {
 		"office_agent_runtime",
 		"office_cost_events",
 		"office_budget_policies",
+		"office_budget_claims",
 		"runs",
 		"office_routines",
 		"office_routine_triggers",

--- a/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard proves the claim
+// discard and the policy row update are one transaction
+// (AC-OFFICE-COSTS-002.8): when the row update fails after the discard has
+// already run, the whole transaction rolls back, so the claim survives
+// alongside the un-updated policy. failBudgetPolicyUpdateErr is a
+// test-only failpoint (see base.go) standing in for a fault-injecting
+// driver.
+func TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("pragma fk: %v", err)
+	}
+	if _, _, err := settingsstore.Provide(db, db, nil); err != nil {
+		t.Fatalf("settings store init: %v", err)
+	}
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+
+	ctx := context.Background()
+	policy := &models.BudgetPolicy{
+		WorkspaceID:       "ws-rollback",
+		ScopeType:         "workspace",
+		ScopeID:           "ws-rollback",
+		LimitSubcents:     1000,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "notify_only",
+	}
+	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	repo.failBudgetPolicyUpdateErr = errors.New("injected update failure")
+	policy.LimitSubcents = 5000
+	if err := repo.UpdateBudgetPolicy(ctx, policy); err == nil {
+		t.Fatal("expected the injected update failure to surface")
+	}
+
+	var claimCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ?`, policy.ID,
+	).Scan(&claimCount); err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if claimCount != 1 {
+		t.Fatalf("claim count after rolled-back update = %d, want 1 (discard must roll back with the failed update)", claimCount)
+	}
+
+	stored, err := repo.GetBudgetPolicy(ctx, policy.ID)
+	if err != nil {
+		t.Fatalf("get policy: %v", err)
+	}
+	if stored.LimitSubcents != 1000 {
+		t.Fatalf("limit_subcents after rolled-back update = %d, want unchanged 1000", stored.LimitSubcents)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
@@ -24,6 +24,10 @@ func TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	// Pin all work to one connection: each SQLite :memory: connection is a
+	// separate empty database, so a pooled second connection would miss the
+	// tables/rows the first one created.
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
 		t.Fatalf("pragma fk: %v", err)

--- a/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
@@ -53,7 +53,7 @@ func TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard(t *testing.T) {
 	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
 		t.Fatalf("create policy: %v", err)
 	}
-	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil {
+	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 

--- a/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_atomicity_internal_test.go
@@ -16,7 +16,8 @@ import (
 // discard and the policy row update are one transaction
 // (AC-OFFICE-COSTS-002.8): when the row update fails after the discard has
 // already run, the whole transaction rolls back, so the claim survives
-// alongside the un-updated policy. failBudgetPolicyUpdateErr is a
+// alongside the un-updated policy, and the policy's revision does not
+// advance either (AC-OFFICE-COSTS-003.6). failBudgetPolicyUpdateErr is a
 // test-only failpoint (see base.go) standing in for a fault-injecting
 // driver.
 func TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard(t *testing.T) {
@@ -79,5 +80,8 @@ func TestUpdateBudgetPolicy_FailedUpdateRollsBackDiscard(t *testing.T) {
 	}
 	if stored.LimitSubcents != 1000 {
 		t.Fatalf("limit_subcents after rolled-back update = %d, want unchanged 1000", stored.LimitSubcents)
+	}
+	if stored.Revision != 1 {
+		t.Fatalf("revision after rolled-back update = %d, want unchanged 1 (a rolled-back update must not consume a revision number)", stored.Revision)
 	}
 }

--- a/apps/backend/internal/office/repository/sqlite/budget_claims_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_claims_postgres_test.go
@@ -1,0 +1,97 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// TestPostgresBudgetClaims is the PostgreSQL twin of the office_budget_claims
+// coverage in budgets_test.go (REQ-OFFICE-COSTS-002, ADR 0027): office_budget_claims
+// carries a forward foreign key to office_budget_policies, which SQLite tolerates at
+// CREATE TABLE time but PostgreSQL rejects, so the two tables' creation order is a
+// dialect-sensitive contract; Claim's INSERT ... ON CONFLICT DO NOTHING and the
+// db.IsForeignKeyViolation classifier it relies on are dialect-sensitive too. This
+// proves fresh-boot, boot replay, claim win/lose, the foreign-key-violation miss, and
+// cascade delete all hold on a real PostgreSQL backend. Skips unless
+// KANDEV_TEST_POSTGRES_DSN is set.
+func TestPostgresBudgetClaims(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	ctx := context.Background()
+
+	// office_budget_policies (and thus office_budget_claims' FK target) has no
+	// dependency of its own on the task repository, but office repo init as a
+	// whole does, mirroring production boot order (see cost_event_contract_postgres_test.go).
+	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+
+	// First boot: office_budget_claims must be created after office_budget_policies
+	// so its forward FK reference resolves on Postgres.
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	// Second boot: the schema must replay without error.
+	if _, err := sqlite.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("second boot (replay): %v", err)
+	}
+
+	policy := &models.BudgetPolicy{
+		WorkspaceID:       "pg-budget-ws",
+		ScopeType:         "workspace",
+		ScopeID:           "pg-budget-ws",
+		LimitSubcents:     1000,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "notify_only",
+	}
+	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create budget policy: %v", err)
+	}
+
+	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("first claim should win")
+	}
+
+	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if claimed {
+		t.Fatal("second claim on the same (policy, period, level) must not win")
+	}
+
+	// A foreign-key violation (no such policy) must classify as an ordinary
+	// miss, not a store error — db.IsForeignKeyViolation's PostgreSQL branch.
+	claimed, err = repo.Claim(ctx, uuid.NewString(), "lifetime", "alert")
+	if err != nil {
+		t.Fatalf("claim against a nonexistent policy must not be a store error, got: %v", err)
+	}
+	if claimed {
+		t.Fatal("claim against a nonexistent policy must not win")
+	}
+
+	if err := repo.DeleteBudgetPolicy(ctx, policy.ID); err != nil {
+		t.Fatalf("delete budget policy: %v", err)
+	}
+	var claimCount int
+	if err := db.GetContext(ctx, &claimCount,
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = $1`, policy.ID,
+	); err != nil {
+		t.Fatalf("count claims after delete: %v", err)
+	}
+	if claimCount != 0 {
+		t.Fatalf("claim count after policy delete = %d, want 0 (FK ON DELETE CASCADE)", claimCount)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budget_claims_postgres_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_claims_postgres_test.go
@@ -56,7 +56,7 @@ func TestPostgresBudgetClaims(t *testing.T) {
 		t.Fatalf("create budget policy: %v", err)
 	}
 
-	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestPostgresBudgetClaims(t *testing.T) {
 		t.Fatal("first claim should win")
 	}
 
-	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision)
 	if err != nil {
 		t.Fatalf("second claim: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestPostgresBudgetClaims(t *testing.T) {
 
 	// A foreign-key violation (no such policy) must classify as an ordinary
 	// miss, not a store error — db.IsForeignKeyViolation's PostgreSQL branch.
-	claimed, err = repo.Claim(ctx, uuid.NewString(), "lifetime", "alert")
+	claimed, err = repo.Claim(ctx, uuid.NewString(), "lifetime", "alert", 1)
 	if err != nil {
 		t.Fatalf("claim against a nonexistent policy must not be a store error, got: %v", err)
 	}
@@ -93,5 +93,93 @@ func TestPostgresBudgetClaims(t *testing.T) {
 	}
 	if claimCount != 0 {
 		t.Fatalf("claim count after policy delete = %d, want 0 (FK ON DELETE CASCADE)", claimCount)
+	}
+}
+
+// TestPostgresBudgetClaims_RevisionFencingAndFourColumnKey is the PostgreSQL
+// twin of the revision-fencing coverage in budget_revision_fencing_test.go:
+// under READ COMMITTED a claim's WHERE EXISTS fence check and the row it
+// inserts both need proving on a real PostgreSQL backend, not just SQLite's
+// single-writer connection. It covers both halves called out by the fence
+// design: the fence itself refuses an insert against a superseded revision
+// (a stale evaluation cannot emit an obsolete claim), and revision being
+// part of the primary key means a claim row already recorded for an old
+// revision does not collide with — and so cannot suppress — a fresh
+// evaluation's claim at the new revision. Skips unless
+// KANDEV_TEST_POSTGRES_DSN is set.
+func TestPostgresBudgetClaims_RevisionFencingAndFourColumnKey(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	ctx := context.Background()
+
+	if _, err := taskrepo.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("init task repo: %v", err)
+	}
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+
+	policy := &models.BudgetPolicy{
+		WorkspaceID:       "pg-budget-fencing-ws",
+		ScopeType:         "workspace",
+		ScopeID:           "pg-budget-fencing-ws",
+		LimitSubcents:     1000,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "notify_only",
+	}
+	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create budget policy: %v", err)
+	}
+	staleRevision := policy.Revision
+
+	// A claim recorded at the current revision, before any update.
+	claimed, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", staleRevision)
+	if err != nil {
+		t.Fatalf("claim at revision %d: %v", staleRevision, err)
+	}
+	if !claimed {
+		t.Fatal("claim at the current revision should win")
+	}
+
+	if err := repo.UpdateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+	if policy.Revision != staleRevision+1 {
+		t.Fatalf("revision after update = %d, want %d", policy.Revision, staleRevision+1)
+	}
+
+	// The fence: a claim presented with the now-superseded revision must be
+	// refused, even though it targets a different period so it collides
+	// with nothing already in the table.
+	claimed, err = repo.Claim(ctx, policy.ID, "stale-period", "alert", staleRevision)
+	if err != nil {
+		t.Fatalf("stale-revision claim must be an ordinary miss, got error: %v", err)
+	}
+	if claimed {
+		t.Fatal("a claim presented with a superseded revision must not win")
+	}
+
+	// The four-column key: the update's claim discard removes the
+	// pre-update "lifetime" row, so this reasserts a claim on the same
+	// (policy, period, level) at the new revision, and it must win despite
+	// revision being part of the primary key rather than sharing a row with
+	// the old one.
+	claimed, err = repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision)
+	if err != nil {
+		t.Fatalf("claim at the new revision: %v", err)
+	}
+	if !claimed {
+		t.Fatal("claim at the current (post-update) revision should win")
+	}
+
+	var claimCount int
+	if err := db.GetContext(ctx, &claimCount,
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = $1`, policy.ID,
+	); err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if claimCount != 1 {
+		t.Fatalf("claim rows for policy = %d, want 1 (the stale-revision attempt must not have inserted a row)", claimCount)
 	}
 }

--- a/apps/backend/internal/office/repository/sqlite/budget_claims_recreate_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_claims_recreate_internal_test.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/db"
+	runssqlite "github.com/kandev/kandev/internal/runs/repository/sqlite"
+)
+
+// TestRecreateBudgetClaimsForRevision_FailureIsVisible covers the other
+// half of AC-OFFICE-COSTS-003.3a: a failed recreate must reach the caller
+// that initializes the schema, not be logged and swallowed the way the
+// neighbouring runMigrations()/activateRunOutcome() calls are.
+// failBudgetClaimsRecreateErr is a test-only failpoint (see base.go)
+// standing in for a fault-injecting driver; the repo is built by hand
+// (mirroring NewWithDB) so the failpoint can be set before initSchema runs,
+// while the database still carries the pre-.3 three-column claims table the
+// probe needs to find revision absent in.
+func TestRecreateBudgetClaimsForRevision_FailureIsVisible(t *testing.T) {
+	sqlDB, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE office_budget_policies (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			limit_subcents INTEGER NOT NULL,
+			period TEXT NOT NULL,
+			alert_threshold_pct INTEGER DEFAULT 80,
+			action_on_exceed TEXT DEFAULT 'notify_only',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE office_budget_claims (
+			policy_id TEXT NOT NULL,
+			period_key TEXT NOT NULL,
+			level TEXT NOT NULL,
+			claimed_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (policy_id, period_key, level),
+			FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE
+		);
+	`); err != nil {
+		t.Fatalf("seed legacy office_budget_claims: %v", err)
+	}
+
+	repo := &Repository{
+		Repository:                  runssqlite.NewWithDB(sqlDB, sqlDB),
+		db:                          sqlDB,
+		ro:                          sqlDB,
+		migrate:                     db.NewMigrateLogger(sqlDB, nil),
+		failBudgetClaimsRecreateErr: errors.New("injected recreate failure"),
+	}
+
+	if err := repo.initSchema(); err == nil {
+		t.Fatal("expected initSchema to surface the injected recreate failure, got nil error")
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budget_claims_recreate_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_claims_recreate_internal_test.go
@@ -65,3 +65,92 @@ func TestRecreateBudgetClaimsForRevision_FailureIsVisible(t *testing.T) {
 		t.Fatal("expected initSchema to surface the injected recreate failure, got nil error")
 	}
 }
+
+// budgetClaimsHasRevisionColumn reports whether office_budget_claims
+// currently declares a revision column, distinguishing the old three-column
+// shape from the final four-column one.
+func budgetClaimsHasRevisionColumn(t *testing.T, sqlDB *sqlx.DB) bool {
+	t.Helper()
+	var count int
+	if err := sqlDB.Get(&count,
+		`SELECT COUNT(*) FROM pragma_table_info('office_budget_claims') WHERE name = 'revision'`,
+	); err != nil {
+		t.Fatalf("probe office_budget_claims columns: %v", err)
+	}
+	return count == 1
+}
+
+// TestRecreateBudgetClaimsForRevision_AtomicAcrossDropAndCreate covers the
+// crash-safety half of AC-OFFICE-COSTS-003.3a: DROP and CREATE must commit
+// or fail together, not as two independent statements. A boot interrupted
+// between them must not leave office_budget_claims absent, because a
+// missing table and an old-shape table both probe as "revision absent" and
+// an unconditional DROP TABLE (no IF EXISTS) on an already-missing table
+// would error forever on every later boot. failBudgetClaimsRecreateAfterDropErr
+// (see base.go) fires after DROP has run but before CREATE, inside the same
+// transaction, standing in for a process crash at that point.
+func TestRecreateBudgetClaimsForRevision_AtomicAcrossDropAndCreate(t *testing.T) {
+	sqlDB, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE office_budget_policies (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			limit_subcents INTEGER NOT NULL,
+			period TEXT NOT NULL,
+			alert_threshold_pct INTEGER DEFAULT 80,
+			action_on_exceed TEXT DEFAULT 'notify_only',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE office_budget_claims (
+			policy_id TEXT NOT NULL,
+			period_key TEXT NOT NULL,
+			level TEXT NOT NULL,
+			claimed_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (policy_id, period_key, level),
+			FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE
+		);
+	`); err != nil {
+		t.Fatalf("seed legacy office_budget_claims: %v", err)
+	}
+
+	repo := &Repository{
+		Repository: runssqlite.NewWithDB(sqlDB, sqlDB),
+		db:         sqlDB,
+		ro:         sqlDB,
+		migrate:    db.NewMigrateLogger(sqlDB, nil),
+	}
+
+	repo.failBudgetClaimsRecreateAfterDropErr = errors.New("injected crash between drop and create")
+	if err := repo.initSchema(); err == nil {
+		t.Fatal("expected initSchema to surface the injected failure, got nil error")
+	}
+	if budgetClaimsHasRevisionColumn(t, sqlDB) {
+		t.Fatal("a failure between DROP and CREATE must not leave the new shape partially applied")
+	}
+	var count int
+	if err := sqlDB.Get(&count,
+		`SELECT COUNT(*) FROM pragma_table_info('office_budget_claims')`,
+	); err != nil {
+		t.Fatalf("count office_budget_claims columns: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("a failure between DROP and CREATE must not leave office_budget_claims absent; the DROP must roll back too")
+	}
+
+	repo.failBudgetClaimsRecreateAfterDropErr = nil
+	if err := repo.initSchema(); err != nil {
+		t.Fatalf("retry boot after the injected failure must self-heal, got: %v", err)
+	}
+	if !budgetClaimsHasRevisionColumn(t, sqlDB) {
+		t.Fatal("retry boot must complete the recreate and leave the revision column present")
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budget_exceeded_atomicity_internal_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_exceeded_atomicity_internal_test.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/office/models"
+)
+
+// TestClaimExceeded_CompanionFailure_RollsBackWholePair proves the
+// exceeded-level claim and its alert-level companion are one transaction
+// (AC-OFFICE-COSTS-003.10): when the companion insert fails after the
+// exceeded insert has already run, the whole transaction rolls back, so
+// neither row survives. failBudgetExceededCompanionErr is a test-only
+// failpoint (see base.go) standing in for a fault-injecting driver.
+func TestClaimExceeded_CompanionFailure_RollsBackWholePair(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("pragma fk: %v", err)
+	}
+	if _, _, err := settingsstore.Provide(db, db, nil); err != nil {
+		t.Fatalf("settings store init: %v", err)
+	}
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+
+	ctx := context.Background()
+	policy := &models.BudgetPolicy{
+		WorkspaceID:       "ws-companion-rollback",
+		ScopeType:         "workspace",
+		ScopeID:           "ws-companion-rollback",
+		LimitSubcents:     1000,
+		Period:            "monthly",
+		AlertThresholdPct: 80,
+		ActionOnExceed:    "notify_only",
+	}
+	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	repo.failBudgetExceededCompanionErr = errors.New("injected companion failure")
+	claimed, err := repo.ClaimExceeded(ctx, policy.ID, "lifetime", policy.Revision)
+	if err == nil {
+		t.Fatal("expected the injected companion failure to surface")
+	}
+	if claimed {
+		t.Fatal("a failed pair must report claimed=false")
+	}
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ?`, policy.ID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("claim rows after a rolled-back pair = %d, want 0 (neither row must survive)", count)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budget_revision_fencing_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budget_revision_fencing_test.go
@@ -1,0 +1,424 @@
+package sqlite_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// TestBudgetPolicyRevisionMigration_LegacyRowsBackfillToOne covers
+// AC-OFFICE-COSTS-003.1: a database created before the revision column
+// exists gets it added as NOT NULL DEFAULT 1, an existing row is backfilled
+// to 1, and a boot replay is a no-op (no new local error classifier is
+// exercised beyond db.IsDuplicateColumnError, ADR 0027).
+func TestBudgetPolicyRevisionMigration_LegacyRowsBackfillToOne(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Seed the pre-.3 office_budget_policies shape (no revision column) and
+	// a legacy row, before the repo (and its migration) ever runs.
+	if _, err := db.Exec(`
+		CREATE TABLE office_budget_policies (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			limit_subcents INTEGER NOT NULL,
+			period TEXT NOT NULL,
+			alert_threshold_pct INTEGER DEFAULT 80,
+			action_on_exceed TEXT DEFAULT 'notify_only',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		)`); err != nil {
+		t.Fatalf("seed legacy office_budget_policies: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO office_budget_policies (
+			id, workspace_id, scope_type, scope_id, limit_subcents, period, created_at, updated_at
+		) VALUES ('legacy-1', 'ws-legacy', 'workspace', 'ws-legacy', 1000, 'monthly', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	if _, err := sqlite.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+
+	var revision int64
+	if err := db.QueryRow(`SELECT revision FROM office_budget_policies WHERE id = 'legacy-1'`).Scan(&revision); err != nil {
+		t.Fatalf("select revision on legacy row: %v", err)
+	}
+	if revision != 1 {
+		t.Fatalf("legacy row revision = %d, want 1", revision)
+	}
+
+	// Boot replay must be a no-op, not an error.
+	if _, err := sqlite.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("second boot (replay): %v", err)
+	}
+}
+
+// legacyBudgetClaimsFixture builds an in-memory database still carrying
+// PR #3287's three-column office_budget_claims shape (no revision, no FK
+// dependency needed for these assertions), so the AC-OFFICE-COSTS-003.3a
+// recreate actually has to run rather than being short-circuited by a fresh
+// database's inline final-shape DDL.
+func legacyBudgetClaimsFixture(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(`
+		CREATE TABLE office_budget_policies (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			limit_subcents INTEGER NOT NULL,
+			period TEXT NOT NULL,
+			alert_threshold_pct INTEGER DEFAULT 80,
+			action_on_exceed TEXT DEFAULT 'notify_only',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE office_budget_claims (
+			policy_id TEXT NOT NULL,
+			period_key TEXT NOT NULL,
+			level TEXT NOT NULL,
+			claimed_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (policy_id, period_key, level),
+			FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE
+		);
+	`); err != nil {
+		t.Fatalf("seed legacy office_budget_claims: %v", err)
+	}
+	return db
+}
+
+// TestRecreateBudgetClaims_OldShapeDatabase_GuardedAcrossBoots covers
+// AC-OFFICE-COSTS-003.3a: booting against a database still carrying the
+// pre-.3 three-column claim table runs the recreate (destroying whatever
+// claims existed before that boot, which AC-OFFICE-COSTS-003.3 expressly
+// permits); a claim written *after* that boot survives a second boot, which
+// must probe, find revision present, and do nothing.
+func TestRecreateBudgetClaims_OldShapeDatabase_GuardedAcrossBoots(t *testing.T) {
+	db := legacyBudgetClaimsFixture(t)
+	if _, err := db.Exec(`
+		INSERT INTO office_budget_policies (
+			id, workspace_id, scope_type, scope_id, limit_subcents, period, created_at, updated_at
+		) VALUES ('p1', 'ws-1', 'workspace', 'ws-1', 1000, 'monthly', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed policy: %v", err)
+	}
+	// A claim held before the cutover boot: the recreate is permitted to
+	// destroy it (AC-OFFICE-COSTS-003.3's accepted first-run behavior).
+	if _, err := db.Exec(`
+		INSERT INTO office_budget_claims (policy_id, period_key, level, claimed_at)
+		VALUES ('p1', 'lifetime', 'alert', CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed pre-cutover claim: %v", err)
+	}
+
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("first boot (cutover): %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM office_budget_claims`).Scan(&count); err != nil {
+		t.Fatalf("count claims after cutover: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("claims after cutover = %d, want 0 (pre-cutover claims are destroyed by the recreate)", count)
+	}
+
+	var revisionColExists int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('office_budget_claims') WHERE name = 'revision'`).
+		Scan(&revisionColExists); err != nil {
+		t.Fatalf("probe revision column: %v", err)
+	}
+	if revisionColExists != 1 {
+		t.Fatal("office_budget_claims.revision must exist after the cutover boot")
+	}
+
+	// A claim written after the cutover boot must survive a second boot.
+	ctx := context.Background()
+	if claimed, err := repo.Claim(ctx, "p1", "lifetime", "alert", 1); err != nil || !claimed {
+		t.Fatalf("post-cutover claim: claimed=%v err=%v", claimed, err)
+	}
+
+	if _, err := sqlite.NewWithDB(db, db, nil); err != nil {
+		t.Fatalf("second boot (replay): %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM office_budget_claims`).Scan(&count); err != nil {
+		t.Fatalf("count claims after replay: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("claims after replay boot = %d, want 1 (the probe must no-op on a second boot)", count)
+	}
+}
+
+// TestCreateBudgetPolicy_AssignsRevisionOne_IgnoringPresentedValue covers
+// AC-OFFICE-COSTS-003.4: revision is always 1 on create, regardless of any
+// value already set on the policy struct passed in, and the assigned value
+// is written back so the caller sees what the row actually holds.
+func TestCreateBudgetPolicy_AssignsRevisionOne_IgnoringPresentedValue(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+
+	policy := createTestBudgetPolicy(t, repo, "ws-revision-create")
+	policy.Revision = 777 // presented before a hypothetical re-create; must not survive.
+	policy.ID = ""        // force a fresh insert
+	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	if policy.Revision != 1 {
+		t.Fatalf("revision returned to caller = %d, want 1", policy.Revision)
+	}
+
+	var stored int64
+	if err := db.QueryRow(`SELECT revision FROM office_budget_policies WHERE id = ?`, policy.ID).Scan(&stored); err != nil {
+		t.Fatalf("select stored revision: %v", err)
+	}
+	if stored != 1 {
+		t.Fatalf("stored revision = %d, want 1", stored)
+	}
+}
+
+// TestUpdateBudgetPolicy_NonexistentPolicy_ReturnsErrorNoCommit covers the
+// AC-OFFICE-COSTS-003.5 tightening: updating a policy id that no longer
+// exists rolls the transaction back and reports an error, a behavior change
+// from #3287 where the update ignored its affected-row count and reported
+// success.
+func TestUpdateBudgetPolicy_NonexistentPolicy_ReturnsErrorNoCommit(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+
+	policy := createTestBudgetPolicy(t, repo, "ws-revision-missing")
+	if err := repo.DeleteBudgetPolicy(ctx, policy.ID); err != nil {
+		t.Fatalf("delete policy: %v", err)
+	}
+
+	policy.LimitSubcents = 9999
+	if err := repo.UpdateBudgetPolicy(ctx, policy); err == nil {
+		t.Fatal("expected an error updating a policy id that no longer exists")
+	}
+}
+
+// TestUpdateBudgetPolicy_ConcurrentUpdates_RevisionAdvancesByTwo covers
+// concurrency case 6 of the forced-to-invent pass: two concurrent updates
+// each bump by 1, and the final revision is r+2 with no increment lost —
+// serialized by SQLite's single-writer connection, exactly as production
+// runs (internal/db/pool.go).
+func TestUpdateBudgetPolicy_ConcurrentUpdates_RevisionAdvancesByTwo(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-revision-concurrent")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func(limit int64) {
+			defer wg.Done()
+			p, err := repo.GetBudgetPolicy(ctx, policy.ID)
+			if err != nil {
+				t.Errorf("get policy: %v", err)
+				return
+			}
+			p.LimitSubcents = limit
+			if err := repo.UpdateBudgetPolicy(ctx, p); err != nil {
+				t.Errorf("update policy: %v", err)
+			}
+		}(int64(2000 + i))
+	}
+	wg.Wait()
+
+	var revision int64
+	if err := db.QueryRow(`SELECT revision FROM office_budget_policies WHERE id = ?`, policy.ID).Scan(&revision); err != nil {
+		t.Fatalf("select final revision: %v", err)
+	}
+	if revision != 3 {
+		t.Fatalf("final revision = %d, want 3 (started at 1, two updates each +1)", revision)
+	}
+}
+
+// TestClaim_RaceA_StaleRevisionRefused_FreshRevisionSucceeds covers
+// AC-OFFICE-COSTS-003.8/.9/.15 (the verification.md "Race A regression"
+// bullet): a claim presenting a superseded revision is refused as an
+// ordinary miss (no error), and the slot for the new revision stays open so
+// a claim at the current revision still wins.
+func TestClaim_RaceA_StaleRevisionRefused_FreshRevisionSucceeds(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-race-a")
+	staleRevision := policy.Revision // 1
+
+	// Concurrent UpdateBudgetPolicy commits, bumping the stored revision to 2.
+	policy.LimitSubcents = 2000
+	if err := repo.UpdateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+	if policy.Revision != staleRevision+1 {
+		t.Fatalf("revision after update = %d, want %d", policy.Revision, staleRevision+1)
+	}
+
+	// The stale evaluation's claim, fenced to the superseded revision, must
+	// be refused with no error.
+	claimed, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", staleRevision)
+	if err != nil {
+		t.Fatalf("stale claim must not be a store error, got: %v", err)
+	}
+	if claimed {
+		t.Fatal("a claim fenced to a superseded revision must not win")
+	}
+
+	// The slot for the new revision must still be open.
+	claimed, err = repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision)
+	if err != nil {
+		t.Fatalf("fresh-revision claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("a claim fenced to the current revision must win even after a stale claim was refused")
+	}
+}
+
+// TestClaim_InvalidInput_FailsOpenNotSilently covers AC-OFFICE-COSTS-003.13:
+// each of the four primary-key components, when invalid, is a claim-store
+// error (never the silent miss AC-OFFICE-COSTS-003.9 reserves for a refused
+// fence), so the guard must run before the fenced statement rather than as
+// part of it.
+func TestClaim_InvalidInput_FailsOpenNotSilently(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-invalid-input")
+
+	cases := []struct {
+		name             string
+		policyID, period string
+		level            string
+		revision         int64
+	}{
+		{"zero revision", policy.ID, "lifetime", "alert", 0},
+		{"negative revision", policy.ID, "lifetime", "alert", -1},
+		{"empty policy id", "", "lifetime", "alert", policy.Revision},
+		{"empty period key", policy.ID, "", "alert", policy.Revision},
+		{"empty level", policy.ID, "lifetime", "", policy.Revision},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claimed, err := repo.Claim(ctx, tc.policyID, tc.period, tc.level, tc.revision)
+			if err == nil {
+				t.Fatalf("expected a claim-store error for %s, got claimed=%v err=nil", tc.name, claimed)
+			}
+			if claimed {
+				t.Fatalf("an errored claim attempt must report claimed=false, got true for %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestClaimExceeded_HappyPath_BothRowsExistAtSameRevision covers
+// AC-OFFICE-COSTS-003.10/.11 on a healthy store: a successful ClaimExceeded
+// call commits both the exceeded-level and alert-level companion rows at
+// the same policy, period and revision.
+func TestClaimExceeded_HappyPath_BothRowsExistAtSameRevision(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-exceeded-happy")
+
+	claimed, err := repo.ClaimExceeded(ctx, policy.ID, "lifetime", policy.Revision)
+	if err != nil {
+		t.Fatalf("claim exceeded: %v", err)
+	}
+	if !claimed {
+		t.Fatal("first exceeded claim should win")
+	}
+
+	for _, level := range []string{"exceeded", "alert"} {
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ? AND period_key = 'lifetime' AND level = ? AND revision = ?`,
+			policy.ID, level, policy.Revision,
+		).Scan(&count); err != nil {
+			t.Fatalf("count %s claim: %v", level, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s claim rows = %d, want 1", level, count)
+		}
+	}
+}
+
+// TestClaimExceeded_CompanionConflictIsPairSuccess covers the first
+// verification.md "pair outcomes that are successes, not failures" case:
+// with an alert-level claim already held, an over-limit evaluation's
+// companion insert conflicts, but the pair still commits and the exceeded
+// claim is won.
+func TestClaimExceeded_CompanionConflictIsPairSuccess(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-companion-conflict")
+
+	if claimed, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision); err != nil || !claimed {
+		t.Fatalf("seed alert claim: claimed=%v err=%v", claimed, err)
+	}
+
+	claimed, err := repo.ClaimExceeded(ctx, policy.ID, "lifetime", policy.Revision)
+	if err != nil {
+		t.Fatalf("claim exceeded: %v", err)
+	}
+	if !claimed {
+		t.Fatal("exceeded claim must still win despite the companion insert conflicting")
+	}
+}
+
+// TestClaimExceeded_AlreadyHeld_NoCompanionAttempted covers the second
+// verification.md "pair outcomes" case: with an exceeded-level claim
+// already held, a second over-limit evaluation's exceeded insert writes
+// nothing, and no companion insert is attempted.
+func TestClaimExceeded_AlreadyHeld_NoCompanionAttempted(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-exceeded-already-held")
+
+	if claimed, err := repo.ClaimExceeded(ctx, policy.ID, "lifetime", policy.Revision); err != nil || !claimed {
+		t.Fatalf("first exceeded claim: claimed=%v err=%v", claimed, err)
+	}
+	// Remove the companion so a second, incorrectly-attempted companion
+	// insert would be observable.
+	if _, err := db.Exec(
+		`DELETE FROM office_budget_claims WHERE policy_id = ? AND level = 'alert'`, policy.ID,
+	); err != nil {
+		t.Fatalf("remove companion: %v", err)
+	}
+
+	claimed, err := repo.ClaimExceeded(ctx, policy.ID, "lifetime", policy.Revision)
+	if err != nil {
+		t.Fatalf("second exceeded claim: %v", err)
+	}
+	if claimed {
+		t.Fatal("a second exceeded claim at an already-held (policy, period, revision) must not win")
+	}
+
+	var companionCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ? AND level = 'alert'`, policy.ID,
+	).Scan(&companionCount); err != nil {
+		t.Fatalf("count companion rows: %v", err)
+	}
+	if companionCount != 0 {
+		t.Fatal("no companion insert must be attempted when the exceeded insert itself writes no row")
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/budgets.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 
+	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/office/models"
 )
 
@@ -42,11 +44,13 @@ func (r *Repository) GetBudgetPolicy(ctx context.Context, id string) (*models.Bu
 	return &policy, err
 }
 
-// ListBudgetPolicies returns all budget policies for a workspace.
+// ListBudgetPolicies returns all budget policies for a workspace, ordered by
+// created_at with id as a tiebreak so evaluation order is total and
+// reproducible.
 func (r *Repository) ListBudgetPolicies(ctx context.Context, workspaceID string) ([]*models.BudgetPolicy, error) {
 	var policies []*models.BudgetPolicy
 	err := r.ro.SelectContext(ctx, &policies, r.ro.Rebind(
-		`SELECT * FROM office_budget_policies WHERE workspace_id = ? ORDER BY created_at`), workspaceID)
+		`SELECT * FROM office_budget_policies WHERE workspace_id = ? ORDER BY created_at ASC, id ASC`), workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -56,22 +60,74 @@ func (r *Repository) ListBudgetPolicies(ctx context.Context, workspaceID string)
 	return policies, nil
 }
 
-// UpdateBudgetPolicy updates an existing budget policy.
+// UpdateBudgetPolicy updates an existing budget policy and discards that
+// policy's claims in the same transaction, so either both apply or neither
+// does.
 func (r *Repository) UpdateBudgetPolicy(ctx context.Context, policy *models.BudgetPolicy) error {
 	policy.UpdatedAt = time.Now().UTC()
-	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := r.updateBudgetPolicyTx(ctx, tx, policy); err != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			return fmt.Errorf("%w; rollback: %v", err, rollbackErr)
+		}
+		return err
+	}
+	return tx.Commit()
+}
+
+func (r *Repository) updateBudgetPolicyTx(ctx context.Context, tx *sqlx.Tx, policy *models.BudgetPolicy) error {
+	if _, err := tx.ExecContext(ctx, tx.Rebind(
+		`DELETE FROM office_budget_claims WHERE policy_id = ?`), policy.ID); err != nil {
+		return fmt.Errorf("discard claims: %w", err)
+	}
+	if r.failBudgetPolicyUpdateErr != nil {
+		return r.failBudgetPolicyUpdateErr
+	}
+	_, err := tx.ExecContext(ctx, tx.Rebind(`
 		UPDATE office_budget_policies SET
 			scope_type = ?, scope_id = ?, limit_subcents = ?, period = ?,
 			alert_threshold_pct = ?, action_on_exceed = ?, updated_at = ?
 		WHERE id = ?
 	`), policy.ScopeType, policy.ScopeID, policy.LimitSubcents, policy.Period,
 		policy.AlertThresholdPct, policy.ActionOnExceed, policy.UpdatedAt, policy.ID)
-	return err
+	if err != nil {
+		return fmt.Errorf("update policy: %w", err)
+	}
+	return nil
 }
 
-// DeleteBudgetPolicy deletes a budget policy by ID.
+// DeleteBudgetPolicy deletes a budget policy by ID. Its claims are removed by
+// the office_budget_claims foreign key's ON DELETE CASCADE, not here.
 func (r *Repository) DeleteBudgetPolicy(ctx context.Context, id string) error {
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(
 		`DELETE FROM office_budget_policies WHERE id = ?`), id)
 	return err
+}
+
+// Claim atomically records that (policyID, periodKey, level) may emit its
+// budget notification. claimed=true means this call won and the caller
+// should emit; claimed=false with a nil error means an earlier evaluation
+// already holds the claim, or the referenced policy no longer exists — a
+// foreign-key violation is deliberately reported as an ordinary miss, not a
+// store failure.
+func (r *Repository) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		INSERT INTO office_budget_claims (policy_id, period_key, level, claimed_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(policy_id, period_key, level) DO NOTHING
+	`), policyID, periodKey, level, time.Now().UTC())
+	if err != nil {
+		if db.IsForeignKeyViolation(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }

--- a/apps/backend/internal/office/repository/sqlite/budgets.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets.go
@@ -13,7 +13,11 @@ import (
 	"github.com/kandev/kandev/internal/office/models"
 )
 
-// CreateBudgetPolicy creates a new budget policy.
+// CreateBudgetPolicy creates a new budget policy. Its revision is always
+// assigned 1, regardless of any value already set on policy — including a
+// nonzero one presented for creation. The assigned value is written back
+// onto policy so the caller (the create response) reports what the row
+// actually holds rather than leaning on the column's DEFAULT 1.
 func (r *Repository) CreateBudgetPolicy(ctx context.Context, policy *models.BudgetPolicy) error {
 	if policy.ID == "" {
 		policy.ID = uuid.New().String()
@@ -21,15 +25,16 @@ func (r *Repository) CreateBudgetPolicy(ctx context.Context, policy *models.Budg
 	now := time.Now().UTC()
 	policy.CreatedAt = now
 	policy.UpdatedAt = now
+	policy.Revision = 1
 
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		INSERT INTO office_budget_policies (
 			id, workspace_id, scope_type, scope_id, limit_subcents, period,
-			alert_threshold_pct, action_on_exceed, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			alert_threshold_pct, action_on_exceed, created_at, updated_at, revision
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`), policy.ID, policy.WorkspaceID, policy.ScopeType, policy.ScopeID,
 		policy.LimitSubcents, policy.Period, policy.AlertThresholdPct,
-		policy.ActionOnExceed, policy.CreatedAt, policy.UpdatedAt)
+		policy.ActionOnExceed, policy.CreatedAt, policy.UpdatedAt, policy.Revision)
 	return err
 }
 
@@ -78,6 +83,15 @@ func (r *Repository) UpdateBudgetPolicy(ctx context.Context, policy *models.Budg
 	return tx.Commit()
 }
 
+// updateBudgetPolicyTx discards the policy's claims, bumps its revision by
+// exactly 1 in-SQL, and reads the new revision back onto policy, all in the
+// caller's transaction. The bump is expressed as revision = revision + 1
+// rather than a value computed from a prior read, so two concurrent updates
+// can never write the same revision. If no row matches id — the policy was
+// deleted between the caller's read and this write — the RETURNING
+// read-back yields sql.ErrNoRows, which propagates as an error so the
+// caller rolls the whole transaction back rather than committing an empty
+// update.
 func (r *Repository) updateBudgetPolicyTx(ctx context.Context, tx *sqlx.Tx, policy *models.BudgetPolicy) error {
 	if _, err := tx.ExecContext(ctx, tx.Rebind(
 		`DELETE FROM office_budget_claims WHERE policy_id = ?`), policy.ID); err != nil {
@@ -86,14 +100,20 @@ func (r *Repository) updateBudgetPolicyTx(ctx context.Context, tx *sqlx.Tx, poli
 	if r.failBudgetPolicyUpdateErr != nil {
 		return r.failBudgetPolicyUpdateErr
 	}
-	_, err := tx.ExecContext(ctx, tx.Rebind(`
+	err := tx.QueryRowContext(ctx, tx.Rebind(`
 		UPDATE office_budget_policies SET
 			scope_type = ?, scope_id = ?, limit_subcents = ?, period = ?,
-			alert_threshold_pct = ?, action_on_exceed = ?, updated_at = ?
+			alert_threshold_pct = ?, action_on_exceed = ?, updated_at = ?,
+			revision = revision + 1
 		WHERE id = ?
+		RETURNING revision
 	`), policy.ScopeType, policy.ScopeID, policy.LimitSubcents, policy.Period,
-		policy.AlertThresholdPct, policy.ActionOnExceed, policy.UpdatedAt, policy.ID)
+		policy.AlertThresholdPct, policy.ActionOnExceed, policy.UpdatedAt, policy.ID,
+	).Scan(&policy.Revision)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("update policy: not found: %s", policy.ID)
+		}
 		return fmt.Errorf("update policy: %w", err)
 	}
 	return nil
@@ -107,27 +127,193 @@ func (r *Repository) DeleteBudgetPolicy(ctx context.Context, id string) error {
 	return err
 }
 
-// Claim atomically records that (policyID, periodKey, level) may emit its
-// budget notification. claimed=true means this call won and the caller
-// should emit; claimed=false with a nil error means an earlier evaluation
-// already holds the claim, or the referenced policy no longer exists — a
-// foreign-key violation is deliberately reported as an ordinary miss, not a
-// store failure.
-func (r *Repository) Claim(ctx context.Context, policyID, periodKey, level string) (bool, error) {
-	res, err := r.db.ExecContext(ctx, r.db.Rebind(`
-		INSERT INTO office_budget_claims (policy_id, period_key, level, claimed_at)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(policy_id, period_key, level) DO NOTHING
-	`), policyID, periodKey, level, time.Now().UTC())
+// budgetClaimLevelExceeded and budgetClaimLevelAlert are the claim-level
+// literals ClaimExceeded writes for its atomic pair. Level is otherwise
+// caller-supplied data, not a package concept, but ClaimExceeded's exported
+// signature does not take a level parameter, so its two writes need names
+// of their own.
+const (
+	budgetClaimLevelExceeded = "exceeded"
+	budgetClaimLevelAlert    = "alert"
+)
+
+// execRebinder is the subset of *sqlx.DB / *sqlx.Tx a fenced claim insert
+// needs, so the same statement can run standalone or inside ClaimExceeded's
+// transaction.
+type execRebinder interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Rebind(string) string
+}
+
+// validateClaimInput reports whether a claim attempt's primary-key
+// components are all well-formed. Every failure here is a programming
+// error, not a superseded snapshot, so the caller treats it as a
+// claim-store error and fails open rather than as the silent miss a
+// refused fence produces.
+func validateClaimInput(policyID, periodKey, level string, revision int64) error {
+	if revision <= 0 {
+		return fmt.Errorf("claim: revision must be positive, got %d", revision)
+	}
+	if policyID == "" {
+		return fmt.Errorf("claim: policy id must not be empty")
+	}
+	if periodKey == "" {
+		return fmt.Errorf("claim: period key must not be empty")
+	}
+	if level == "" {
+		return fmt.Errorf("claim: level must not be empty")
+	}
+	return nil
+}
+
+// claimInsertFenced inserts a claim row only if policyID still holds
+// exactly revision at the moment the statement runs, checked as part of the
+// same statement so no evaluation can observe a matching revision and then
+// insert against a superseded one. A policy that no longer exists at all
+// fails the same EXISTS check, which is how a deleted policy's claim
+// attempt is refused without ever reaching the foreign-key constraint. The
+// FK violation classifier is kept as a defensive fallback only: dropping it
+// would let a genuine foreign-key error read as an ordinary miss.
+func claimInsertFenced(ctx context.Context, ex execRebinder, policyID, periodKey, level string, revision int64) (bool, error) {
+	res, err := ex.ExecContext(ctx, ex.Rebind(`
+		INSERT INTO office_budget_claims (policy_id, period_key, level, revision, claimed_at)
+		SELECT ?, ?, ?, ?, ?
+		WHERE EXISTS (SELECT 1 FROM office_budget_policies WHERE id = ? AND revision = ?)
+		ON CONFLICT(policy_id, period_key, level, revision) DO NOTHING
+	`), policyID, periodKey, level, revision, time.Now().UTC(), policyID, revision)
 	if err != nil {
 		if db.IsForeignKeyViolation(err) {
 			return false, nil
 		}
 		return false, err
 	}
+	return rowsAffectedOne(res)
+}
+
+// claimInsertCompanion inserts the alert-level companion row for an
+// already-won exceeded claim, keyed to the same revision with no fence of
+// its own — its key already names the revision, so a row written against a
+// revision that has since moved is inert rather than wrong. Any error,
+// including a foreign-key violation from a policy deleted mid-transaction,
+// is returned unmodified so ClaimExceeded rolls the whole pair back rather
+// than committing a lone exceeded claim.
+func claimInsertCompanion(ctx context.Context, tx *sqlx.Tx, policyID, periodKey string, revision int64) (bool, error) {
+	res, err := tx.ExecContext(ctx, tx.Rebind(`
+		INSERT INTO office_budget_claims (policy_id, period_key, level, revision, claimed_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(policy_id, period_key, level, revision) DO NOTHING
+	`), policyID, periodKey, budgetClaimLevelAlert, revision, time.Now().UTC())
+	if err != nil {
+		return false, err
+	}
+	return rowsAffectedOne(res)
+}
+
+func rowsAffectedOne(res sql.Result) (bool, error) {
 	affected, err := res.RowsAffected()
 	if err != nil {
 		return false, err
 	}
 	return affected == 1, nil
+}
+
+// Claim atomically records that (policyID, periodKey, level) may emit its
+// budget notification, fenced to revision: the claim is recorded only while
+// revision is still the policy's stored revision. claimed=true means this
+// call won and the caller should emit; claimed=false with a nil error means
+// an earlier evaluation already holds the claim, the referenced policy no
+// longer exists, or the presented revision has been superseded — all three
+// are the same ordinary miss.
+func (r *Repository) Claim(ctx context.Context, policyID, periodKey, level string, revision int64) (bool, error) {
+	if err := validateClaimInput(policyID, periodKey, level, revision); err != nil {
+		return false, err
+	}
+	return claimInsertFenced(ctx, r.db, policyID, periodKey, level, revision)
+}
+
+// ClaimExceeded atomically records the exceeded-level claim and, only when
+// that claim is won by this call, its alert-level companion claim, in one
+// transaction: once it commits, either both rows exist for that policy,
+// period and revision, or this call wrote neither. The fence is evaluated
+// once, on the exceeded insert; the companion insert carries no fence of
+// its own. Returns whether the exceeded-level row was inserted by this
+// call — the companion's own outcome (won, or an ordinary conflict with an
+// alert-level claim an earlier evaluation already holds) never changes it.
+func (r *Repository) ClaimExceeded(ctx context.Context, policyID, periodKey string, revision int64) (bool, error) {
+	if err := validateClaimInput(policyID, periodKey, budgetClaimLevelExceeded, revision); err != nil {
+		return false, err
+	}
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	claimed, err := r.claimExceededTx(ctx, tx, policyID, periodKey, revision)
+	if err != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			return false, fmt.Errorf("%w; rollback: %v", err, rollbackErr)
+		}
+		return false, err
+	}
+	if !claimed {
+		return false, tx.Commit()
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *Repository) claimExceededTx(
+	ctx context.Context, tx *sqlx.Tx, policyID, periodKey string, revision int64,
+) (bool, error) {
+	claimed, err := claimInsertFenced(ctx, tx, policyID, periodKey, budgetClaimLevelExceeded, revision)
+	if err != nil {
+		return false, err
+	}
+	if !claimed {
+		// Refused by the fence, or conflicting with an exceeded claim
+		// already held: no emission to protect, so the companion insert
+		// must not be attempted.
+		return false, nil
+	}
+	if r.failBudgetExceededCompanionErr != nil {
+		return false, r.failBudgetExceededCompanionErr
+	}
+	if _, err := claimInsertCompanion(ctx, tx, policyID, periodKey, revision); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// recreateBudgetClaimsForRevision takes effect at most once per database:
+// it probes whether office_budget_claims already declares revision and does
+// nothing when it does, which is every boot after the first on a fresh
+// database (createCostTables already declares the final shape there) and
+// every boot after the first successful recreate on an upgraded one. On a
+// database still carrying the pre-revision three-column table, it drops and
+// recreates office_budget_claims with the four-column primary key the
+// current schema requires. It is not expressed as an r.migrate.Apply
+// statement: that runner re-executes its SQL on every boot and is
+// idempotent only because an already-exists error is swallowed, which
+// would destroy claim state on every boot here. It returns its error to
+// its caller rather than swallowing it, so a failed recreate is visible
+// rather than silently leaving the old three-column key in place.
+func (r *Repository) recreateBudgetClaimsForRevision() error {
+	exists, err := columnExists(r.db, "office_budget_claims", "revision")
+	if err != nil {
+		return fmt.Errorf("probe office_budget_claims.revision: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if r.failBudgetClaimsRecreateErr != nil {
+		return r.failBudgetClaimsRecreateErr
+	}
+	if _, err := r.db.Exec(`DROP TABLE office_budget_claims`); err != nil {
+		return fmt.Errorf("drop office_budget_claims: %w", err)
+	}
+	if _, err := r.db.Exec(budgetClaimsDDL); err != nil {
+		return fmt.Errorf("recreate office_budget_claims: %w", err)
+	}
+	return nil
 }

--- a/apps/backend/internal/office/repository/sqlite/budgets.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets.go
@@ -292,12 +292,16 @@ func (r *Repository) claimExceededTx(
 // every boot after the first successful recreate on an upgraded one. On a
 // database still carrying the pre-revision three-column table, it drops and
 // recreates office_budget_claims with the four-column primary key the
-// current schema requires. It is not expressed as an r.migrate.Apply
-// statement: that runner re-executes its SQL on every boot and is
-// idempotent only because an already-exists error is swallowed, which
-// would destroy claim state on every boot here. It returns its error to
-// its caller rather than swallowing it, so a failed recreate is visible
-// rather than silently leaving the old three-column key in place.
+// current schema requires, as one transaction: DROP and CREATE either both
+// commit or neither does, so a boot interrupted between them leaves the
+// table exactly as it was rather than absent, and a retried boot always
+// finds the table in a state the probe can classify. It is not expressed as
+// an r.migrate.Apply statement: that runner re-executes its SQL on every
+// boot and is idempotent only because an already-exists error is
+// swallowed, which would destroy claim state on every boot here. It
+// returns its error to its caller rather than swallowing it, so a failed
+// recreate is visible rather than silently leaving the old three-column
+// key in place.
 func (r *Repository) recreateBudgetClaimsForRevision() error {
 	exists, err := columnExists(r.db, "office_budget_claims", "revision")
 	if err != nil {
@@ -309,11 +313,21 @@ func (r *Repository) recreateBudgetClaimsForRevision() error {
 	if r.failBudgetClaimsRecreateErr != nil {
 		return r.failBudgetClaimsRecreateErr
 	}
-	if _, err := r.db.Exec(`DROP TABLE office_budget_claims`); err != nil {
+	tx, err := r.db.Beginx()
+	if err != nil {
+		return fmt.Errorf("begin office_budget_claims recreate: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE IF EXISTS office_budget_claims`); err != nil {
+		_ = tx.Rollback()
 		return fmt.Errorf("drop office_budget_claims: %w", err)
 	}
-	if _, err := r.db.Exec(budgetClaimsDDL); err != nil {
+	if r.failBudgetClaimsRecreateAfterDropErr != nil {
+		_ = tx.Rollback()
+		return r.failBudgetClaimsRecreateAfterDropErr
+	}
+	if _, err := tx.Exec(budgetClaimsDDL); err != nil {
+		_ = tx.Rollback()
 		return fmt.Errorf("recreate office_budget_claims: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }

--- a/apps/backend/internal/office/repository/sqlite/budgets_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets_test.go
@@ -24,6 +24,10 @@ func newBudgetClaimsRepoWithFK(t *testing.T) (*sqlite.Repository, *sqlx.DB) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	// Pin all work to one connection: each SQLite :memory: connection is a
+	// separate empty database, so a pooled second connection would miss the
+	// tables/rows the first one created.
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
 		t.Fatalf("pragma fk: %v", err)

--- a/apps/backend/internal/office/repository/sqlite/budgets_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets_test.go
@@ -3,53 +3,243 @@ package sqlite_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
 	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
 )
 
-func TestBudgetPolicy_CRUD(t *testing.T) {
-	repo := newTestRepo(t)
-	ctx := context.Background()
+// newBudgetClaimsRepoWithFK builds an in-memory repo with
+// PRAGMA foreign_keys=ON enabled, so the office_budget_claims cascade is
+// actually enforced (production always runs with _foreign_keys=on; the
+// default newTestRepo does not). Mirrors newRouteAttemptsRepoWithFK.
+func newBudgetClaimsRepoWithFK(t *testing.T) (*sqlite.Repository, *sqlx.DB) {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("pragma fk: %v", err)
+	}
+	if _, _, err := settingsstore.Provide(db, db, nil); err != nil {
+		t.Fatalf("settings store init: %v", err)
+	}
+	// office_task_tree_holds and friends carry an FK to the task-package
+	// owned "tasks" table; with foreign_keys=ON that table must exist (even
+	// empty) for a workspace-wide DELETE to validate the constraint.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS tasks (
+		id TEXT PRIMARY KEY,
+		workspace_id TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create tasks: %v", err)
+	}
+	repo, err := sqlite.NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	return repo, db
+}
 
+func createTestBudgetPolicy(t *testing.T, repo *sqlite.Repository, workspaceID string) *models.BudgetPolicy {
+	t.Helper()
 	policy := &models.BudgetPolicy{
-		WorkspaceID:       "ws-1",
-		ScopeType:         "agent",
-		ScopeID:           "agent-1",
-		LimitSubcents:     50000,
+		WorkspaceID:       workspaceID,
+		ScopeType:         "workspace",
+		ScopeID:           workspaceID,
+		LimitSubcents:     1000,
 		Period:            "monthly",
 		AlertThresholdPct: 80,
 		ActionOnExceed:    "notify_only",
 	}
-	if err := repo.CreateBudgetPolicy(ctx, policy); err != nil {
-		t.Fatalf("create: %v", err)
+	if err := repo.CreateBudgetPolicy(context.Background(), policy); err != nil {
+		t.Fatalf("create budget policy: %v", err)
 	}
+	return policy
+}
 
-	got, err := repo.GetBudgetPolicy(ctx, policy.ID)
+func countBudgetClaims(t *testing.T, db *sqlx.DB, policyID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM office_budget_claims WHERE policy_id = ?`, policyID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	return count
+}
+
+func TestClaim_FirstCallWinsSecondCallDoesNotReclaim(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-claim")
+
+	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
 	if err != nil {
-		t.Fatalf("get: %v", err)
+		t.Fatalf("first claim: %v", err)
 	}
-	if got.LimitSubcents != 50000 {
-		t.Errorf("limit_subcents = %d, want 50000", got.LimitSubcents)
+	if !claimed {
+		t.Fatal("first claim should win")
 	}
 
-	policies, err := repo.ListBudgetPolicies(ctx, "ws-1")
+	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
 	if err != nil {
-		t.Fatalf("list: %v", err)
+		t.Fatalf("second claim: %v", err)
 	}
-	if len(policies) != 1 {
-		t.Fatalf("count = %d, want 1", len(policies))
+	if claimed {
+		t.Fatal("second claim on the same (policy, period, level) must not win")
 	}
+}
 
-	policy.LimitSubcents = 100000
-	if err := repo.UpdateBudgetPolicy(ctx, policy); err != nil {
-		t.Fatalf("update: %v", err)
+func TestClaim_DifferentPeriodOrLevelIsIndependent(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-claim-2")
+
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil || !claimed {
+		t.Fatalf("claim september alert: claimed=%v err=%v", claimed, err)
 	}
-	got, _ = repo.GetBudgetPolicy(ctx, policy.ID)
-	if got.LimitSubcents != 100000 {
-		t.Errorf("updated limit_subcents = %d, want 100000", got.LimitSubcents)
+	// A different period (new window) is unclaimed (AC-OFFICE-COSTS-002.7).
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-10-01T00:00:00Z", "alert"); err != nil || !claimed {
+		t.Fatalf("claim october alert: claimed=%v err=%v", claimed, err)
+	}
+	// A different level in the same period is unclaimed.
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "exceeded"); err != nil || !claimed {
+		t.Fatalf("claim september exceeded: claimed=%v err=%v", claimed, err)
+	}
+}
+
+func TestClaim_ForeignKeyViolationReturnsFalseWithNoError(t *testing.T) {
+	repo, _ := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+
+	claimed, err := repo.Claim(ctx, uuid.NewString(), "lifetime", "alert")
+	if err != nil {
+		t.Fatalf("claim against a nonexistent policy must not be a store error, got: %v", err)
+	}
+	if claimed {
+		t.Fatal("claim against a nonexistent policy must not win")
+	}
+}
+
+func TestDeleteBudgetPolicy_CascadesClaims(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-cascade-1")
+
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 1 {
+		t.Fatalf("claim count before delete = %d, want 1", got)
 	}
 
 	if err := repo.DeleteBudgetPolicy(ctx, policy.ID); err != nil {
-		t.Fatalf("delete: %v", err)
+		t.Fatalf("delete budget policy: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 0 {
+		t.Fatalf("claim count after single-policy delete = %d, want 0", got)
+	}
+}
+
+func TestDeleteWorkspaceData_CascadesBudgetClaims(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-cascade-2")
+
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	if err := repo.DeleteWorkspaceData(ctx, "ws-cascade-2"); err != nil {
+		t.Fatalf("delete workspace data: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 0 {
+		t.Fatalf("claim count after workspace delete = %d, want 0", got)
+	}
+}
+
+func TestDeleteBudgetPoliciesForRemovedScopes_CascadesClaims(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-cascade-3")
+
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// No valid scope IDs remain, so the reconciliation sweep removes every
+	// workspace-scoped policy (mirrors infra.Reconciler.reconcileBudgetPolicies).
+	if _, err := repo.DeleteBudgetPoliciesForRemovedScopes(ctx, "workspace", nil); err != nil {
+		t.Fatalf("delete for removed scopes: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 0 {
+		t.Fatalf("claim count after reconcile delete = %d, want 0", got)
+	}
+}
+
+func TestUpdateBudgetPolicy_DiscardsClaims(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	policy := createTestBudgetPolicy(t, repo, "ws-update-1")
+
+	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 1 {
+		t.Fatalf("claim count before update = %d, want 1", got)
+	}
+
+	policy.LimitSubcents = 2000
+	if err := repo.UpdateBudgetPolicy(ctx, policy); err != nil {
+		t.Fatalf("update budget policy: %v", err)
+	}
+	if got := countBudgetClaims(t, db, policy.ID); got != 0 {
+		t.Fatalf("claim count after update = %d, want 0 (AC-OFFICE-COSTS-002.8)", got)
+	}
+
+	updated, err := repo.GetBudgetPolicy(ctx, policy.ID)
+	if err != nil {
+		t.Fatalf("get updated policy: %v", err)
+	}
+	if updated.LimitSubcents != 2000 {
+		t.Fatalf("limit_subcents = %d, want 2000", updated.LimitSubcents)
+	}
+}
+
+func TestListBudgetPolicies_OrdersByCreatedAtThenID(t *testing.T) {
+	repo, db := newBudgetClaimsRepoWithFK(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Two policies sharing the same created_at have no defined order from
+	// created_at alone; id is the deterministic tiebreak (AC-OFFICE-COSTS-002.16).
+	for _, id := range []string{"policy-b", "policy-a"} {
+		if _, err := db.Exec(
+			`INSERT INTO office_budget_policies (
+				id, workspace_id, scope_type, scope_id, limit_subcents, period,
+				alert_threshold_pct, action_on_exceed, created_at, updated_at
+			) VALUES (?, 'ws-order', 'workspace', 'ws-order', 100, 'monthly', 80, 'notify_only', ?, ?)`,
+			id, now, now,
+		); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	policies, err := repo.ListBudgetPolicies(ctx, "ws-order")
+	if err != nil {
+		t.Fatalf("list budget policies: %v", err)
+	}
+	if len(policies) != 2 {
+		t.Fatalf("policies = %d, want 2", len(policies))
+	}
+	if policies[0].ID != "policy-a" || policies[1].ID != "policy-b" {
+		t.Fatalf("order = [%s, %s], want [policy-a, policy-b]", policies[0].ID, policies[1].ID)
 	}
 }

--- a/apps/backend/internal/office/repository/sqlite/budgets_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets_test.go
@@ -84,7 +84,7 @@ func TestClaim_FirstCallWinsSecondCallDoesNotReclaim(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-claim")
 
-	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestClaim_FirstCallWinsSecondCallDoesNotReclaim(t *testing.T) {
 		t.Fatal("first claim should win")
 	}
 
-	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert")
+	claimed, err = repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision)
 	if err != nil {
 		t.Fatalf("second claim: %v", err)
 	}
@@ -106,15 +106,15 @@ func TestClaim_DifferentPeriodOrLevelIsIndependent(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-claim-2")
 
-	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil || !claimed {
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision); err != nil || !claimed {
 		t.Fatalf("claim september alert: claimed=%v err=%v", claimed, err)
 	}
 	// A different period (new window) is unclaimed (AC-OFFICE-COSTS-002.7).
-	if claimed, err := repo.Claim(ctx, policy.ID, "2026-10-01T00:00:00Z", "alert"); err != nil || !claimed {
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-10-01T00:00:00Z", "alert", policy.Revision); err != nil || !claimed {
 		t.Fatalf("claim october alert: claimed=%v err=%v", claimed, err)
 	}
 	// A different level in the same period is unclaimed.
-	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "exceeded"); err != nil || !claimed {
+	if claimed, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "exceeded", policy.Revision); err != nil || !claimed {
 		t.Fatalf("claim september exceeded: claimed=%v err=%v", claimed, err)
 	}
 }
@@ -123,7 +123,7 @@ func TestClaim_ForeignKeyViolationReturnsFalseWithNoError(t *testing.T) {
 	repo, _ := newBudgetClaimsRepoWithFK(t)
 	ctx := context.Background()
 
-	claimed, err := repo.Claim(ctx, uuid.NewString(), "lifetime", "alert")
+	claimed, err := repo.Claim(ctx, uuid.NewString(), "lifetime", "alert", 1)
 	if err != nil {
 		t.Fatalf("claim against a nonexistent policy must not be a store error, got: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestDeleteBudgetPolicy_CascadesClaims(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-cascade-1")
 
-	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 	if got := countBudgetClaims(t, db, policy.ID); got != 1 {
@@ -157,7 +157,7 @@ func TestDeleteWorkspaceData_CascadesBudgetClaims(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-cascade-2")
 
-	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestDeleteBudgetPoliciesForRemovedScopes_CascadesClaims(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-cascade-3")
 
-	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert"); err != nil {
+	if _, err := repo.Claim(ctx, policy.ID, "lifetime", "alert", policy.Revision); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
@@ -193,7 +193,7 @@ func TestUpdateBudgetPolicy_DiscardsClaims(t *testing.T) {
 	ctx := context.Background()
 	policy := createTestBudgetPolicy(t, repo, "ws-update-1")
 
-	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert"); err != nil {
+	if _, err := repo.Claim(ctx, policy.ID, "2026-09-01T00:00:00Z", "alert", policy.Revision); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 	if got := countBudgetClaims(t, db, policy.ID); got != 1 {
@@ -203,6 +203,9 @@ func TestUpdateBudgetPolicy_DiscardsClaims(t *testing.T) {
 	policy.LimitSubcents = 2000
 	if err := repo.UpdateBudgetPolicy(ctx, policy); err != nil {
 		t.Fatalf("update budget policy: %v", err)
+	}
+	if policy.Revision != 2 {
+		t.Fatalf("revision returned to caller = %d, want 2", policy.Revision)
 	}
 	if got := countBudgetClaims(t, db, policy.ID); got != 0 {
 		t.Fatalf("claim count after update = %d, want 0 (AC-OFFICE-COSTS-002.8)", got)
@@ -214,6 +217,9 @@ func TestUpdateBudgetPolicy_DiscardsClaims(t *testing.T) {
 	}
 	if updated.LimitSubcents != 2000 {
 		t.Fatalf("limit_subcents = %d, want 2000", updated.LimitSubcents)
+	}
+	if updated.Revision != 2 {
+		t.Fatalf("stored revision = %d, want 2", updated.Revision)
 	}
 }
 

--- a/apps/backend/internal/office/repository/sqlite/budgets_test.go
+++ b/apps/backend/internal/office/repository/sqlite/budgets_test.go
@@ -37,10 +37,16 @@ func newBudgetClaimsRepoWithFK(t *testing.T) (*sqlite.Repository, *sqlx.DB) {
 	}
 	// office_task_tree_holds and friends carry an FK to the task-package
 	// owned "tasks" table; with foreign_keys=ON that table must exist (even
-	// empty) for a workspace-wide DELETE to validate the constraint.
+	// empty) for a workspace-wide DELETE to validate the constraint. title/
+	// description/identifier are included so migrateTaskFTS's backfill (which
+	// selects them unconditionally once a "tasks" table exists) doesn't fail
+	// schema init on this minimal fixture.
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS tasks (
 		id TEXT PRIMARY KEY,
-		workspace_id TEXT NOT NULL DEFAULT ''
+		workspace_id TEXT NOT NULL DEFAULT '',
+		title TEXT DEFAULT '',
+		description TEXT DEFAULT '',
+		identifier TEXT DEFAULT ''
 	)`); err != nil {
 		t.Fatalf("create tasks: %v", err)
 	}

--- a/docs/specs/budget-claim-revision-fencing/amendments.md
+++ b/docs/specs/budget-claim-revision-fencing/amendments.md
@@ -1,0 +1,51 @@
+# Budget claim fencing: amendments to REQ-OFFICE-COSTS-002
+
+Companion to [spec.md](spec.md) (`REQ-OFFICE-COSTS-003`), alongside
+[verification.md](verification.md), [prior-art.md](prior-art.md) and
+[input-inventory.md](input-inventory.md). Split out for the specification linter's
+per-file size ceiling; the five files are one spec.
+
+Every entry below amends a criterion of `REQ-OFFICE-COSTS-002`. Nothing here is a new
+acceptance criterion of `REQ-OFFICE-COSTS-003`; those are all in
+[spec.md](spec.md#acceptance-criteria).
+
+This spec is a delta on a contract that is itself unmerged. Each amendment is named so
+Spec Review can check it against #3287 rather than re-deriving it.
+
+- **`AC-OFFICE-COSTS-002.8`** — its stale-evaluation carve-out ("An evaluation already in
+  flight when the discard commits ... may therefore insert a claim keyed to the pre-update
+  period and level, suppressing the first post-update notification; that outcome is
+  permitted rather than prevented") is **superseded**. `AC-OFFICE-COSTS-003.8`/`.9`/`.15`
+  now prevent it. The criterion's atomicity requirement is unchanged and now also covers
+  the revision bump. The rejection of a lock spanning evaluation and update stands.
+- **`AC-OFFICE-COSTS-002.5`** — the companion alert claim is no longer a separate,
+  independently-failing write. Its "conditional on the claim store accepting that companion
+  write" clause and the consequence it describes ("the de-escalation protection lapses for
+  that one period") are **removed**: under `AC-OFFICE-COSTS-003.10` the pair is atomic, so
+  a companion failure is a pair failure and lands on the ordinary
+  `AC-OFFICE-COSTS-002.14` fail-open path. Its precedence rule is unchanged. A
+  fault-injection test still shall not assert the companion claim was recorded.
+- **`AC-OFFICE-COSTS-002.10`** — unchanged in force. Its scope widens: "exactly one
+  submission" now also holds for the previously unaddressed alert-band-versus-over-limit
+  pair, in the direction stated by `AC-OFFICE-COSTS-003.12`.
+- **`AC-OFFICE-COSTS-002.13`** — unchanged in meaning; one case joins its enumeration: an
+  evaluation whose claim was refused on a superseded revision reports `submitted` false,
+  because no row went out. Its existing rule already settles this.
+- **`AC-OFFICE-COSTS-002.14a`** — unchanged in outcome; the mechanism moves from the
+  foreign-key classifier to the fence's existence check, which subsumes it.
+- **`AC-OFFICE-COSTS-002.14`** — unchanged in force; its scope widens twice. The invalid
+  claim inputs of `AC-OFFICE-COSTS-003.13` become claim-store errors it governs, and the
+  atomic pair of `AC-OFFICE-COSTS-003.10` is a single claim attempt under it, so a pair
+  failure is one fail-open emission, one log and one counter increment rather than two;
+  `AC-OFFICE-COSTS-003.14` fixes which level that log names. Its exclusion of a failed
+  claim *discard* is unchanged and now also covers a failed revision bump, which rides the
+  same transaction and is reported to the caller by `AC-OFFICE-COSTS-002.8`.
+- **`AC-OFFICE-COSTS-002.15`** — not amended. A claim still survives a spend that falls
+  back below the level it was taken at; revision changes nothing there, because only an
+  update or a period rollover releases a claim and both already did.
+- **Not amended:** `.1`, `.2`, `.2a`, `.3`, `.4`, `.4a`, `.6`, `.6a`, `.7`, `.9`, `.11`,
+  `.12`, `.16`, `.17`, and every entry in `REQ-OFFICE-COSTS-002`'s `## Out of scope`.
+- **Documentation follow-up, not this card:** once #3287 merges, fold these criteria into
+  `docs/specs/office/requirements/costs.md` as `REQ-OFFICE-COSTS-003` with a matching
+  system-design part and retire this slug directory. Editing that file now would conflict
+  with the unmerged PR this spec depends on.

--- a/docs/specs/budget-claim-revision-fencing/input-inventory.md
+++ b/docs/specs/budget-claim-revision-fencing/input-inventory.md
@@ -1,0 +1,60 @@
+# Budget claim fencing: input inventory
+
+Companion to [spec.md](spec.md) (`REQ-OFFICE-COSTS-003`), alongside
+[verification.md](verification.md), [prior-art.md](prior-art.md) and
+[amendments.md](amendments.md). Split out for the specification linter's per-file size
+ceiling; the five files are one spec.
+
+Every shape below was read out of the code on #3287's head, not inferred. It is the
+sampled state Build starts from — reference, not acceptance criteria.
+
+
+Sampled by reading the code, not inferred.
+
+**`office_budget_policies`** (`repository/sqlite/base.go`) — columns `id, workspace_id,
+scope_type, scope_id, limit_subcents, period, alert_threshold_pct, action_on_exceed,
+created_at, updated_at`. **No revision or version column.** `GetBudgetPolicy` and
+`ListBudgetPolicies` both use `SELECT *` with `sqlx` `StructScan`/`SelectContext` into
+`models.BudgetPolicy`, so adding a column **requires** a matching struct field — `sqlx`
+fails with `missing destination name <column>` otherwise. This is a hard coupling, not a
+style choice.
+
+**`office_budget_claims`** (added by #3287) — `policy_id, period_key, level, claimed_at`,
+`PRIMARY KEY (policy_id, period_key, level)`, `FOREIGN KEY (policy_id) REFERENCES
+office_budget_policies(id) ON DELETE CASCADE`. Created by `createCostTables()` with
+`CREATE TABLE IF NOT EXISTS`, **after** `office_budget_policies` (Postgres rejects the
+forward reference). `Repository.Claim` is `INSERT ... ON CONFLICT(policy_id, period_key,
+level) DO NOTHING`; `claimed` is `RowsAffected() == 1`; `db.IsForeignKeyViolation(err)`
+maps to `(false, nil)`.
+
+**`Repository.UpdateBudgetPolicy`** (#3287) — `BeginTxx`; `DELETE FROM
+office_budget_claims WHERE policy_id = ?`; `UPDATE office_budget_policies SET ... WHERE id
+= ?`; `Commit`. A test-only failpoint `failBudgetPolicyUpdateErr` sits between the two.
+
+**`evaluatePolicy`** (#3287) — reads the clock once, derives `boundary` once, derives
+`periodKey` once, then `switch { case spent >= limit: ...; case spent >= threshold: ... }`.
+The exceeded branch calls `claimAndEmit(..., claimLevelExceeded, func() {
+s.claimCompanionAlert(...) })`; the `afterClaim` callback runs **between** the exceeded
+claim and the emission decision. This callback seam is the mechanism Race B exploits.
+
+**`office_activity_log`** — `id TEXT PRIMARY KEY` (a random UUID), `created_at TIMESTAMP`,
+index `(workspace_id, created_at DESC)`. Every reader orders `ORDER BY created_at DESC`
+with **no tiebreak column**. `CreateActivityEntry` sets `created_at = time.Now().UTC()` at
+write time, only when the caller left it zero. `ActivityLogger.LogActivity` returns
+nothing.
+
+**Budget surfaces on current `main`** — `dashboard/service_inbox.go:170`
+`listBudgetInboxEntries` lists `budget.alert` **and** `budget.exceeded` as two separate
+`ListActivityEntriesByAction` calls concatenated (`append(alerts, exceeded...)`), each
+already sorted internally — **not** interleaved by timestamp. That arrived with PR #3276
+(`677e01204`), which merged after #3287 branched, so #3287's statement that "only
+`budget.alert` feeds the Office inbox list" is **stale against `main`**.
+`apps/web/.../activity/activity-feed.tsx` renders `res.activity` in server order with no
+client-side sort, so the **activity feed** is the one surface where the two rows interleave
+and `created_at` alone decides.
+
+**`updateBudget` handler** (`costs/handler.go:168`) — `GetBudgetPolicy` →
+`applyBudgetPatch` → `UpdateBudgetPolicy`, an unfenced read-modify-write that returns the
+in-memory `policy` as the response body. `models.BudgetPolicy` is mapped by hand to
+`apps/web/lib/state/slices/office/types.ts:138` in camelCase, which ignores unrecognised
+JSON fields.

--- a/docs/specs/budget-claim-revision-fencing/prior-art.md
+++ b/docs/specs/budget-claim-revision-fencing/prior-art.md
@@ -1,0 +1,77 @@
+# Budget claim fencing: prior art
+
+Companion to [spec.md](spec.md) (`REQ-OFFICE-COSTS-003`), alongside
+[verification.md](verification.md), [input-inventory.md](input-inventory.md) and
+[amendments.md](amendments.md). Split out for the specification linter's per-file size
+ceiling; the five files are one spec. This file
+is the research record behind [Design decisions](spec.md#design-decisions) — it is
+provenance, not contract, and nothing in it is an acceptance criterion.
+
+
+Three legs, each opening with a receipt.
+
+### Our own prior reasoning (wiki) — searched, unavailable on this runner
+
+Receipt: `wiki-query` could not be run. `ls -d ~/.claude/skills/*wiki*` → no match;
+`~/.obsidian-wiki/` does not exist; `OBSIDIAN_VAULT_PATH` is unset; `qmd` is not on
+`PATH`. This card runs on the **neo** SSH executor, whose home is `/Users/neo`; neither the
+vault nor the `qmd` MCP server is provisioned here. Intended query: idempotent alerting,
+fencing tokens, crossing-versus-level notification semantics. Nothing retrieved and nothing
+claimed — the forks below are **not** established as unopposed by prior positions; re-run
+with vault access before treating them as settled. #3287's own `costs-03.md` recorded the
+same negative result from a different machine for a different cause, so two independent
+runs have now failed this leg.
+
+### What other products shipped (saas-kb) — unavailable
+
+Receipt: the `saas-kb` MCP server and its `search_fsm_docs` tool are absent from this
+session's tool list; no tool discovery is exposed. Intended query: `category: "ai_sdlc"`,
+budget/spend-limit alerting and its concurrency handling in agent platforms (Devin,
+OpenHands, Warp, Factory.ai, Augment). Nothing retrieved; not substituted.
+
+### In-repo prior art — found, and it decides the mechanism
+
+Receipt: `grep -rn "revision\|generation" apps/backend/internal --include='*.go'`, plus
+reading each hit's write path. Three implementations of this fencing pattern already
+exist, and they agree on all four details:
+
+| Site | Column | Bump | Fence |
+| --- | --- | --- | --- |
+| `office/repository/sqlite/workspace_groups.go:233,267` | `ownership_generation INTEGER NOT NULL DEFAULT 1` | `task/repository/sqlite/task.go:1555` `= ownership_generation + 1` | `WHERE id = ? AND ownership_generation = ?`, `(bool, error)` from `RowsAffected() == 1` |
+| `gitlab/store_config.go:57` | `revision` | `= gitlab_configs.revision + 1` | `RETURNING revision` reads the post-bump value back |
+| `user/store/sqlite.go:342` | `settings_revision` | `= settings_revision + 1` | `WHERE id = ? AND settings_revision = ?` + `RETURNING` — a full CAS |
+
+`ClaimWorkspaceGroupCleanup`'s comment states the governing principle: *"The active-member
+predicate is part of the same write so a caller cannot race a membership admission between
+its read and this claim."* That is Race A, already solved, one package away. It is on
+`main` but not on #3287's head, which branched earlier — read it there, not on the build
+base.
+
+A fourth precedent decides the *migration* shape rather than the fence.
+`office/repository/sqlite/run_outcome_activation.go` guards a schema-dependent action
+behind a `columnExists` probe and states why in its own comment: `MigrateLogger.Apply`
+"swallows failures at WARN, so this probe is the only thing standing between a failed
+migration and a consumer wrongly believing the mechanism is live." That helper sits in the
+same package as `office_budget_claims`; it and its reasoning carry
+`AC-OFFICE-COSTS-003.3a`.
+
+**Researched, then cut from the contract — provenance for deferred work.** Serializing the
+recreate so two initializers cannot both perform it was researched here and then excluded;
+it lives in [spec.md's Out of scope](spec.md#out-of-scope), and this paragraph is the record
+that seeds it. `task/repository/sqlite/worktree_ownership_migration.go` is the repository's
+one-time destructive cutover. It probes for a legacy artifact with `tableExists` and returns
+early when it is gone, takes a fixed advisory lock whose comment states the rule —
+*"All instances must derive the same bigint so a second boot waits for the first to finish
+the cutover instead of racing it"* — and, in its own words, "never uses the best-effort
+MigrateLogger path, whose contract swallows unexpected failures." It is the only advisory-lock
+precedent in play: `run_outcome_activation.go` above takes no lock. A follow-up should read it
+there and choose a new lock id rather than reusing `taskWorktreeCutoverLockID`.
+
+**What this spec takes:** the column shape, the in-SQL `+ 1` bump (never
+read-modify-write in Go), the predicate-inside-the-write fence, `(claimed bool, err error)`
+read from `RowsAffected`, and `RETURNING revision` for the read-back. **What it departs
+from:** `users.settings_revision` fences a *user-facing* write against a client-supplied
+expected revision. This spec's revision is **server-assigned and never accepted from a
+client** — it fences a background evaluation against a user-facing write, the opposite
+direction. Client-supplied would make it optimistic concurrency for the budget PATCH
+endpoint, excluded under [spec.md's Out of scope](spec.md#out-of-scope).

--- a/docs/specs/budget-claim-revision-fencing/spec.md
+++ b/docs/specs/budget-claim-revision-fencing/spec.md
@@ -1,0 +1,456 @@
+# Budget claim fencing: a claim must belong to the policy revision that earned it
+
+**Status:** spec
+**Area:** backend — `internal/office/costs` (evaluation), `internal/office/repository/sqlite`
+(claim store, policy store), `internal/office/models` (policy struct)
+**Slug:** `budget-claim-revision-fencing`
+**Requirement id:** `REQ-OFFICE-COSTS-003`
+**Depends on:** PR #3287 (`REQ-OFFICE-COSTS-002`) — **open, unmerged**; see
+[Dependency and sequencing](#dependency-and-sequencing)
+**Amends:** `AC-OFFICE-COSTS-002.5`, `.8`, `.10`, `.13`, `.14a` as introduced by PR #3287 —
+see [Amendments](#amendments-to-req-office-costs-002)
+
+---
+
+## Why
+
+`REQ-OFFICE-COSTS-002` (PR #3287) makes `budget.alert` / `budget.exceeded` idempotent with
+a durable claim table keyed `(policy_id, period_key, level)`. Two reviewers found the same
+structural gap from opposite ends: **the claim key carries no evidence of which policy
+revision earned it, nor of what else has already been claimed for that period.** #3287
+deliberately accepted both (`AC-OFFICE-COSTS-002.8`'s stale-evaluation carve-out). This
+spec closes them.
+
+**Race A — stale-snapshot claim poisoning**
+([coderabbitai](https://github.com/kdlbs/kandev/pull/3287#discussion_r3914827075)).
+`CheckBudget` calls `ListBudgetPolicies` once, then hands each already-read
+`*BudgetPolicy` to `evaluatePolicy`, so an evaluation works from a snapshot. If
+`UpdateBudgetPolicy` discards that policy's claims and commits new values mid-evaluation,
+the evaluation's `Claim` insert lands **after** the discard and writes the old threshold's
+outcome into the new revision's claim slot. Two user-visible harms:
+
+- **(A1) obsolete emission** — a `budget.alert` row whose `limit_subcents` describes the
+  policy the user just replaced;
+- **(A2) suppressed legitimate crossing** — the next evaluation that genuinely reaches a
+  level under the *new* policy finds the slot taken and stays silent until the next update
+  or period rollover.
+
+**Race B — `budget.alert` submitted after `budget.exceeded`**
+([cubic-dev-ai](https://github.com/kdlbs/kandev/pull/3287#discussion_r3914856011)).
+`claimAndEmit`'s `afterClaim` seam runs `claimCompanionAlert` *after* the exceeded claim,
+not atomically with it. An alert-band evaluation racing an over-limit one can win the alert
+claim in that gap and emit `budget.alert` describing a below-limit spend after
+`budget.exceeded` has gone out. Both rows land once each; the defect is that a period
+already over its limit still produces an alert-band notification at all.
+
+## Dependency and sequencing
+
+**This work cannot be built on `origin/main`.** Verified 2026-09-07 at `origin/main` =
+`cd7823631`: `office_budget_claims`, `Repository.Claim`, `periodKeyFor` and
+`BudgetCheckResult.AlertSubmitted` do not exist there, and `gh pr view 3287` reports
+`"state":"OPEN"`, `"mergedAt":null`. Every symbol this spec modifies is introduced by
+#3287 (head `feature/budget-alerts-should-c2t`).
+
+Build shall branch from #3287's head, not `main`, and shall record which commit in the task
+plan. If #3287 has merged by then, branch from `main` as normal. This is a sequencing fact,
+not an open question: no contract below turns on it except `AC-OFFICE-COSTS-003.3`,
+where it selects only which file the claim-table DDL is edited in — never what schema the
+running database ends up with, which `AC-OFFICE-COSTS-003.3a` settles on every boot.
+
+## Prior art
+
+Three legs, each opening with a receipt, in [prior-art.md](prior-art.md): the wiki leg and
+the saas-kb leg both came back **unavailable on this runner** and are recorded there with
+their receipts and intended queries, so neither fork below is established as unopposed by
+prior positions. The in-repo leg **found four precedents and decided both mechanisms** —
+three agreeing fencing implementations (`ownership_generation`, `gitlab_configs.revision`,
+`users.settings_revision`) that fix the column shape, the in-SQL `+ 1` bump, the
+predicate-inside-the-write fence and the `RETURNING` read-back, and
+`run_outcome_activation.go`'s `columnExists` probe, which fixes the migration shape behind
+`AC-OFFICE-COSTS-003.3a`. Where this spec departs from a precedent is stated there too.
+
+## Input inventory
+
+Sampled by reading the code on #3287's head, not inferred, and recorded in
+[input-inventory.md](input-inventory.md): the two tables and their exact columns, the
+`SELECT *` / `StructScan` coupling that makes `AC-OFFICE-COSTS-003.2` mandatory rather than
+cosmetic, `UpdateBudgetPolicy`'s transaction shape and its test-only failpoint,
+`evaluatePolicy`'s snapshot-then-claim ordering and the `afterClaim` seam Race B exploits,
+`office_activity_log`'s missing tiebreak column, the two budget surfaces on `main`
+(including the PR #3276 change that makes #3287's inbox claim stale), and the `updateBudget`
+handler's unfenced read-modify-write.
+
+## Design decisions
+
+**Fork 1 — fence, or serialize?** coderabbitai offered both. **Fence.** #3287's
+`AC-OFFICE-COSTS-002.8` already rejected serialization with a reason this spec accepts
+verbatim: a lock spanning the evaluation and the update *"would put a user-facing write
+behind a background evaluation."* A revision fence costs one column and one predicate and
+holds no lock across the evaluation.
+
+**Fork 2 — reuse `updated_at`, or add a column?** **Add `revision`.** `updated_at` is
+already bumped on every update, so it looks free, but two updates inside one clock tick
+produce the same value, timestamp round-tripping through the driver is not guaranteed to
+survive exact-equality comparison, and a backwards clock step breaks monotonicity. An
+`INTEGER` counter has none of those failure modes, and all three in-repo precedents chose
+one.
+
+**Fork 3 — is `revision` a fence only, or also part of the claim's key? Both, and both are
+load-bearing.** The fence alone is sufficient on SQLite, whose single writer connection
+(`internal/db/pool.go`) serializes the claim insert against the update transaction. It is
+**not** sufficient on PostgreSQL under `READ COMMITTED`: a claim insert whose `WHERE
+EXISTS` reads the pre-update revision before the update commits will insert a row that the
+update's already-executed `DELETE` cannot remove, leaving a stale claim behind. Putting
+`revision` in the claim's primary key neutralises that survivor — it is keyed to a
+superseded revision and can never match a later evaluation. So: **the fence prevents the
+obsolete emission (A1); the revision in the key prevents the suppression (A2).** Removing
+either reopens one half on one dialect.
+
+This does not contradict #3287's exclusion of `workspace_id` from the claim row. That
+exclusion was about *duplicating a fact the policy already owns*, which could drift.
+`revision` on a claim is not a copy of the policy's current revision — it is the identity
+of *which* revision earned this claim, which is a different fact and cannot drift.
+
+**Fork 4 — how to close Race B.** cubic proposed making the exceeded and companion claims
+atomic, *or* making alert claims reject an already-claimed exceeded level. **Atomicity is
+necessary; the rejection rule is not, once atomicity holds.** Atomicity is also
+*insufficient* as a fix for the ordering symptom — worth stating, because that is the
+obvious reading of the comment: if the alert-band evaluation wins the alert claim *first*,
+atomicity of the exceeded pair changes nothing and both rows still go out unordered. What
+atomicity buys is the invariant **"an exceeded claim implies an alert claim at the same
+revision"**; given it, an alert-band evaluation arriving after an exceeded claim finds the
+alert row present and suppresses via the ordinary primary-key conflict. The rejection rule
+would be a second, divergent answer to a question the key already answers — the pattern
+#3287 explicitly refuses.
+
+**Fork 5 — the residual write-order inversion is excluded, deliberately.** Rationale and
+bound in [Out of scope](#out-of-scope).
+
+## Contract
+
+### REQ-OFFICE-COSTS-003: Budget claims are fenced to the policy revision that earned them
+
+**Intent:** A budget claim shall be valid only for the policy revision the evaluation
+actually read, and an evaluation whose snapshot has been superseded shall neither emit nor
+suppress.
+
+**User story:** As a workspace owner who has just raised a budget limit, I want the next
+real crossing of the *new* limit to notify me, and I do not want a notification quoting
+the limit I replaced.
+
+#### Acceptance criteria
+
+Terminology (`evaluation period`, `alert level`, `limit level`, `reaches a level`, `claim`,
+`emit`, `submit`) is inherited unchanged from `REQ-OFFICE-COSTS-002`'s `## Terminology`.
+**Policy revision** is added: a per-policy integer that identifies one immutable set of
+policy field values, assigned by the server, starting at 1 and increasing by exactly 1 on
+each successful update.
+
+- **AC-OFFICE-COSTS-003.1:** `office_budget_policies` shall carry a `revision` column,
+  `INTEGER NOT NULL DEFAULT 1`, added by a replayable `ALTER TABLE ... ADD COLUMN`
+  migration registered through the existing `r.migrate.Apply(name, sql)` mechanism, so
+  that existing rows are backfilled to 1 and a boot replay is a no-op. No new local
+  error-string classifier shall be introduced; `db.IsDuplicateColumnError` is the only
+  one (ADR 0027).
+- **AC-OFFICE-COSTS-003.2:** `models.BudgetPolicy` shall carry the matching field, so
+  that the existing `SELECT *` reads in `GetBudgetPolicy` and `ListBudgetPolicies` keep
+  scanning. The field shall be serialized in the policy's JSON representation as a
+  read-only diagnostic under the JSON key `revision`; the frontend `BudgetPolicy` type
+  need not change, and the field shall not be suppressed from JSON.
+- **AC-OFFICE-COSTS-003.3:** `office_budget_claims` shall carry a `revision INTEGER NOT
+  NULL` column, and its primary key shall be `(policy_id, period_key, level, revision)`.
+  `createCostTables` shall declare that shape, **and** the recreate of
+  `AC-OFFICE-COSTS-003.3a` — dropping `office_budget_claims` and recreating it with that
+  same four-column primary key — shall run on every boot, whatever #3287's state. Declaring the
+  final shape is not sufficient on its own, and an implementation that relies on it alone
+  does not satisfy this criterion: `createCostTables` issues `CREATE TABLE IF NOT EXISTS`,
+  which is a no-op against a database that has already executed #3287's three-column
+  `CREATE TABLE`. Such a database would keep the three-column table and its three-column
+  primary key, so every fenced insert would fail on the missing column and every
+  evaluation would take the `AC-OFFICE-COSTS-002.14` fail-open path from then on —
+  emitting a duplicate notification, an error log and a counter increment on each pass,
+  violating `AC-OFFICE-COSTS-002.11`, and leaving this requirement's fence permanently
+  inert — while a suite that only ever builds a fresh database stays green.
+  `AC-OFFICE-COSTS-003.3a`'s probe is what closes that, and it costs nothing where the old
+  shape never existed: it finds `revision` present and does nothing, which is exactly its
+  second-boot behavior. Whether #3287 has merged — `gh pr view 3287 --json state`, the
+  only check Build shall consult, deployment state being neither observable from the
+  repository nor to be consulted — therefore selects only **where the final-shape DDL is
+  edited**: #3287's own `CREATE TABLE` statement while it is open, the same statement on
+  `main` once it has merged. It does not decide whether the recreate runs. Deciding that
+  from a probe of the live schema rather than from the fork is the point: the fork is
+  answered when Build authors the change, whereas the shape of the database this code
+  meets is settled later, when it deploys. No `r.migrate.Apply` migration shall be added
+  for this table; `AC-OFFICE-COSTS-003.3a` is expressly not one. Claims are pure
+  suppression state, and losing them costs at most one additional notification per policy
+  per period, which
+  `AC-OFFICE-COSTS-002.17` already describes as the accepted first-run behavior.
+- **AC-OFFICE-COSTS-003.3a:** The recreate path shall take effect at most once per
+  database. It shall first probe whether `office_budget_claims` already declares
+  `revision` — the office repository's existing `columnExists` helper answers this on both
+  dialects — and shall do nothing when it does. It shall **not** be expressed as an
+  `r.migrate.Apply` statement: that runner re-executes its SQL on every boot and is
+  idempotent only because an already-exists error is swallowed, so an unguarded
+  `DROP TABLE` / `CREATE TABLE` pair succeeds on every boot and destroys claim state each
+  time, violating `AC-OFFICE-COSTS-002.11`. It shall return its error to its caller rather
+  than swallowing it, so a failed recreate is visible rather than silently leaving the old
+  three-column key in place. It shall run after `office_budget_claims` exists, so it probes
+  the real table rather than racing its creation. A claim attempt arriving from an
+  already-running backend while the recreate is in flight is **not** required to succeed:
+  it is an ordinary claim-store error and takes the `AC-OFFICE-COSTS-002.14` fail-open path,
+  costing one further notification per evaluation that attempts a claim inside the recreate
+  window, beyond the one `AC-OFFICE-COSTS-003.3` already accepts for discarding the claims
+  themselves: that path emits without recording a claim, so it does not suppress the next
+  healthy evaluation. This criterion therefore does not require the recreate to lock
+  concurrent claim traffic out, and an implementation that does lock it out satisfies it
+  equally.
+- **AC-OFFICE-COSTS-003.4:** When a budget policy is created, the system shall assign it
+  revision 1, regardless of any revision value presented for creation — zero, or any other.
+  The system shall make that assigned value available to the caller on the created policy,
+  for the same reason `AC-OFFICE-COSTS-003.5` requires the post-update value to be read back:
+  the create response carries the policy, and `AC-OFFICE-COSTS-003.2` makes `revision` a
+  field of it, so a create that stores 1 while handing its caller a zero would report a
+  revision the database does not hold. Satisfying this criterion by the column's `DEFAULT 1`
+  alone therefore does not satisfy it.
+- **AC-OFFICE-COSTS-003.5:** When a budget policy is updated, the system shall increase
+  that policy's revision by exactly 1, in the same transaction as the row update and the
+  claim discard that `AC-OFFICE-COSTS-002.8` requires. The increase shall be expressed as
+  an in-SQL `revision = revision + 1`, never as a value computed in application code from
+  a prior read, so that two concurrent updates cannot both write the same revision. The
+  system shall read the post-update revision back within that transaction and shall make
+  it available to the caller, so that the value returned to whoever performed the update
+  is the value now stored. If the update matches no policy row — the policy was deleted
+  between the caller's read and this write — the read-back returns nothing, and the system
+  shall roll the transaction back and return an error to the caller rather than committing
+  an empty update. This tightens the pre-`REQ-OFFICE-COSTS-003` behavior, where the update
+  ignored its affected-row count and reported success. The obligation is at the repository
+  boundary only: the `updateBudget` handler already maps every update error to HTTP 500,
+  and giving this particular case a 404 instead is a separate user-facing change, excluded
+  under [Out of scope](#out-of-scope).
+- **AC-OFFICE-COSTS-003.6:** If an update transaction is rolled back for any reason, then
+  the policy's revision shall be unchanged. A rolled-back update shall not consume a
+  revision number.
+- **AC-OFFICE-COSTS-003.7:** The system shall not accept a revision from an API client.
+  The budget-policy update request body shall have no revision field, and supplying one
+  shall have no effect on the stored revision.
+- **AC-OFFICE-COSTS-003.8:** When an evaluation attempts a claim **whose outcome decides
+  an emission**, it shall present the revision from the same policy snapshot it computed
+  spend and levels from, and the claim shall be recorded only while that revision is still
+  the policy's stored revision. The revision check and the insert shall be a single
+  statement, so no evaluation can observe a matching revision and then insert against a
+  superseded one. That single-statement rule governs the fence check only. It does not
+  forbid the input guard `AC-OFFICE-COSTS-003.13` requires, which shall run **before** the
+  statement is issued: once the statement has run, a zero-row result carries no distinction
+  between a refused fence, a policy that no longer exists and an already-held claim, all
+  three being the silent miss of `AC-OFFICE-COSTS-003.9`, so any outcome that must be told
+  apart from them has to be settled before the statement rather than read out of it. A
+  claim that decides no emission — the companion of `AC-OFFICE-COSTS-003.10` — is exempt;
+  see there.
+- **AC-OFFICE-COSTS-003.9:** When a claim is refused because the presented revision is no
+  longer the policy's stored revision, the system shall treat it exactly as
+  `AC-OFFICE-COSTS-002.3` treats an already-held claim: no activity row, no error log, no
+  counter increment, and the evaluation shall report `submitted` false for that level and
+  shall still return its result to its caller without error. Enforcement
+  (`AC-OFFICE-COSTS-002.12`) is unaffected: `pause_agent` and the pre-execution denial
+  still run off the level check.
+- **AC-OFFICE-COSTS-003.10:** When an evaluation reaches the limit level, the system shall
+  record the exceeded-level claim and the companion alert-level claim of
+  `AC-OFFICE-COSTS-002.5` **atomically**: once the transaction commits either both rows
+  exist for that policy, period and revision, or this evaluation wrote neither. The
+  `budget.exceeded` emission shall be decided by
+  whether the exceeded-level row was inserted by this evaluation; the companion row's
+  outcome shall not change it. The fence shall be evaluated **once for the pair**, on the
+  exceeded-level insert; the companion insert shall carry no fence of its own, because its
+  key already names the revision, so a companion row written against a revision that has
+  since moved is inert rather than wrong. Re-checking the fence on the companion insert is
+  prohibited: it could refuse there after succeeding on the exceeded insert, breaking
+  `AC-OFFICE-COSTS-003.11`. Two outcomes of the pair are named here so that neither is left
+  to inference. **A companion insert that conflicts with an alert-level claim already held
+  for that policy, period and revision is a success for the pair,** not a failure: that row
+  is the ordinary trace of an earlier alert-band evaluation, `AC-OFFICE-COSTS-003.11`'s
+  invariant is satisfied by its presence however it arrived, and the transaction shall
+  commit and the `budget.exceeded` row shall go out. Reading the companion's zero affected
+  rows as a pair failure is prohibited — it would withhold a `budget.exceeded` that the
+  exceeded insert had already earned, which `AC-OFFICE-COSTS-002.5` forbids. **When the
+  exceeded insert itself writes no row** — refused by the fence, or conflicting with an
+  exceeded claim already held — the companion insert shall not be attempted and the pair
+  shall commit having written nothing: there is no emission to protect, and
+  `AC-OFFICE-COSTS-003.11` is not engaged.
+- **AC-OFFICE-COSTS-003.11:** The system shall maintain the invariant: **if an
+  exceeded-level claim exists for a given policy, period and revision, an alert-level
+  claim exists for that same policy, period and revision.** No operation shall create an
+  exceeded-level claim without it.
+- **AC-OFFICE-COSTS-003.12:** While an exceeded-level claim is held for a policy, period
+  and revision, an evaluation of that policy whose spend reaches the alert level shall not
+  emit `budget.alert` for that period and revision. This shall follow from
+  `AC-OFFICE-COSTS-003.11` and the claim's primary key, and shall not be implemented as a
+  separate read of the exceeded claim before emitting.
+- **AC-OFFICE-COSTS-003.13:** If a claim attempt presents a revision less than or equal to
+  zero, an empty policy id, an empty period key, or an empty level, then the system shall
+  report a claim-store error, which `AC-OFFICE-COSTS-002.14` then handles by emitting,
+  logging and incrementing the counter. Those four are exactly the components of the claim's
+  primary key, and the guard covers all four rather than a subset: such input is a
+  programming error rather than a superseded snapshot, and shall degrade toward an extra
+  notification, never toward silence. An empty level leaves
+  `AC-OFFICE-COSTS-003.14`'s log unambiguous — that field names the level whose emission the
+  failed claim governs, which is fixed by the calling branch rather than by the rejected
+  value.
+- **AC-OFFICE-COSTS-003.14:** The claim-store failure counter shall keep its single label
+  value `op=claim`. The accompanying structured log's `level` field shall carry the level
+  whose *emission* the failed claim governs — `exceeded` for the atomic pair of
+  `AC-OFFICE-COSTS-003.10`, `alert` for an alert-band claim — so the field never carries a
+  sentinel or two meanings.
+- **AC-OFFICE-COSTS-003.15:** A claim row whose revision is no longer the policy's stored
+  revision shall never suppress an emission and shall not be read for any decision. The
+  claim discard of `AC-OFFICE-COSTS-002.8` shall remove **all** of a policy's claims
+  regardless of revision, and shall not be narrowed to the current revision, so such rows
+  are reclaimed by the next update or by the policy's deletion cascade. No retention job
+  shall be added.
+
+## Forced-to-invent pass
+
+**Ordering.** Policy evaluation order is unchanged: `created_at ASC, id ASC`
+(`AC-OFFICE-COSTS-002.16`). Within the update transaction: discard claims, update the row
+(including the revision bump), read the revision back, commit — discard first, as #3287
+specifies. Within `AC-OFFICE-COSTS-003.10`'s atomic pair the exceeded row is inserted
+first, because its insertion decides the emission; the companion alert row follows in the
+same transaction. The relative order of the two resulting `office_activity_log` rows is
+**not** specified — see [Out of scope](#out-of-scope).
+
+**Idempotency and retry.** Nothing here is retried. A refused claim (already held,
+superseded revision, deleted policy) is terminal for that evaluation; the next trigger
+re-evaluates from a fresh snapshot. Re-running an identical evaluation after a successful
+claim produces no second row. An update with unchanged field values still bumps the
+revision and still discards claims — the revision counts *update operations*, not *value
+changes*, matching `AC-OFFICE-COSTS-002.8`'s refusal to compare old and new values.
+
+**Concurrency — two callers, same row.** Enumerated exhaustively:
+
+1. *Two evaluations, same policy, period, level, same revision, healthy store.* The
+   primary key admits one. Exactly one submission (`AC-OFFICE-COSTS-002.10` preserved).
+2. *Evaluation vs. `UpdateBudgetPolicy`, evaluation claims after the update commits.* The
+   fence refuses. No obsolete row; the claim slot for the new revision stays open, so the
+   next evaluation that reaches a level emits. **Race A closed.**
+3. *Evaluation vs. `UpdateBudgetPolicy`, evaluation claims before the update commits.* The
+   claim is accepted and the row emitted — correctly, since the policy still held those
+   values at that instant. The update's discard then removes the claim (SQLite), or it
+   survives keyed to the superseded revision and is inert (PostgreSQL `READ COMMITTED`).
+   Either way no later evaluation is suppressed.
+4. *Alert-band evaluation vs. over-limit evaluation, exceeded claims first.* The
+   alert-band evaluation finds the companion alert row present and suppresses. Only
+   `budget.exceeded` is emitted. **Race B's semantic half closed.**
+5. *Alert-band evaluation vs. over-limit evaluation, alert claims first.* Both emit, once
+   each. Their activity-log order is unconstrained — the named residual.
+6. *Two concurrent `UpdateBudgetPolicy` calls.* Serialized by the single writer (SQLite)
+   or the row lock (PostgreSQL). Each bumps by 1; the final revision is `r+2`; no
+   increment is lost. Which caller's *field values* win is the pre-existing unfenced
+   read-modify-write in `updateBudget`, excluded below.
+7. *Evaluation vs. `DeleteBudgetPolicy`.* The fence's existence check fails, so the claim
+   is refused with no row, no log and no counter — `AC-OFFICE-COSTS-002.14a` preserved,
+   now reached through the fence rather than through the foreign key. The foreign-key
+   classifier is retained because the constraint still carries `AC-OFFICE-COSTS-002.9`'s
+   cascade, and dropping the classifier would let a genuine foreign-key error read as a
+   store fault.
+
+**Nil / empty / error.** Revision `<= 0`, empty policy id, empty period key, empty level:
+claim-store error, fail open (`AC-OFFICE-COSTS-003.13`). Claim-store error during the
+atomic pair: the transaction rolls back, no claim is held, the evaluation emits
+`budget.exceeded` and records the failure — `AC-OFFICE-COSTS-002.14` continues to take precedence over
+`AC-OFFICE-COSTS-002.5` and `.10`. Activity write failure after a successful claim: one
+notification lost, not retried, not reported (`AC-OFFICE-COSTS-002.2a`, unchanged).
+Discard failure during an update: whole update rolls back, revision unchanged, error
+returned to the caller (`AC-OFFICE-COSTS-002.8`, extended by
+`AC-OFFICE-COSTS-003.6`).
+
+**Defaults and boundaries.** Revision starts at 1, is `int64`, never resets and is never
+reused for a policy id; a period rollover, a backend restart and a claim discard all leave
+it alone. Existing rows migrate to 1. A `period` change still side-steps this whole class
+of races by moving `period_key`. Row growth stays bounded by `policies × periods × 2` in
+steady state, plus case 3's inert survivors, which the next update or deletion reclaims —
+no retention job (`AC-OFFICE-COSTS-003.15`).
+
+## Amendments to REQ-OFFICE-COSTS-002
+
+Which `REQ-OFFICE-COSTS-002` criteria this spec supersedes, widens, or leaves untouched —
+all 21 of them, named individually — is in [amendments.md](amendments.md). No acceptance
+criterion of `REQ-OFFICE-COSTS-003` lives there.
+
+## Out of scope
+
+- **Serializing `AC-OFFICE-COSTS-003.3a`'s recreate across two initializers.** `.3a` requires
+  the recreate to take effect at most once per database, guarded by its `columnExists` probe;
+  it does **not** require two backends initializing the same database to be prevented from
+  both performing it. **Window:** two backends cold-starting simultaneously against one
+  PostgreSQL database still carrying the pre-`.3` three-column `office_budget_claims` — not
+  reachable on SQLite, whose writer pool is `MaxOpenConns(1)` (`internal/db/pool.go`), and not
+  reachable at all once any boot has completed the recreate. **Residual:** both probe, both
+  find `revision` absent, both drop and recreate; the table still ends in the four-column
+  shape `AC-OFFICE-COSTS-003.3` mandates. Worst case one initializer's `CREATE` races the
+  other's `DROP` and errors, which `.3a` already requires be returned to its caller, so that
+  backend fails to boot, restarts, probes, finds `revision` present and does nothing. Claim
+  loss across the window is already permitted by `AC-OFFICE-COSTS-003.3` via
+  `AC-OFFICE-COSTS-002.17`. **Mechanism for a follow-up:** a shared advisory lock, as in
+  `task/repository/sqlite/worktree_ownership_migration.go:216`, which takes
+  `pg_advisory_xact_lock` on a fixed bigint so every instance derives the same value and a
+  second boot waits for the first; a follow-up must choose a **new** lock id, not reuse that
+  file's `taskWorktreeCutoverLockID`, which would cross-block an unrelated migration.
+  **Why not here:** no in-repo precedent for this mechanism carries a concurrency test, so a
+  follow-up has to decide whether to set that bar rather than assume it exists.
+- **The residual `budget.alert`-after-`budget.exceeded` write-order inversion.** When an
+  alert-band evaluation wins the alert claim strictly before a concurrent over-limit
+  evaluation claims `exceeded` (concurrency case 5), both rows are submitted and the order
+  in which they reach `office_activity_log` is unconstrained, so the activity feed can
+  render them exceeded-then-alert. **Bound:** at most one such pair per policy, period and
+  revision, under genuine concurrency only. **Harm:** display only — both rows are
+  individually truthful about the spend they observed, neither is duplicated, neither is
+  lost, and the Office inbox is unaffected because `listBudgetInboxEntries` concatenates
+  the two actions as separate already-sorted lists rather than interleaving them. **Why not
+  fixed:** closing it needs either a lock spanning claim and emit — the mechanism
+  `AC-OFFICE-COSTS-002.8` rejected and Fork 1 upholds — or a monotonic ordering key on
+  `office_activity_log`, a table shared by every Office surface whose only ordering today
+  is `created_at DESC` with no tiebreak, so two rows written in one clock tick already have
+  undefined relative order. Promising an order for this one pair would be a new table-wide
+  guarantee, not a fix; a follow-up wanting it should specify the guarantee for the whole
+  activity log first.
+- **Optimistic concurrency for the budget-policy HTTP API.** `updateBudget` does an
+  unfenced `GetBudgetPolicy` → patch → `UpdateBudgetPolicy`, so two concurrent PATCHes can
+  lose one caller's field values. The revision column added here would make that fixable —
+  `AC-OFFICE-COSTS-003.7` deliberately declines — but an expected-revision request field, a
+  conflict status code, and the frontend threading are a separate user-facing change. The
+  same exclusion covers the status code for `AC-OFFICE-COSTS-003.5`'s deleted-policy case:
+  the handler's existing "any update error is a 500" mapping stands, and turning that one
+  case into a 404 belongs with the rest of this endpoint's error contract, not here.
+- **Everything `REQ-OFFICE-COSTS-002` already excluded**, inherited unchanged rather than
+  restated: unifying the three disagreeing spend-window implementations
+  (`costs.periodCutoff`, `backendapp.budgetEvaluator.spendForPolicy`,
+  `cron.periodStartFor`, and `BudgetPeriod.Valid()` accepting a wider `period` set than
+  `periodCutoff` honours), changing when a policy reaches a level, the cron budget-alert
+  trigger, resolving or expiring inbox items, `budget.exceeded` visibility, and a
+  user-facing notification-frequency setting. Nothing here depends on any of them.
+- **Correcting #3287's stale claim that only `budget.alert` feeds the Office inbox.** PR
+  #3276 changed that on `main` after #3287 branched; it is recorded in
+  [Input inventory](#input-inventory) so Build does not rely on it. Editing #3287's own
+  design documents is not this card's work.
+
+## Verification
+
+Test strategy, per criterion, is in [verification.md](verification.md); research
+provenance is in [prior-art.md](prior-art.md); sampled code shapes are in
+[input-inventory.md](input-inventory.md); the `REQ-OFFICE-COSTS-002` deltas are in
+[amendments.md](amendments.md). They are separate files because this document sits against
+the specification linter's 32,768-byte ceiling for its kind, the same reason
+`costs-03.md` / `costs-04.md` are split. The five files are one spec.
+
+## User-visible surfaces (E2E decision input)
+
+Backend-only: no new HTTP route, no request-body change, no required frontend change, no
+new user-facing string. The two surfaces that read these rows — the Office inbox
+(`/office/inbox`) and the workspace activity feed (`/office/workspace/.../activity`) — are
+unchanged in code and see strictly fewer and more accurate rows. `revision` appears as an
+additional read-only field in the budget-policy JSON, which the hand-written frontend type
+ignores.
+
+**Recommendation: no new E2E coverage.** The behavior is a concurrency property between two
+backend goroutines and a database transaction, observable at the repository and evaluation
+boundaries and not reproducible through the UI. Go integration tests plus the PostgreSQL
+twin are the right level.

--- a/docs/specs/budget-claim-revision-fencing/verification.md
+++ b/docs/specs/budget-claim-revision-fencing/verification.md
@@ -1,0 +1,91 @@
+# Budget claim fencing: verification
+
+Companion to [spec.md](spec.md) (`REQ-OFFICE-COSTS-003`), alongside
+[prior-art.md](prior-art.md), [input-inventory.md](input-inventory.md) and
+[amendments.md](amendments.md). Criterion ids below are spec.md's. Split out for the
+specification linter's per-file size ceiling; the five files are one spec.
+
+## Test strategy
+
+Every criterion is observable at the repository or evaluation boundary. Assert submissions
+on the activity **logger**, never with a `SELECT` against `office_activity_log`
+(`AC-OFFICE-COSTS-002.2a`).
+
+- **Race A regression (`.8`, `.9`, `.15`).** Read a policy snapshot at revision `r`; run
+  `UpdateBudgetPolicy` to completion; attempt the snapshot's claim. Assert no activity row
+  submitted, no error log, no counter increment. Then evaluate at revision `r+1` with spend
+  reaching a level under the new values and assert exactly one row **is** submitted. That
+  second half is the point — a test asserting only the first half also passes against an
+  implementation that has merely broken emission.
+- **Race B regression (`.10`, `.11`, `.12`).** With an exceeded-level claim already held
+  for `(policy, period, revision)`, evaluate the same policy with spend in the alert band.
+  Assert zero `budget.alert` submissions. Separately assert the invariant directly: after
+  any successful exceeded claim, both rows exist at that revision.
+- **Atomicity of the pair (`.10`).** Inject a failure between the two inserts using the
+  same style of failpoint #3287 added for the discard (`failBudgetPolicyUpdateErr`,
+  `budget_atomicity_internal_test.go`), and assert neither row exists and the evaluation
+  fails open per `AC-OFFICE-COSTS-002.14`.
+- **Revision lifecycle (`.4`, `.5`, `.6`).** Create → 1, asserted on what the create path
+  hands back to its caller and not only on the stored row — the two disagree if the
+  implementation leans on the column's `DEFAULT 1` — and asserted again after presenting a
+  nonzero revision for creation, which must not survive. Update → 2, and the value returned
+  to the updater is 2. Rolled-back update → unchanged. Two concurrent updates → `r+2`.
+  Update naming a policy id that does not exist → the transaction rolls back and the caller
+  gets an error, asserted as a behavior change from #3287, where that update committed and
+  reported success.
+- **Pair outcomes that are successes, not failures (`.10`, `.11`).** Two cases, both
+  asserting a `budget.exceeded` row IS submitted. With an alert-level claim already held at
+  `(policy, period, revision)`, run an over-limit evaluation: the companion insert conflicts,
+  the pair still commits, `budget.exceeded` goes out, and both rows exist. Then, with an
+  exceeded-level claim already held, run another over-limit evaluation: the exceeded insert
+  writes nothing, no companion insert is attempted, nothing is emitted, and no claim-store
+  failure is logged or counted. A test that only proves the happy pair misses both.
+- **Invalid claim input is not a silent miss (`.13`, and `.8`'s guard ordering).** Call the
+  claim path with revision `0`, then with an empty policy id, then with an empty period key,
+  then with an empty level. Each shall report a claim-store error and fail open — the
+  notification IS emitted, the
+  counter increments, the error is logged — which is the opposite of `.9`'s silent refusal.
+  This is the criterion that fails if the guard is implemented as a `WHERE` predicate
+  instead of running before the fenced statement.
+- **Which level the failure log names (`.14`).** With the claim store faulted, assert the
+  structured log's `level` field is `exceeded` for the atomic pair of `.10` and `alert` for
+  a standalone alert-band claim, and that a pair failure produces exactly one log line and
+  one counter increment rather than two. The counter's label stays `op=claim` throughout.
+- **Revision is server-owned on the wire (`.2`, `.7`).** Assert `revision` appears in the
+  budget-policy JSON under that key and is not suppressed. Then PATCH a budget policy with
+  a `revision` field in the request body and assert the stored revision is the server's
+  own bump, unaffected by the value supplied.
+- **Migration replay (`.1`, ADR 0027).** Fresh boot and boot replay on one connection,
+  asserting the column exists once and replay is a no-op, with no new classifier.
+- **The recreate is guarded (`.3a`).** Boot once against a database still carrying the
+  pre-`.3` three-column claim table — so the cutover actually runs rather than being
+  short-circuited by the probe — **then** write claims, **then** boot a second time and
+  assert those claims are still there. The regression this guards is
+  `AC-OFFICE-COSTS-002.11`, and an unguarded `DROP`/`CREATE` pair passes a single-boot test
+  and fails this one. That ordering is load-bearing rather than incidental: claims written
+  *before* the first boot are destroyed by the cutover itself, which
+  `AC-OFFICE-COSTS-003.3` expressly permits, so a test that holds claims across the first
+  boot asserts something a correct implementation does not promise. Assert the probe finds
+  `revision` present on the second boot and does nothing. This bullet applies on every
+  build: `AC-OFFICE-COSTS-003.3` runs the recreate whatever #3287's state, so there is no
+  longer a merge precondition to record.
+- **A failed recreate is visible, not swallowed (`.3a`).** Inject a failure into the
+  recreate — the `failBudgetPolicyUpdateErr` failpoint style #3287 already uses in
+  `budget_atomicity_internal_test.go`, or the shape of `TestCutover_RollbackAtEveryFailpoint`
+  in `worktree_ownership_migration_test.go` — and assert the error reaches the caller that
+  initializes the schema rather than being logged and dropped. This is the bullet that
+  separates a correct implementation from the most likely wrong one, which is why it is
+  worth its own case: the two calls sitting immediately beside the recreate's slot in
+  `initSchema`, `r.runMigrations()` and `r.activateRunOutcome()`, both return nothing and
+  are invoked bare, and the migration runner they use "swallows failures at WARN". A
+  recreate wired to match its neighbours passes every other bullet here while violating
+  `.3a`'s requirement that a failed recreate be visible rather than silently leaving the
+  old three-column key in place.
+- **PostgreSQL twin (`.3`, `.8`, Fork 3).** Extend #3287's `TestPostgresBudgetClaims`
+  (`KANDEV_TEST_POSTGRES_DSN`) to cover the fenced insert and the four-column key. Fork 3's
+  argument is dialect-specific, so a SQLite-only proof does not establish it. If the DSN is
+  unavailable on the build runner, record that in the task plan with the skip output as the
+  receipt — do not silently omit it.
+- **Suppression boundary (`AC-OFFICE-COSTS-002.12`).** A refused claim on a superseded
+  revision must still pause an unpaused in-scope agent and still deny a pre-execution
+  check.

--- a/docs/specs/office/README.md
+++ b/docs/specs/office/README.md
@@ -96,6 +96,8 @@ dashboard projections, and Office testing contracts.
 - [Office Config Sync Reconciliation System Design](system-design/config-sync-reconciliation.md)
 - [Office: Cost Tracking & Budget Management System Design Part 1](system-design/costs-01.md)
 - [Office: Cost Tracking & Budget Management System Design Part 2](system-design/costs-02.md)
+- [Office: Budget Notification Idempotency System Design (Part 3)](system-design/costs-03.md)
+- [Office: Budget Notification Idempotency System Design (Part 4)](system-design/costs-04.md)
 - [Office Live Updates System Design Part 1](system-design/live-updates-01.md)
 - [Office Live Updates System Design Part 2](system-design/live-updates-02.md)
 - [Office per-agent and per-role tier selection System Design Part 1](system-design/office-agent-tier-routing-01.md)

--- a/docs/specs/office/requirements/costs.md
+++ b/docs/specs/office/requirements/costs.md
@@ -2,7 +2,7 @@
 status: active
 system: office
 created: 2026-04-25
-updated: 2026-08-18
+updated: 2026-09-02
 owners:
   - cfl
 ---
@@ -11,6 +11,31 @@ owners:
 ## Overview
 
 Autonomous agents consume tokens on every turn, and when multiple agents run unattended across many tasks, spending can escalate without visibility. Kandev tracks analytics (task counts, turn counts, agent usage) but has no concept of monetary cost. Users have no way to know how much a task cost, which agent is most expensive, or to set guardrails that prevent runaway spending. Without cost tracking and budgets, autonomous operation is a financial black box.
+
+## Terminology
+
+- **Evaluation period:** The window over which a policy's spend is summed,
+  identified by the window's start instant. A policy whose window is the whole
+  history of the workspace has a single, non-resetting period.
+- **Alert level:** `limit_subcents * alert_threshold_pct / 100`, using the
+  existing integer arithmetic.
+- **Limit level:** `limit_subcents`.
+- **Reaches a level:** Spend is at or above the alert level and strictly below
+  the limit (alert level), or spend is at or above the limit (limit level).
+  These are mutually exclusive within one evaluation; this requirement does not
+  change that.
+- **Claim:** A durable record that a given (policy, evaluation period, level) has
+  already produced its notification.
+- **Emit:** Write the corresponding `budget.alert` or `budget.exceeded` row to
+  the Office activity log.
+- **Submit:** Hand that row to the Office activity logger. Submission is
+  observable to the evaluation that performs it; the durability of the resulting
+  write is not, because `ActivityLogger.LogActivity` returns nothing. Criteria
+  describing what an evaluation *reports about itself* therefore say "submit";
+  criteria describing the user-visible outcome say "emit". Submitting is not the
+  same as holding a claim, and neither implies the other: an evaluation can hold a
+  claim without submitting (AC-OFFICE-COSTS-002.5), and submit without holding one
+  (AC-OFFICE-COSTS-002.14).
 
 ## Requirements
 
@@ -29,6 +54,237 @@ Autonomous agents consume tokens on every turn, and when multiple agents run una
 - **AC-OFFICE-COSTS-001.7:** For providers without usable wire telemetry (codex per-turn split, amp), a disk-runner subsystem reads on-disk session files via pinned `@ccusage/*` packages and feeds normalized cost events into the same pipeline.
 - **AC-OFFICE-COSTS-001.8:** The cost explorer UI surfaces aggregations and lets the user manage budget policies.
 
+### REQ-OFFICE-COSTS-002: Budget notifications fire on crossings, not on every evaluation
+
+**Intent:** `budget.alert` and `budget.exceeded` are notifications, and the
+[state machine](../system-design/costs-01.md#state-machine) defines them as
+crossing events ("spend crosses `alert_threshold_pct`"). Budget evaluation is
+implemented as a level check that runs on unrelated triggers: after every cost
+event, before every agent launch, and after every task reassignment into a
+project. Once a policy sits above its threshold each of those writes another
+activity row, so one over-budget policy floods the Office inbox (which lists
+`budget.alert` rows and counts them toward the badge) with duplicates carrying no
+new information — a reassignment adding no spend at all still produces one. This
+requirement makes the notification idempotent per policy, per period, per level,
+while leaving enforcement (pausing an agent, blocking a run) the level check it
+must remain.
+
+**User story:** As a workspace owner with an over-budget project, I want one
+budget notification per policy per period, so that my inbox stays usable and a
+new notification still means something changed.
+
+#### Acceptance criteria
+
+Terminology used below is defined in [Terminology](#terminology).
+
+- **AC-OFFICE-COSTS-002.1:** When a budget policy is evaluated and its spend is
+  at or above its alert level but below its limit, and no alert-level claim
+  exists for that policy and evaluation period, the system shall record the
+  claim and submit a `budget.alert` row to the Office activity log.
+- **AC-OFFICE-COSTS-002.2:** When a budget policy is evaluated and its spend is
+  at or above its limit, and no exceeded-level claim exists for that policy and
+  evaluation period, the system shall record the claim and submit a
+  `budget.exceeded` row to the Office activity log.
+- **AC-OFFICE-COSTS-002.2a:** Every criterion asserting an emission outcome
+  (AC-OFFICE-COSTS-002.1, .2, .7, .8, .10, .14, .17, and any added later) requires the
+  row to be *submitted*, not durably observed: `LogActivity` returns no error, so a
+  failed activity-log write is invisible to the evaluation that claimed.
+  At most one notification per (policy, evaluation period, level) may be lost this
+  way, and the system shall not retry it, release the claim, or report that loss.
+  This is the accepted direction of claim-then-emit ordering; the opposite ordering
+  would re-introduce the flood this requirement exists to remove.
+- **AC-OFFICE-COSTS-002.3:** When a budget policy is evaluated and a claim
+  already exists for the level that the current spend reaches, for that policy
+  and evaluation period, the system shall record no activity row for that level.
+- **AC-OFFICE-COSTS-002.4:** AC-OFFICE-COSTS-002.1 through AC-OFFICE-COSTS-002.3 shall hold identically
+  for every caller that evaluates a policy: the post-cost-event hook, the
+  pre-execution budget gate, and the task-reassignment project evaluation. The
+  behavior shall be implemented once, at the single evaluation function all
+  callers converge on, so that no caller carries its own copy of it and a future
+  fourth caller inherits it.
+- **AC-OFFICE-COSTS-002.4a:** The task-reassignment caller named in
+  AC-OFFICE-COSTS-002.4 does not exist in this repository yet; it arrives with
+  PR #3276. Its clause of AC-OFFICE-COSTS-002.4 is therefore conditional on that
+  call site being present. When it is absent at implementation time, the
+  implementer shall record the deferral in the task plan under a heading reading
+  exactly `## DEFERRED: AC-OFFICE-COSTS-002.4 reassignment coverage`, naming the
+  absent symbol and the PR it waits on. That heading is the auditable record: a
+  code comment does not satisfy this criterion, and AC-OFFICE-COSTS-002.4 shall not
+  be reported as fully closed while it is present. The other two callers are
+  unaffected and remain fully required.
+- **AC-OFFICE-COSTS-002.5:** When an evaluation records an exceeded-level claim,
+  the system shall also record the alert-level claim for the same policy and
+  period, so that a spend that jumps from below the alert level to above the
+  limit never emits a later `budget.alert` for the same period. This obligation is
+  conditional on the claim store accepting that companion write. When the
+  companion alert-level claim fails with a claim-store error, the system shall not
+  retry it, shall not fail the evaluation, and shall not withhold the
+  `budget.exceeded` row that the exceeded-level claim has already earned; it shall
+  record the failure exactly as AC-OFFICE-COSTS-002.14 requires.
+  AC-OFFICE-COSTS-002.14 takes precedence over this criterion, for the same reason
+  it takes precedence over AC-OFFICE-COSTS-002.10: a degraded claim store must
+  degrade to an extra notification, never to a failed evaluation or a withheld
+  `budget.exceeded`. The cost is bounded and accepted — the de-escalation
+  protection lapses for that one period, so a later evaluation landing in the alert
+  band may emit one `budget.alert`. A test of this criterion shall therefore assert
+  the companion claim on a healthy store, and a fault-injection test shall not
+  assert that the companion claim was recorded.
+- **AC-OFFICE-COSTS-002.6:** A claim shall be scoped to the policy's evaluation
+  period, and the evaluation period shall be the same window used to compute
+  that policy's spend, so a policy whose spend window never resets shall have a
+  claim that never resets.
+- **AC-OFFICE-COSTS-002.6a:** A single evaluation shall determine its period
+  boundary exactly once, and shall use that one value both to compute the policy's
+  spend and to identify the claim. An evaluation shall not derive the boundary a
+  second time from a second reading of the clock. The unit here is the evaluation
+  of one policy: when one trigger evaluates several policies, each policy's spend
+  and claim shall agree with each other, but the policies need not share a boundary
+  value, since no criterion compares one policy's period to another's. An evaluation spanning a period boundary would otherwise sum spend
+  against one window and claim against the next, re-arming the notification once
+  per boundary for every policy whose window resets — invisible in steady state,
+  so it shall be closed structurally rather than left to the implementation.
+- **AC-OFFICE-COSTS-002.7:** When the evaluation period advances to a new
+  window, the system shall treat the new period as unclaimed and emit again on
+  the first evaluation that reaches a level.
+- **AC-OFFICE-COSTS-002.8:** When a budget policy is updated, the system shall
+  discard that policy's claims for every period and level, so the next
+  evaluation that reaches a level under the updated policy emits. The row update
+  and the claim discard shall be atomic: either both apply or neither does. When
+  the discard fails, the update shall fail with it and return an error to the
+  caller, leaving the stored policy and its claims both unchanged. Partially
+  applying the pair is prohibited: an update that succeeds while its discard fails
+  leaves claims that silently suppress the notification this criterion mandates.
+  The discard's guarantee is scoped to evaluations that begin
+  after the update commits. An evaluation already in flight when the discard
+  commits has read its policy, spend and levels beforehand, and may therefore
+  insert a claim keyed to the pre-update period and level, suppressing the first
+  post-update notification; that outcome is permitted rather than prevented. The
+  window is bounded by one evaluation's duration, costs at most one suppressed
+  notification, self-corrects at the next period, and is side-stepped entirely by a
+  `period` change, which moves `period_key`. The alternative, a lock spanning both
+  the evaluation and the update, is rejected: it would put a user-facing write
+  behind a background evaluation.
+- **AC-OFFICE-COSTS-002.9:** When a budget policy row is deleted by any path, the
+  system shall delete that policy's claims. This shall hold for all three
+  deletion paths that exist: single-policy deletion, workspace deletion, and the
+  startup reconciliation that removes policies whose agent or project scope no
+  longer exists. Claim deletion shall be a property of the policy row's removal,
+  not of any one calling method, so a future fourth deletion path inherits it
+  without change.
+- **AC-OFFICE-COSTS-002.10:** When two evaluations of the same policy, period and
+  level run concurrently **and the claim store returns no error to either
+  evaluation**, the system shall submit exactly one activity row for that level.
+  When the claim store returns an error to either evaluation,
+  AC-OFFICE-COSTS-002.14 takes precedence over this criterion and duplicate rows
+  are permitted: the healthy caller emits because it won the claim, the faulted
+  caller because it fails open. Ordered this way deliberately — a broken claim store
+  must degrade to duplicate notifications, never to silence, and a duplicate under
+  an already-degraded store is the pre-existing behavior this requirement replaces,
+  so it is no worse than today.
+- **AC-OFFICE-COSTS-002.11:** Claim state shall survive a backend restart: a
+  restart within an unchanged evaluation period shall not cause a policy that
+  has already emitted at a level to emit again at that level.
+- **AC-OFFICE-COSTS-002.12:** Suppressing a notification shall not suppress
+  enforcement: when spend is at or above the limit, `pause_agent` shall still
+  pause an unpaused in-scope agent, and `pause_agent` / `block_new_tasks` shall
+  still deny a pre-execution budget check, regardless of whether a claim already
+  exists.
+- **AC-OFFICE-COSTS-002.13:** An evaluation result shall report, per level, both
+  whether the policy is at or above that level and whether this evaluation
+  submitted the notification, so a caller can distinguish "over budget" from
+  "newly over budget". "Submitted" carries exactly the meaning fixed in
+  [Terminology](#terminology) — this evaluation handed that level's row to the
+  activity logger — and nothing beyond it. The claim is the mechanism that decides
+  whether to submit; it is not part of what the field reports. The field shall
+  therefore be true in every case where this evaluation put a row into the
+  activity log and false in every case where it did not, which settles every case,
+  including these:
+  - reaches the level and wins the claim: row submitted, field true;
+  - reaches the level but an earlier evaluation already holds the claim: no row,
+    field false;
+  - records the companion alert-level claim under AC-OFFICE-COSTS-002.5 while
+    emitting `budget.exceeded`: no `budget.alert` row, so the alert-level field is
+    false even though this evaluation held that claim;
+  - the claim store errors and the evaluation emits anyway under
+    AC-OFFICE-COSTS-002.14: a row went out, so the field is **true** even though no
+    claim was held.
+  The last case is the one a "held the claim *and* submitted" reading gets wrong:
+  it would report false while duplicating a user-visible notification, hiding every
+  fail-open emission from the callers this field exists to serve. Narrowed by
+  AC-OFFICE-COSTS-002.2a in the other direction: `LogActivity` returns nothing, so
+  a caller shall not read the field as a guarantee that the row is readable.
+- **AC-OFFICE-COSTS-002.14:** When the claim store cannot be read or written, the
+  system shall emit the notification and record the failure as an error log and
+  a counter increment, so a broken claim store degrades to the previous
+  duplicate-notification behavior rather than to silence. An evaluation that emits
+  under this criterion reports `submitted` true, per AC-OFFICE-COSTS-002.13. This
+  criterion is scoped to claim reads and writes performed **during an evaluation**,
+  the only place a claim-store fault is otherwise silent: the evaluation continues,
+  the caller sees no error, and without the counter nothing distinguishes a broken
+  store from a quiet one. A failed claim *discard* during a policy update is
+  deliberately outside it and shall not be counted or logged under it:
+  AC-OFFICE-COSTS-002.8 governs it, rolling the update back and returning the error,
+  so it is already visible to whoever made the edit, and a second weaker signal
+  would imply the discard can fail silently, which AC-OFFICE-COSTS-002.8 forbids.
+- **AC-OFFICE-COSTS-002.14a:** A claim rejected because the policy it references
+  no longer exists is not a claim-store failure and shall be excluded from
+  AC-OFFICE-COSTS-002.14: the system shall record no activity row, no error log and
+  no counter increment. A policy deleted mid-evaluation warrants no notification,
+  and counting its absence as a storage fault would both emit a notification naming
+  a policy the user removed and report a healthy store as broken.
+- **AC-OFFICE-COSTS-002.15:** When a policy's spend falls back below a level it
+  has already claimed within the same period, the system shall keep the claim, so
+  spend that re-crosses the same level in the same period does not emit again.
+- **AC-OFFICE-COSTS-002.16:** Policies applicable to one evaluation shall be
+  evaluated in ascending `created_at` order with ascending `id` as the tiebreak.
+- **AC-OFFICE-COSTS-002.17:** On the first evaluation after this behavior is
+  deployed, a policy already at or above a level shall have no claim for the
+  current period and shall therefore emit once at that level, and then be quiet
+  for the remainder of the period.
+
 ## System design
 
 The migrated technical source is split into [part 1](../system-design/costs-01.md), [part 2](../system-design/costs-02.md).
+`REQ-OFFICE-COSTS-002` is designed in [part 3](../system-design/costs-03.md) (the
+claim store and control flow) and [part 4](../system-design/costs-04.md)
+(suppression boundary, failure and recovery, persistence, security,
+observability). Parts 3 and 4 are one design; part 3 carries the requirement
+mapping for both.
+
+## Out of scope
+
+These exclusions scope `REQ-OFFICE-COSTS-002`.
+
+- **Changing when a policy reaches a level.** The arithmetic named under
+  [Terminology](#terminology) is preserved verbatim, including its existing edge
+  behavior: `alert_threshold_pct = 100` never reaches the alert level (the
+  alert level equals the limit and the alert branch requires spend strictly
+  below the limit); `limit_subcents <= 0` is permanently at the limit level; and
+  an evaluation never reaches both levels at once. This requirement changes how
+  often a level emits, never whether it is reached. Correcting any of that is a
+  separate contract change.
+- **Unifying the three spend-window implementations.** `costs.periodCutoff`,
+  `backendapp.budgetEvaluator.spendForPolicy` and `cron.periodStartFor` each
+  compute a period boundary and disagree: the first two treat `daily` and
+  `yearly` policies as lifetime windows even though `BudgetPeriod.Valid()`
+  accepts them, and the third understands `weekly`, which the enum does not.
+  AC-OFFICE-COSTS-002.6 sidesteps the disagreement by deriving the claim period from
+  the same window the policy's spend already uses, so a claim can never reset on a
+  schedule the spend does not. It does not fix the divergence. A follow-up should
+  make one function authoritative and decide what `daily` and `yearly` mean; until
+  then a `daily` policy keeps a lifetime spend window and a single non-resetting
+  claim.
+- **The cron budget-alert trigger.** `internal/scheduler/cron.BudgetHandler` fires
+  `engine.TriggerOnBudgetAlert` on its own thresholds (50/80/90/100) with its own
+  in-process dedup, and is inert in production because
+  `budgetTaskScope.ResolveAlertTaskID` returns an empty task id. Prior art for the
+  claim key shape (see the system design), but a different notification channel and
+  unchanged here.
+- **Resolving or expiring inbox items.** `budget.alert` rows are surfaced as inbox
+  items with a hardcoded `active` status and no resolve action. This requirement
+  reduces how many are created; it adds no lifecycle to the ones that exist.
+- **`budget.exceeded` visibility.** Only `budget.alert` feeds the Office inbox list
+  and badge count; `budget.exceeded` reaches the activity log only. This requirement
+  makes both idempotent without changing which surfaces read them.
+- **A user-facing setting for notification frequency.** Idempotency is
+  unconditional; no per-policy "re-notify every N" control.

--- a/docs/specs/office/system-design/costs-03.md
+++ b/docs/specs/office/system-design/costs-03.md
@@ -1,0 +1,402 @@
+---
+status: draft
+system: office
+requirements:
+  - REQ-OFFICE-COSTS-002
+created: 2026-09-02
+updated: 2026-09-02
+owners:
+  - cfl
+---
+# Office: Budget Notification Idempotency System Design (Part 3)
+
+Part 3 holds the contract: what the claim store is, and the control flow that uses
+it. Its operational half — suppression boundary, failure and recovery, persistence,
+security and observability — is [part 4](costs-04.md).
+
+## Purpose and boundaries
+
+Office owns budget policies, their evaluation, and the `budget.alert` /
+`budget.exceeded` rows they produce. This part designs the durable claim state
+that turns those two rows from a level check into a crossing notification, per
+`REQ-OFFICE-COSTS-002`.
+
+Adjacent contracts this design uses but does not own:
+
+- **Office activity log** (`office_activity_log`, `shared.ActivityLogger`) is the
+  emission sink. It is fire-and-forget: `LogActivity` returns nothing, so a
+  failed write is not observable to the caller. That constraint drives the
+  claim-then-emit ordering below.
+- **Office inbox** (`dashboard.DashboardService.inboxBudgetAlertItems`,
+  `GetInboxCount`) is the user-visible surface that reads `budget.alert` rows.
+  It is unchanged; it simply stops receiving duplicates.
+- **Spend rollups** (`Repository.GetCostForAgentSince` /
+  `GetCostForProjectSince` / `SumCostsSince`) define the spend window. This
+  design reads the window boundary they are given; it does not redefine it.
+- **Agent pause** (`shared.AgentWriter.UpdateAgentStatusFields`) and the
+  pre-execution gate (`shared.BudgetChecker`) are enforcement, not notification,
+  and are deliberately outside the suppression boundary.
+
+## Prior art
+
+Three legs. Two of them are recorded as unavailable rather than skipped.
+
+### Our own prior reasoning (wiki) — searched, unavailable
+
+Receipt: resolved `OBSIDIAN_VAULT_PATH=/Users/henry/Documents/henry/wiki`,
+`QMD_WIKI_COLLECTION=wiki` from `~/.obsidian-wiki/config` (`@henry`, pinned).
+Intended query: idempotent alerting, crossing-versus-level notification semantics.
+Neither leg could run — `obsidian-wiki`/`qmd` are not on `PATH` here and the grep
+fallback is sandbox-blocked (`ls: /Users/henry/Documents/: Operation not
+permitted`). Nothing retrieved, nothing claimed: re-run with vault access before
+treating the forks below as unopposed by prior positions.
+
+### What other products shipped (saas-kb) — unavailable
+
+Receipt: the `saas-kb` MCP server and its `search_fsm_docs` tool are absent from
+this session's tool list, with no tool discovery exposed. Intended query:
+`category: "ai_sdlc"`, budget and spend-limit alerting in agent platforms (Devin,
+OpenHands, Warp, Factory.ai, Augment). Nothing retrieved; not substituted.
+
+### In-repo prior art — found, and it decides the key shape
+
+`internal/scheduler/cron/budget.go` already solved this exact problem for a
+different notification channel. `BudgetHandler.tryFire` dedupes on
+
+```text
+workspace_id | scope_type | scope_id | threshold | period_start
+```
+
+and `periodStartFor` anchors that key to the policy's period start so it resets at
+a boundary. Its own comment names the gap this design closes: *"Phase 5 keeps
+state in-memory for simplicity; a process restart re-fires once per active
+crossing [...] A future iteration may persist this."*
+
+We take the key shape and reject two details. The scope tuple becomes
+`policy_id`, because two policies can cover one scope (the schema and
+`costs-01.md` both allow "monthly + total") and a scope-keyed claim would let one
+policy's emission silence the other's. And the state is persisted rather than
+in-process, because `costs-01.md` already promises "Monthly reset is idempotent:
+backend restart mid-month does not refire", which an in-memory map cannot
+deliver (AC-002.11).
+
+We depart once more: the cron handler dedupes on a fixed ladder (50/80/90/100)
+ignoring the policy's `alert_threshold_pct`, while this design keys on the two
+levels the policy actually defines. The mechanisms stay independent; see the
+requirement's `## Out of scope`.
+
+## Requirement mapping
+
+| Requirement | Design section |
+| --- | --- |
+| `REQ-OFFICE-COSTS-002` (all ACs) | [Control flow](#control-flow) |
+| AC-002.1–.3, .2a, .5, .10 | [Claim-then-emit](#claim-then-emit) |
+| AC-002.4, .4a | [Call sites](#call-sites) |
+| AC-002.6, .6a, .7, .15 | [Period identity](#period-identity) |
+| AC-002.8, .9, .11, .17 | [Persistence](costs-04.md#persistence) (part 4) |
+| AC-002.8, .9, .14a | [Repository surface](#repository-surface) |
+| AC-002.14 (counter, log), .8 (why the discard is excluded) | [Observability](costs-04.md#observability) (part 4) |
+| AC-002.13 | [Evaluation result](#evaluation-result) |
+| AC-002.12 | [Suppression boundary](costs-04.md#suppression-boundary) (part 4) |
+| AC-002.10, .14, .14a | [Failure and recovery](costs-04.md#failure-and-recovery) (part 4) |
+| AC-002.16 | [Evaluation order](#evaluation-order) |
+
+## Components and responsibilities
+
+- **`costs.CostService.evaluatePolicy`** — where all three call sites converge.
+  It computes spend and levels exactly as today and gains one responsibility: ask
+  the claim store whether this (policy, period, level) may emit, and emit only if
+  so.
+- **Claim store** — a new Office-owned table plus repository methods on
+  `costs.Repository`: atomically claim a (policy, period, level), and discard a
+  policy's claims as part of that policy's update. No business logic, no clock,
+  and no deletion method — deletion is a schema property, see below.
+- **`costs.BudgetCheckResult`** — extended so a caller can distinguish "at or
+  above this level" from "this evaluation emitted" (AC-002.13). The existing
+  `AlertFired` / `LimitExceed` fields keep their present meaning (level reached),
+  because `CheckPreExecutionBudget` gates on `LimitExceed` and must not start
+  allowing runs the moment a claim exists.
+- **`office/repository/sqlite`** — owns the table DDL in the Office schema
+  initializer, the foreign key that deletes claims, and the transaction that
+  discards them on update. **The claim lifecycle lives at the persistence layer,
+  not at a service method.** This is the load-bearing decision of this design.
+  Anchoring it to a service method would be wrong here, because two service
+  facades already expose those exact method names —
+  `costs.CostService` (`internal/office/costs/budgets.go`) and
+  `office/service.Service` (`internal/office/service/service.go`) — and the second
+  calls `s.repo` directly, inheriting nothing. Three deletion paths already
+  exist, and only one of them goes through `DeleteBudgetPolicy` at all (see
+  [Persistence](costs-04.md#persistence)). Anchoring the rule to the row rather than to a
+  method is what makes AC-002.8 and AC-002.9 hold for every path, including the
+  ones nobody remembers to update.
+
+Nothing changes in the frontend: the inbox, badge count and costs page read the
+same rows, just fewer of them.
+
+## Data and contracts
+
+### Claim record
+
+One row per (policy, evaluation period, level).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `policy_id` | string | The budget policy this claim belongs to. Not the scope tuple — see [Prior art](#prior-art). |
+| `period_key` | string | Canonical identity of the evaluation period. See [Period identity](#period-identity). |
+| `level` | string | Exactly `alert` or `exceeded`. Any other value is a bug, not an extension point. |
+| `claimed_at` | timestamp | When recorded. Diagnostic only; never read for a decision. |
+
+`(policy_id, period_key, level)` is the primary key. That uniqueness constraint
+is the concurrency control (AC-002.10) — not an advisory lock, not a
+read-then-write guard.
+
+`policy_id` carries
+`FOREIGN KEY (policy_id) REFERENCES office_budget_policies(id) ON DELETE CASCADE`.
+That constraint — not a method — is how AC-002.9 is satisfied, for every deletion
+path at once. The pattern is already established in this schema: nine `ON DELETE CASCADE`
+foreign keys across seven tables, `office_routine_triggers` and `office_routine_runs` hang off
+`office_routines` exactly this way, and the SQLite DSN sets `_foreign_keys=on` for
+both the read-write and read-only pools, so the cascade is live rather than
+declarative. `labels.go` already relies on the same mechanism in production.
+
+`workspace_id` is intentionally absent: a claim is reachable only through its
+policy, which already carries the workspace, and duplicating it would create a
+second answer that could drift. The foreign key makes that structural.
+
+### Repository surface
+
+**One** new operation on `costs.Repository`, plus a change to an existing one.
+Both are implemented in `office/repository/sqlite`:
+
+- **Claim** `(policy_id, period_key, level) -> (claimed bool, err error)`.
+  Inserts the row and reports whether *this* call inserted it. Must be a single
+  statement so two concurrent callers cannot both observe "not claimed". Returns
+  `claimed=false` with no error when the row already existed.
+  **The conflict-resolution form is contract, not local style: use
+  `INSERT ... ON CONFLICT(policy_id, period_key, level) DO NOTHING`, and
+  specifically NOT `INSERT OR IGNORE`.** The targeted form resolves only the named
+  primary-key conflict and lets every other constraint violation surface as an
+  ordinary Go `error`, which is what makes the foreign-key rule below implementable
+  at all. `claimed` is the statement's **affected-row count**: 1 inserted, 0 already
+  existed. That reading holds on both dialects (SQLite's `sqlite3_changes()`
+  excludes a row skipped by conflict resolution; PostgreSQL's command tag counts
+  only inserted rows), so no `RETURNING` and no follow-up `SELECT` is needed — and a
+  `SELECT` would reintroduce the read-then-write race the primary key prevents.
+  `INSERT OR IGNORE` instead applies IGNORE resolution to *every* constraint
+  violation, foreign keys included: an insert failing only its FK check returns zero
+  rows and **no error**, indistinguishable from "already claimed", leaving nothing
+  for `db.IsForeignKeyViolation` and making the FK rule below dead code. Worth
+  naming because `INSERT OR IGNORE` is the established idiom *in this package* for a
+  table of this exact shape (`labels.go` writes `office_task_labels`, which carries
+  two `ON DELETE CASCADE` foreign keys, that way), and AC-002.14a's black-box
+  outcome converges under both forms, so no test catches the substitution.
+  **Foreign-key violation is not a store failure.** An evaluation that listed a
+  policy, then raced its deletion, fails the insert on the foreign key because the
+  parent row is gone. Treat that specific error as `claimed=false, err=nil` —
+  suppress the emission, do not log it, do not increment
+  `budget_claim_failures_total`. It is not a degraded store but a policy that no
+  longer exists, and none warrants a notification; routing it through AC-002.14's
+  fail-open path would emit a `budget.alert` naming a deleted policy and report a
+  healthy store as broken. Classify with the shared `internal/db` helpers, never a
+  local `strings.Contains` on the message.
+- **`Repository.UpdateBudgetPolicy`** gains the discard, *inside* the same
+  transaction as the row update, and not as a separate exported method — that is
+  the point: both service facades already call this one repository method, so
+  putting the discard here is what makes them agree (AC-002.8, closing the second
+  half of the two-facade problem in
+  [Components](#components-and-responsibilities)). Order within the transaction:
+  delete the policy's claims, then update the row. On any error roll back and return
+  it; the caller sees a failed update with policy and claims both unchanged.
+  `UpdateBudgetPolicy` is today a single untransacted `ExecContext`, so this
+  introduces a `BeginTxx` / `Commit` / `Rollback` wrapper matching
+  `workspace_deletion.go`'s. The discard is idempotent: deleting zero claim rows is
+  success, not an error — a policy that never reached a level has no claims, and
+  that is the common case, not the edge case.
+
+There is **no** "discard by policy" and **no** "discard by workspace" method: the
+foreign key does both deletions, so an explicit method would be a second, divergent
+answer to the same question — the one call sites forget. There is no read-only "is
+claimed?" method either; it would invite a check-then-emit call site that
+reintroduces the race the primary key exists to prevent.
+
+### Evaluation result
+
+`BudgetCheckResult` gains one boolean per level recording whether this
+evaluation **submitted** that level's notification. Existing fields are
+unchanged:
+
+- `AlertFired` / `LimitExceed` — the policy reaches that level *now*. Level
+  check. Used for gating.
+- the two new fields — this evaluation handed that level's row to the activity
+  logger. Crossing. Used for assertions and for any future caller that wants to
+  react only to new crossings.
+
+A field reports **submission only**; holding the claim is the mechanism that
+decides whether to submit and is not part of what the field says (AC-002.13
+enumerates all four reachable cases). Two of them are counter-intuitive and are
+why this is spelled out: the AC-002.5 companion claim is *held* while the
+alert-level field reads **false** (no `budget.alert` row went out), and a
+fail-open emission under AC-002.14 holds *no* claim while the field reads **true**
+(a row did). Reading the field as "held the claim and submitted" gets that second
+case backwards and hides every fail-open emission from the callers the field
+exists to serve.
+
+The word is **submitted**, not *emitted* (AC-002.13, and the `Emit` / `Submit`
+split in the requirement's Terminology). `LogActivity` returns nothing, so the
+evaluation cannot observe whether its row became durable. A field documented as
+"emitted" would promise a durability guarantee AC-002.2a says is unavailable, and
+a caller would be entitled to believe it.
+
+## Control flow
+
+### Period identity
+
+`period_key` is derived from the same window boundary the policy's spend is
+computed against, not from an independently-chosen calendar rule. The evaluation
+reads the clock **once** and derives that boundary **once**: `evaluatePolicy`
+calls `periodCutoff` with a single evaluation timestamp, hands the resulting
+instant to the spend rollup, and formats that same instant as `period_key`
+(AC-002.6a).
+
+**This requires a contract change at an internal seam.** Today
+`getSpendForPolicy` calls `periodCutoff(string(policy.Period), time.Now())`
+itself and returns only `(int64, error)`, so the instant is discarded before
+`evaluatePolicy` regains control and is unreachable from the claim site. The
+boundary must move up to the caller — either `evaluatePolicy` computes it and
+passes it in, or `getSpendForPolicy` returns it alongside the spend. Either
+satisfies AC-002.6a; leaving the seam alone does not.
+
+Recomputing the boundary at claim time is **prohibited**, and is named because it
+is the path of least resistance: a second `periodCutoff(period, time.Now())`
+compiles, reads naturally, and agrees with the first except exactly at a boundary
+— spend summed against September, claim written against October — re-arming the
+policy once per boundary forever, invisibly in steady state. That is why AC-002.6
+is phrased as an equality rather than as a calendar:
+
+- A non-zero window start renders as that instant formatted RFC3339 in UTC
+  (`2026-09-01T00:00:00Z`). The layout is fixed and is part of the contract: it
+  is a stored key, so changing the layout later orphans every existing claim and
+  re-fires every policy once.
+- A zero window start — `periodCutoff`'s "no filter / lifetime" answer — renders
+  as the literal `lifetime`. It is not the RFC3339 rendering of the zero time,
+  because that reads as a real instant and would be silently reset by any future
+  change that starts passing a real epoch-anchored floor.
+
+The consequence is deliberate. A `daily` or `yearly` policy today gets a lifetime
+spend window from `periodCutoff`, so it also gets a non-resetting claim: it
+notifies once, ever, consistent with a limit that never resets. A calendar-derived
+key would instead reset the claim daily against a spend total that never resets,
+re-firing forever on the same accumulated spend — this requirement's own defect,
+reintroduced through the back door. The divergence between the three period
+functions is real and is named in the requirement's `## Out of scope`; this design
+refuses to depend on resolving it.
+
+Because the key is the window start, a new window is automatically unclaimed
+(AC-002.7), and no scheduled job, cleanup pass, or reset trigger exists or is
+needed.
+
+### Claim-then-emit
+
+Within `evaluatePolicy`, for whichever level the spend reaches:
+
+1. Compute spend and levels exactly as today.
+2. If the spend reaches the **limit** level: claim `exceeded`; then also claim
+   `alert` (AC-002.5). Run the `pause_agent` side effect regardless — see
+   [Suppression boundary](costs-04.md#suppression-boundary). `Claim` returns
+   `(claimed bool, err error)`, so the `exceeded` claim has **three** outcomes and
+   each decides the emission differently. Do not collapse them to two:
+   - `claimed=true, err=nil` — this evaluation won the claim: **emit**.
+   - `claimed=false, err=nil` — an earlier evaluation already holds it, or the
+     policy was deleted mid-evaluation (AC-002.14a): **do not emit**.
+   - `err != nil` — the claim store is degraded: **emit anyway**, and log and count
+     it (AC-002.14, [Observability](costs-04.md#observability)). Suppressing here is
+     the one outcome AC-002.14 exists to prevent, and it is what any two-state
+     summary of this step ("emit only if the claim succeeded") silently produces,
+     which is why all three outcomes are written out instead.
+   The companion `alert` claim's **outcome** is discarded — claimed and
+   already-claimed are equally fine, and neither changes whether
+   `budget.exceeded` is emitted. Its **error** is not discarded: a claim-store
+   error here is logged and counted exactly like any other (see
+   [Observability](costs-04.md#observability)), because it is the same degraded
+   store AC-002.14 exists to make visible. It still does not change the
+   `budget.exceeded` emission, and it is not retried. Naming this matters
+   because the consequence is specific and otherwise silent: if the companion
+   claim errors, the de-escalation hole below reopens **for that period only** —
+   a later evaluation landing in the alert band emits one `budget.alert` — and
+   the counter is the only signal that this is what happened. **AC-002.5 carries
+   the matching carve-out**: its "shall also record" is conditional on the store
+   accepting the companion write, with AC-002.14 taking precedence when it does
+   not. So a test of AC-002.5 asserts the companion claim on a **healthy** store,
+   and a fault-injection test must not assert it was recorded — the same split
+   AC-002.10 and AC-002.14 already require.
+3. Else if the spend reaches the **alert** level: claim `alert`, and decide the
+   `budget.alert` emission from the same three outcomes as step 2.
+4. Else: no claim, no emission. Note that a spend that has fallen back below a
+   claimed level does **not** release the claim (AC-002.15); nothing in this
+   flow ever deletes a claim.
+
+The order is claim first, emit second, and that ordering is forced rather than
+preferred. `ActivityLogger.LogActivity` returns nothing, so emit-then-claim
+cannot know whether it has anything to claim, and a claim written after a failed
+emit would silence a notification that never happened. Claim-then-emit has the
+opposite failure: a successful claim whose emission then fails loses exactly one
+notification for that period. That is the accepted trade — one lost notification
+under an already-degraded activity log, versus a flood under normal operation,
+which is the defect being fixed.
+
+Step 2's unconditional alert-claim closes the de-escalation hole: without it, a
+policy whose spend jumps straight past the limit never claims `alert`, so a
+later reassignment that drags spend back into the band between the alert level
+and the limit would emit a `budget.alert` — a *new* notification describing a
+*reduction* in spend.
+
+### Call sites
+
+All three converge on `evaluatePolicy`, so all three inherit the behavior with
+no per-caller logic (AC-002.4):
+
+| Caller | Trigger | Path |
+| --- | --- | --- |
+| `Service.CheckBudget` (post-cost-event subscriber, `service/event_subscribers.go`) | every recorded cost event | `EvaluateBudget` → `CheckBudget` → `evaluatePolicy` |
+| `SchedulerIntegration.checkBudget` (pre-execution gate, `service/scheduler_integration.go`) | every run dispatch | `CheckPreExecutionBudget` → `CheckBudget` → `evaluatePolicy` |
+| `DashboardService` task reassignment (`dashboard/service_tasks.go`, added by PR #3276) | every reassignment into a project | `EvaluateProjectBudget` → `evaluatePolicy` |
+
+`EvaluateProjectBudget` does not exist at this branch's merge base (`c51ec0a21`);
+PR #3276 is open against `main`. Apply the behavior at `evaluatePolicy`, which is
+present today, and add the reassignment coverage AC-002.4 names once that call
+site exists — the reassignment row above is the only deferred part of this design,
+and because the behavior lives at `evaluatePolicy` rather than per caller, that
+call site inherits it the moment it lands. The deferred item is the **test
+coverage**, not the behavior.
+
+The deferral has a named, auditable home (AC-002.4a): a heading in the **task
+plan** reading exactly
+
+```text
+## DEFERRED: AC-OFFICE-COSTS-002.4 reassignment coverage
+```
+
+naming the absent symbol (`EvaluateProjectBudget`) and the PR it waits on (#3276).
+The task plan is this board's running record — it is the Kandev artifact behind
+`get_task_plan_kandev` / `update_task_plan_kandev`, not a file in the repository,
+it survives context resets, and every later step reads it. A code comment is
+explicitly **not** sufficient: nothing on this board reads code comments, which is
+how a deferral becomes a silent drop. While that heading is present, AC-002.4 is
+not fully closed and no step may report it as such.
+
+### Evaluation order
+
+`Repository.ListBudgetPolicies` currently orders by `created_at` alone, which is
+not unique: two policies created in the same second have no defined relative
+order, so which emits first can differ between runs. The ordering becomes
+`created_at ASC, id ASC` (AC-002.16); `id` is the primary key, so the ordering is
+total. This matters because each policy's emission is now one-shot per period, so
+a non-deterministic order makes the activity-log sequence non-reproducible and
+any test asserting on it flaky rather than wrong.
+
+---
+
+Enforcement boundaries, failure handling, persistence, security and observability
+are designed in [part 4](costs-04.md). They are split out because this design
+reached the specification linter's 32,768-byte ceiling for a system-design file;
+the two parts are one design and part 4 has no requirement mapping of its own.

--- a/docs/specs/office/system-design/costs-04.md
+++ b/docs/specs/office/system-design/costs-04.md
@@ -1,0 +1,213 @@
+---
+status: draft
+system: office
+requirements:
+  - REQ-OFFICE-COSTS-002
+created: 2026-09-02
+updated: 2026-09-02
+owners:
+  - cfl
+---
+# Office: Budget Notification Idempotency System Design (Part 4)
+
+The operational half of [part 3](costs-03.md), split out when that file reached the
+specification linter's 32,768-byte ceiling for a system-design file. Part 3 defines
+the claim store and the control flow that uses it; part 4 defines what the claim
+must **not** gate, how the design behaves when a component fails, where the state
+lives, and what it exposes. The two parts are one design against
+`REQ-OFFICE-COSTS-002` and share part 3's
+[requirement mapping](costs-03.md#requirement-mapping).
+
+## Suppression boundary
+
+The most dangerous way to implement this requirement is to gate too much on the
+claim. Enforcement is a level check and must stay one (AC-002.12):
+
+- **`pause_agent`** runs on every evaluation where spend is at or above the limit,
+  claim or no claim: a user who un-pauses an agent that is still over budget must
+  see it re-paused next evaluation. `pauseAgentForBudget` already no-ops on an
+  already-paused agent, so repeating it is cheap and idempotent.
+- **`CheckPreExecutionBudget`** keeps denying on `LimitExceed` for `pause_agent`
+  and `block_new_tasks` policies, reading the level and never the claim. A policy
+  that already emitted must still block every subsequent run.
+- **`BudgetCheckResult.AlertFired` / `LimitExceed`** keep meaning "reaches this
+  level". Only the two new fields report submission.
+
+One rule: the claim gates writes to `office_activity_log` and nothing else.
+
+## Failure and recovery
+
+- **Claim store read/write error** (AC-002.14): treat the claim as not held, emit,
+  log at error level, increment the counter, and report `submitted` true because a
+  row went out (AC-002.13). Rationale: this requirement fixes a flood produced by
+  *normal* operation, whereas a broken store is exceptional, and degrading it to
+  "duplicates plus an error signal" beats "silently stop warning the user about
+  money". A store broken for a whole period reproduces today's behavior exactly,
+  and the counter makes that visible. The error must not fail the evaluation:
+  `evaluatePolicy` still returns its result and the cost event is not rolled back.
+- **Activity write fails after a successful claim**: one notification is lost for
+  that (policy, period, level). Not detectable from the caller; see
+  [Claim-then-emit](costs-03.md#claim-then-emit) for why this is the accepted direction.
+- **Concurrent evaluation of the same policy**: resolved by the primary key.
+  Exactly one caller inserts; the other observes `claimed=false` and suppresses.
+  AC-002.10's "exactly one" is a count of **submissions**, not of durable rows:
+  assert it on the activity logger, never with a `SELECT` against
+  `office_activity_log`. AC-002.2a makes the durability of any one row unobservable,
+  so a durable-row assertion is testing something the contract does not promise.
+  No transaction spanning claim and emit is required, and none should be added —
+  the activity write is not transactional with anything.
+- **Concurrent evaluation where the claim store also faults**: the two rules above
+  compose into a duplicate, and AC-002.10 says so explicitly. The healthy caller
+  wins the insert and emits; the faulted caller fails open per AC-002.14 and also
+  emits. Two rows for one crossing. **AC-002.14 takes precedence over AC-002.10** —
+  a documented tie-break, not an oversight: a duplicate under a broken store is
+  today's behavior, whereas suppressing on claim-store error converts a storage
+  fault into silent under-notification about money. Do not "fix" it with a retry
+  loop inside the claim; a retry outliving the evaluation moves the fault into the
+  cost-event path, which AC-002.14 forbids. Unlikely on SQLite, where
+  `internal/db/pool.go` uses a single writer connection to serialize writes; a real
+  path on Postgres. Test consequence, which is why this is written down: the
+  AC-002.10 concurrency test must run against a **healthy** store, and the
+  AC-002.14 fault-injection test must not assert single emission. Written the other
+  way round they contradict each other and one is flaky rather than wrong.
+- **Claim discard fails during a policy update** (AC-002.8): the whole update
+  fails and rolls back. See [Repository surface](costs-03.md#repository-surface). The
+  caller gets an error, the policy keeps its old values, and the claims survive
+  intact — consistent with the un-updated policy they belong to.
+- **An in-flight evaluation claims just after an update's discard commits**: it
+  read its spend and levels before the update, so it may insert a claim keyed to
+  the pre-update period and level, suppressing one notification under the new
+  policy. Real rather than theoretical: `CheckBudget` calls `ListBudgetPolicies`
+  once, then passes each already-read `*BudgetPolicy` into `evaluatePolicy`, so a
+  policy updated mid-loop is evaluated from a stale read. **AC-002.8 carries the
+  matching carve-out**, scoping the discard's guarantee to evaluations beginning
+  after the update commits. Bounded by one evaluation's duration, and accepted
+  rather than locked against: the alternative is a lock spanning the evaluation and
+  the update, putting a user-facing write behind a background evaluation. A
+  `period` change moves `period_key` and side-steps it entirely; a limit or
+  threshold change costs at most one suppressed notification, self-correcting at
+  the next period.
+- **Backend restart mid-period**: claims are on disk, so a restart changes nothing
+  (AC-002.11) — the promise `costs-01.md` already makes and the cron handler's
+  in-memory map cannot keep.
+- **Policy re-created with the same scope**: a new policy row means a new
+  `policy_id` means no claims, so it emits once. Correct — it is a new policy.
+
+## Persistence
+
+- **Table**: one new Office-owned table created in the Office SQLite schema
+  initializer, using `CREATE TABLE IF NOT EXISTS` so startup replay is safe. It
+  must be created **after** `office_budget_policies` in the initializer, because
+  its foreign key references that table: SQLite tolerates a forward reference at
+  `CREATE TABLE` and only fails later at DML time, but PostgreSQL rejects it
+  outright, so the ordering is a correctness requirement on one dialect and a
+  latent trap on the other. Per ADR 0027, the change needs fresh-plus-replay
+  coverage on the same connection at the schema owner's boundary, and no new
+  local `strings.Contains(err.Error(), ...)` replay classifier —
+  `db.IsDuplicateColumnError` / `db.IsAlreadyExistsError` are the only
+  classifiers.
+- **Deployment / first run** (AC-002.17): the table starts empty, so the first
+  evaluation after deployment emits once per policy per reached level, then goes
+  quiet for the rest of the period. No backfill runs, and none should be written:
+  pre-claiming from existing activity rows would suppress the one notification
+  telling the user the new behavior is live, and the activity log carries the
+  policy id only inside a JSON `details` string with no index to match on.
+- **Policy update**: discard all of the policy's claims on *any* update
+  (AC-002.8), unconditionally, without comparing old and new field values.
+  `limit_subcents` and `alert_threshold_pct` matter most since they redefine what
+  a level means, but `UpdateBudgetPolicy` receives only the new state, so a
+  narrower rule would need a read-compare-write against the stored row — both a
+  race and a second place for "changed" to drift. The cost is that editing an
+  unrelated field (say `action_on_exceed`) re-arms the notification once, which
+  is acceptable: a human just edited the policy. A `period` change moves
+  `period_key` anyway, so it would re-arm regardless.
+- **Policy deletion, all three paths** (AC-002.9): handled by the foreign key's
+  `ON DELETE CASCADE`, so **no code change is required at any of them**. All three
+  are enumerated because only one goes through `DeleteBudgetPolicy`:
+  1. `Repository.DeleteBudgetPolicy` — the single-policy delete behind the HTTP
+     route.
+  2. The workspace-deletion sweep in `repository/sqlite/workspace_deletion.go`,
+     whose existing `DELETE FROM office_budget_policies WHERE workspace_id = ?`
+     now cascades. It needs **no** new statement, and must not gain one ordered
+     before the policies delete — the cascade already covers it.
+  3. `Repository.DeleteBudgetPoliciesForRemovedScopes`, called from
+     `infra.Reconciler.reconcileBudgetPolicies` at startup to drop policies
+     whose agent or project scope no longer exists. This path bypasses
+     `DeleteBudgetPolicy` entirely and would have orphaned claims permanently,
+     since [Retention](#persistence) is deliberately none.
+
+  A fourth deletion path added later inherits the cascade for free — the whole
+  argument for putting this in the schema rather than a service method, and why
+  AC-002.9 is phrased as a property of the row's removal.
+- **Retention**: none. Growth is bounded by `policies × periods × 2` (two rows
+  per policy per period) and needs no pruning job. Row count is not surfaced.
+- **Backups**: covered by the standard Office SQLite snapshot.
+
+## Security
+
+No new trust boundary. Claims are reachable only through a policy, and policies are
+already workspace-scoped by `officeWorkspaceScopeMiddleware`. No new HTTP route is
+added, so `officeParamScopeResolvers`, `officeScopedSubResourceParams` and
+`officeWorkspacelessRoutes` need no entry and `TestOfficeRouteScopeCompleteness`
+stays green unmodified. Claims carry no user content, spend figures or PII: a
+policy id, a period key, a level, a timestamp.
+
+## Observability
+
+- **Counter** for claim-store failures (AC-002.14), exported through the
+  existing `expvar` surface at `/debug/vars` in dev mode. Concretely:
+
+  | | |
+  | --- | --- |
+  | Name | `budget_claim_failures_total` |
+  | Shape | `expvar.NewMap`, matching its siblings — **not** a plain `Int` |
+  | Label key | `op`, with exactly one value: `claim` |
+  | Home | a new file in **`internal/office/costs`**, which owns `evaluatePolicy` and every increment site |
+
+  The home needs stating because the obvious neighbours sit in a *different*
+  package: `cost_events_written_total` / `cost_events_dropped_total` live in
+  `internal/office/service/cost_metrics.go`, and their increment helpers are
+  unexported methods on `*service.Service`, unreachable from `costs`. So this
+  counter sits beside the code that increments it, while following their *shape*
+  (label-keyed `expvar.Map`, not Int) because `/debug/vars` is a contract surface
+  and a lone Int among Maps would be the odd one out.
+
+  `claim` covers both the level claim and the AC-002.5 companion claim, and the
+  label stays at that one value: the log below carries the policy id and level, so
+  the counter does not need that cardinality and must not grow it.
+
+  **The in-transaction discard is deliberately NOT counted, and a later reader must
+  not "fix" the omission.** Three reasons, the first decisive. (1) A discard failure
+  is not silent: AC-002.8 rolls the update back and returns the error, so the person
+  who edited the policy sees it fail. This counter is for the failure that *is*
+  silent — an evaluation that fails open, continues, and tells nobody (AC-002.14 is
+  now scoped to evaluation-time claim reads and writes for exactly this reason). A
+  second, weaker signal for a failure that already surfaces would imply the discard
+  can fail quietly, which AC-002.8 forbids. (2) A discard spans every period and
+  level of one policy, so it has no `level` for the log line below; a sentinel would
+  make that field mean two things. (3) It is not reachable from this package: the
+  discard runs inside `Repository.UpdateBudgetPolicy` in `office/repository/sqlite`,
+  which has no production import of `internal/office/costs`; **both** facades reach
+  it and `office/service.Service.UpdateBudgetPolicy` calls `s.repo` directly without
+  entering `costs`; and the repository returns one `error` for both halves of the
+  transaction, so even from inside `costs` a discard failure is indistinguishable
+  from a row-update failure without a typed error this design does not define.
+  Counting it would mean an unnamed `sqlite`→`costs` import edge or over-counting
+  every failed update — the same two-facade trap
+  [Components](costs-03.md#components-and-responsibilities) puts the discard in the repository
+  to avoid.
+
+  A non-zero value means notifications are being duplicated and the claim store
+  needs attention — it is the only signal that distinguishes "quiet because
+  nothing crossed" from "loud because the store is broken".
+- **Structured log** at error level on a claim-store failure during an
+  evaluation, carrying the policy id and the level being claimed. Both fields are
+  always available here, because every increment site is a claim attempt for a
+  known policy at a known level.
+- **No log line on ordinary suppression.** Suppression is the steady state; a
+  log per suppressed evaluation would move the flood from the inbox to the log
+  file. The activity log itself is the record of what fired.
+
+## Related decisions
+
+- [ADR 0027: Replayable schema migrations across SQLite and Postgres](../../../decisions/0027-replayable-schema-migrations.md)


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3532/c8ce75376fc3.html)
<!-- kandev-pr-walkthrough-end -->

A stale-read budget evaluation could still write a claim after its policy changed underneath it, and an over-limit crossing could still let a late alert land after the exceeded notification already fired; this fences every claim to the policy revision it was actually evaluated against.

**Today:** an evaluation that reads policy revision N can claim and notify using a limit that revision N+1 already replaced, and a concurrent alert-level evaluation can submit `budget.alert` after `budget.exceeded` already fired for the same crossing.

**After this:** `office_budget_policies.revision` is a server-assigned counter bumped atomically on every update; `office_budget_claims` carries `revision` as the 4th column of its primary key, so a claim only survives for the exact revision that earned it, and a stale-revision claim attempt is refused rather than silently accepted. An exceeded-level claim and its alert-level companion are claimed together in one transaction, so the alert can never be submitted after the exceeded notification already went out.

**Who hits this:** any workspace owner who updates a budget policy (raises/lowers a limit, changes the threshold) while an evaluation is in flight against the old values, or whose usage crosses both the alert and exceeded thresholds in close succession.

**Scope:** `apps/backend/internal/office/costs` and `apps/backend/internal/office/repository/sqlite` claim/policy read-modify-write paths, plus the `office_budget_policies`/`office_budget_claims` schema and their migrations.

**Not here:** two residuals the spec explicitly excludes (see [spec](docs/specs/budget-claim-revision-fencing/spec.md#out-of-scope)) — serializing the one-time `office_budget_claims` recreate across two backends cold-starting simultaneously against a shared, not-yet-migrated PostgreSQL database (SQLite's single-writer pool makes this unreachable there, and Postgres' worst case is a returned boot error, not corruption); and the residual `budget.alert`-after-`budget.exceeded` *activity-log write-order* inversion when both claims are won by genuinely concurrent evaluations (bounded to at most one such pair per policy/period/revision, and both events are still correctly claimed and emitted — only their log order is unconstrained).

## Important Changes

- `office_budget_policies` gains a server-assigned `revision` column, starting at 1 and incremented in-SQL on every successful update (rolled-back updates don't consume a number); API clients cannot set it.
- `office_budget_claims`'s primary key becomes `(policy_id, period_key, level, revision)`, fenced by a single-statement `INSERT...SELECT...WHERE EXISTS` against the policy's current revision, so a claim against a superseded revision is refused rather than accepted.
- `Repository.ClaimExceeded` claims the `exceeded` row and its `alert` companion atomically in one transaction (`claimExceededAndEmit` in `costs/budgets.go`), closing the window where a concurrent alert-only evaluation could submit after `budget.exceeded` already fired.
- Databases created before this change get `office_budget_claims` recreated in place (transactional DROP+CREATE guarded by a `columnExists` probe), returning the error to the caller on failure instead of leaving mismatched schema.
- An update discards a policy's existing claims (unchanged from REQ-OFFICE-COSTS-002) but now does so at its new revision, so the next evaluation starts clean against the values it will actually read.

## Validation

- `CGO_ENABLED=1 go test -tags fts5 ./internal/office/...` — full office suite passes, including 16 new/updated tests in `internal/office/repository/sqlite` covering AC-OFFICE-COSTS-003.1, .3a, .4–.6, .8–.10, .13 (`budget_revision_fencing_test.go`, `budget_claims_recreate_internal_test.go`, `budget_exceeded_atomicity_internal_test.go`) and wire-level AC.2/.4/.7 (`handler_budget_revision_test.go`).
- `make typecheck test lint` (repo root) — typecheck clean; `test-backend` fails only in 11 packages unrelated to this change (`internal/agent/managedruntime`, `internal/agent/runtime/lifecycle`, `internal/agent/settings/controller`, `internal/agentctl/server/{api,config,process}`, `internal/launcher`, `internal/system/storage/workspaces`, `internal/task/{handlers,service}`, `internal/worktree`) plus one pre-existing failure in `internal/office/repository/sqlite` (`TestMigrate_PriorityIdempotent`, a test file this PR does not touch) — all reproduced identically against `origin/main` at the branch's merge-base in a separate scratch worktree, proving they predate this change.
- `golangci-lint run ./...` — 0 issues. `eslint --max-warnings 0` (web) — clean. `make lint-format` — clean. `pnpm run i18n:ratchet` — clean (no `apps/web` files touched). `lint-harness-files.py --all`, `lint-spec-files.py --all`, `lint-architecture.py --all` — all pass.
- `go test ./internal/office/repository/sqlite/... -run TestPostgresBudgetClaims_RevisionFencingAndFourColumnKey` — environment-gated on `KANDEV_TEST_POSTGRES_DSN`; not runnable in this sandbox (no PostgreSQL available), left in place per `apps/backend/AGENTS.md`'s dialect-sensitive-method coverage rule.

## Possible Improvements

Low risk: the schema change is additive and migration-guarded, but the two out-of-scope residuals above (cross-initializer PostgreSQL recreate race; activity-log write-order under genuine concurrency) remain open follow-up candidates if either surfaces in practice.

## Related Issues

Follow-up to #3287, addressing two concurrency findings raised there:
- coderabbitai: [fence claims to the policy revision](https://github.com/kdlbs/kandev/pull/3287#discussion_r3914827075)
- cubic-dev-ai: [alert-vs-exceeded race on a concurrent over-limit evaluation](https://github.com/kdlbs/kandev/pull/3287#discussion_r3914856011)

Design doc: [`docs/specs/budget-claim-revision-fencing/spec.md`](docs/specs/budget-claim-revision-fencing/spec.md)

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->