### PR TITLE
fix(lifecycle): resolve worktree dir by sanitized repo name on launch admission

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -1701,10 +1701,11 @@ func validateLaunchWorkspaceAdmission(ctx context.Context, req *LaunchRequest, w
 	}
 	for index, repository := range repositories {
 		candidate := workspacePath
+		entry := workspaceRepositoryEntryName(repository.RepoName)
 		if index > 0 {
-			candidate = filepath.Join(workspacePath, repository.RepoName)
+			candidate = filepath.Join(workspacePath, entry)
 		} else if len(repositories) > 1 && validateLocalRepositoryWorkspace(ctx, candidate, repository.RepositoryPath) != nil {
-			candidate = filepath.Join(workspacePath, repository.RepoName)
+			candidate = filepath.Join(workspacePath, entry)
 		}
 		// A missing worktree during ACP resume must reach WorktreePreparer.
 		// It classifies a deleted branch and returns the typed recovery error
@@ -1718,6 +1719,19 @@ func validateLaunchWorkspaceAdmission(ctx context.Context, req *LaunchRequest, w
 		}
 	}
 	return nil
+}
+
+// workspaceRepositoryEntryName returns the directory segment below the task
+// root that holds a repository's checkout. A launch spec carries the
+// repository's display name, which may contain path separators or a drive
+// letter; the worktree manager sanitizes it before creating the directory, so
+// admission has to resolve the same segment or it inspects a path that was
+// never written. An unusable name is left as-is for the caller to reject.
+func workspaceRepositoryEntryName(repoName string) string {
+	if sanitized := worktree.SanitizeRepoDirName(repoName); sanitized != "" {
+		return sanitized
+	}
+	return repoName
 }
 
 func shouldDeferMissingWorktreeResumeValidation(req *LaunchRequest, workspacePath string) bool {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_workspace_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_workspace_test.go
@@ -2,12 +2,14 @@ package lifecycle
 
 import (
 	"context"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/worktree"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -136,6 +138,65 @@ func TestValidateLaunchWorkspaceAdmissionDefersMissingWorktreeResume(t *testing.
 
 	if err := validateLaunchWorkspaceAdmission(context.Background(), req, missing); err != nil {
 		t.Fatalf("validateLaunchWorkspaceAdmission() rejected a missing worktree resume: %v", err)
+	}
+}
+
+// TestValidateLaunchWorkspaceAdmissionUsesSanitizedRepositoryDirectory pins the
+// multi-repo task root layout: launch specs carry the repository display name,
+// which the worktree manager sanitized into the directory segment it actually
+// created. Admission must look under that same segment.
+func TestValidateLaunchWorkspaceAdmissionUsesSanitizedRepositoryDirectory(t *testing.T) {
+	root := t.TempDir()
+	first := initGitRepo(t)
+	second := initGitRepo(t)
+	addLinkedWorktree(t, first, filepath.Join(root, worktree.SanitizeRepoDirName("kdlbs/kandev")))
+	addLinkedWorktree(t, second, filepath.Join(root, worktree.SanitizeRepoDirName("kdlbs/docs")))
+
+	req := &LaunchRequest{
+		ExecutorType: string(models.ExecutorTypeLocal),
+		Repositories: []RepoLaunchSpec{
+			{RepositoryID: "repository-1", RepositoryPath: first, RepoName: "kdlbs/kandev"},
+			{RepositoryID: "repository-2", RepositoryPath: second, RepoName: "kdlbs/docs"},
+		},
+	}
+
+	if err := validateLaunchWorkspaceAdmission(context.Background(), req, root); err != nil {
+		t.Fatalf("validateLaunchWorkspaceAdmission() rejected a sanitized repository directory: %v", err)
+	}
+}
+
+// TestValidateLaunchWorkspaceAdmissionRejectsUnrelatedSanitizedWorktreeOnResume
+// keeps the resume path fail-closed once the sanitized directory is the one
+// inspected: a checkout of a different repository must not be admitted just
+// because the raw display name resolves to nothing.
+func TestValidateLaunchWorkspaceAdmissionRejectsUnrelatedSanitizedWorktreeOnResume(t *testing.T) {
+	root := t.TempDir()
+	first := initGitRepo(t)
+	second := initGitRepo(t)
+	unrelated := initGitRepo(t)
+	addLinkedWorktree(t, first, filepath.Join(root, worktree.SanitizeRepoDirName("kdlbs/kandev")))
+	addLinkedWorktree(t, unrelated, filepath.Join(root, worktree.SanitizeRepoDirName("kdlbs/docs")))
+
+	req := &LaunchRequest{
+		ExecutorType: string(models.ExecutorTypeWorktree),
+		ACPSessionID: "acp-session-1",
+		Repositories: []RepoLaunchSpec{
+			{RepositoryID: "repository-1", RepositoryPath: first, RepoName: "kdlbs/kandev"},
+			{RepositoryID: "repository-2", RepositoryPath: second, RepoName: "kdlbs/docs"},
+		},
+	}
+
+	if err := validateLaunchWorkspaceAdmission(context.Background(), req, root); err == nil {
+		t.Fatal("validateLaunchWorkspaceAdmission() accepted an unrelated checkout at the sanitized directory")
+	}
+}
+
+func addLinkedWorktree(t *testing.T, source, destination string) {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "add", "--detach", destination)
+	cmd.Dir = source
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add %q: %v: %s", destination, err, output)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_workspace_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_workspace_test.go
@@ -195,6 +195,7 @@ func addLinkedWorktree(t *testing.T, source, destination string) {
 	t.Helper()
 	cmd := exec.Command("git", "worktree", "add", "--detach", destination)
 	cmd.Dir = source
+	cmd.Env = newIsolatedGitEnv()
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add %q: %v: %s", destination, err, output)
 	}


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3580/c14bbf822ce2.html)
<!-- kandev-pr-walkthrough-end -->

Resuming a multi-repository task failed with `required worktree is unavailable for reuse` whenever a repository's display name was not usable as a directory segment, because launch admission looked for the checkout under the raw name while the worktree manager had created it under the sanitized one. Admission now resolves the same segment the worktree manager wrote, so those resumes succeed and a mismatched checkout is still rejected.

## Validation

- `go test ./internal/agent/runtime/lifecycle/ -run TestValidateLaunchWorkspaceAdmission -count=1` — 4 tests pass. The two new ones fail before this change: the first with the exact reported error, the second because the old code skipped a wrong checkout as "missing" instead of rejecting it.
- `make -C apps/backend lint` — 0 issues.
- Manually verified on Windows against a dev instance built from this branch. A multi-repository task whose first repository is registered under an absolute path resumed successfully, where every previous resume attempt failed.

Note: `TestResolvePreparerSetupScript_WorktreePlaceholders` fails on Windows both with and without this change. It asserts a POSIX path separator and is unrelated.

## Possible Improvements

Low risk. The helper falls back to the raw name when sanitization yields an empty string, which preserves the existing rejection for a name with no usable characters.

## Checklist

- [ ] If I do not have repository write access and this is a large architectural change, I discussed the direction in a linked issue before opening this PR.
- [ ] This PR contains one logical change; unrelated work is split into separate PRs.
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->