### PR TITLE
fix: include npm global bin in service path (#3571)

### DIFF
--- a/apps/backend/internal/launcher/service.go
+++ b/apps/backend/internal/launcher/service.go
@@ -480,7 +480,7 @@ type nativeServiceUnitInput struct {
 }
 
 const (
-	systemdServicePath = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:%h/.local/bin:%h/.bun/bin:%h/.opencode/bin"
+	systemdServicePath = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:%h/.local/bin:%h/.bun/bin:%h/.opencode/bin:%h/.npm-global/bin"
 	launchdServicePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 )
 

--- a/apps/backend/internal/launcher/service_npm_path_test.go
+++ b/apps/backend/internal/launcher/service_npm_path_test.go
@@ -31,10 +31,18 @@ func TestSystemdServicePathExecutesNPMGlobalCLI(t *testing.T) {
 	})
 	var servicePath string
 	for _, line := range strings.Split(unit, "\n") {
-		if value, ok := strings.CutPrefix(line, "Environment=PATH="); ok {
-			servicePath = strings.ReplaceAll(value, "%h", home)
-			break
+		value, ok := strings.CutPrefix(line, "Environment=")
+		if !ok {
+			continue
 		}
+		value = strings.Trim(value, `"`)
+		value, ok = strings.CutPrefix(value, "PATH=")
+		if !ok {
+			continue
+		}
+		// %h is the systemd home-dir specifier; it differs from input.HomeDir (kandev data dir).
+		servicePath = strings.ReplaceAll(value, "%h", home)
+		break
 	}
 	if servicePath == "" {
 		t.Fatal("generated unit has no PATH environment entry")

--- a/apps/backend/internal/launcher/service_npm_path_test.go
+++ b/apps/backend/internal/launcher/service_npm_path_test.go
@@ -1,0 +1,59 @@
+package launcher
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSystemdServicePathExecutesNPMGlobalCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("systemd service PATH is POSIX-only")
+	}
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".npm-global", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const cli = "kandev-test-npm-global-agent"
+	wantPath := filepath.Join(binDir, cli)
+	if err := os.WriteFile(wantPath, []byte("#!/bin/sh\nprintf 'npm-global-agent-ok'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unit := renderSystemdUnit(nativeServiceUnitInput{
+		Executable: "/opt/kandev/bin/kandev",
+		HomeDir:    filepath.Join(home, ".kandev"),
+	})
+	var servicePath string
+	for _, line := range strings.Split(unit, "\n") {
+		if value, ok := strings.CutPrefix(line, "Environment=PATH="); ok {
+			servicePath = strings.ReplaceAll(value, "%h", home)
+			break
+		}
+	}
+	if servicePath == "" {
+		t.Fatal("generated unit has no PATH environment entry")
+	}
+	t.Setenv("PATH", servicePath)
+	resolved, err := exec.LookPath(cli)
+	if err != nil {
+		t.Fatalf("global npm CLI is not discoverable with generated service PATH: %v", err)
+	}
+	if resolved != wantPath {
+		t.Fatalf("resolved CLI = %q, want %q", resolved, wantPath)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, cli).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute global npm CLI: %v: %s", err, output)
+	}
+	if string(output) != "npm-global-agent-ok" {
+		t.Fatalf("CLI output = %q", output)
+	}
+}

--- a/docs/public/run-as-a-service.md
+++ b/docs/public/run-as-a-service.md
@@ -340,3 +340,16 @@ Reinstall using the upgraded `kandev` binary, preserve the original `--system` a
 ### Service starts but agents fail
 
 Read service logs first. A service has a smaller `PATH` and no interactive shell environment, so tools or credentials visible in a terminal may be absent. Configure executor credentials through Kandev's profile/settings paths, use stable executable paths, and verify Docker/SSH/Sprites connectivity as described in [Executors](executors.md#troubleshooting).
+
+Linux user services include `~/.npm-global/bin` in their generated `PATH` for
+agent CLIs installed with that npm prefix. After upgrading an existing user
+service, regenerate its unit and restart it to apply the updated `PATH`:
+
+```bash
+# Repeat your original install-time flags when used.
+kandev service install
+kandev service restart
+```
+
+Restarting alone does not update an older unit's `PATH`. Other custom npm
+prefixes are not automatically added to the service environment.


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3573/f84a255a9e8c.html)
<!-- kandev-pr-walkthrough-end -->

The generated Linux systemd service `PATH` omitted npm's default user-global bin directory, so CLIs such as Pi installed with npm were unavailable to service-launched agents. This adds `%h/.npm-global/bin` to the generated path and documents the reinstall/restart recovery for existing services.

## Validation

- `env -u KANDEV_INTERNAL_CONFIG_FILE -u KANDEV_INTERNAL_CONFIG_HOME_FILE -u KANDEV_INTERNAL_AGENTCTL_STARTUP_CONFIG go test ./internal/launcher -count=1`
- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`
- `git diff --check`
- Commit hooks passed: Go format, Go lint, public-copy guard, and Conventional Commits validation.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #3571


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->