### PR TITLE
fix(executor): detach inherited environment on executor mismatch

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -1292,8 +1292,27 @@ func (e *Executor) LaunchPreparedSession(ctx context.Context, task *v1.Task, ses
 	if err != nil {
 		return nil, err
 	}
+	// An inherited environment (inherit_parent / shared_group) is owned by the
+	// task that materialized it, so the child cannot share it across an executor
+	// boundary. Failing the whole launch strands the child: it can never attach
+	// to a parent environment on one executor while elected onto another. Detach
+	// instead — the child materializes a fresh environment on its elected
+	// executor and leaves the parent's environment untouched. prepareExecutorTransition
+	// has already stripped req.WorkspacePath and req.WorkspaceReuseRequired for
+	// this launch, so nil-ing existingEnv routes the child through the normal
+	// fresh-materialization path in persistTaskEnvironment.
 	if existingEnv != nil && existingEnv.TaskID != task.ID && existingEnv.ExecutorType != "" && existingEnv.ExecutorType != req.ExecutorType {
-		return nil, fmt.Errorf("%w: inherited task environment belongs to executor %q, launch selected %q", models.ErrWorkspaceReuseUnsafe, existingEnv.ExecutorType, req.ExecutorType)
+		inheritedExecutorType := existingEnv.ExecutorType
+		existingEnv = nil
+		session.TaskEnvironmentID = ""
+		session.WorkspacePath = ""
+		assignLaunchTaskEnvironmentID(session, nil)
+		req.TaskEnvironmentID = session.TaskEnvironmentID
+		e.logger.Info("detaching inherited task environment for executor mismatch",
+			zap.String("task_id", task.ID),
+			zap.String("session_id", session.ID),
+			zap.String("inherited_executor_type", inheritedExecutorType),
+			zap.String("elected_executor_type", req.ExecutorType))
 	}
 	if execCfg.ExecutorID != "" {
 		session.ExecutorID = execCfg.ExecutorID

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -1061,6 +1061,20 @@ func taskUsesInheritedWorkspace(task *v1.Task) bool {
 	return mode == "inherit_parent" || mode == "shared_group"
 }
 
+func rejectInheritedEnvironmentExecutorMismatch(
+	task *v1.Task,
+	env *models.TaskEnvironment,
+	requestedExecutorType string,
+) error {
+	if task == nil || !taskUsesInheritedWorkspace(task) || env == nil ||
+		env.TaskID == "" || env.TaskID == task.ID || env.ExecutorType == "" ||
+		env.ExecutorType == requestedExecutorType {
+		return nil
+	}
+	return fmt.Errorf("%w: inherited task environment belongs to executor %q, launch selected %q",
+		models.ErrWorkspaceReuseUnsafe, env.ExecutorType, requestedExecutorType)
+}
+
 func (e *Executor) resolveLaunchTaskEnvironment(
 	ctx context.Context,
 	task *v1.Task,
@@ -1292,15 +1306,16 @@ func (e *Executor) LaunchPreparedSession(ctx context.Context, task *v1.Task, ses
 	if err != nil {
 		return nil, err
 	}
-	// An inherited environment (inherit_parent / shared_group) is owned by the
-	// task that materialized it, so the child cannot share it across an executor
-	// boundary. Failing the whole launch strands the child: it can never attach
-	// to a parent environment on one executor while elected onto another. Detach
-	// instead — the child materializes a fresh environment on its elected
-	// executor and leaves the parent's environment untouched. prepareExecutorTransition
-	// has already stripped req.WorkspacePath and req.WorkspaceReuseRequired for
-	// this launch, so nil-ing existingEnv routes the child through the normal
-	// fresh-materialization path in persistTaskEnvironment.
+	// An inherited policy keeps the child bound to its canonical environment and
+	// group membership. Do not detach across executor types without an explicit
+	// policy transition that updates both records.
+	if err := rejectInheritedEnvironmentExecutorMismatch(task, existingEnv, req.ExecutorType); err != nil {
+		return nil, err
+	}
+	// A non-policy session can still carry a foreign environment reference from
+	// an older launch. Detach it after prepareExecutorTransition cleared the
+	// stale workspace path and reuse flag; persistTaskEnvironment then creates a
+	// fresh environment owned by the child and leaves the foreign row untouched.
 	if existingEnv != nil && existingEnv.TaskID != task.ID && existingEnv.ExecutorType != "" && existingEnv.ExecutorType != req.ExecutorType {
 		inheritedExecutorType := existingEnv.ExecutorType
 		existingEnv = nil

--- a/apps/backend/internal/orchestrator/executor/executor_inherited_env_detach_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_inherited_env_detach_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// A child session that inherited its parent's environment must still launch
+// when it is elected onto a different executor from the one that materialized
+// the inherited environment. Rejecting the launch strands the child: it cannot
+// attach to a parent environment that lives on one executor while being elected
+// onto another. Instead the child detaches and materializes a fresh environment
+// on its elected executor, leaving the parent's environment untouched.
+func TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch(t *testing.T) {
+	repo := newMockRepository()
+	repo.tasks["task-parent"] = &models.Task{ID: "task-parent"}
+	repo.taskEnvironments["env-parent"] = &models.TaskEnvironment{
+		ID:           "env-parent",
+		TaskID:       "task-parent",
+		ExecutorType: string(models.ExecutorTypeLocal),
+		Status:       models.TaskEnvironmentStatusReady,
+	}
+	repo.executors[models.ExecutorIDLocalDocker] = &models.Executor{
+		ID:     models.ExecutorIDLocalDocker,
+		Type:   models.ExecutorTypeLocalDocker,
+		Status: models.ExecutorStatusActive,
+	}
+	session := &models.TaskSession{
+		ID:                "session-child",
+		TaskID:            "task-child",
+		AgentProfileID:    "profile-123",
+		TaskEnvironmentID: "env-parent",
+		State:             models.TaskSessionStateCreated,
+		StartedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+	repo.sessions[session.ID] = session
+
+	var launchedExecutorType string
+	exec := newTestExecutor(t, &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			launchedExecutorType = req.ExecutorType
+			return &LaunchAgentResponse{AgentExecutionID: "exec-child", Status: v1.AgentStatusStarting}, nil
+		},
+	}, repo)
+
+	_, err := exec.LaunchPreparedSession(context.Background(),
+		&v1.Task{ID: session.TaskID, WorkspaceID: "ws-1"}, session.ID,
+		LaunchOptions{AgentProfileID: session.AgentProfileID, ExecutorID: models.ExecutorIDLocalDocker, Prompt: "test"})
+	if err != nil {
+		t.Fatalf("LaunchPreparedSession() error = %v, want nil after detaching inherited environment", err)
+	}
+	if launchedExecutorType != string(models.ExecutorTypeLocalDocker) {
+		t.Fatalf("launched executor type = %q, want %q", launchedExecutorType, models.ExecutorTypeLocalDocker)
+	}
+	if len(repo.createTaskEnvironmentCalls) != 1 {
+		t.Fatalf("created %d task environments, want 1 fresh environment for the detached child", len(repo.createTaskEnvironmentCalls))
+	}
+	created := repo.createTaskEnvironmentCalls[0]
+	if created.TaskID != session.TaskID {
+		t.Fatalf("created environment TaskID = %q, want %q (child owns its detach), not the parent's %q", created.TaskID, session.TaskID, "task-parent")
+	}
+	if created.ExecutorType != string(models.ExecutorTypeLocalDocker) {
+		t.Fatalf("created environment ExecutorType = %q, want %q", created.ExecutorType, models.ExecutorTypeLocalDocker)
+	}
+	if created.ID == "env-parent" {
+		t.Fatalf("detached child re-bound to the parent environment %q", created.ID)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_inherited_env_detach_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_inherited_env_detach_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -19,10 +20,11 @@ func TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch(t 
 	repo := newMockRepository()
 	repo.tasks["task-parent"] = &models.Task{ID: "task-parent"}
 	repo.taskEnvironments["env-parent"] = &models.TaskEnvironment{
-		ID:           "env-parent",
-		TaskID:       "task-parent",
-		ExecutorType: string(models.ExecutorTypeLocal),
-		Status:       models.TaskEnvironmentStatusReady,
+		ID:            "env-parent",
+		TaskID:        "task-parent",
+		ExecutorType:  string(models.ExecutorTypeLocal),
+		Status:        models.TaskEnvironmentStatusReady,
+		WorkspacePath: "/parent/workspace",
 	}
 	repo.executors[models.ExecutorIDLocalDocker] = &models.Executor{
 		ID:     models.ExecutorIDLocalDocker,
@@ -34,16 +36,21 @@ func TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch(t 
 		TaskID:            "task-child",
 		AgentProfileID:    "profile-123",
 		TaskEnvironmentID: "env-parent",
+		WorkspacePath:     "/parent/workspace",
 		State:             models.TaskSessionStateCreated,
 		StartedAt:         time.Now(),
 		UpdatedAt:         time.Now(),
 	}
 	repo.sessions[session.ID] = session
 
-	var launchedExecutorType string
+	var launchedExecutorType, launchedTaskEnvironmentID, launchedWorkspacePath string
+	var launchedWorkspaceReuseRequired bool
 	exec := newTestExecutor(t, &mockAgentManager{
 		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
 			launchedExecutorType = req.ExecutorType
+			launchedTaskEnvironmentID = req.TaskEnvironmentID
+			launchedWorkspacePath = req.WorkspacePath
+			launchedWorkspaceReuseRequired = req.WorkspaceReuseRequired
 			return &LaunchAgentResponse{AgentExecutionID: "exec-child", Status: v1.AgentStatusStarting}, nil
 		},
 	}, repo)
@@ -57,6 +64,15 @@ func TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch(t 
 	if launchedExecutorType != string(models.ExecutorTypeLocalDocker) {
 		t.Fatalf("launched executor type = %q, want %q", launchedExecutorType, models.ExecutorTypeLocalDocker)
 	}
+	if launchedTaskEnvironmentID == "" || launchedTaskEnvironmentID == "env-parent" {
+		t.Fatalf("launched task environment ID = %q, want a fresh child environment", launchedTaskEnvironmentID)
+	}
+	if launchedWorkspacePath != "" {
+		t.Fatalf("launched workspace path = %q, want stale inherited path cleared", launchedWorkspacePath)
+	}
+	if launchedWorkspaceReuseRequired {
+		t.Fatal("detached child launch must not require reuse of the inherited environment")
+	}
 	if len(repo.createTaskEnvironmentCalls) != 1 {
 		t.Fatalf("created %d task environments, want 1 fresh environment for the detached child", len(repo.createTaskEnvironmentCalls))
 	}
@@ -69,5 +85,72 @@ func TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch(t 
 	}
 	if created.ID == "env-parent" {
 		t.Fatalf("detached child re-bound to the parent environment %q", created.ID)
+	}
+	if parent := repo.taskEnvironments["env-parent"]; parent.TaskID != "task-parent" || parent.ExecutorType != string(models.ExecutorTypeLocal) || parent.WorkspacePath != "/parent/workspace" {
+		t.Fatalf("parent environment changed during detach: %+v", parent)
+	}
+	persistedSession := repo.sessions[session.ID]
+	if persistedSession.TaskEnvironmentID != created.ID {
+		t.Fatalf("persisted child session environment = %q, want %q", persistedSession.TaskEnvironmentID, created.ID)
+	}
+	if persistedSession.WorkspacePath != created.WorkspacePath {
+		t.Fatalf("persisted child session workspace path = %q, want %q", persistedSession.WorkspacePath, created.WorkspacePath)
+	}
+}
+
+func TestLaunchPreparedSession_RejectsInheritedEnvironmentExecutorMismatch(t *testing.T) {
+	repo := newMockRepository()
+	repo.tasks["task-parent"] = &models.Task{ID: "task-parent"}
+	parent := &models.TaskEnvironment{
+		ID:            "env-parent",
+		TaskID:        "task-parent",
+		ExecutorType:  string(models.ExecutorTypeLocal),
+		Status:        models.TaskEnvironmentStatusReady,
+		WorkspacePath: "/parent/workspace",
+	}
+	repo.taskEnvironments[parent.ID] = parent
+	session := &models.TaskSession{
+		ID:                "session-child",
+		TaskID:            "task-child",
+		AgentProfileID:    "profile-123",
+		TaskEnvironmentID: parent.ID,
+		WorkspacePath:     parent.WorkspacePath,
+		State:             models.TaskSessionStateCreated,
+		StartedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+	repo.sessions[session.ID] = session
+
+	launched := false
+	exec := newTestExecutor(t, &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			launched = true
+			return nil, nil
+		},
+	}, repo)
+	task := &v1.Task{
+		ID:          session.TaskID,
+		WorkspaceID: "ws-1",
+		Metadata: map[string]interface{}{
+			"workspace": map[string]interface{}{"mode": "inherit_parent"},
+		},
+	}
+
+	_, err := exec.LaunchPreparedSession(context.Background(), task, session.ID,
+		LaunchOptions{AgentProfileID: session.AgentProfileID, ExecutorID: models.ExecutorIDLocalDocker, Prompt: "test"})
+	if !errors.Is(err, models.ErrWorkspaceReuseUnsafe) {
+		t.Fatalf("LaunchPreparedSession() error = %v, want ErrWorkspaceReuseUnsafe", err)
+	}
+	if launched {
+		t.Fatal("LaunchAgent was called for an inherited environment on a different executor")
+	}
+	if len(repo.createTaskEnvironmentCalls) != 0 {
+		t.Fatalf("created %d task environments, want none", len(repo.createTaskEnvironmentCalls))
+	}
+	if got := repo.taskEnvironments[parent.ID]; got.TaskID != parent.TaskID || got.ExecutorType != parent.ExecutorType || got.WorkspacePath != parent.WorkspacePath {
+		t.Fatalf("parent environment changed after rejected launch: %+v", got)
+	}
+	if got := repo.sessions[session.ID]; got.TaskEnvironmentID != parent.ID || got.WorkspacePath != parent.WorkspacePath {
+		t.Fatalf("child session changed after rejected launch: %+v", got)
 	}
 }

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -1248,6 +1248,9 @@ func (e *Executor) prepareResumeRepositorySettings(
 	if err != nil {
 		return "", nil, nil, err
 	}
+	if err := rejectInheritedEnvironmentExecutorMismatch(task, existingEnv, req.ExecutorType); err != nil {
+		return "", existingEnv, nil, err
+	}
 	if session.TaskEnvironmentID != "" {
 		req.TaskEnvironmentID = session.TaskEnvironmentID
 	}

--- a/apps/backend/internal/orchestrator/executor/executor_resume_inherited_env_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_inherited_env_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // TestResolveResumeTaskEnvironment_ReusesInheritedEnvironment is a regression
@@ -53,6 +54,43 @@ func TestResolveResumeTaskEnvironment_ReusesInheritedEnvironment(t *testing.T) {
 	}
 	if session.TaskEnvironmentID != "env-parent" {
 		t.Fatalf("session.TaskEnvironmentID = %q, want env-parent", session.TaskEnvironmentID)
+	}
+}
+
+func TestPrepareResumeRepositorySettings_RejectsInheritedExecutorMismatch(t *testing.T) {
+	repo := newMockRepository()
+	exec := newTestExecutor(t, &mockAgentManager{}, repo)
+	repo.tasks["task-parent"] = &models.Task{ID: "task-parent"}
+	repo.taskEnvironments["env-parent"] = &models.TaskEnvironment{
+		ID:           "env-parent",
+		TaskID:       "task-parent",
+		ExecutorType: string(models.ExecutorTypeLocal),
+		Status:       models.TaskEnvironmentStatusReady,
+	}
+	task := &v1.Task{
+		ID:          "task-child",
+		WorkspaceID: "ws-1",
+		Metadata: map[string]interface{}{
+			"workspace": map[string]interface{}{"mode": "shared_group"},
+		},
+	}
+	session := &models.TaskSession{
+		ID:                "sess-child",
+		TaskID:            task.ID,
+		AgentProfileID:    "profile-123",
+		TaskEnvironmentID: "env-parent",
+	}
+	req := &LaunchAgentRequest{
+		TaskID:       task.ID,
+		ExecutorType: string(models.ExecutorTypeLocalDocker),
+	}
+
+	_, _, _, err := exec.prepareResumeRepositorySettings(context.Background(), task, session, req)
+	if !errors.Is(err, models.ErrWorkspaceReuseUnsafe) {
+		t.Fatalf("prepareResumeRepositorySettings() error = %v, want ErrWorkspaceReuseUnsafe", err)
+	}
+	if session.TaskEnvironmentID != "env-parent" {
+		t.Fatalf("session TaskEnvironmentID = %q, want env-parent", session.TaskEnvironmentID)
 	}
 }
 


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3565/2d1d2ff6c4ef.html)
<!-- kandev-pr-walkthrough-end -->

## Problem

When a child session inherits its parent's task environment (`inherit_parent` / `shared_group`), that environment is owned by the task that materialized it. If the child is elected onto a different executor than the one that materialized the inherited environment, `LaunchPreparedSession` returned `models.ErrWorkspaceReuseUnsafe` and aborted the launch.

That hard failure strands the child: it can never attach to a parent environment living on one executor while being elected onto another, so the launch can only be retried into the same dead end.

## Fix

Detach instead of fail. On an inherited-env executor mismatch, the child clears its inherited binding (`session.TaskEnvironmentID`, `session.WorkspacePath`), nil-ing `existingEnv` so it materializes a fresh environment on its elected executor, and leaves the parent's environment untouched.

`prepareExecutorTransition` has already stripped `req.WorkspacePath` / `req.WorkspaceReuseRequired` for this launch, so nil-ing `existingEnv` routes the child through the normal fresh-materialization path in `persistTaskEnvironment`.

## Changes

- `apps/backend/internal/orchestrator/executor/executor_execute.go`: replace the `ErrWorkspaceReuseUnsafe` return with a detach block (clear binding, reassign `TaskEnvironmentID`, log the mismatch).
- `apps/backend/internal/orchestrator/executor/executor_inherited_env_detach_test.go`: regression test asserting the child detaches, launches on the elected executor, materializes exactly one fresh environment owned by the child, and does not re-bind to the parent's environment.

## Verification

- `go test ./internal/orchestrator/executor/ -count=1`
- `go test -race ./internal/orchestrator/executor/ -run TestLaunchPreparedSession_DetachesInheritedEnvironmentOnExecutorMismatch -count=1`
- `go vet ./internal/orchestrator/executor/`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->