### PR TITLE
fix: recognize leading [canceled] in Cursor stream-reset errors

### DIFF
--- a/apps/backend/internal/agent/runtime/routingerr/cursor_retriable_stream_reset_test.go
+++ b/apps/backend/internal/agent/runtime/routingerr/cursor_retriable_stream_reset_test.go
@@ -1,8 +1,13 @@
 package routingerr
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 const realCursorRetriableStreamReset = "Error: RetriableError: HTTP/2 stream closed with error code CANCEL (0x8)"
+
+const leadingCanceledCursorRetriableStreamReset = "Error: RetriableError: [canceled] HTTP/2 stream closed with error code CANCEL (0x8)"
 
 const wantCursorRetriableStreamResetRuleID = "cursor.retriable_stream_reset.v1"
 
@@ -106,6 +111,47 @@ func TestClassifyCursorRetriable(t *testing.T) {
 	})
 	if overlapped.Code != CodeProviderOverloaded {
 		t.Fatalf("overlapping overload classified as %q, want %q", overlapped.Code, CodeProviderOverloaded)
+	}
+}
+
+func TestClassifyCursorRetriableLeadingCanceled(t *testing.T) {
+	resetInjection()
+
+	e := Classify(Input{
+		Phase:      PhasePromptSend,
+		ProviderID: "cursor-acp",
+		Stderr:     leadingCanceledCursorRetriableStreamReset,
+	})
+	if e == nil {
+		t.Fatal("expected non-nil Error")
+	}
+	if e.Code != CodeAgentTransportLost {
+		t.Fatalf("Code = %q, want %q", e.Code, CodeAgentTransportLost)
+	}
+	if !e.AutoRetryable {
+		t.Fatal("AutoRetryable = false, want true")
+	}
+	if e.FallbackAllowed {
+		t.Fatal("FallbackAllowed = true, want false")
+	}
+	if got := Decide(ContextKanban, e, time.Time{}); got != DecisionShortRetry {
+		t.Fatalf("Decide(ContextKanban, ...) = %q, want %q", got, DecisionShortRetry)
+	}
+}
+
+func TestClassifyCursorRetriableCancellationRemainsManual(t *testing.T) {
+	resetInjection()
+
+	for _, message := range []string{
+		"context canceled: " + leadingCanceledCursorRetriableStreamReset,
+		"cancel escalated: " + leadingCanceledCursorRetriableStreamReset,
+	} {
+		t.Run(message, func(t *testing.T) {
+			e := Classify(Input{Phase: PhasePromptSend, Stderr: message})
+			if got := Decide(ContextKanban, e, time.Time{}); got != DecisionManual {
+				t.Fatalf("Decide(ContextKanban, Classify(%q)) = %q, want %q", message, got, DecisionManual)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/routingerr/cursor_retriable_stream_reset_test.go
+++ b/apps/backend/internal/agent/runtime/routingerr/cursor_retriable_stream_reset_test.go
@@ -137,6 +137,15 @@ func TestClassifyCursorRetriableLeadingCanceled(t *testing.T) {
 	if got := Decide(ContextKanban, e, time.Time{}); got != DecisionShortRetry {
 		t.Fatalf("Decide(ContextKanban, ...) = %q, want %q", got, DecisionShortRetry)
 	}
+	if e.Class != ClassTransient {
+		t.Fatalf("Class = %q, want %q", e.Class, ClassTransient)
+	}
+	if e.Confidence != ConfHigh {
+		t.Fatalf("Confidence = %q, want %q", e.Confidence, ConfHigh)
+	}
+	if e.UserAction {
+		t.Fatal("UserAction = true, want false")
+	}
 }
 
 func TestClassifyCursorRetriableCancellationRemainsManual(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/routingerr/runtime_rules.go
+++ b/apps/backend/internal/agent/runtime/routingerr/runtime_rules.go
@@ -147,7 +147,7 @@ var transportLostRe = regexp.MustCompile(`(?i)peer disconnected|connection close
 // Requiring the whole normalized message prevents ordinary provider prose from
 // combining the control prefix with an unrelated transport fragment.
 var cursorRetriableStreamResetRe = regexp.MustCompile(
-	`(?i)^\s*Error:\s*RetriableError:\s*HTTP/2 stream closed with error code CANCEL \(0x8\)(?:\s+\[canceled\])?\s*$`,
+	`(?i)^\s*Error:\s*RetriableError:\s*(?:\[canceled\]\s+)?HTTP/2 stream closed with error code CANCEL \(0x8\)(?:\s+\[canceled\])?\s*$`,
 )
 
 // overloadedRe matches the transient 529 Overloaded signature: either the

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_cursor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_cursor.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	cursorRetriableStreamResetPrefix  = "Error: RetriableError:"
-	cursorRetriableStreamResetMessage = "Error: RetriableError: HTTP/2 stream closed with error code CANCEL (0x8)"
-	cursorRetriableStreamResetMaxTail = 256
+	cursorRetriableStreamResetPrefix                 = "Error: RetriableError:"
+	cursorRetriableStreamResetMessage                = "Error: RetriableError: HTTP/2 stream closed with error code CANCEL (0x8)"
+	cursorRetriableStreamResetLeadingCanceledMessage = "Error: RetriableError: [canceled] HTTP/2 stream closed with error code CANCEL (0x8)"
+	cursorRetriableStreamResetMaxTail                = 256
 )
 
 // isCursorRetriableStreamReset recognizes Cursor's complete transport control
@@ -27,6 +28,7 @@ func isCursorRetriableStreamReset(text string) bool {
 		return false
 	}
 	return strings.EqualFold(trimmed, cursorRetriableStreamResetMessage) ||
+		strings.EqualFold(trimmed, cursorRetriableStreamResetLeadingCanceledMessage) ||
 		strings.EqualFold(trimmed, cursorRetriableStreamResetMessage+" [canceled]")
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_cursor_retriable_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/dialect_cursor_retriable_test.go
@@ -12,6 +12,8 @@ import (
 
 const cursorRetriableStreamResetChunk = "Error: RetriableError: HTTP/2 stream closed with error code CANCEL (0x8)"
 
+const cursorRetriableStreamResetLeadingCanceledChunk = "Error: RetriableError: [canceled] HTTP/2 stream closed with error code CANCEL (0x8)"
+
 func cursorMessageNotification(sessionID, text string) acpsdk.SessionNotification {
 	return makeNotification(sessionID, acpsdk.SessionUpdate{
 		AgentMessageChunk: &acpsdk.SessionUpdateAgentMessageChunk{
@@ -39,6 +41,19 @@ func TestCursorRetriableStreamResetSuppressesExactCurrentChunk(t *testing.T) {
 
 	if events := drainEvents(a); len(events) != 0 {
 		t.Fatalf("exact Cursor control chunk emitted %d events: %+v", len(events), events)
+	}
+}
+
+func TestCursorRetriableStreamResetSuppressesLeadingCanceledCurrentChunk(t *testing.T) {
+	a, turn := newCursorPromptTurn(t, 7)
+
+	a.handleACPUpdate(cursorMessageNotification("session-1", cursorRetriableStreamResetLeadingCanceledChunk), 7)
+
+	if !turn.cursorRetriableFailure() {
+		t.Fatal("leading-[canceled] Cursor control chunk did not set retriable marker")
+	}
+	if events := drainEvents(a); len(events) != 0 {
+		t.Fatalf("leading-[canceled] Cursor control chunk emitted %d events: %+v", len(events), events)
 	}
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3544/0fb02099e3a3.html)
<!-- kandev-pr-walkthrough-end -->

Cursor's leading `[canceled]` stream-reset diagnostic was not recognized because the token appeared between `RetriableError:` and the HTTP/2 text, so the error fell into manual recovery. This extends both anchored fingerprints and adds regressions so it remains a structured transport-loss short retry while genuine context cancellation and cancel escalation remain manual.

## Validation

- `cd apps/backend && go test -race ./internal/agent/runtime/routingerr/... ./internal/agentctl/server/adapter/transport/acp/...`
- `make -C apps/backend lint`
- Staged Go formatting check and `git diff --check`

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->