### PR TITLE
fix(executor): scope legacy empty-branch environment fallback per repository

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_environment_reuse.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_reuse.go
@@ -112,7 +112,7 @@ func currentTaskDirName(env *models.TaskEnvironment) string {
 func canonicalInventoryMatches(spec RepoSpec, rows []*models.TaskEnvironmentRepo, useWorktree bool) int {
 	matches := 0
 	expectedBranchSlug := launchRepoBranchIdentitySlug(spec)
-	allowLegacyEmptyBranch := expectedBranchSlug != "" && !hasBranchScopedEnvironmentRepoRows(rows)
+	allowLegacyEmptyBranch := expectedBranchSlug != "" && !repositoryHasBranchScopedRepoRow(rows, spec.RepositoryID)
 	for _, row := range rows {
 		branchMatches := worktree.SanitizeBranchSlug(row.BranchSlug) == expectedBranchSlug
 		if allowLegacyEmptyBranch && row.BranchSlug == "" {
@@ -458,6 +458,20 @@ func hasBranchScopedEnvironmentWorktrees(env *models.TaskEnvironment) bool {
 func hasBranchScopedEnvironmentRepoRows(repos []*models.TaskEnvironmentRepo) bool {
 	for _, repo := range repos {
 		if repo.RepositoryID != "" && repo.WorktreeID != "" && worktree.SanitizeBranchSlug(repo.BranchSlug) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// repositoryHasBranchScopedRepoRow reports whether the inventory already has an
+// active branch for a single repository. Unlike hasBranchScopedEnvironmentRepoRows
+// it ignores the worktree identifier, because a local executor's scoped row
+// legitimately has an empty worktree ID; treating it as unscoped would re-enable
+// the legacy empty-branch fallback and let a stale row over-match the slot.
+func repositoryHasBranchScopedRepoRow(repos []*models.TaskEnvironmentRepo, repositoryID string) bool {
+	for _, repo := range repos {
+		if repo.RepositoryID == repositoryID && worktree.SanitizeBranchSlug(repo.BranchSlug) != "" {
 			return true
 		}
 	}

--- a/apps/backend/internal/orchestrator/executor/executor_environment_reuse.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_reuse.go
@@ -464,11 +464,9 @@ func hasBranchScopedEnvironmentRepoRows(repos []*models.TaskEnvironmentRepo) boo
 	return false
 }
 
-// repositoryHasBranchScopedRepoRow reports whether the inventory already has an
-// active branch for a single repository. Unlike hasBranchScopedEnvironmentRepoRows
-// it ignores the worktree identifier, because a local executor's scoped row
-// legitimately has an empty worktree ID; treating it as unscoped would re-enable
-// the legacy empty-branch fallback and let a stale row over-match the slot.
+// repositoryHasBranchScopedRepoRow reports whether repos contains a row for
+// repositoryID with a non-empty sanitized branch slug. WorktreeID is not
+// required because local executor rows can be branch-scoped without a worktree.
 func repositoryHasBranchScopedRepoRow(repos []*models.TaskEnvironmentRepo, repositoryID string) bool {
 	for _, repo := range repos {
 		if repo.RepositoryID == repositoryID && worktree.SanitizeBranchSlug(repo.BranchSlug) != "" {

--- a/apps/backend/internal/orchestrator/executor/executor_environment_reuse_inventory_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_reuse_inventory_test.go
@@ -57,3 +57,30 @@ func TestValidateReuseEnvironmentInventory_MismatchedRowsStillRefused(t *testing
 		t.Fatalf("validateReuseEnvironmentInventory() with mismatched rows = %v, want ErrWorkspaceReuseUnsafe", err)
 	}
 }
+
+// A local executor publishes a branch-scoped row with an empty worktree ID, and
+// may still carry a legacy empty-branch worktree row from an older capture. The
+// guard must match exactly the scoped row for the branch and not also match the
+// legacy row, or it over-counts and falsely refuses an otherwise-complete
+// canonical inventory.
+func TestValidateReuseEnvironmentInventory_ScopedBranchPlusLegacyEmptyRowAttaches(t *testing.T) {
+	repo := newMockRepository()
+	repo.taskRepositories["task-repo-1"] = &models.TaskRepository{ID: "task-repo-1", TaskID: "task-1", RepositoryID: "repo-1"}
+	e := newTestExecutor(t, &mockAgentManager{}, repo)
+	req := &LaunchAgentRequest{
+		TaskID:                 "task-1",
+		WorkspaceReuseRequired: true,
+		Repositories: []RepoSpec{
+			{RepositoryID: "repo-1", BranchIdentitySlug: "main"},
+		},
+	}
+	env := &models.TaskEnvironment{ID: "env-1"}
+	repo.taskEnvironmentRepos[env.ID] = []*models.TaskEnvironmentRepo{
+		{RepositoryID: "repo-1", BranchSlug: "main", WorktreeID: ""},
+		{RepositoryID: "repo-1", BranchSlug: "", WorktreeID: "worktree-legacy"},
+	}
+
+	if err := e.validateReuseEnvironmentInventory(context.Background(), req, env); err != nil {
+		t.Fatalf("validateReuseEnvironmentInventory() = %v, want nil", err)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_environment_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_test.go
@@ -66,6 +66,18 @@ func TestCanonicalInventoryMatches_AcceptsLegacyUnscopedRowWhenNoScopedRowsExist
 	}
 }
 
+func TestCanonicalInventoryMatches_ScopedLocalBranchSuppressesLegacyFallback(t *testing.T) {
+	spec := RepoSpec{RepositoryID: "repo-1", BranchIdentitySlug: "main"}
+	rows := []*models.TaskEnvironmentRepo{
+		{RepositoryID: "repo-1", BranchSlug: "main", WorktreeID: ""},
+		{RepositoryID: "repo-1", BranchSlug: "", WorktreeID: "worktree-legacy"},
+	}
+
+	if got := canonicalInventoryMatches(spec, rows, false); got != 1 {
+		t.Fatalf("canonicalInventoryMatches() = %d, want 1 (scoped row must suppress legacy fallback)", got)
+	}
+}
+
 func TestReuseExistingEnvironment_WorktreeReuseKeepsTaskDirName(t *testing.T) {
 	repo := newMockRepository()
 	e := newTestExecutor(t, &mockAgentManager{}, repo)

--- a/apps/backend/internal/orchestrator/executor/executor_environment_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_test.go
@@ -78,6 +78,18 @@ func TestCanonicalInventoryMatches_ScopedLocalBranchSuppressesLegacyFallback(t *
 	}
 }
 
+func TestCanonicalInventoryMatches_ScopedRowOnOtherRepoDoesNotSuppressFallbackForThisRepo(t *testing.T) {
+	spec := RepoSpec{RepositoryID: "repo-1", BranchIdentitySlug: "main"}
+	rows := []*models.TaskEnvironmentRepo{
+		{RepositoryID: "repo-1", BranchSlug: "", WorktreeID: "worktree-legacy"},
+		{RepositoryID: "repo-2", BranchSlug: "main", WorktreeID: "worktree-scoped"},
+	}
+
+	if got := canonicalInventoryMatches(spec, rows, true); got != 1 {
+		t.Fatalf("canonicalInventoryMatches() = %d, want 1 (other repo's scoped row must not suppress repo-1 fallback)", got)
+	}
+}
+
 func TestReuseExistingEnvironment_WorktreeReuseKeepsTaskDirName(t *testing.T) {
 	repo := newMockRepository()
 	e := newTestExecutor(t, &mockAgentManager{}, repo)

--- a/docs/plans/workspace-reuse-empty-branch-fallback/plan.md
+++ b/docs/plans/workspace-reuse-empty-branch-fallback/plan.md
@@ -1,0 +1,92 @@
+---
+created: 2026-09-11
+status: draft
+requirements:
+  - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-001
+  - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-003
+system_design:
+  - ../../specs/tasks/system-design/additional-session-workspace-reuse.md
+legacy_specs: []
+---
+
+# Implementation Plan: Workspace Reuse Empty-Branch Fallback Scope
+
+## Overview
+
+Make the canonical-inventory match for a repository/branch slot scoped per
+repository so a legacy empty-branch row no longer double-counts against an
+already branch-scoped slot. This removes a false `workspace_reuse_unsafe`
+refusal for inherited `local` environments that carry both a scoped branch row
+and a stale empty-branch worktree row.
+
+## Scope
+
+### In scope
+
+- Scope the empty-branch fallback in `canonicalInventoryMatches` per repository.
+- Recognize a non-empty-branch row as branch-scoped regardless of worktree ID.
+- Add a regression test at the `canonicalInventoryMatches` and
+  `validateReuseEnvironmentInventory` boundaries.
+
+### Out of scope
+
+- Deleting, cleaning, or rewriting stale worktree repo rows on executor drift.
+- Changing the worktree-ID reuse fallback (`reuseExistingRepositoryWorktrees`).
+- Any schema migration or new workspace ledger.
+
+## Confirmed root cause
+
+`canonicalInventoryMatches` gates the legacy empty-branch fallback on the global
+`hasBranchScopedEnvironmentRepoRows` predicate. That predicate requires
+`RepositoryID != "" && WorktreeID != "" && sanitize(BranchSlug) != ""`, so a
+`local` executor environment whose only scoped row is
+`{branch: "main", worktree: ""}` is treated as unscoped and enables the fallback.
+A stale legacy empty-branch worktree row (`{branch: "", worktree_id: set}`) then
+also matches the `main` slot, yielding `matches == 2`; the guard rejects because
+it requires `== 1`. The runtime surfaces this as "canonical workspace repository
+inventory has no matching entry for repository ... branch main", which is
+misleading: the slot over-matches, it is not missing.
+
+## Technical approach
+
+- Add `repositoryHasBranchScopedRow(rows, repositoryID) bool` that returns true
+  when any row for `repositoryID` carries a non-empty sanitized branch slug,
+  independent of worktree ID or status.
+- In `canonicalInventoryMatches` (`apps/backend/internal/orchestrator/executor/executor_environment_reuse.go:115`),
+  replace `!hasBranchScopedEnvironmentRepoRows(rows)` with
+  `!repositoryHasBranchScopedRow(rows, spec.RepositoryID)`.
+- Leave the existing `hasBranchScopedEnvironmentRepoRows` predicate and the
+  worktree-ID reuse path untouched.
+- Prefer `newMockRepository()` / `newTestExecutor()` fixtures already used by
+  `executor_environment_reuse_inventory_test.go` and `executor_environment_test.go`.
+
+## Tests
+
+- `TestCanonicalInventoryMatches_ScopedLocalBranchSuppressesLegacyFallback`:
+  spec `{repo-1, main}`, rows `[{repo-1, main}, {repo-1, "", worktree set}]`,
+  `useWorktree=false`, expect `1` match (fails before the correction with `2`).
+- `TestValidateReuseEnvironmentInventory_ScopedBranchPlusLegacyEmptyRowAttaches`:
+  same rows via mock repo, `WorkspaceReuseRequired=true`, expect `nil` error.
+- Existing `TestCanonicalInventoryMatches_AcceptsLegacyUnscopedRowWhenNoScopedRowsExist`
+  and `TestValidateReuseEnvironmentInventory_MismatchedRowsStillRefused` must
+  keep passing.
+
+## Work orders
+
+- [ ] [Task 01: Scope the empty-branch fallback per repository](task-01-per-repo-empty-branch-fallback.md)
+
+## Verification results
+
+Pending.
+
+## Risks
+
+- The deployed backend is pinned to `8b64aed17` (v0.94.0-40) while upstream
+  `origin/main` has advanced to `8e38e2a0` (v0.94.0-50). The changed file
+  `executor_environment_reuse.go` is identical on both, but the PR base and the
+  deploy target must be reconciled by the operator at pull-request time.
+- `repositoryHasBranchScopedRow` intentionally ignores row status, matching the
+  existing predicate's behavior; do not introduce status-aware scoping in this
+  change without a separate requirement.
+- The worktree-ID reuse fallback must not be altered, or it could regress
+  branch-scoped worktree attachment for the Worktree executor.

--- a/docs/plans/workspace-reuse-empty-branch-fallback/plan.md
+++ b/docs/plans/workspace-reuse-empty-branch-fallback/plan.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-09-11
-status: draft
+status: complete
 requirements:
   - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-001
   - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-003
@@ -73,11 +73,13 @@ misleading: the slot over-matches, it is not missing.
 
 ## Work orders
 
-- [ ] [Task 01: Scope the empty-branch fallback per repository](task-01-per-repo-empty-branch-fallback.md)
+- [x] [Task 01: Scope the empty-branch fallback per repository](task-01-per-repo-empty-branch-fallback.md)
 
 ## Verification results
 
-Pending.
+`go test ./internal/orchestrator/executor -run 'TestCanonicalInventoryMatches|TestValidateReuseEnvironmentInventory' -count=1` passes.
+`go test ./internal/orchestrator/executor -count=1` passes.
+`python3 scripts/lint-spec-files.py --all` passes.
 
 ## Risks
 

--- a/docs/plans/workspace-reuse-empty-branch-fallback/task-01-per-repo-empty-branch-fallback.md
+++ b/docs/plans/workspace-reuse-empty-branch-fallback/task-01-per-repo-empty-branch-fallback.md
@@ -1,0 +1,89 @@
+---
+id: "01-per-repo-empty-branch-fallback"
+title: "Scope the empty-branch fallback per repository"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+requirements:
+  - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-001
+  - REQ-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-003
+acceptance_criteria:
+  - AC-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-001.1
+  - AC-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-003.2
+  - AC-TASKS-ADDITIONAL-SESSION-WORKSPACE-REUSE-003.3
+system_design:
+  - ../../specs/tasks/system-design/additional-session-workspace-reuse.md
+---
+
+# Task 01: Scope the empty-branch fallback per repository
+
+## Summary
+
+Change `canonicalInventoryMatches` so the legacy empty-branch fallback applies
+per repository instead of globally, and recognize a non-empty branch slug as
+branch-scoped even when the row has no worktree ID. A repository that already
+has a `main` row must not also match a stale empty-branch row, restoring an
+exact match of one row per branch slot.
+
+## In scope
+
+- Add `repositoryHasBranchScopedRow(rows, repositoryID)`.
+- Update `canonicalInventoryMatches` to use the per-repository predicate.
+- Add the two regression tests named in the plan.
+
+## Out of scope
+
+- Worktree-ID reuse fallback changes.
+- Decommissioning stale legacy repo rows.
+- Schema changes or new persistence models.
+
+## Acceptance
+
+- `canonicalInventoryMatches` counts exactly one row for a
+  `{repo, main}` slot when that repository has a `main` row (no worktree) plus a
+  legacy empty-branch worktree row, under `useWorktree=false`.
+- `validateReuseEnvironmentInventory` returns `nil` for that inventory instead of
+  `ErrWorkspaceReuseUnsafe`.
+- The legacy-only case (single empty-branch row, no scoped rows) still matches.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/orchestrator/executor -run 'TestCanonicalInventoryMatches|TestValidateReuseEnvironmentInventory' -count=1
+cd apps/backend && go test ./internal/orchestrator/executor -count=1
+python3 scripts/lint-spec-files.py --all
+```
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/executor/executor_environment_reuse.go`
+- `apps/backend/internal/orchestrator/executor/executor_environment_test.go`
+- `apps/backend/internal/orchestrator/executor/executor_environment_reuse_inventory_test.go`
+
+## Dependencies
+
+None
+
+## Risks
+
+- Do not broaden or narrow the guard's mismatched-inventory refusal beyond the
+  per-repository fallback scoping; `MismatchedRowsStillRefused` must still fail.
+- Keep `repositoryHasBranchScopedRow` status-agnostic to match the existing
+  predicate and avoid unrelated behavior changes.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- `docs/specs/tasks/system-design/additional-session-workspace-reuse.md` section
+  "Launch admission".
+- Existing predicates `hasBranchScopedEnvironmentRepoRows` and the
+  `canonicalInventoryMatches` guard in `executor_environment_reuse.go`.
+- Existing `canonicalInventoryMatches` tests in `executor_environment_test.go`.
+
+## Results
+
+Pending.

--- a/docs/plans/workspace-reuse-empty-branch-fallback/task-01-per-repo-empty-branch-fallback.md
+++ b/docs/plans/workspace-reuse-empty-branch-fallback/task-01-per-repo-empty-branch-fallback.md
@@ -1,7 +1,7 @@
 ---
 id: "01-per-repo-empty-branch-fallback"
 title: "Scope the empty-branch fallback per repository"
-status: pending
+status: completed
 wave: 1
 depends_on: []
 plan: "plan.md"
@@ -86,4 +86,5 @@ None
 
 ## Results
 
-Pending.
+All acceptance criteria are met. `go test ./internal/orchestrator/executor -count=1` passes.
+`python3 scripts/lint-spec-files.py --all` passes.

--- a/docs/specs/tasks/system-design/additional-session-workspace-reuse.md
+++ b/docs/specs/tasks/system-design/additional-session-workspace-reuse.md
@@ -114,6 +114,13 @@ inventory validation and filesystem validation:
 - the validated path belongs to the selected environment, not a stale session
   projection.
 
+The canonical inventory match for a slot is scoped per repository. The legacy
+empty-branch fallback stands in for a repository's branch slot only when that
+repository has no row carrying a non-empty branch slug; branch scoping does not
+depend on a worktree identifier, so a local-executor row with a branch and no
+worktree ID is already branch-scoped and suppresses the fallback for its own
+repository. A slot therefore never matches more than one row.
+
 Validation is read-only and uses the existing bounded Git inspection path. It
 does not read file contents or alter the index, HEAD, branch, tracked files, or
 untracked files. Remote executors validate through their executor-owned


### PR DESCRIPTION
<!-- kandev-pr-walkthrough-start -->
> [!TIP]
> **PR walkthrough:** [Open the visual walkthrough](https://walkthrough.kandev.ai/pr/3595/9ba038e225e3.html)
<!-- kandev-pr-walkthrough-end -->

## Summary

Fixes a residual workspace-reuse defect: the legacy empty-branch environment fallback was gated globally instead of per repository.

`canonicalInventoryMatches` used `hasBranchScopedEnvironmentRepoRows` to decide whether a legacy empty-branch row could satisfy a slot. That helper returns true when *any* repository has a branch-scoped row, so a repository that legitimately published a scoped row (a local executor's scoped row carries an empty worktree ID) still had its legacy empty-branch row accepted. A stale legacy row could then over-match the slot after the scoped row already satisfied it.

## Change

- Add `repositoryHasBranchScopedRepoRow(rows, repositoryID)`, which checks only the target repository instead of the whole inventory.
- Gate the legacy empty-branch fallback on that per-repository check.

## Scope

- `apps/backend/internal/orchestrator/executor/executor_environment_reuse.go`
- Regression tests in `executor_environment_reuse_inventory_test.go` and `executor_environment_test.go`
- Spec update in `docs/specs/tasks/system-design/additional-session-workspace-reuse.md`
- Plan/work order in `docs/plans/workspace-reuse-empty-branch-fallback/`

## Testing

- `go test ./internal/orchestrator/executor/` passes.
- New tests cover a scoped local branch suppressing the legacy fallback, and a scoped-branch plus legacy-row inventory still attaching.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->