### PR TITLE
fix(lifecycle): forward TaskID in the Docker create-instance request

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/container.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/container.go
@@ -116,6 +116,7 @@ func buildContainerCreateInstanceRequest(
 		AutoStart:                  false,
 		McpServers:                 config.McpServers,
 		SessionID:                  config.SessionID,
+		TaskID:                     config.TaskID,
 		DisableAskQuestion:         disableAskQuestion,
 		AssumeMcpSse:               assumeMcpSse,
 		AssumeMcpHttp:              assumeMcpHttp,

--- a/apps/backend/internal/agent/runtime/lifecycle/container_create_instance_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/container_create_instance_test.go
@@ -1,0 +1,20 @@
+package lifecycle
+
+import "testing"
+
+// Regression: the Docker executor's fresh-launch create-instance request forwarded
+// SessionID but dropped TaskID, so the MCP server built inside every new container
+// ran with an empty task binding and task-bound tools (step_complete_kandev,
+// set_task_title_kandev, ...) failed with "requires a bound task".
+func TestBuildContainerCreateInstanceRequestForwardsTaskAndSession(t *testing.T) {
+	config := ContainerConfig{TaskID: "task-123", SessionID: "session-456"}
+
+	req := buildContainerCreateInstanceRequest(config, "claude-acp", false, false, false, false, nil)
+
+	if req.TaskID != "task-123" {
+		t.Fatalf("TaskID = %q, want %q", req.TaskID, "task-123")
+	}
+	if req.SessionID != "session-456" {
+		t.Fatalf("SessionID = %q, want %q", req.SessionID, "session-456")
+	}
+}


### PR DESCRIPTION
## Problem

`buildContainerCreateInstanceRequest` (`apps/backend/internal/agent/runtime/lifecycle/container.go`) forwards `SessionID` but not `TaskID` to agentctl. The MCP server built inside every freshly launched **Local Docker** container therefore runs with an empty task binding, and task-bound tools fail for agents running in containers:

- `step_complete_kandev` → `step_complete_kandev requires a bound task and session`
- `set_task_title_kandev` → `set_task_title_kandev requires a bound task`

The reconnect path (`buildReconnectCreateInstanceRequest`) and the standalone/SSH/Sprites/Kubernetes builders already forward both identifiers, so only the fresh Docker launch is affected. This looks like the same defect as #2643 (closed by its author for non-technical reasons).

## Reproduction (kandev v0.94.0, Local Docker executor profile, Claude agent)

1. Workflow step whose prompt ends with a `step_complete_kandev` call, task launched on a Local Docker profile.
2. The agent finishes its work and calls `step_complete_kandev`.
3. Result: `requires a bound task and session`; the task stays on its step. The container environment does carry `KANDEV_TASK_ID` / `KANDEV_SESSION_ID`, and the agentctl log shows the MCP server enabled with the session id only.

With this change the container-side MCP server binds the task and the step completes normally.

## Change

- `container.go`: forward `config.TaskID` in the create-instance request (one line).
- `container_create_instance_test.go`: regression test asserting the builder forwards both `TaskID` and `SessionID`.

## Validation

- `gofmt -l` clean on the two files
- `go vet ./internal/agent/runtime/lifecycle/`
- `go test ./internal/agent/runtime/lifecycle/ -run TestBuildContainerCreateInstanceRequestForwardsTaskAndSession -count=1` → ok
- Manually verified on a self-hosted kandev 0.94.0 (Docker executor, Claude ACP agent): with the task id forwarded to agentctl, `step_complete_kandev` succeeds from inside a fresh container.

No UI change, no public docs impact.

## Checklist

- [x] This PR contains one logical change; unrelated work is split into separate PRs.
- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] I checked whether this affects public docs in `docs/public/**` — no docs change needed (bug fix, no behavior change for users beyond the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJBBp1qpZ772ibT6QLCwkt


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Maintainer note: the repository's `no-docs-allow` exception is applied because this is an internal executor bug fix with no public documentation change.
